### PR TITLE
feat(infra): add optional HTTPS/TLS support with Let's Encrypt

### DIFF
--- a/infra/app-server.tf
+++ b/infra/app-server.tf
@@ -24,6 +24,10 @@ resource "aws_instance" "app_server" {
     project       = var.project
     stage         = var.stage
     gpu_server_ip = aws_eip.gpu_server.public_ip
+    # HTTPS/TLS configuration
+    domain_name   = var.domain_name
+    app_subdomain = var.app_subdomain
+    certbot_email = var.certbot_email
   })
 
   tags = {

--- a/infra/gpu-server.tf
+++ b/infra/gpu-server.tf
@@ -17,7 +17,7 @@ resource "aws_spot_instance_request" "gpu_server" {
   spot_price                     = var.gpu_spot_max_price
   wait_for_fulfillment           = true
   spot_type                      = "persistent"
-  instance_interruption_behavior = "stop"  # Stop (not terminate) on interruption
+  instance_interruption_behavior = "stop" # Stop (not terminate) on interruption
 
   root_block_device {
     volume_size           = var.gpu_server_volume_size
@@ -25,7 +25,12 @@ resource "aws_spot_instance_request" "gpu_server" {
     delete_on_termination = true
   }
 
-  user_data = file("${path.module}/scripts/gpu-server.sh")
+  user_data = templatefile("${path.module}/scripts/gpu-server.sh", {
+    # HTTPS/TLS configuration
+    domain_name   = var.domain_name
+    gpu_subdomain = var.gpu_subdomain
+    certbot_email = var.certbot_email
+  })
 
   tags = {
     Name    = "${var.project}-${var.stage}-gpu-server"

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -45,7 +45,7 @@ output "gpu_server_ip" {
   value       = aws_eip.gpu_server.public_ip
 }
 
-# URLs
+# URLs (conditional HTTPS when domain is configured)
 output "supabase_studio_url" {
   description = "Supabase Studio URL"
   value       = "http://${aws_eip.app_server.public_ip}:3000"
@@ -53,22 +53,22 @@ output "supabase_studio_url" {
 
 output "supabase_api_url" {
   description = "Supabase API URL"
-  value       = "http://${aws_eip.app_server.public_ip}"
+  value       = var.domain_name != "" ? "https://${var.app_subdomain}.${var.domain_name}" : "http://${aws_eip.app_server.public_ip}"
 }
 
 output "chromadb_url" {
   description = "ChromaDB URL"
-  value       = "http://${aws_eip.app_server.public_ip}:8001"
+  value       = var.domain_name != "" ? "https://${var.app_subdomain}.${var.domain_name}/chromadb" : "http://${aws_eip.app_server.public_ip}:8001"
 }
 
 output "vllm_api_url" {
   description = "vLLM API URL (OpenAI-compatible)"
-  value       = "http://${aws_eip.gpu_server.public_ip}:8000"
+  value       = var.domain_name != "" ? "https://${var.gpu_subdomain}.${var.domain_name}/v1" : "http://${aws_eip.gpu_server.public_ip}:8000"
 }
 
 output "embeddings_api_url" {
   description = "Embeddings API URL"
-  value       = "http://${aws_eip.gpu_server.public_ip}:8001"
+  value       = var.domain_name != "" ? "https://${var.gpu_subdomain}.${var.domain_name}/embeddings" : "http://${aws_eip.gpu_server.public_ip}:8001"
 }
 
 # SSH Commands
@@ -110,11 +110,11 @@ output "backup_plan_id" {
 output "backend_env_vars" {
   description = "Environment variables for backend configuration"
   value = {
-    SUPABASE_URL          = "http://${aws_eip.app_server.public_ip}"
-    VECTOR_DB_CHROMA_URL  = "http://${aws_eip.app_server.public_ip}:8001"
-    LLM_URL               = "http://${aws_eip.gpu_server.public_ip}:8000"
+    SUPABASE_URL          = var.domain_name != "" ? "https://${var.app_subdomain}.${var.domain_name}" : "http://${aws_eip.app_server.public_ip}"
+    VECTOR_DB_CHROMA_URL  = var.domain_name != "" ? "https://${var.app_subdomain}.${var.domain_name}/chromadb" : "http://${aws_eip.app_server.public_ip}:8001"
+    LLM_URL               = var.domain_name != "" ? "https://${var.gpu_subdomain}.${var.domain_name}/v1" : "http://${aws_eip.gpu_server.public_ip}:8000"
     EMBEDDINGS_PROVIDER   = "ollama"
-    EMBEDDINGS_OLLAMA_URL = "http://${aws_eip.gpu_server.public_ip}:8001"
+    EMBEDDINGS_OLLAMA_URL = var.domain_name != "" ? "https://${var.gpu_subdomain}.${var.domain_name}/embeddings" : "http://${aws_eip.gpu_server.public_ip}:8001"
     RELATIONAL_DB_HOST    = aws_eip.app_server.public_ip
     RELATIONAL_DB_PORT    = "5432"
   }

--- a/infra/project.tfvars.example
+++ b/infra/project.tfvars.example
@@ -51,6 +51,21 @@ gpu_spot_max_price = "0.60"
 backup_retention_days = 7  # Number of days to keep backups
 
 # =============================================================================
+# HTTPS/TLS Configuration (Optional)
+# =============================================================================
+# Uncomment and set domain_name to enable HTTPS with Let's Encrypt certificates.
+# Requires: DNS A records pointing subdomains to the Elastic IPs after deployment.
+#
+# Example DNS setup:
+#   api.yourdomain.com  → App Server Elastic IP (from terraform output)
+#   gpu.yourdomain.com  → GPU Server Elastic IP (from terraform output)
+#
+# domain_name   = "yourdomain.com"
+# app_subdomain = "api"   # Results in: api.yourdomain.com
+# gpu_subdomain = "gpu"   # Results in: gpu.yourdomain.com
+# certbot_email = "admin@yourdomain.com"
+
+# =============================================================================
 # Scaling Options
 # =============================================================================
 #

--- a/infra/security-groups.tf
+++ b/infra/security-groups.tf
@@ -35,7 +35,7 @@ resource "aws_security_group" "app_server" {
     from_port   = 3000
     to_port     = 3000
     protocol    = "tcp"
-    cidr_blocks = [var.allowed_ssh_cidr]  # Restrict in production
+    cidr_blocks = [var.allowed_ssh_cidr] # Restrict in production
   }
 
   # GraphQL API
@@ -95,6 +95,24 @@ resource "aws_security_group" "gpu_server" {
     to_port     = 22
     protocol    = "tcp"
     cidr_blocks = [var.allowed_ssh_cidr]
+  }
+
+  # HTTP (for Let's Encrypt certificate validation)
+  ingress {
+    description = "HTTP (Let's Encrypt ACME)"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # HTTPS (for TLS traffic when domain is configured)
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -80,3 +80,31 @@ variable "backup_retention_days" {
   type        = number
   default     = 7
 }
+
+# -----------------------------------------------------------------------------
+# HTTPS/TLS Configuration (Optional)
+# -----------------------------------------------------------------------------
+
+variable "domain_name" {
+  description = "Base domain name for HTTPS (e.g., yourdomain.com). Leave empty to disable HTTPS."
+  type        = string
+  default     = ""
+}
+
+variable "app_subdomain" {
+  description = "Subdomain for app server (e.g., 'api' for api.yourdomain.com)"
+  type        = string
+  default     = "api"
+}
+
+variable "gpu_subdomain" {
+  description = "Subdomain for GPU server (e.g., 'gpu' for gpu.yourdomain.com)"
+  type        = string
+  default     = "gpu"
+}
+
+variable "certbot_email" {
+  description = "Email for Let's Encrypt certificate notifications"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

- Add optional HTTPS support using nginx + certbot for Let's Encrypt certificates
- Add domain configuration variables (domain_name, app_subdomain, gpu_subdomain, certbot_email)
- Update bootstrap scripts with nginx reverse proxy and automatic SSL certificate setup
- Open ports 80/443 on GPU server security group for HTTPS traffic
- Update outputs with conditional HTTPS URLs when domain is configured
- Add comprehensive HTTPS/TLS documentation to README

## How It Works

HTTPS is **optional** - only enabled when `domain_name` is configured in terraform.tfvars:

```hcl
domain_name   = "yourdomain.com"
certbot_email = "admin@yourdomain.com"
```

Without a domain, servers continue to work with HTTP on Elastic IPs.

## Setup Flow

1. Deploy infrastructure to get Elastic IPs
2. Create DNS A records pointing subdomains to IPs
3. Set `domain_name` in terraform.tfvars
4. Re-apply to configure HTTPS

## Service URLs

| Service | With Domain | Without Domain |
|---------|-------------|----------------|
| Supabase API | `https://api.yourdomain.com` | `http://<ip>:8000` |
| ChromaDB | `https://api.yourdomain.com/chromadb` | `http://<ip>:8001` |
| vLLM | `https://gpu.yourdomain.com/v1` | `http://<ip>:8000` |
| Embeddings | `https://gpu.yourdomain.com/embeddings` | `http://<ip>:8001` |

## Test plan

- [x] Terraform validates successfully
- [x] Shell scripts pass syntax check
- [ ] Deploy with domain_name set and verify HTTPS works
- [ ] Verify certificate auto-renewal is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)