### PR TITLE
perf(db): add database indexes for common query patterns (PERF-004)

### DIFF
--- a/apps/backend/src/db/entities/user-login.entity.ts
+++ b/apps/backend/src/db/entities/user-login.entity.ts
@@ -8,6 +8,7 @@ import {
   UpdateDateColumn,
   OneToOne,
   JoinColumn,
+  Index,
 } from 'typeorm';
 import { UserEntity } from './user.entity';
 
@@ -40,9 +41,11 @@ export class UserLoginEntity extends BaseEntity {
 
   // Failed login tracking (for security)
   @Column({ type: 'integer', default: 0 })
+  @Index('idx_user_logins_failed_attempts')
   public failedLoginAttempts!: number;
 
   @Column({ type: 'timestamptz', nullable: true })
+  @Index('idx_user_logins_locked_until')
   public lockedUntil?: Date;
 
   @Field()

--- a/apps/backend/src/db/entities/user.entity.ts
+++ b/apps/backend/src/db/entities/user.entity.ts
@@ -13,6 +13,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   DeleteDateColumn,
+  Index,
 } from 'typeorm';
 import { AuthStrategy } from 'src/common/enums/auth-strategy.enum';
 
@@ -32,6 +33,7 @@ export class UserEntity extends BaseEntity {
 
   @Field()
   @Column({ type: 'varchar', length: 255, select: true, unique: true })
+  @Index('idx_users_email')
   public email!: string;
 
   @Field({ nullable: true })

--- a/apps/backend/src/db/entities/webauthn-challenge.entity.ts
+++ b/apps/backend/src/db/entities/webauthn-challenge.entity.ts
@@ -12,6 +12,7 @@ import {
  * Challenges are single-use and expire after 5 minutes.
  */
 @Entity('webauthn_challenges')
+@Index('idx_webauthn_challenges_lookup', ['identifier', 'type'])
 export class WebAuthnChallengeEntity extends BaseEntity {
   // Email address or anonymous session identifier
   @PrimaryColumn({ type: 'varchar', length: 255 })


### PR DESCRIPTION
## Summary
Add database indexes to improve query performance on frequently accessed columns, addressing full table scan issues as data grows.

## Changes
- **UserEntity**: Add index on `email` for auth lookups (critical for login performance)
- **UserLoginEntity**: Add indexes on `failedLoginAttempts` and `lockedUntil` for security monitoring queries
- **WebAuthnChallengeEntity**: Add composite index on `(identifier, type)` for faster challenge lookups during WebAuthn authentication

## Indexes Added
| Entity | Index Name | Columns | Purpose |
|--------|-----------|---------|---------|
| users | idx_users_email | email | Auth lookups |
| user_logins | idx_user_logins_failed_attempts | failedLoginAttempts | Security monitoring |
| user_logins | idx_user_logins_locked_until | lockedUntil | Account lockout queries |
| webauthn_challenges | idx_webauthn_challenges_lookup | (identifier, type) | Challenge verification |

## Test plan
- [x] Build passes for all services
- [x] All 982 tests pass
- [ ] Verify indexes are created on database sync/migration
- [ ] Run EXPLAIN on common queries to confirm index usage

Fixes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)