### PR TITLE
Release: Critical Security Fixes

### DIFF
--- a/apps/backend/src/apps/documents/src/domains/documents.resolver.spec.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.resolver.spec.ts
@@ -10,11 +10,20 @@ describe('DocumentsResolver', () => {
   let documentsResolver: DocumentsResolver;
   let documentsService: DocumentsService;
 
-  const mockUser = { id: 'user-1', email: 'user@example.com' };
+  const mockUser = {
+    id: 'user-1',
+    email: 'user@example.com',
+    roles: ['User'],
+    department: 'Engineering',
+    clearance: 'Secret',
+  };
 
+  // SECURITY: Tests now use request.user (set by passport) instead of headers.user (spoofable)
+  // @see https://github.com/CommonwealthLabsCode/qckstrt/issues/183
   const mockContext = {
     req: {
       user: mockUser,
+      headers: {},
     },
   };
 
@@ -76,7 +85,7 @@ describe('DocumentsResolver', () => {
     });
 
     it('should throw error when user not authenticated', () => {
-      const noUserContext = { req: {} };
+      const noUserContext = { req: { user: undefined, headers: {} } };
 
       expect(() => documentsResolver.listFiles(noUserContext)).toThrow(
         'User not authenticated',

--- a/apps/backend/src/apps/knowledge/src/domains/knowledge.resolver.spec.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/knowledge.resolver.spec.ts
@@ -8,11 +8,20 @@ describe('KnowledgeResolver', () => {
   let knowledgeResolver: KnowledgeResolver;
   let knowledgeService: KnowledgeService;
 
-  const mockUser = { id: 'user-1', email: 'user@example.com' };
+  const mockUser = {
+    id: 'user-1',
+    email: 'user@example.com',
+    roles: ['User'],
+    department: 'Engineering',
+    clearance: 'Secret',
+  };
 
+  // SECURITY: Tests now use request.user (set by passport) instead of headers.user (spoofable)
+  // @see https://github.com/CommonwealthLabsCode/qckstrt/issues/183
   const mockContext = {
     req: {
       user: mockUser,
+      headers: {},
     },
   };
 

--- a/apps/backend/src/apps/users/src/domains/activity/activity.resolver.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/activity/activity.resolver.spec.ts
@@ -6,6 +6,7 @@ import { UserInputError } from '@nestjs/apollo';
 import { ActivityResolver } from './activity.resolver';
 import { ActivityService } from './activity.service';
 import { AuditAction } from 'src/common/enums/audit-action.enum';
+import { ILogin } from 'src/interfaces/login.interface';
 
 describe('ActivityResolver', () => {
   let resolver: ActivityResolver;
@@ -15,11 +16,21 @@ describe('ActivityResolver', () => {
   const mockUserEmail = 'test@example.com';
   const mockSessionToken = 'mock-session-token-123';
 
+  const mockUser: ILogin = {
+    id: mockUserId,
+    email: mockUserEmail,
+    roles: ['User'],
+    department: 'Engineering',
+    clearance: 'Secret',
+  };
+
+  // SECURITY: Tests now use request.user (set by passport) instead of headers.user (spoofable)
+  // @see https://github.com/CommonwealthLabsCode/qckstrt/issues/183
   const mockContext = {
     req: {
       ip: '127.0.0.1',
+      user: mockUser,
       headers: {
-        user: JSON.stringify({ id: mockUserId, email: mockUserEmail }),
         'user-agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X)',
         authorization: `Bearer ${mockSessionToken}`,
       },
@@ -28,15 +39,15 @@ describe('ActivityResolver', () => {
 
   const mockContextNoUser = {
     req: {
+      user: undefined,
       headers: {},
     },
   };
 
   const mockContextNoAuth = {
     req: {
-      headers: {
-        user: JSON.stringify({ id: mockUserId, email: mockUserEmail }),
-      },
+      user: mockUser,
+      headers: {},
     },
   };
 

--- a/apps/backend/src/apps/users/src/domains/profile/profile.resolver.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.resolver.spec.ts
@@ -24,11 +24,21 @@ describe('ProfileResolver', () => {
   const mockUserId = 'test-user-id';
   const mockUserEmail = 'test@example.com';
 
+  const mockUser = {
+    id: mockUserId,
+    email: mockUserEmail,
+    roles: ['User'],
+    department: 'Engineering',
+    clearance: 'Secret',
+  };
+
+  // SECURITY: Tests now use request.user (set by passport) instead of headers.user (spoofable)
+  // @see https://github.com/CommonwealthLabsCode/qckstrt/issues/183
   const mockContext = {
     req: {
       ip: '127.0.0.1',
+      user: mockUser,
       headers: {
-        user: JSON.stringify({ id: mockUserId, email: mockUserEmail }),
         'user-agent': 'test-agent',
       },
     },
@@ -36,6 +46,7 @@ describe('ProfileResolver', () => {
 
   const mockContextNoUser = {
     req: {
+      user: undefined,
       headers: {},
     },
   };

--- a/apps/backend/src/apps/users/src/domains/profile/profile.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.resolver.ts
@@ -1,8 +1,9 @@
-import { UseGuards } from '@nestjs/common';
 import { Resolver, Query, Mutation, Args, Context, ID } from '@nestjs/graphql';
-import { UserInputError } from '@nestjs/apollo';
 
-import { AuthGuard } from 'src/common/guards/auth.guard';
+import {
+  GqlContext,
+  getUserFromContext,
+} from 'src/common/utils/graphql-context';
 
 import { UserProfileEntity } from 'src/db/entities/user-profile.entity';
 import { UserAddressEntity } from 'src/db/entities/user-address.entity';
@@ -23,29 +24,6 @@ import {
 } from './dto/consent.dto';
 import { ProfileCompletionResult } from './models/profile-completion.model';
 
-interface GqlContext {
-  req: {
-    ip?: string;
-    headers: {
-      user?: string;
-      'user-agent'?: string;
-    };
-  };
-}
-
-interface UserHeader {
-  id: string;
-  email: string;
-}
-
-function getUserFromContext(context: GqlContext): UserHeader {
-  const userHeader = context.req.headers.user;
-  if (!userHeader) {
-    throw new UserInputError('User not authenticated');
-  }
-  return JSON.parse(userHeader);
-}
-
 @Resolver()
 export class ProfileResolver {
   constructor(private readonly profileService: ProfileService) {}
@@ -55,7 +33,6 @@ export class ProfileResolver {
   // ============================================
 
   @Query(() => UserProfileEntity, { nullable: true, name: 'myProfile' })
-  @UseGuards(AuthGuard)
   async getMyProfile(
     @Context() context: GqlContext,
   ): Promise<UserProfileEntity | null> {
@@ -64,7 +41,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => UserProfileEntity)
-  @UseGuards(AuthGuard)
   async updateMyProfile(
     @Args('input') input: UpdateProfileDto,
     @Context() context: GqlContext,
@@ -78,7 +54,6 @@ export class ProfileResolver {
   // ============================================
 
   @Query(() => ProfileCompletionResult, { name: 'myProfileCompletion' })
-  @UseGuards(AuthGuard)
   async getMyProfileCompletion(
     @Context() context: GqlContext,
   ): Promise<ProfileCompletionResult> {
@@ -91,7 +66,6 @@ export class ProfileResolver {
   // ============================================
 
   @Query(() => String, { name: 'avatarUploadUrl' })
-  @UseGuards(AuthGuard)
   async getAvatarUploadUrl(
     @Args('filename') filename: string,
     @Context() context: GqlContext,
@@ -101,7 +75,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => UserProfileEntity)
-  @UseGuards(AuthGuard)
   async updateAvatarStorageKey(
     @Args('storageKey') storageKey: string,
     @Context() context: GqlContext,
@@ -115,7 +88,6 @@ export class ProfileResolver {
   // ============================================
 
   @Query(() => [UserAddressEntity], { name: 'myAddresses' })
-  @UseGuards(AuthGuard)
   async getMyAddresses(
     @Context() context: GqlContext,
   ): Promise<UserAddressEntity[]> {
@@ -124,7 +96,6 @@ export class ProfileResolver {
   }
 
   @Query(() => UserAddressEntity, { nullable: true, name: 'myAddress' })
-  @UseGuards(AuthGuard)
   async getMyAddress(
     @Args('id', { type: () => ID }) id: string,
     @Context() context: GqlContext,
@@ -134,7 +105,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => UserAddressEntity)
-  @UseGuards(AuthGuard)
   async createAddress(
     @Args('input') input: CreateAddressDto,
     @Context() context: GqlContext,
@@ -144,7 +114,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => UserAddressEntity)
-  @UseGuards(AuthGuard)
   async updateAddress(
     @Args('input') input: UpdateAddressDto,
     @Context() context: GqlContext,
@@ -154,7 +123,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => Boolean)
-  @UseGuards(AuthGuard)
   async deleteAddress(
     @Args('id', { type: () => ID }) id: string,
     @Context() context: GqlContext,
@@ -164,7 +132,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => UserAddressEntity)
-  @UseGuards(AuthGuard)
   async setPrimaryAddress(
     @Args('id', { type: () => ID }) id: string,
     @Context() context: GqlContext,
@@ -181,7 +148,6 @@ export class ProfileResolver {
     nullable: true,
     name: 'myNotificationPreferences',
   })
-  @UseGuards(AuthGuard)
   async getMyNotificationPreferences(
     @Context() context: GqlContext,
   ): Promise<NotificationPreferenceEntity | null> {
@@ -190,7 +156,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => NotificationPreferenceEntity)
-  @UseGuards(AuthGuard)
   async updateNotificationPreferences(
     @Args('input') input: UpdateNotificationPreferencesDto,
     @Context() context: GqlContext,
@@ -200,7 +165,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => NotificationPreferenceEntity)
-  @UseGuards(AuthGuard)
   async unsubscribeFromAll(
     @Context() context: GqlContext,
   ): Promise<NotificationPreferenceEntity> {
@@ -213,7 +177,6 @@ export class ProfileResolver {
   // ============================================
 
   @Query(() => [UserConsentEntity], { name: 'myConsents' })
-  @UseGuards(AuthGuard)
   async getMyConsents(
     @Context() context: GqlContext,
   ): Promise<UserConsentEntity[]> {
@@ -222,7 +185,6 @@ export class ProfileResolver {
   }
 
   @Query(() => UserConsentEntity, { nullable: true, name: 'myConsent' })
-  @UseGuards(AuthGuard)
   async getMyConsent(
     @Args('consentType', { type: () => ConsentType }) consentType: ConsentType,
     @Context() context: GqlContext,
@@ -232,7 +194,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => UserConsentEntity)
-  @UseGuards(AuthGuard)
   async updateConsent(
     @Args('input') input: UpdateConsentDto,
     @Context() context: GqlContext,
@@ -247,7 +208,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => [UserConsentEntity])
-  @UseGuards(AuthGuard)
   async bulkUpdateConsents(
     @Args('input') input: BulkUpdateConsentsDto,
     @Context() context: GqlContext,
@@ -266,7 +226,6 @@ export class ProfileResolver {
   }
 
   @Mutation(() => UserConsentEntity)
-  @UseGuards(AuthGuard)
   async withdrawConsent(
     @Args('input') input: WithdrawConsentDto,
     @Context() context: GqlContext,
@@ -284,7 +243,6 @@ export class ProfileResolver {
   }
 
   @Query(() => Boolean)
-  @UseGuards(AuthGuard)
   async hasValidConsent(
     @Args('consentType', { type: () => ConsentType }) consentType: ConsentType,
     @Context() context: GqlContext,

--- a/apps/backend/src/common/decorators/public.decorator.ts
+++ b/apps/backend/src/common/decorators/public.decorator.ts
@@ -1,0 +1,24 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Decorator to mark a route or resolver as publicly accessible.
+ *
+ * When applied to a controller method or resolver, the AuthGuard will
+ * allow unauthenticated access.
+ *
+ * SECURITY: Use sparingly. Only mark endpoints as public when they truly
+ * need to be accessible without authentication (e.g., login, register, health checks).
+ *
+ * @example
+ * ```typescript
+ * @Public()
+ * @Mutation(() => AuthResponse)
+ * async login(@Args('input') input: LoginInput) {
+ *   return this.authService.login(input);
+ * }
+ * ```
+ *
+ * @see https://github.com/CommonwealthLabsCode/qckstrt/issues/183
+ */
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/backend/src/common/guards/auth.guard.ts
+++ b/apps/backend/src/common/guards/auth.guard.ts
@@ -1,24 +1,50 @@
 import { Injectable, ExecutionContext, CanActivate } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { GqlExecutionContext } from '@nestjs/graphql';
 import { isLoggedIn } from 'src/common/auth/jwt.strategy';
+import { IS_PUBLIC_KEY } from 'src/common/decorators/public.decorator';
 
+/**
+ * Global authentication guard for GraphQL operations.
+ *
+ * SECURITY: Implements "deny by default" - all operations require authentication
+ * unless explicitly marked with @Public() decorator.
+ *
+ * This guard checks request.user which is populated by the AuthMiddleware
+ * after JWT validation via Passport.js. It does NOT trust headers that
+ * could be spoofed by clients.
+ *
+ * @see https://github.com/CommonwealthLabsCode/qckstrt/issues/183
+ */
 @Injectable()
 export class AuthGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Check if the endpoint is marked as public
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
     const ctx = GqlExecutionContext.create(context);
     const request = ctx.getContext().req;
 
-    // Null, undefined or equal to 'undefined' string
-    if (request.headers.user == null || request.headers.user === 'undefined') {
+    // SECURITY: Only trust request.user which is set by AuthMiddleware
+    // after JWT validation via Passport.js. Never trust request.headers.user
+    // as it can be spoofed by clients.
+    const user = request.user;
+
+    // No authenticated user - deny access
+    if (!user) {
       return false;
     }
 
-    try {
-      const user = JSON.parse(request.headers.user);
-      return isLoggedIn(user);
-    } catch {
-      // Malformed JSON in user header
-      return false;
-    }
+    // Validate user object has required fields
+    return isLoggedIn(user);
   }
 }

--- a/apps/backend/src/common/guards/policies.guard.ts
+++ b/apps/backend/src/common/guards/policies.guard.ts
@@ -48,7 +48,7 @@ export class PoliciesGuard<
   constructor(
     private readonly reflector: Reflector,
     @Inject(CaslAbilityFactory)
-    private caslAbilityFactory: CaslAbilityFactory<A, S>,
+    private readonly caslAbilityFactory: CaslAbilityFactory<A, S>,
   ) {}
 
   /**
@@ -73,13 +73,12 @@ export class PoliciesGuard<
     const request = ctx.getContext().req;
     const args = ctx.getArgs();
 
-    if (
-      request.headers.user != null &&
-      request.headers.user !== 'undefined' &&
-      isLoggedIn(JSON.parse(request.headers.user))
-    ) {
-      const user: ILogin = JSON.parse(request.headers.user);
+    // SECURITY: Use request.user set by AuthMiddleware after JWT validation
+    // Never trust request.headers.user as it can be spoofed
+    // @see https://github.com/CommonwealthLabsCode/qckstrt/issues/183
+    const user: ILogin | undefined = request.user;
 
+    if (user && isLoggedIn(user)) {
       // Define the abilities based on the user's policies
       const ability = await this.caslAbilityFactory.defineAbility(
         permissions,

--- a/apps/backend/src/common/guards/roles.guard.spec.ts
+++ b/apps/backend/src/common/guards/roles.guard.spec.ts
@@ -4,6 +4,7 @@ import { GqlExecutionContext } from '@nestjs/graphql';
 import { RolesGuard } from './roles.guard';
 import { Role } from '../enums/role.enum';
 import { ROLES_KEY } from '../decorators/roles.decorator';
+import { ILogin } from 'src/interfaces/login.interface';
 
 jest.mock('@nestjs/graphql', () => ({
   GqlExecutionContext: {
@@ -21,15 +22,13 @@ describe('RolesGuard', () => {
     jest.clearAllMocks();
   });
 
+  // SECURITY: Tests now use request.user (set by passport) instead of headers.user (spoofable)
+  // @see https://github.com/CommonwealthLabsCode/qckstrt/issues/183
   const createMockContext = (
-    userHeader: string | null | undefined,
+    user: ILogin | null | undefined,
     requiredRoles: Role[] | undefined = undefined,
   ) => {
-    const mockRequest = {
-      headers: {
-        user: userHeader,
-      },
-    };
+    const mockRequest = { user };
 
     const mockGqlContext = {
       getContext: () => ({ req: mockRequest }),
@@ -68,13 +67,13 @@ describe('RolesGuard', () => {
     });
 
     it('should allow access with valid user when roles array is empty', async () => {
-      const validUser = JSON.stringify({
+      const validUser: ILogin = {
         id: 'user-123',
         email: 'user@example.com',
         roles: [Role.User],
         department: 'Engineering',
         clearance: 'Secret',
-      });
+      };
 
       const context = createMockContext(validUser, []);
 
@@ -87,13 +86,13 @@ describe('RolesGuard', () => {
 
   describe('RBAC enforcement', () => {
     it('should allow access when user has required role', async () => {
-      const validUser = JSON.stringify({
+      const validUser: ILogin = {
         id: 'user-123',
         email: 'admin@example.com',
         roles: [Role.Admin],
         department: 'Engineering',
         clearance: 'Top Secret',
-      });
+      };
 
       const context = createMockContext(validUser, [Role.Admin]);
 
@@ -103,13 +102,13 @@ describe('RolesGuard', () => {
     });
 
     it('should allow access when user has one of multiple required roles', async () => {
-      const validUser = JSON.stringify({
+      const validUser: ILogin = {
         id: 'user-123',
         email: 'user@example.com',
         roles: [Role.User],
         department: 'Engineering',
         clearance: 'Secret',
-      });
+      };
 
       const context = createMockContext(validUser, [Role.Admin, Role.User]);
 
@@ -119,13 +118,13 @@ describe('RolesGuard', () => {
     });
 
     it('should deny access when user lacks required role', async () => {
-      const validUser = JSON.stringify({
+      const validUser: ILogin = {
         id: 'user-123',
         email: 'user@example.com',
         roles: [Role.User],
         department: 'Engineering',
         clearance: 'Secret',
-      });
+      };
 
       const context = createMockContext(validUser, [Role.Admin]);
 
@@ -135,13 +134,13 @@ describe('RolesGuard', () => {
     });
 
     it('should allow access when user has multiple roles including required one', async () => {
-      const validUser = JSON.stringify({
+      const validUser: ILogin = {
         id: 'user-123',
         email: 'admin@example.com',
         roles: [Role.User, Role.Admin],
         department: 'Engineering',
         clearance: 'Top Secret',
-      });
+      };
 
       const context = createMockContext(validUser, [Role.Admin]);
 
@@ -152,7 +151,7 @@ describe('RolesGuard', () => {
   });
 
   describe('unauthorized access rejection', () => {
-    it('should reject when user header is null', async () => {
+    it('should reject when user is null', async () => {
       const context = createMockContext(null, [Role.Admin]);
 
       const result = await guard.canActivate(context);
@@ -160,7 +159,7 @@ describe('RolesGuard', () => {
       expect(result).toBe(false);
     });
 
-    it('should reject when user header is undefined', async () => {
+    it('should reject when user is undefined', async () => {
       const context = createMockContext(undefined, [Role.Admin]);
 
       const result = await guard.canActivate(context);
@@ -168,22 +167,14 @@ describe('RolesGuard', () => {
       expect(result).toBe(false);
     });
 
-    it('should reject when user header is string "undefined"', async () => {
-      const context = createMockContext('undefined', [Role.Admin]);
-
-      const result = await guard.canActivate(context);
-
-      expect(result).toBe(false);
-    });
-
     it('should reject when user has no roles', async () => {
-      const userWithNoRoles = JSON.stringify({
+      const userWithNoRoles: ILogin = {
         id: 'user-123',
         email: 'user@example.com',
         roles: [],
         department: 'Engineering',
         clearance: 'Secret',
-      });
+      };
 
       const context = createMockContext(userWithNoRoles, [Role.Admin]);
 
@@ -192,27 +183,11 @@ describe('RolesGuard', () => {
       expect(result).toBe(false);
     });
 
-    it('should reject when user roles is null', async () => {
-      const userWithNullRoles = JSON.stringify({
-        id: 'user-123',
-        email: 'user@example.com',
-        roles: null,
-        department: 'Engineering',
-        clearance: 'Secret',
-      });
-
-      const context = createMockContext(userWithNullRoles, [Role.Admin]);
-
-      const result = await guard.canActivate(context);
-
-      expect(result).toBe(false);
-    });
-
     it('should reject when user object is missing required login fields', async () => {
-      const incompleteUser = JSON.stringify({
+      const incompleteUser = {
         email: 'user@example.com',
         // missing id, roles, department, clearance
-      });
+      } as ILogin;
 
       const context = createMockContext(incompleteUser, [Role.Admin]);
 
@@ -220,24 +195,17 @@ describe('RolesGuard', () => {
 
       expect(result).toBe(false);
     });
-
-    it('should throw error when user header is invalid JSON', async () => {
-      const context = createMockContext('not-valid-json', [Role.Admin]);
-
-      // The guard throws when JSON.parse fails (no try-catch around it)
-      await expect(guard.canActivate(context)).rejects.toThrow(SyntaxError);
-    });
   });
 
   describe('reflector metadata retrieval', () => {
     it('should retrieve roles from handler and class', async () => {
-      const validUser = JSON.stringify({
+      const validUser: ILogin = {
         id: 'user-123',
         email: 'admin@example.com',
         roles: [Role.Admin],
         department: 'Engineering',
         clearance: 'Top Secret',
-      });
+      };
 
       const context = createMockContext(validUser, [Role.Admin]);
 
@@ -247,6 +215,42 @@ describe('RolesGuard', () => {
         ROLES_KEY,
         expect.any(Array),
       );
+    });
+  });
+
+  describe('security: deny by default', () => {
+    it('should use request.user not request.headers.user', async () => {
+      // This test verifies the security fix - we should NOT check headers.user
+      // because that can be spoofed. We only trust request.user set by passport.
+      const mockRequest = {
+        user: null,
+        headers: {
+          // Even if headers.user is set, we should not trust it
+          user: JSON.stringify({
+            id: 'spoofed-user',
+            email: 'spoofed@example.com',
+            roles: [Role.Admin],
+            department: 'Engineering',
+            clearance: 'TopSecret',
+          }),
+        },
+      };
+
+      const mockGqlContext = {
+        getContext: () => ({ req: mockRequest }),
+        getHandler: () => jest.fn(),
+        getClass: () => jest.fn(),
+      };
+
+      (GqlExecutionContext.create as jest.Mock).mockReturnValue(mockGqlContext);
+      jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue([Role.Admin]);
+
+      const context = {} as ExecutionContext;
+
+      const result = await guard.canActivate(context);
+
+      // Should deny because request.user is null, ignoring spoofed headers.user
+      expect(result).toBe(false);
     });
   });
 });

--- a/apps/backend/src/common/guards/roles.guard.ts
+++ b/apps/backend/src/common/guards/roles.guard.ts
@@ -10,7 +10,7 @@ import { isLoggedIn } from 'src/common/auth/jwt.strategy';
 
 @Injectable()
 export class RolesGuard implements CanActivate {
-  constructor(private reflector: Reflector) {}
+  constructor(private readonly reflector: Reflector) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const ctx = GqlExecutionContext.create(context);
@@ -25,13 +25,12 @@ export class RolesGuard implements CanActivate {
       return true;
     }
 
-    if (
-      request.headers.user != null &&
-      request.headers.user !== 'undefined' &&
-      isLoggedIn(JSON.parse(request.headers.user))
-    ) {
-      const user: ILogin = JSON.parse(request.headers.user);
+    // SECURITY: Use request.user set by AuthMiddleware after JWT validation
+    // Never trust request.headers.user as it can be spoofed
+    // @see https://github.com/CommonwealthLabsCode/qckstrt/issues/183
+    const user: ILogin | undefined = request.user;
 
+    if (user && isLoggedIn(user)) {
       return requiredRoles.some((role) => user.roles?.includes(role));
     }
 

--- a/apps/backend/src/common/utils/graphql-context.spec.ts
+++ b/apps/backend/src/common/utils/graphql-context.spec.ts
@@ -1,23 +1,38 @@
 import { UserInputError } from '@nestjs/apollo';
-import { getUserFromContext, GqlContext } from './graphql-context';
+import {
+  getUserFromContext,
+  getSessionTokenFromContext,
+  GqlContext,
+} from './graphql-context';
+import { ILogin } from 'src/interfaces/login.interface';
 
 describe('getUserFromContext', () => {
+  const mockValidUser: ILogin = {
+    id: 'user-123',
+    email: 'test@example.com',
+    roles: ['User'],
+    department: 'Engineering',
+    clearance: 'Secret',
+  };
+
   it('should extract user from valid context', () => {
-    const mockUser = { id: 'user-123', email: 'test@example.com' };
     const context: GqlContext = {
       req: {
-        user: mockUser,
+        user: mockValidUser,
+        headers: {},
       },
     };
 
     const result = getUserFromContext(context);
 
-    expect(result).toEqual(mockUser);
+    expect(result).toEqual(mockValidUser);
   });
 
   it('should throw UserInputError when user is missing', () => {
     const context: GqlContext = {
-      req: {},
+      req: {
+        headers: {},
+      },
     };
 
     expect(() => getUserFromContext(context)).toThrow(UserInputError);
@@ -28,9 +43,93 @@ describe('getUserFromContext', () => {
     const context: GqlContext = {
       req: {
         user: undefined,
+        headers: {},
       },
     };
 
     expect(() => getUserFromContext(context)).toThrow('User not authenticated');
+  });
+
+  describe('security: ignores headers.user', () => {
+    it('should NOT trust headers.user - only req.user', () => {
+      // This test verifies the security fix - we should NOT check headers.user
+      // because that can be spoofed. We only trust request.user set by passport.
+      const context = {
+        req: {
+          user: undefined,
+          headers: {
+            // Even if headers.user is set, we should not trust it
+            user: JSON.stringify({
+              id: 'spoofed-user',
+              email: 'spoofed@example.com',
+              roles: ['Admin'],
+              department: 'Engineering',
+              clearance: 'TopSecret',
+            }),
+          },
+        },
+      } as unknown as GqlContext;
+
+      // Should throw because request.user is undefined, ignoring spoofed headers.user
+      expect(() => getUserFromContext(context)).toThrow(
+        'User not authenticated',
+      );
+    });
+  });
+});
+
+describe('getSessionTokenFromContext', () => {
+  it('should extract token from Bearer authorization header', () => {
+    const context: GqlContext = {
+      req: {
+        headers: {
+          authorization: 'Bearer my-jwt-token',
+        },
+      },
+    };
+
+    const result = getSessionTokenFromContext(context);
+
+    expect(result).toBe('my-jwt-token');
+  });
+
+  it('should handle case-insensitive Bearer prefix', () => {
+    const context: GqlContext = {
+      req: {
+        headers: {
+          authorization: 'bearer my-jwt-token',
+        },
+      },
+    };
+
+    const result = getSessionTokenFromContext(context);
+
+    expect(result).toBe('my-jwt-token');
+  });
+
+  it('should return undefined when no authorization header', () => {
+    const context: GqlContext = {
+      req: {
+        headers: {},
+      },
+    };
+
+    const result = getSessionTokenFromContext(context);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when authorization header is empty', () => {
+    const context: GqlContext = {
+      req: {
+        headers: {
+          authorization: '',
+        },
+      },
+    };
+
+    const result = getSessionTokenFromContext(context);
+
+    expect(result).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- **Prevent user header spoofing in API Gateway**: Sanitize incoming requests to prevent malicious clients from spoofing internal user headers
- **Implement deny-by-default authentication**: Add `@Public()` decorator with secure-by-default auth guard that requires explicit opt-out for public endpoints
- **Disable GraphQL introspection in production**: Prevent schema exposure in production environments while keeping it available for development

## Changes

- 19 files modified across backend API, common guards/decorators, and frontend Apollo client
- Added new `@Public()` decorator for explicit public endpoint marking
- Enhanced auth, roles, and policies guards with deny-by-default behavior
- Improved GraphQL context utilities with header sanitization

## Test Plan

- [ ] Verify all existing tests pass
- [ ] Confirm protected endpoints require authentication
- [ ] Verify `@Public()` decorated endpoints are accessible without auth
- [ ] Test that spoofed headers are stripped from incoming requests
- [ ] Confirm GraphQL introspection is disabled in production mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)