### PR TITLE
security: add IP restriction validation and CloudWatch monitoring

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -11,12 +11,13 @@
 #
 # File Structure:
 # - main.tf             : Terraform & provider configuration (this file)
-# - variables.tf        : Input variables
+# - variables.tf        : Input variables (with security validation)
 # - data.tf             : Data sources (AMIs, availability zones)
 # - vpc.tf              : VPC, subnets, internet gateway, routes
 # - security-groups.tf  : Security groups and rules
 # - iam.tf              : IAM roles, policies, instance profile
 # - secrets.tf          : Secrets Manager and random passwords
+# - monitoring.tf       : CloudWatch alarms and SNS alerts
 # - app-server.tf       : Application server EC2 instance
 # - gpu-server.tf       : GPU spot instance for AI inference
 # - outputs.tf          : Output values

--- a/infra/monitoring.tf
+++ b/infra/monitoring.tf
@@ -1,0 +1,200 @@
+# =============================================================================
+# CloudWatch Monitoring & Alarms
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# SNS Topic for Alerts (optional - configure email subscription manually)
+# -----------------------------------------------------------------------------
+
+resource "aws_sns_topic" "alerts" {
+  name = "${var.project}-${var.stage}-alerts"
+
+  tags = {
+    Name    = "${var.project}-${var.stage}-alerts"
+    Project = var.project
+    Stage   = var.stage
+  }
+}
+
+# -----------------------------------------------------------------------------
+# App Server Alarms
+# -----------------------------------------------------------------------------
+
+# CPU utilization alarm
+resource "aws_cloudwatch_metric_alarm" "app_server_cpu" {
+  alarm_name          = "${var.project}-${var.stage}-app-server-cpu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = "App server CPU utilization exceeds 80%"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    InstanceId = aws_instance.app_server.id
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.stage}-app-server-cpu"
+    Project = var.project
+    Stage   = var.stage
+  }
+}
+
+# Instance status check alarm
+resource "aws_cloudwatch_metric_alarm" "app_server_status" {
+  alarm_name          = "${var.project}-${var.stage}-app-server-status"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "StatusCheckFailed"
+  namespace           = "AWS/EC2"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "App server failed status check"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    InstanceId = aws_instance.app_server.id
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.stage}-app-server-status"
+    Project = var.project
+    Stage   = var.stage
+  }
+}
+
+# Disk usage alarm (requires CloudWatch agent, but alarm is ready)
+resource "aws_cloudwatch_metric_alarm" "app_server_disk" {
+  alarm_name          = "${var.project}-${var.stage}-app-server-disk"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "disk_used_percent"
+  namespace           = "CWAgent"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 85
+  alarm_description   = "App server disk usage exceeds 85%"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+  treat_missing_data  = "notBreaching"  # Don't alarm if agent not installed
+
+  dimensions = {
+    InstanceId = aws_instance.app_server.id
+    path       = "/"
+    fstype     = "ext4"
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.stage}-app-server-disk"
+    Project = var.project
+    Stage   = var.stage
+  }
+}
+
+# -----------------------------------------------------------------------------
+# GPU Server Alarms
+# -----------------------------------------------------------------------------
+
+# GPU server status check alarm
+resource "aws_cloudwatch_metric_alarm" "gpu_server_status" {
+  alarm_name          = "${var.project}-${var.stage}-gpu-server-status"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "StatusCheckFailed"
+  namespace           = "AWS/EC2"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 0
+  alarm_description   = "GPU server failed status check (may indicate spot interruption)"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    InstanceId = aws_spot_instance_request.gpu_server.spot_instance_id
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.stage}-gpu-server-status"
+    Project = var.project
+    Stage   = var.stage
+  }
+}
+
+# GPU server CPU alarm
+resource "aws_cloudwatch_metric_alarm" "gpu_server_cpu" {
+  alarm_name          = "${var.project}-${var.stage}-gpu-server-cpu"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 90
+  alarm_description   = "GPU server CPU utilization exceeds 90%"
+  alarm_actions       = [aws_sns_topic.alerts.arn]
+  ok_actions          = [aws_sns_topic.alerts.arn]
+
+  dimensions = {
+    InstanceId = aws_spot_instance_request.gpu_server.spot_instance_id
+  }
+
+  tags = {
+    Name    = "${var.project}-${var.stage}-gpu-server-cpu"
+    Project = var.project
+    Stage   = var.stage
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Spot Instance Interruption Warning
+# -----------------------------------------------------------------------------
+
+# EventBridge rule for spot instance interruption warnings
+resource "aws_cloudwatch_event_rule" "spot_interruption" {
+  name        = "${var.project}-${var.stage}-spot-interruption"
+  description = "Capture EC2 Spot Instance Interruption Warnings"
+
+  event_pattern = jsonencode({
+    source      = ["aws.ec2"]
+    detail-type = ["EC2 Spot Instance Interruption Warning"]
+  })
+
+  tags = {
+    Name    = "${var.project}-${var.stage}-spot-interruption"
+    Project = var.project
+    Stage   = var.stage
+  }
+}
+
+resource "aws_cloudwatch_event_target" "spot_interruption_sns" {
+  rule      = aws_cloudwatch_event_rule.spot_interruption.name
+  target_id = "send-to-sns"
+  arn       = aws_sns_topic.alerts.arn
+}
+
+# Allow EventBridge to publish to SNS
+resource "aws_sns_topic_policy" "alerts" {
+  arn = aws_sns_topic.alerts.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEventBridge"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.alerts.arn
+      }
+    ]
+  })
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -89,6 +89,12 @@ output "secrets_arn" {
   sensitive   = true
 }
 
