### PR TITLE
feat: add soft delete support for GDPR/CCPA compliance

### DIFF
--- a/apps/backend/src/db/entities/document.entity.ts
+++ b/apps/backend/src/db/entities/document.entity.ts
@@ -6,6 +6,7 @@ import {
   BaseEntity,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
   Index,
 } from 'typeorm';
 
@@ -50,4 +51,10 @@ export class DocumentEntity extends BaseEntity {
     select: true,
   })
   public updatedAt!: Date;
+
+  @DeleteDateColumn({
+    type: 'timestamptz',
+    select: false,
+  })
+  public deletedAt?: Date;
 }

--- a/apps/backend/src/db/entities/user.entity.ts
+++ b/apps/backend/src/db/entities/user.entity.ts
@@ -6,6 +6,7 @@ import {
   BaseEntity,
   CreateDateColumn,
   UpdateDateColumn,
+  DeleteDateColumn,
 } from 'typeorm';
 
 @ObjectType()
@@ -43,4 +44,11 @@ export class UserEntity extends BaseEntity {
     select: true,
   })
   public updated!: Date;
+
+  @Field({ nullable: true })
+  @DeleteDateColumn({
+    type: 'timestamptz',
+    select: false,
+  })
+  public deletedAt?: Date;
 }

--- a/apps/backend/src/db/migrations/1734732000000-AddSoftDeleteColumns.ts
+++ b/apps/backend/src/db/migrations/1734732000000-AddSoftDeleteColumns.ts
@@ -1,0 +1,59 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration: Add soft delete columns for GDPR/CCPA compliance
+ *
+ * Adds deletedAt column to users and documents tables to enable
+ * soft delete functionality. This supports:
+ * - Right to be forgotten (GDPR Article 17)
+ * - Data deletion requests (CCPA)
+ * - Data recovery within retention period
+ *
+ * Note: Audit logs are NOT included as they must remain immutable
+ * for compliance and legal purposes.
+ */
+export class AddSoftDeleteColumns1734732000000 implements MigrationInterface {
+  name = 'AddSoftDeleteColumns1734732000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add deletedAt column to users table
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      ADD COLUMN "deletedAt" TIMESTAMPTZ DEFAULT NULL
+    `);
+
+    // Add deletedAt column to documents table
+    await queryRunner.query(`
+      ALTER TABLE "documents"
+      ADD COLUMN "deletedAt" TIMESTAMPTZ DEFAULT NULL
+    `);
+
+    // Create indexes for efficient soft delete queries
+    await queryRunner.query(`
+      CREATE INDEX "IDX_users_deletedAt" ON "users" ("deletedAt")
+      WHERE "deletedAt" IS NULL
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_documents_deletedAt" ON "documents" ("deletedAt")
+      WHERE "deletedAt" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop indexes
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_documents_deletedAt"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_users_deletedAt"`);
+
+    // Remove deletedAt columns
+    await queryRunner.query(`
+      ALTER TABLE "documents"
+      DROP COLUMN IF EXISTS "deletedAt"
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE "users"
+      DROP COLUMN IF EXISTS "deletedAt"
+    `);
+  }
+}


### PR DESCRIPTION
## Summary
- Add `@DeleteDateColumn` to `UserEntity` and `DocumentEntity` for soft delete support
- Create migration to add `deletedAt` columns with partial indexes for efficient queries
- Supports GDPR Article 17 (right to be forgotten) and CCPA data deletion requests

## Changes
- `UserEntity`: Added `deletedAt` field with `@DeleteDateColumn`
- `DocumentEntity`: Added `deletedAt` field with `@DeleteDateColumn`
- New migration: `AddSoftDeleteColumns` for production deployments

## Design Decisions
- **AuditLogEntity excluded**: Audit logs must remain immutable for compliance/legal purposes
- **Partial indexes**: Indexes on `deletedAt IS NULL` for efficient queries on active records
- **select: false**: `deletedAt` hidden by default to avoid exposing deletion status

## Test plan
- [x] All existing tests pass
- [ ] Verify soft delete works with `entity.softRemove()`
- [ ] Verify standard queries filter out soft-deleted records
- [ ] Verify `withDeleted()` includes deleted records

🤖 Generated with [Claude Code](https://claude.com/claude-code)