### PR TITLE
docs: remove non-existent Files Service references

### DIFF
--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -20,13 +20,13 @@ QCKSTRT is built on a modular, provider-based architecture with three core princ
 └─────────────────────────────────────────────────────────────┘
                             ↓
         ┌──────────────┬─────────────┬──────────────┐
-        ↓              ↓             ↓              ↓
-   ┌────────┐    ┌──────────┐  ┌──────────┐  ┌──────────┐
-   │ Users  │    │Documents │  │Knowledge │  │  Files   │
-   │Service │    │ Service  │  │ Service  │  │ Service  │
-   └────────┘    └──────────┘  └──────────┘  └──────────┘
-        │              │             │              │
-        ↓              ↓             ↓              ↓
+        ↓              ↓             ↓
+   ┌────────┐    ┌──────────┐  ┌──────────┐
+   │ Users  │    │Documents │  │Knowledge │
+   │Service │    │ Service  │  │ Service  │
+   └────────┘    └──────────┘  └──────────┘
+        │              │             │
+        ↓              ↓             ↓
    ┌────────────────────────────────────────────────────┐
    │              Provider Layer (Pluggable)            │
    ├────────────────────────────────────────────────────┤
@@ -53,10 +53,10 @@ QCKSTRT is built on a modular, provider-based architecture with three core princ
 ### Documents Service
 - **Technology**: NestJS + Apollo Federation
 - **Port**: 3002
-- **Purpose**: Document storage and metadata management
+- **Purpose**: Document storage, metadata management, and file processing
 - **Location**: `apps/backend/src/apps/documents`
 - **Database**: Relational (Document metadata)
-- **Storage**: S3-compatible object storage
+- **Storage**: Supabase Storage
 
 ### Knowledge Service
 - **Technology**: NestJS + Apollo Federation
@@ -67,12 +67,6 @@ QCKSTRT is built on a modular, provider-based architecture with three core princ
   - Embeddings generation (Xenova/Ollama)
   - Vector search (ChromaDB/pgvector)
   - LLM inference (Ollama with Falcon 7B)
-
-### Files Service
-- **Technology**: NestJS + Apollo Federation
-- **Port**: 3004
-- **Purpose**: File processing and OCR
-- **Location**: `apps/backend/src/apps/files`
 
 ## Provider Architecture
 
@@ -86,9 +80,9 @@ All external dependencies use the **Strategy Pattern + Dependency Injection** fo
 | `@qckstrt/vectordb-provider` | Vector storage & search | `VECTOR_DB_PROVIDER` |
 | `@qckstrt/embeddings-provider` | Text embeddings | `EMBEDDINGS_PROVIDER` |
 | `@qckstrt/llm-provider` | LLM inference | `LLM_PROVIDER` |
-| `@qckstrt/storage-provider` | File storage (Supabase/S3) | `STORAGE_PROVIDER` |
-| `@qckstrt/auth-provider` | Authentication (Supabase/Cognito) | `AUTH_PROVIDER` |
-| `@qckstrt/secrets-provider` | Secrets management (Supabase/AWS) | `SECRETS_PROVIDER` |
+| `@qckstrt/storage-provider` | File storage (Supabase) | `STORAGE_PROVIDER` |
+| `@qckstrt/auth-provider` | Authentication (Supabase) | `AUTH_PROVIDER` |
+| `@qckstrt/secrets-provider` | Secrets management (Supabase Vault) | `SECRETS_PROVIDER` |
 | `@qckstrt/extraction-provider` | Text extraction | `EXTRACTION_PROVIDER` |
 
 ### Relational Database Provider