+# Monitoring
+output "alerts_sns_topic_arn" {
+  description = "SNS topic ARN for alerts (subscribe your email to receive notifications)"
+  value       = aws_sns_topic.alerts.arn
+}
+
 # Backend Environment Variables
 output "backend_env_vars" {
   description = "Environment variables for backend configuration"

--- a/infra/project.tfvars.example
+++ b/infra/project.tfvars.example
@@ -19,9 +19,10 @@ stage   = "dev"  # dev, staging, prod
 # Create one with: aws ec2 create-key-pair --key-name qckstrt-key --query 'KeyMaterial' --output text > qckstrt-key.pem
 ssh_key_name = "qckstrt-key"
 
-# Security - IMPORTANT: Restrict SSH access in production!
-# Use your IP with /32 suffix (e.g., "203.0.113.50/32")
-allowed_ssh_cidr = "0.0.0.0/0"  # Change to "YOUR_IP/32" in production
+# Security - REQUIRED: Set to your IP address
+# Find your IP: curl -s https://ifconfig.me
+# Format: "YOUR_IP/32" (e.g., "203.0.113.50/32")
+allowed_ssh_cidr = "REPLACE_WITH_YOUR_IP/32"  # <-- You MUST change this!
 
 # =============================================================================
 # Instance Configuration

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -32,9 +32,13 @@ variable "ssh_key_name" {
 }
 
 variable "allowed_ssh_cidr" {
-  description = "CIDR block allowed for SSH access (restrict to your IP)"
+  description = "CIDR block allowed for SSH/admin access (e.g., '203.0.113.50/32' for your IP)"
   type        = string
-  default     = "0.0.0.0/0"  # Change to your IP/32 in production
+
+  validation {
+    condition     = var.allowed_ssh_cidr != "0.0.0.0/0"
+    error_message = "allowed_ssh_cidr cannot be 0.0.0.0/0. Please restrict to your IP address (e.g., '203.0.113.50/32'). Find your IP at https://ifconfig.me"
+  }
 }
 
 variable "app_server_instance_type" {


### PR DESCRIPTION
## Summary
- Remove insecure `0.0.0.0/0` default for `allowed_ssh_cidr` (now required)
- Add terraform validation to block open SSH/admin access
- Add CloudWatch alarms for CPU, status checks, disk usage
- Add SNS topic for alerts with EventBridge spot interruption warnings

## Security Improvements
- **IP restriction enforced**: Users must explicitly set their IP address
- **Validation error**: Terraform will fail if `0.0.0.0/0` is used
- **Monitoring**: CPU (80%/90%), status checks, disk (85%), spot interruptions

## Test plan
- [x] All 165 tests pass
- [x] Terraform validation blocks `0.0.0.0/0`
- [ ] Deploy and verify CloudWatch alarms

🤖 Generated with [Claude Code](https://claude.com/claude-code)