### PR TITLE
ci: add workflow to enforce PRs to main from develop only

### DIFF
--- a/.github/workflows/validate-main-pr.yml
+++ b/.github/workflows/validate-main-pr.yml
@@ -1,0 +1,24 @@
+name: Validate Main PR
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    name: Verify PR from develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source branch
+        run: |
+          if [[ "${{ github.head_ref }}" != "develop" ]]; then
+            echo "::error::PRs to main must come from the develop branch"
+            echo ""
+            echo "Current source branch: ${{ github.head_ref }}"
+            echo ""
+            echo "To fix this:"
+            echo "1. Merge your changes to develop first"
+            echo "2. Create a PR from develop to main"
+            exit 1
+          fi
+          echo "✅ PR is from develop branch - allowed"


### PR DESCRIPTION
## Summary
- Added GitHub Action workflow that validates PRs to main must originate from the develop branch
- Prevents accidental direct merges to main that can cause branch divergence

## Details
This workflow runs on PRs targeting main and fails if the source branch is not `develop`. This enforces a clean gitflow where:
- Feature branches → develop
- develop → main (releases)

## Setup Required
After merging, add `Validate Main PR / Verify PR from develop` as a required status check for the main branch in repository settings.

## Test plan
- [x] Workflow syntax validated
- [x] Will fail PRs from non-develop branches
- [x] Will pass PRs from develop branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)