@@ -105,7 +99,6 @@ interface IRelationalDBProvider {
 
 **Implementations**:
 - `PostgresProvider` - Default (via Supabase)
-- `AuroraProvider` - AWS serverless
 
 **See**: [Data Layer Architecture](data-layer.md)
 
@@ -203,12 +196,9 @@ RELATIONAL_DB_PROVIDER=postgres
 VECTOR_DB_PROVIDER=chromadb
 EMBEDDINGS_PROVIDER=xenova
 LLM_MODEL=falcon
-
-# AWS Alternative
-RELATIONAL_DB_PROVIDER=aurora
-AUTH_PROVIDER=cognito
-STORAGE_PROVIDER=s3
-SECRETS_PROVIDER=aws
+AUTH_PROVIDER=supabase
+STORAGE_PROVIDER=supabase
+SECRETS_PROVIDER=supabase
 ```
 
 ### Configuration Files
@@ -263,15 +253,15 @@ AWS/Cloud Infrastructure
 - LLM inference runs locally
 
 ### Authentication
-- User authentication via Supabase Auth (default) or AWS Cognito
+- User authentication via Supabase Auth
 - Service-to-service auth via API keys
 - GraphQL field-level authorization
 
 ### Infrastructure
-- Self-hosted Supabase stack (default)
+- Self-hosted Supabase stack
 - Encryption at rest (PostgreSQL, Supabase Storage)
 - Encryption in transit (TLS/HTTPS)
-- Secrets management via Supabase Vault (default) or AWS Secrets Manager
+- Secrets management via Supabase Vault
 
 ## Monitoring & Observability
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -76,7 +76,7 @@ cp apps/backend/.env.example apps/backend/.env
 # Backend services
 cd apps/backend
 npm run start:dev
-# This starts all microservices (API Gateway, Users, Documents, Knowledge, Files)
+# This starts all microservices (API Gateway, Users, Documents, Knowledge)
 
 # Frontend (in another terminal)
 cd apps/frontend
@@ -137,12 +137,12 @@ query {
 │         API Gateway (Apollo Federation)          │
 │          http://localhost:3000                   │
 └──────────────────────────────────────────────────┘
-          ↓           ↓           ↓          ↓
-    ┌─────────┐ ┌──────────┐ ┌────────┐ ┌────────┐
-    │ Users   │ │Documents │ │Knowledge│ │ Files  │
-    │  :3001  │ │  :3002   │ │  :3003 │ │  :3004 │
-    └─────────┘ └──────────┘ └────────┘ └────────┘
-          ↓           ↓           ↓          ↓
+          ↓           ↓           ↓
+    ┌─────────┐ ┌──────────┐ ┌──────────┐
+    │ Users   │ │Documents │ │Knowledge │
+    │  :3001  │ │  :3002   │ │  :3003   │
+    └─────────┘ └──────────┘ └──────────┘
+          ↓           ↓           ↓
 ┌────────────────────────────────────────────────────┐
 │              Provider Layer                        │
 ├────────────────────────────────────────────────────┤
@@ -161,16 +161,10 @@ qckstrt/
 │   ├── backend/
 │   │   ├── src/
 │   │   │   ├── apps/          # Microservices
-│   │   │   │   ├── api/       # GraphQL Gateway (port 3000)
 │   │   │   │   ├── users/     # Users Service (port 3001)
 │   │   │   │   ├── documents/ # Documents Service (port 3002)
-│   │   │   │   ├── knowledge/ # Knowledge/RAG Service (port 3003)
-│   │   │   │   └── files/     # Files Service (port 3004)
-│   │   │   ├── providers/     # Pluggable providers
-│   │   │   │   ├── embeddings/
-│   │   │   │   ├── vectordb/
-│   │   │   │   ├── relationaldb/
-│   │   │   │   └── llm/
+│   │   │   │   └── knowledge/ # Knowledge/RAG Service (port 3003)
+│   │   │   ├── api/           # GraphQL Gateway (port 3000)
 │   │   │   ├── db/            # Database module
 │   │   │   └── config/        # Configuration
 │   │   └── .env               # Local environment config
@@ -453,13 +447,12 @@ For production deployment, see:
 - [Docker Setup](docker-setup.md) (Production configuration)
 
 **Key Changes for Production**:
-1. Use managed PostgreSQL or Aurora: `RELATIONAL_DB_PROVIDER=aurora`
+1. Use managed PostgreSQL (Supabase Cloud or self-hosted)
 2. Consider pgvector: `VECTOR_DB_PROVIDER=pgvector`
 3. Use managed Ollama with GPU instances
 4. Enable SSL/TLS for all connections
 5. Set up monitoring and logging
 6. Configure backups
-7. Switch to AWS services if needed: Cognito, S3, Secrets Manager
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove Files Service from architecture diagrams (only 3 services exist: Users, Documents, Knowledge)
- Update Documents Service description to include file processing
- Fix project structure to reflect actual directory layout
- Remove outdated AWS provider references
- Simplify production deployment guidance

## Changes

**[system-overview.md](docs/architecture/system-overview.md)**:
- Updated architecture diagram to show 3 services
- Removed Files Service section
- Updated Documents Service to include file processing
- Changed storage reference to Supabase Storage
- Removed AWS alternatives

**[getting-started.md](docs/guides/getting-started.md)**:
- Updated microservices list and architecture diagram
- Fixed project structure documentation
- Removed AWS-specific production guidance

## Test plan
- [x] No code changes, documentation only
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)