### PR TITLE
fix: update dependabot.yml to satisfy schema requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,23 @@
 # Dependabot configuration
 # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# NOTE: Scheduled version updates are disabled. Dependencies are managed manually.
-# GitHub Security Alerts (Dependabot security updates) remain active and will still
-# create PRs for known vulnerabilities. Configure these in:
+# NOTE: Scheduled version updates are effectively disabled via open-pull-requests-limit: 0.
+# Dependencies are managed manually. GitHub Security Alerts (Dependabot security updates)
+# remain active and will still create PRs for known vulnerabilities. Configure these in:
 # Settings > Security > Code security and analysis > Dependabot security updates
 
 version: 2
-updates: []
+updates:
+  # npm - disabled via open-pull-requests-limit: 0
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0
+
+  # GitHub Actions - disabled via open-pull-requests-limit: 0
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Summary
- Fix Dependabot schema validation error by using `open-pull-requests-limit: 0` instead of empty `updates: []` array
- This satisfies Dependabot's schema requirements while still preventing version update PRs from being created
- Security alerts remain enabled (configured separately in GitHub settings)

## Changes
- Updated `.github/dependabot.yml` to include npm and github-actions ecosystems with `open-pull-requests-limit: 0`

## Test plan
- [x] Verify dependabot.yml passes schema validation
- [x] Confirm no version update PRs will be created due to `open-pull-requests-limit: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)