### PR TITLE
feat: add pagination to search results with metadata

### DIFF
--- a/apps/backend/src/apps/knowledge/src/domains/knowledge.resolver.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/knowledge.resolver.ts
@@ -4,6 +4,7 @@ import { UseGuards } from '@nestjs/common';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { Action } from 'src/common/enums/action.enum';
 import { Permissions } from 'src/common/decorators/permissions.decorator';
+import { PaginatedSearchResults } from './models/search-result.model';
 
 /**
  * Knowledge Resolver
@@ -28,7 +29,7 @@ export class KnowledgeResolver {
     return this.knowledgeService.answerQuery(userId, query);
   }
 
-  @Query(() => [String])
+  @Query(() => PaginatedSearchResults)
   @UseGuards(AuthGuard)
   @Permissions({
     action: Action.Read,
@@ -38,9 +39,10 @@ export class KnowledgeResolver {
   async searchText(
     @Args({ name: 'userId', type: () => ID }) userId: string,
     @Args('query') query: string,
-    @Args({ name: 'count', type: () => Int, defaultValue: 3 }) count: number,
-  ): Promise<string[]> {
-    return this.knowledgeService.searchText(userId, query, count);
+    @Args({ name: 'skip', type: () => Int, defaultValue: 0 }) skip: number,
+    @Args({ name: 'take', type: () => Int, defaultValue: 10 }) take: number,
+  ): Promise<PaginatedSearchResults> {
+    return this.knowledgeService.searchText(userId, query, skip, take);
   }
 
   @Mutation(() => Boolean)

--- a/apps/backend/src/apps/knowledge/src/domains/models/search-result.model.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/models/search-result.model.ts
@@ -1,0 +1,31 @@
+import { ObjectType, Field, Float, Int } from '@nestjs/graphql';
+
+/**
+ * Single search result with metadata
+ */
+@ObjectType()
+export class SearchResult {
+  @Field()
+  content!: string;
+
+  @Field()
+  documentId!: string;
+
+  @Field(() => Float)
+  score!: number;
+}
+
+/**
+ * Paginated search results with metadata
+ */
+@ObjectType()
+export class PaginatedSearchResults {
+  @Field(() => [SearchResult])
+  results!: SearchResult[];
+
+  @Field(() => Int)
+  total!: number;
+
+  @Field()
+  hasMore!: boolean;
+}

--- a/apps/frontend/lib/graphql/knowledge.ts
+++ b/apps/frontend/lib/graphql/knowledge.ts
@@ -19,14 +19,27 @@ export interface AnswerQueryVars {
   query: string;
 }
 
+export interface SearchResult {
+  content: string;
+  documentId: string;
+  score: number;
+}
+
+export interface PaginatedSearchResults {
+  results: SearchResult[];
+  total: number;
+  hasMore: boolean;
+}
+
 export interface SearchTextData {
-  searchText: string[];
+  searchText: PaginatedSearchResults;
 }
 
 export interface SearchTextVars {
   userId: string;
   query: string;
-  count?: number;
+  skip?: number;
+  take?: number;
 }
 
 export const INDEX_DOCUMENT = gql`
@@ -42,7 +55,15 @@ export const ANSWER_QUERY = gql`
 `;
 
 export const SEARCH_TEXT = gql`
-  query SearchText($userId: ID!, $query: String!, $count: Int) {
-    searchText(userId: $userId, query: $query, count: $count)
+  query SearchText($userId: ID!, $query: String!, $skip: Int, $take: Int) {
+    searchText(userId: $userId, query: $query, skip: $skip, take: $take) {
+      results {
+        content
+        documentId
+        score
+      }
+      total
+      hasMore
+    }
   }
 `;

--- a/packages/common/src/providers/vectordb/types.ts
+++ b/packages/common/src/providers/vectordb/types.ts
@@ -17,6 +17,7 @@ export interface IVectorDocument {
     [key: string]: unknown; // Additional metadata
   };
   content: string; // Text content
+  score?: number; // Optional similarity score (0-1, higher is more similar)
 }
 
 /**

--- a/packages/vectordb-provider/__tests__/pgvector.provider.spec.ts
+++ b/packages/vectordb-provider/__tests__/pgvector.provider.spec.ts
@@ -218,6 +218,7 @@ describe("PgVectorProvider", () => {
         embedding: [0.1, 0.2],
         metadata: { source: "doc-1", userId: "user-1" },
         content: "content 1",
+        score: 0.95,
       });
     });
 

--- a/packages/vectordb-provider/src/providers/pgvector.provider.ts
+++ b/packages/vectordb-provider/src/providers/pgvector.provider.ts
@@ -223,6 +223,7 @@ export class PgVectorProvider implements IVectorDBProvider {
           user_id: string;
           content: string;
           embedding_text: string;
+          similarity: number;
         }) => ({
           id: row.id,
           embedding: this.parseEmbedding(row.embedding_text),
@@ -231,6 +232,7 @@ export class PgVectorProvider implements IVectorDBProvider {
             userId: row.user_id,
           },
           content: row.content,
+          score: row.similarity,
         }),
       );
 


### PR DESCRIPTION
## Summary

- Add offset-based pagination (`skip`/`take`) to `searchText` GraphQL query
- Include document ID and similarity score in search results
- Add `PaginatedSearchResults` and `SearchResult` GraphQL types
- Update vector DB provider to return similarity scores
- Add "Load More Results" button to frontend RAG demo
- Display relevance scores as percentages in search results

## Changes

### Backend
- Created `search-result.model.ts` with GraphQL types for paginated results
- Updated `knowledge.service.ts` with pagination logic and metadata
- Updated `knowledge.resolver.ts` with `skip`/`take` parameters
- Added comprehensive tests for pagination functionality

### Frontend
- Updated GraphQL types in `knowledge.ts`
- Updated RAG demo page with pagination state and "Load More" button
- Display document IDs and similarity scores in results
- Added tests for pagination controls

### Common/Packages
- Added optional `score` field to `IVectorDocument` interface
- Updated pgvector provider to include similarity score

## Test plan

- [x] Backend tests pass (191 tests)
- [x] Frontend tests pass (68 tests)
- [x] Build succeeds
- [ ] Manual testing of pagination in RAG demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)