### PR TITLE
ci: add workflow to enforce PRs to main from develop only (#133)

### DIFF
--- a/.github/workflows/validate-main-pr.yml
+++ b/.github/workflows/validate-main-pr.yml
@@ -1,0 +1,24 @@
+name: Validate Main PR
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-source-branch:
+    name: Verify PR from develop
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR source branch
+        run: |
+          if [[ "${{ github.head_ref }}" != "develop" ]]; then
+            echo "::error::PRs to main must come from the develop branch"
+            echo ""
+            echo "Current source branch: ${{ github.head_ref }}"
+            echo ""
+            echo "To fix this:"
+            echo "1. Merge your changes to develop first"
+            echo "2. Create a PR from develop to main"
+            exit 1
+          fi
+          echo "✅ PR is from develop branch - allowed"


### PR DESCRIPTION
Adds a GitHub Action that validates PRs to main must originate from the develop branch. This prevents accidental direct merges that can cause branch divergence and merge conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Description

<!-- Provide a brief description of your changes -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Infrastructure/DevOps change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality
- [ ] My code follows the project's coding standards
- [ ] I have run `pnpm lint` and fixed any issues
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added tests for new functionality (if applicable)

### Documentation
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added JSDoc comments for new public APIs (if applicable)

### Accessibility
- [ ] UI changes meet WCAG 2.2 Level AA requirements (if applicable)
- [ ] I have tested with keyboard navigation (if applicable)

### Fork Model Reminder

> **Important**: This is the upstream qckstrt platform repository.
>
> - **Platform improvements** (bug fixes, new features, providers) belong here
> - **Region-specific code** (scrapers, data, configs) belongs in your fork
> - Only `regions/example/` can be modified in upstream
>
> See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

- [ ] I confirm this PR contains platform code, not region-specific implementation

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate the change -->

## Additional Notes

<!-- Any additional context or notes for reviewers -->
