### PR TITLE
feat(api): add health check endpoint

### DIFF
--- a/apps/backend/src/api/src/app.module.ts
+++ b/apps/backend/src/api/src/app.module.ts
@@ -30,6 +30,7 @@ import { JwtStrategy } from 'src/common/auth/jwt.strategy';
 import { AuthMiddleware } from 'src/common/middleware/auth.middleware';
 import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { HttpExceptionFilter } from 'src/common/exceptions/http-exception.filter';
+import { HealthModule } from './health/health.module';
 
 interface GatewayContext {
   user?: string;
@@ -46,6 +47,7 @@ const handleAuth = ({ req }: { req: Request }) => {
 
 @Module({
   imports: [
+    HealthModule,
     ConfigModule.forRoot({
       load: [
         configuration,
@@ -131,6 +133,7 @@ export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
     consumer
       .apply(HMACMiddleware, AuthMiddleware)
+      .exclude({ path: 'health', method: RequestMethod.GET })
       .forRoutes({ path: '*', method: RequestMethod.ALL });
   }
 }

--- a/apps/backend/src/api/src/health/health.controller.spec.ts
+++ b/apps/backend/src/api/src/health/health.controller.spec.ts
@@ -1,0 +1,33 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  });
+
+  describe('check', () => {
+    it('should return health status with ok', () => {
+      const result = controller.check();
+
+      expect(result.status).toBe('ok');
+      expect(result.timestamp).toBeDefined();
+      expect(typeof result.uptime).toBe('number');
+      expect(result.uptime).toBeGreaterThanOrEqual(0);
+      expect(result.version).toBeDefined();
+    });
+
+    it('should return ISO timestamp', () => {
+      const result = controller.check();
+
+      expect(() => new Date(result.timestamp)).not.toThrow();
+      expect(result.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+  });
+});

--- a/apps/backend/src/api/src/health/health.controller.ts
+++ b/apps/backend/src/api/src/health/health.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get } from '@nestjs/common';
+
+interface HealthResponse {
+  status: 'ok' | 'degraded' | 'error';
+  timestamp: string;
+  uptime: number;
+  version: string;
+}
+
+@Controller('health')
+export class HealthController {
+  private readonly startTime = Date.now();
+
+  @Get()
+  check(): HealthResponse {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+      uptime: Math.floor((Date.now() - this.startTime) / 1000),
+      version: process.env.npm_package_version || '0.0.0',
+    };
+  }
+}

--- a/apps/backend/src/api/src/health/health.module.ts
+++ b/apps/backend/src/api/src/health/health.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+
+@Module({
+  controllers: [HealthController],
+})
+export class HealthModule {}


### PR DESCRIPTION
## Summary
- Add `/health` endpoint to API gateway for monitoring and load balancer health checks
- Returns status, timestamp, uptime, and version information
- Excluded from HMAC/Auth middleware for unauthenticated access

## Test plan
- [x] Unit tests pass for health controller
- [x] Backend build succeeds
- [ ] Verify endpoint returns expected JSON response when server is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)