### PR TITLE
feat(secrets): add federated secrets management with pluggable providers (INFRA-011)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -56,10 +56,25 @@ SUPABASE_URL='http://localhost:8000'
 SUPABASE_ANON_KEY='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0'
 SUPABASE_SERVICE_ROLE_KEY='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.EGIM96RAZx35lJzdJsyH-qQwv8Hdp7fsn3W0YpN81IU'
 
-# Provider Selection (Supabase)
+# Provider Selection
 AUTH_PROVIDER='supabase'
 STORAGE_PROVIDER='supabase'
-SECRETS_PROVIDER='supabase'
+
+# ============================================================
+# Secrets Provider Configuration
+# ============================================================
+# Options: env (default), aws, supabase
+#
+# env      - Read secrets from environment variables (universal adapter)
+#            Works with: Docker, Kubernetes, GCP Cloud Run, Azure App Service, etc.
+# aws      - Read secrets from AWS Secrets Manager
+# supabase - Read secrets from Supabase Vault
+#
+SECRETS_PROVIDER='env'
+
+# AWS Secrets Manager Configuration (only needed if SECRETS_PROVIDER='aws')
+# AWS_REGION is already configured above
+# SECRETS_CACHE_TTL=300  # Cache TTL in seconds (default: 300)
 
 # Relational Database Configuration (Supabase PostgreSQL)
 RELATIONAL_DB_PROVIDER='postgres'

--- a/apps/backend/src/config/secrets.config.ts
+++ b/apps/backend/src/config/secrets.config.ts
@@ -4,7 +4,14 @@ import { registerAs } from '@nestjs/config';
  * Secrets Configuration
  *
  * Maps SECRETS_* environment variables to nested config.
+ *
+ * Provider options:
+ * - 'env' (default): Read from process.env (works everywhere)
+ * - 'aws': AWS Secrets Manager
+ * - 'supabase': Supabase Vault
  */
 export default registerAs('secrets', () => ({
-  provider: process.env.SECRETS_PROVIDER || 'supabase',
+  provider: process.env.SECRETS_PROVIDER || 'env',
+  region: process.env.AWS_REGION,
+  cacheTTLSeconds: Number.parseInt(process.env.SECRETS_CACHE_TTL || '300', 10),
 }));

--- a/docs/guides/secrets-management.md
+++ b/docs/guides/secrets-management.md
@@ -1,0 +1,257 @@
+# Secrets Management
+
+This guide covers how to configure and use secrets management in QCKSTRT.
+
+## Overview
+
+QCKSTRT provides a pluggable secrets management system with multiple provider backends. As a starter kit designed to be forked and customized, we support different infrastructure choices:
+
+| Provider | `SECRETS_PROVIDER=` | Use Case |
+|----------|---------------------|----------|
+| EnvProvider | `env` (default) | Local dev, Docker, K8s, GCP, Azure |
+| AWSSecretsProvider | `aws` | AWS deployments |
+| SupabaseVaultProvider | `supabase` | Supabase Cloud users |
+
+**Key Insight**: The `EnvProvider` is the universal adapter. Most cloud platforms (GCP Cloud Run, Azure App Service, Kubernetes, etc.) inject secrets as environment variables, so `SECRETS_PROVIDER=env` works everywhere.
+
+## Architecture
+
+```
+Fork users choose their infrastructure:
+
+  AWS user:      SECRETS_PROVIDER=aws
+  GCP user:      GCP injects env → SECRETS_PROVIDER=env
+  Azure user:    Azure injects env → SECRETS_PROVIDER=env
+  Kubernetes:    K8s secrets → SECRETS_PROVIDER=env
+  Supabase:      SECRETS_PROVIDER=supabase
+  Simple/Local:  SECRETS_PROVIDER=env (default)
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Select your provider (default: env)
+SECRETS_PROVIDER=env
+
+# AWS-specific (only needed for SECRETS_PROVIDER=aws)
+AWS_REGION=us-east-1
+SECRETS_CACHE_TTL=300  # Cache TTL in seconds
+```
+
+### Provider Details
+
+#### EnvProvider (Default)
+
+The simplest and most universal provider. Reads secrets directly from `process.env`.
+
+**Configuration:**
+```bash
+SECRETS_PROVIDER=env  # or omit (this is the default)
+
+# Your secrets as environment variables
+DB_PASSWORD=your-password
+JWT_SECRET=your-secret
+API_KEYS={"client1":"key1","client2":"key2"}
+```
+
+**Use Cases:**
+- Local development
+- Docker Compose
+- Kubernetes (secrets mounted as env vars)
+- GCP Cloud Run (secrets injected as env vars)
+- Azure App Service (configuration as env vars)
+- Any platform that supports environment variable injection
+
+#### AWSSecretsProvider
+
+Retrieves secrets from AWS Secrets Manager with automatic caching to minimize API calls and costs.
+
+**Configuration:**
+```bash
+SECRETS_PROVIDER=aws
+AWS_REGION=us-east-1
+SECRETS_CACHE_TTL=300  # Optional, defaults to 300 seconds
+```
+
+**Authentication:**
+Uses the default AWS credential chain:
+- IAM role (recommended for EC2/ECS/Lambda)
+- Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`)
+- AWS credentials file (`~/.aws/credentials`)
+
+**Caching:**
+- Secrets are cached locally to reduce API calls
+- Default TTL: 5 minutes (configurable via `SECRETS_CACHE_TTL`)
+- Cache can be cleared programmatically
+
+#### SupabaseVaultProvider
+
+Reads secrets from Supabase Vault for Supabase Cloud deployments.
+
+**Configuration:**
+```bash
+SECRETS_PROVIDER=supabase
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+```
+
+## Usage
+
+### Dependency Injection (Recommended)
+
+```typescript
+import { Inject, Injectable } from '@nestjs/common';
+import { SECRETS_PROVIDER, ISecretsProvider } from '@qckstrt/secrets-provider';
+
+@Injectable()
+export class MyService {
+  constructor(
+    @Inject(SECRETS_PROVIDER) private secrets: ISecretsProvider,
+  ) {}
+
+  async doSomething() {
+    // Get a single secret
+    const apiKey = await this.secrets.getSecret('API_KEY');
+
+    // Get multiple secrets at once
+    const secrets = await this.secrets.getSecrets(['DB_PASSWORD', 'JWT_SECRET']);
+
+    // Get a JSON secret with type safety
+    const config = await this.secrets.getSecretJson<{ host: string; port: number }>('DB_CONFIG');
+  }
+}
+```
+
+### Bootstrap Helpers (Before DI Available)
+
+For scenarios where you need secrets before the NestJS DI container is ready:
+
+```typescript
+// EnvProvider helper
+import { getEnvSecret, getEnvSecretOrThrow } from '@qckstrt/secrets-provider';
+
+const optionalValue = getEnvSecret('OPTIONAL_SECRET');
+const requiredValue = getEnvSecretOrThrow('REQUIRED_SECRET'); // Throws if missing
+
+// AWS helper
+import { getAWSSecret } from '@qckstrt/secrets-provider';
+
+const secret = await getAWSSecret('my-secret', 'us-east-1');
+```
+
+## Adding a New Provider
+
+To add support for a new secrets backend:
+
+1. Create a new provider class implementing `ISecretsProvider`:
+
+```typescript
+// packages/secrets-provider/src/providers/my-provider.ts
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ISecretsProvider, SecretsError } from '@qckstrt/common';
+
+@Injectable()
+export class MySecretsProvider implements ISecretsProvider {
+  private readonly logger = new Logger(MySecretsProvider.name);
+
+  constructor(private configService: ConfigService) {
+    // Initialize your provider
+  }
+
+  getName(): string {
+    return 'MySecretsProvider';
+  }
+
+  async getSecret(secretId: string): Promise<string | undefined> {
+    // Implement secret retrieval
+  }
+
+  async getSecrets(secretIds: string[]): Promise<Record<string, string | undefined>> {
+    // Implement batch retrieval
+  }
+
+  async getSecretJson<T>(secretId: string): Promise<T | undefined> {
+    // Implement JSON parsing
+  }
+}
+```
+
+2. Register in the module factory (`secrets.module.ts`):
+
+```typescript
+case 'myprovider':
+  return new MySecretsProvider(configService);
+```
+
+3. Export from `index.ts`:
+
+```typescript
+export { MySecretsProvider } from './providers/my-provider.js';
+```
+
+## Best Practices
+
+### Development
+
+- Use `SECRETS_PROVIDER=env` with secrets in `.env` (gitignored)
+- Never commit real secrets to version control
+
+### Production
+
+- **AWS**: Use IAM roles for authentication (no access keys)
+- **Kubernetes**: Mount secrets as environment variables, use `SECRETS_PROVIDER=env`
+- **GCP/Azure**: Use platform secret injection, use `SECRETS_PROVIDER=env`
+
+### General
+
+- Cache secrets when possible (AWS provider does this automatically)
+- Use `getSecretJson` for structured configuration
+- Validate required secrets at startup, not at runtime
+
+## Troubleshooting
+
+### "AWS_REGION is required"
+
+Set the `AWS_REGION` environment variable when using `SECRETS_PROVIDER=aws`.
+
+### "Secret not found"
+
+- **EnvProvider**: Check that the environment variable is set
+- **AWSSecretsProvider**: Verify the secret exists in AWS Secrets Manager and IAM permissions allow access
+- **SupabaseVaultProvider**: Check the secret exists in Supabase Vault
+
+### Slow Startup with AWS Provider
+
+This is usually due to initial cache population. Consider:
+- Pre-warming the cache with frequently-used secrets
+- Using `SECRETS_CACHE_TTL` to balance freshness vs. performance
+
+## API Reference
+
+### ISecretsProvider Interface
+
+```typescript
+interface ISecretsProvider {
+  /** Get provider name for logging */
+  getName(): string;
+
+  /** Retrieve a single secret by ID */
+  getSecret(secretId: string): Promise<string | undefined>;
+
+  /** Retrieve multiple secrets at once */
+  getSecrets(secretIds: string[]): Promise<Record<string, string | undefined>>;
+
+  /** Retrieve and parse a JSON secret */
+  getSecretJson<T>(secretId: string): Promise<T | undefined>;
+}
+```
+
+### AWSSecretsProvider Additional Methods
+
+```typescript
+/** Clear cached secrets */
+clearCache(secretId?: string): void;
+```

--- a/packages/secrets-provider/__tests__/aws-secrets.provider.spec.ts
+++ b/packages/secrets-provider/__tests__/aws-secrets.provider.spec.ts
@@ -1,0 +1,255 @@
+import { mockClient } from "aws-sdk-client-mock";
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+  ResourceNotFoundException,
+} from "@aws-sdk/client-secrets-manager";
+import { ConfigService } from "@nestjs/config";
+import {
+  AWSSecretsProvider,
+  getAWSSecret,
+} from "../src/providers/aws-secrets.provider";
+import { SecretsError } from "@qckstrt/common";
+
+const mockSecretsManager = mockClient(SecretsManagerClient);
+
+describe("AWSSecretsProvider", () => {
+  let provider: AWSSecretsProvider;
+  let mockConfigService: jest.Mocked<ConfigService>;
+
+  beforeEach(() => {
+    mockSecretsManager.reset();
+
+    mockConfigService = {
+      get: jest.fn((key: string) => {
+        if (key === "AWS_REGION" || key === "secrets.region")
+          return "us-east-1";
+        if (key === "secrets.cacheTTLSeconds") return 300;
+        return undefined;
+      }),
+    } as unknown as jest.Mocked<ConfigService>;
+
+    provider = new AWSSecretsProvider(mockConfigService);
+  });
+
+  describe("constructor", () => {
+    it("should initialize with region from config", () => {
+      expect(provider.getName()).toBe("AWSSecretsProvider");
+    });
+
+    it("should throw SecretsError when region is not configured", () => {
+      const noRegionConfig = {
+        get: jest.fn(() => undefined),
+      } as unknown as ConfigService;
+
+      expect(() => new AWSSecretsProvider(noRegionConfig)).toThrow(
+        SecretsError,
+      );
+    });
+  });
+
+  describe("getSecret", () => {
+    it("should return secret from AWS", async () => {
+      mockSecretsManager.on(GetSecretValueCommand).resolves({
+        SecretString: "aws-secret-value",
+      });
+
+      const result = await provider.getSecret("my-secret");
+
+      expect(result).toBe("aws-secret-value");
+    });
+
+    it("should return undefined for missing secret", async () => {
+      mockSecretsManager.on(GetSecretValueCommand).rejects(
+        new ResourceNotFoundException({
+          message: "Secret not found",
+          $metadata: {},
+        }),
+      );
+
+      const result = await provider.getSecret("missing-secret");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should throw SecretsError for other errors", async () => {
+      mockSecretsManager
+        .on(GetSecretValueCommand)
+        .rejects(new Error("Network error"));
+
+      await expect(provider.getSecret("error-secret")).rejects.toThrow(
+        SecretsError,
+      );
+    });
+
+    it("should return undefined when secret has no string value", async () => {
+      mockSecretsManager.on(GetSecretValueCommand).resolves({
+        SecretString: undefined,
+      });
+
+      const result = await provider.getSecret("binary-secret");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("caching", () => {
+    it("should cache secrets", async () => {
+      mockSecretsManager.on(GetSecretValueCommand).resolves({
+        SecretString: "cached-value",
+      });
+
+      await provider.getSecret("cached-secret");
+      await provider.getSecret("cached-secret");
+
+      expect(mockSecretsManager.calls()).toHaveLength(1);
+    });
+
+    it("should clear specific cached secret", async () => {
+      mockSecretsManager.on(GetSecretValueCommand).resolves({
+        SecretString: "value-to-clear",
+      });
+
+      await provider.getSecret("clear-me");
+      provider.clearCache("clear-me");
+      await provider.getSecret("clear-me");
+
+      expect(mockSecretsManager.calls()).toHaveLength(2);
+    });
+
+    it("should clear all cached secrets", async () => {
+      mockSecretsManager.on(GetSecretValueCommand).resolves({
+        SecretString: "value",
+      });
+
+      await provider.getSecret("secret-1");
+      await provider.getSecret("secret-2");
+      provider.clearCache();
+      await provider.getSecret("secret-1");
+      await provider.getSecret("secret-2");
+
+      expect(mockSecretsManager.calls()).toHaveLength(4);
+    });
+  });
+
+  describe("getSecrets", () => {
+    it("should fetch multiple secrets in parallel", async () => {
+      mockSecretsManager
+        .on(GetSecretValueCommand, { SecretId: "secret-a" })
+        .resolves({ SecretString: "value-a" })
+        .on(GetSecretValueCommand, { SecretId: "secret-b" })
+        .resolves({ SecretString: "value-b" });
+
+      const result = await provider.getSecrets(["secret-a", "secret-b"]);
+
+      expect(result).toEqual({
+        "secret-a": "value-a",
+        "secret-b": "value-b",
+      });
+    });
+
+    it("should return undefined for failed secrets", async () => {
+      mockSecretsManager
+        .on(GetSecretValueCommand, { SecretId: "good-secret" })
+        .resolves({ SecretString: "good-value" })
+        .on(GetSecretValueCommand, { SecretId: "bad-secret" })
+        .rejects(new Error("Failed"));
+
+      const result = await provider.getSecrets(["good-secret", "bad-secret"]);
+
+      expect(result).toEqual({
+        "good-secret": "good-value",
+        "bad-secret": undefined,
+      });
+    });
+  });
+
+  describe("getSecretJson", () => {
+    it("should parse JSON secrets", async () => {
+      mockSecretsManager.on(GetSecretValueCommand).resolves({
+        SecretString: '{"key":"value","count":42}',
+      });
+
+      const result = await provider.getSecretJson<{
+        key: string;
+        count: number;
+      }>("json-secret");
+
+      expect(result).toEqual({ key: "value", count: 42 });
+    });
+
+    it("should return undefined for missing JSON secret", async () => {
+      mockSecretsManager.on(GetSecretValueCommand).rejects(
+        new ResourceNotFoundException({
+          message: "Not found",
+          $metadata: {},
+        }),
+      );
+
+      const result = await provider.getSecretJson("missing-json");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should throw SecretsError for invalid JSON", async () => {
+      mockSecretsManager.on(GetSecretValueCommand).resolves({
+        SecretString: "not valid json",
+      });
+
+      await expect(provider.getSecretJson("invalid-json")).rejects.toThrow(
+        SecretsError,
+      );
+    });
+  });
+});
+
+describe("getAWSSecret helper", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    mockSecretsManager.reset();
+    process.env = { ...originalEnv, AWS_REGION: "us-west-2" };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return secret from AWS", async () => {
+    mockSecretsManager.on(GetSecretValueCommand).resolves({
+      SecretString: "helper-secret-value",
+    });
+
+    const result = await getAWSSecret("helper-test");
+
+    expect(result).toBe("helper-secret-value");
+  });
+
+  it("should use region from parameter", async () => {
+    mockSecretsManager.on(GetSecretValueCommand).resolves({
+      SecretString: "regional-value",
+    });
+
+    const result = await getAWSSecret("regional-secret", "eu-west-1");
+
+    expect(result).toBe("regional-value");
+  });
+
+  it("should throw when region is not available", async () => {
+    delete process.env.AWS_REGION;
+
+    await expect(getAWSSecret("no-region")).rejects.toThrow(
+      "AWS_REGION is required",
+    );
+  });
+
+  it("should throw when secret has no string value", async () => {
+    mockSecretsManager.on(GetSecretValueCommand).resolves({
+      SecretString: undefined,
+    });
+
+    await expect(getAWSSecret("no-value")).rejects.toThrow(
+      "has no string value",
+    );
+  });
+});

--- a/packages/secrets-provider/__tests__/env.provider.spec.ts
+++ b/packages/secrets-provider/__tests__/env.provider.spec.ts
@@ -1,0 +1,173 @@
+import {
+  EnvProvider,
+  getEnvSecret,
+  getEnvSecretOrThrow,
+} from "../src/providers/env.provider";
+import { SecretsError } from "@qckstrt/common";
+
+describe("EnvProvider", () => {
+  let provider: EnvProvider;
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    // Create a fresh copy of environment for each test
+    process.env = { ...originalEnv };
+    provider = new EnvProvider();
+  });
+
+  afterEach(() => {
+    // Restore original environment
+    process.env = originalEnv;
+  });
+
+  describe("getName", () => {
+    it("should return provider name", () => {
+      expect(provider.getName()).toBe("EnvProvider");
+    });
+  });
+
+  describe("getSecret", () => {
+    it("should return secret from environment", async () => {
+      process.env.TEST_SECRET = "secret-value";
+
+      const result = await provider.getSecret("TEST_SECRET");
+
+      expect(result).toBe("secret-value");
+    });
+
+    it("should return undefined for missing secret", async () => {
+      const result = await provider.getSecret("MISSING_SECRET");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should handle empty string value", async () => {
+      process.env.EMPTY_SECRET = "";
+
+      const result = await provider.getSecret("EMPTY_SECRET");
+
+      expect(result).toBe("");
+    });
+  });
+
+  describe("getSecrets", () => {
+    it("should return multiple secrets", async () => {
+      process.env.SECRET_ONE = "value-one";
+      process.env.SECRET_TWO = "value-two";
+
+      const result = await provider.getSecrets(["SECRET_ONE", "SECRET_TWO"]);
+
+      expect(result).toEqual({
+        SECRET_ONE: "value-one",
+        SECRET_TWO: "value-two",
+      });
+    });
+
+    it("should return undefined for missing secrets", async () => {
+      process.env.EXISTING_SECRET = "exists";
+
+      const result = await provider.getSecrets([
+        "EXISTING_SECRET",
+        "MISSING_SECRET",
+      ]);
+
+      expect(result).toEqual({
+        EXISTING_SECRET: "exists",
+        MISSING_SECRET: undefined,
+      });
+    });
+
+    it("should handle empty array", async () => {
+      const result = await provider.getSecrets([]);
+
+      expect(result).toEqual({});
+    });
+  });
+
+  describe("getSecretJson", () => {
+    it("should parse JSON secrets", async () => {
+      process.env.JSON_SECRET = '{"key":"value","number":42}';
+
+      const result = await provider.getSecretJson<{
+        key: string;
+        number: number;
+      }>("JSON_SECRET");
+
+      expect(result).toEqual({ key: "value", number: 42 });
+    });
+
+    it("should return undefined for missing JSON secret", async () => {
+      const result = await provider.getSecretJson("MISSING_JSON");
+
+      expect(result).toBeUndefined();
+    });
+
+    it("should throw SecretsError for invalid JSON", async () => {
+      process.env.INVALID_JSON = "not valid json";
+
+      await expect(provider.getSecretJson("INVALID_JSON")).rejects.toThrow(
+        SecretsError,
+      );
+    });
+
+    it("should parse array JSON", async () => {
+      process.env.ARRAY_SECRET = '["a","b","c"]';
+
+      const result = await provider.getSecretJson<string[]>("ARRAY_SECRET");
+
+      expect(result).toEqual(["a", "b", "c"]);
+    });
+  });
+});
+
+describe("getEnvSecret", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return secret from environment", () => {
+    process.env.HELPER_SECRET = "helper-value";
+
+    const result = getEnvSecret("HELPER_SECRET");
+
+    expect(result).toBe("helper-value");
+  });
+
+  it("should return undefined for missing secret", () => {
+    const result = getEnvSecret("MISSING_HELPER");
+
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("getEnvSecretOrThrow", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("should return secret from environment", () => {
+    process.env.REQUIRED_SECRET = "required-value";
+
+    const result = getEnvSecretOrThrow("REQUIRED_SECRET");
+
+    expect(result).toBe("required-value");
+  });
+
+  it("should throw for missing secret", () => {
+    expect(() => getEnvSecretOrThrow("MISSING_REQUIRED")).toThrow(
+      "Required secret not found in environment: MISSING_REQUIRED",
+    );
+  });
+});

--- a/packages/secrets-provider/package.json
+++ b/packages/secrets-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@qckstrt/secrets-provider",
   "version": "0.1.0",
-  "description": "Secrets provider implementations for QCKSTRT platform (Supabase Vault)",
+  "description": "Secrets provider implementations for QCKSTRT platform (env, AWS, Supabase)",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
@@ -30,6 +30,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@aws-sdk/client-secrets-manager": "^3.700.0",
     "@qckstrt/common": "workspace:*",
     "@supabase/supabase-js": "^2.49.1"
   },
@@ -41,6 +42,7 @@
     "@nestjs/common": "^11.1.9",
     "@nestjs/config": "^4.0.2",
     "@types/jest": "^30.0.0",
+    "aws-sdk-client-mock": "^4.0.0",
     "@types/node": "^22.0.0",
     "jest": "^30.0.0",
     "reflect-metadata": "^0.2.2",

--- a/packages/secrets-provider/src/index.ts
+++ b/packages/secrets-provider/src/index.ts
@@ -2,7 +2,12 @@
  * @qckstrt/secrets-provider
  *
  * Secrets provider implementations for the QCKSTRT platform.
- * Provides pluggable secrets management with Supabase Vault.
+ * Provides pluggable secrets management with multiple backends.
+ *
+ * Providers:
+ * - EnvProvider (default): Read from process.env
+ * - AWSSecretsProvider: AWS Secrets Manager
+ * - SupabaseVaultProvider: Supabase Vault
  */
 
 // Re-export types from common
@@ -12,11 +17,22 @@ export {
   SecretsError,
 } from "@qckstrt/common";
 
+// Module
+export { SecretsModule, SECRETS_PROVIDER } from "./secrets.module.js";
+
 // Providers
+export {
+  EnvProvider,
+  getEnvSecret,
+  getEnvSecretOrThrow,
+} from "./providers/env.provider.js";
+
+export {
+  AWSSecretsProvider,
+  getAWSSecret,
+} from "./providers/aws-secrets.provider.js";
+
 export {
   SupabaseVaultProvider,
   getSecrets,
 } from "./providers/supabase-vault.provider.js";
-
-// Module
-export { SecretsModule } from "./secrets.module.js";

--- a/packages/secrets-provider/src/providers/aws-secrets.provider.ts
+++ b/packages/secrets-provider/src/providers/aws-secrets.provider.ts
@@ -1,0 +1,173 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+  ResourceNotFoundException,
+} from "@aws-sdk/client-secrets-manager";
+import { ISecretsProvider, SecretsError } from "@qckstrt/common";
+
+interface CacheEntry {
+  value: string;
+  expiresAt: number;
+}
+
+/**
+ * AWS Secrets Manager Provider
+ *
+ * Retrieves secrets from AWS Secrets Manager with local caching
+ * to minimize API calls and costs.
+ *
+ * Configuration:
+ *   SECRETS_PROVIDER=aws
+ *   AWS_REGION=us-east-1
+ *   SECRETS_CACHE_TTL=300 (optional, seconds)
+ *
+ * Authentication:
+ *   Uses default AWS credential chain (IAM role, env vars, etc.)
+ *
+ * @see https://github.com/CommonwealthLabsCode/qckstrt/issues/215
+ */
+@Injectable()
+export class AWSSecretsProvider implements ISecretsProvider {
+  private readonly logger = new Logger(AWSSecretsProvider.name);
+  private readonly client: SecretsManagerClient;
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly cacheTTLMs: number;
+
+  constructor(private configService: ConfigService) {
+    const region =
+      configService.get<string>("secrets.region") ||
+      configService.get<string>("AWS_REGION");
+
+    if (!region) {
+      throw new SecretsError(
+        "AWS_REGION is required for AWS Secrets Manager",
+        "CONFIG_ERROR",
+      );
+    }
+
+    this.client = new SecretsManagerClient({ region });
+    this.cacheTTLMs =
+      (configService.get<number>("secrets.cacheTTLSeconds") || 300) * 1000;
+
+    this.logger.log(`AWSSecretsProvider initialized for region: ${region}`);
+  }
+
+  getName(): string {
+    return "AWSSecretsProvider";
+  }
+
+  async getSecret(secretId: string): Promise<string | undefined> {
+    // Check cache first
+    const cached = this.cache.get(secretId);
+    if (cached && cached.expiresAt > Date.now()) {
+      this.logger.debug(`Cache hit for secret: ${secretId}`);
+      return cached.value;
+    }
+
+    try {
+      const command = new GetSecretValueCommand({ SecretId: secretId });
+      const response = await this.client.send(command);
+
+      const value = response.SecretString;
+      if (!value) {
+        this.logger.warn(`Secret has no string value: ${secretId}`);
+        return undefined;
+      }
+
+      // Cache the result
+      this.cache.set(secretId, {
+        value,
+        expiresAt: Date.now() + this.cacheTTLMs,
+      });
+
+      this.logger.log(`Retrieved secret from AWS: ${secretId}`);
+      return value;
+    } catch (error) {
+      if (error instanceof ResourceNotFoundException) {
+        this.logger.warn(`Secret not found in AWS: ${secretId}`);
+        return undefined;
+      }
+      this.logger.error(`Error retrieving secret: ${(error as Error).message}`);
+      throw new SecretsError(
+        `Failed to retrieve secret ${secretId}`,
+        "GET_SECRET_ERROR",
+        error as Error,
+      );
+    }
+  }
+
+  async getSecrets(
+    secretIds: string[],
+  ): Promise<Record<string, string | undefined>> {
+    const results: Record<string, string | undefined> = {};
+
+    await Promise.all(
+      secretIds.map(async (secretId) => {
+        try {
+          results[secretId] = await this.getSecret(secretId);
+        } catch {
+          this.logger.error(`Failed to retrieve secret: ${secretId}`);
+          results[secretId] = undefined;
+        }
+      }),
+    );
+
+    return results;
+  }
+
+  async getSecretJson<T>(secretId: string): Promise<T | undefined> {
+    const secret = await this.getSecret(secretId);
+    if (!secret) return undefined;
+
+    try {
+      return JSON.parse(secret) as T;
+    } catch (error) {
+      this.logger.error(`Failed to parse secret as JSON: ${secretId}`);
+      throw new SecretsError(
+        `Failed to parse secret ${secretId} as JSON`,
+        "PARSE_SECRET_ERROR",
+        error as Error,
+      );
+    }
+  }
+
+  /**
+   * Clear cached secrets
+   * @param secretId Optional specific secret to clear, or all if omitted
+   */
+  clearCache(secretId?: string): void {
+    if (secretId) {
+      this.cache.delete(secretId);
+      this.logger.debug(`Cleared cache for secret: ${secretId}`);
+    } else {
+      this.cache.clear();
+      this.logger.debug("Cleared all cached secrets");
+    }
+  }
+}
+
+/**
+ * Helper function for bootstrap scenarios (before DI is available)
+ */
+export async function getAWSSecret(
+  secretName: string,
+  region?: string,
+): Promise<string> {
+  const awsRegion = region || process.env.AWS_REGION;
+
+  if (!awsRegion) {
+    throw new Error("AWS_REGION is required");
+  }
+
+  const client = new SecretsManagerClient({ region: awsRegion });
+  const command = new GetSecretValueCommand({ SecretId: secretName });
+
+  const response = await client.send(command);
+  if (!response.SecretString) {
+    throw new Error(`Secret ${secretName} has no string value`);
+  }
+
+  return response.SecretString;
+}

--- a/packages/secrets-provider/src/providers/env.provider.ts
+++ b/packages/secrets-provider/src/providers/env.provider.ts
@@ -1,0 +1,88 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { ISecretsProvider, SecretsError } from "@qckstrt/common";
+
+/**
+ * Environment Variable Secrets Provider
+ *
+ * The simplest provider - reads secrets directly from process.env.
+ * This is the universal adapter that works with any platform that
+ * supports environment variable injection (Docker, K8s, GCP, Azure, etc.)
+ *
+ * Usage:
+ *   SECRETS_PROVIDER=env (or omit - this is the default)
+ *   Secrets are expected as environment variables:
+ *     DB_PASSWORD=xxx
+ *     JWT_SECRET=yyy
+ */
+@Injectable()
+export class EnvProvider implements ISecretsProvider {
+  private readonly logger = new Logger(EnvProvider.name);
+
+  constructor() {
+    this.logger.log(
+      "EnvProvider initialized - reading secrets from process.env",
+    );
+  }
+
+  getName(): string {
+    return "EnvProvider";
+  }
+
+  async getSecret(secretId: string): Promise<string | undefined> {
+    const value = process.env[secretId];
+
+    if (value === undefined) {
+      this.logger.debug(`Secret not found in environment: ${secretId}`);
+      return undefined;
+    }
+
+    this.logger.debug(`Retrieved secret from environment: ${secretId}`);
+    return value;
+  }
+
+  async getSecrets(
+    secretIds: string[],
+  ): Promise<Record<string, string | undefined>> {
+    const results: Record<string, string | undefined> = {};
+
+    for (const secretId of secretIds) {
+      results[secretId] = await this.getSecret(secretId);
+    }
+
+    return results;
+  }
+
+  async getSecretJson<T>(secretId: string): Promise<T | undefined> {
+    const secret = await this.getSecret(secretId);
+    if (!secret) return undefined;
+
+    try {
+      return JSON.parse(secret) as T;
+    } catch (error) {
+      this.logger.error(`Failed to parse secret as JSON: ${secretId}`);
+      throw new SecretsError(
+        `Failed to parse secret ${secretId} as JSON`,
+        "PARSE_SECRET_ERROR",
+        error as Error,
+      );
+    }
+  }
+}
+
+/**
+ * Helper function for bootstrap scenarios (before DI is available)
+ */
+export function getEnvSecret(secretName: string): string | undefined {
+  return process.env[secretName];
+}
+
+/**
+ * Helper function that throws if secret is not found
+ */
+export function getEnvSecretOrThrow(secretName: string): string {
+  const value = process.env[secretName];
+  if (!value) {
+    throw new Error(`Required secret not found in environment: ${secretName}`);
+  }
+  return value;
+}

--- a/packages/secrets-provider/src/secrets.module.ts
+++ b/packages/secrets-provider/src/secrets.module.ts
@@ -1,35 +1,45 @@
 import { Module, Global } from "@nestjs/common";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { ISecretsProvider } from "@qckstrt/common";
+import { EnvProvider } from "./providers/env.provider.js";
+import { AWSSecretsProvider } from "./providers/aws-secrets.provider.js";
 import { SupabaseVaultProvider } from "./providers/supabase-vault.provider.js";
+
+export const SECRETS_PROVIDER = "SECRETS_PROVIDER";
 
 /**
  * Secrets Module
  *
  * Provides secrets management capabilities using pluggable providers.
+ * Designed for starter kit flexibility - fork users choose their infrastructure.
  *
  * Configure via SECRETS_PROVIDER environment variable:
- * - 'supabase' (default): Supabase Vault
+ * - 'env' (default): Read from process.env (works everywhere)
+ * - 'aws': AWS Secrets Manager
+ * - 'supabase': Supabase Vault
  */
 @Global()
 @Module({
   imports: [ConfigModule],
   providers: [
     {
-      provide: "SECRETS_PROVIDER",
+      provide: SECRETS_PROVIDER,
       useFactory: (configService: ConfigService): ISecretsProvider => {
-        const provider =
-          configService.get<string>("secrets.provider") || "supabase";
+        const provider = configService.get<string>("secrets.provider") || "env";
 
         switch (provider.toLowerCase()) {
+          case "aws":
+            return new AWSSecretsProvider(configService);
           case "supabase":
-          default:
             return new SupabaseVaultProvider(configService);
+          case "env":
+          default:
+            return new EnvProvider();
         }
       },
       inject: [ConfigService],
     },
   ],
-  exports: ["SECRETS_PROVIDER"],
+  exports: [SECRETS_PROVIDER],
 })
 export class SecretsModule {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 4.17.1
       '@langchain/community':
         specifier: ^1.1.0
-        version: 1.1.0(nxvvrexxi32o6afhxwucre4e7a)
+        version: 1.1.0(bmnf7ko662geybhoae7ww4ucxe)
       '@langchain/core':
         specifier: ^1.1.5
         version: 1.1.5(@opentelemetry/api@1.9.0)(openai@6.10.0(ws@8.18.3(bufferutil@4.0.9))(zod@4.1.13))
@@ -755,6 +755,9 @@ importers:
 
   packages/secrets-provider:
     dependencies:
+      '@aws-sdk/client-secrets-manager':
+        specifier: ^3.700.0
+        version: 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@qckstrt/common':
         specifier: workspace:*
         version: link:../common
@@ -774,6 +777,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.3
+      aws-sdk-client-mock:
+        specifier: ^4.0.0
+        version: 4.1.0
       jest:
         specifier: ^30.0.0
         version: 30.2.0(@types/node@22.19.3)
@@ -1231,6 +1237,10 @@ packages:
     resolution: {integrity: sha512-uvEjds8aYA9SzhBS8RKDtsDUhNV9VhqKiHTcmvhM7gJO92q0WTn8/QeFTdNyLc6RxpiDyz+uBxS7PcdNiZzqfA==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/client-secrets-manager@3.971.0':
+    resolution: {integrity: sha512-Afv8K2rYJxtNlEQ+3FatK+bPdYdUF80SxgcZH3adu56x0BZzQ75KDCXLRWDYjNrLn+8OH0eStX/NbAZdwPX9uA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-sqs@3.948.0':
     resolution: {integrity: sha512-Wnv4iLr4NHFvgTE7OWJ0RdAqpLw9UFXkBdOl9Z61SB28Qk0svAY4KaYCUCRtO6IBM+a/ivTK5cuYg6DTMho84A==}
     engines: {node: '>=18.0.0'}
@@ -1238,6 +1248,10 @@ packages:
   '@aws-sdk/client-sso@3.948.0':
     resolution: {integrity: sha512-iWjchXy8bIAVBUsKnbfKYXRwhLgRg3EqCQ5FTr3JbR+QR75rZm4ZOYXlvHGztVTmtAZ+PQVA1Y4zO7v7N87C0A==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/client-sso@3.971.0':
+    resolution: {integrity: sha512-Xx+w6DQqJxDdymYyIxyKJnRzPvVJ4e/Aw0czO7aC9L/iraaV7AG8QtRe93OGW6aoHSh72CIiinnpJJfLsQqP4g==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-textract@3.948.0':
     resolution: {integrity: sha512-+iN1byFQTgeUtcMjPbHlXI4TNCaLMaxhBO+o3JWjbv8hvDTYr45M/PZRBrbLbuyKqeR7m47XUJRneHUWP7aC9A==}
@@ -1247,37 +1261,73 @@ packages:
     resolution: {integrity: sha512-Khq4zHhuAkvCFuFbgcy3GrZTzfSX7ZIjIcW1zRDxXRLZKRtuhnZdonqTUfaWi5K42/4OmxkYNpsO7X7trQOeHw==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/core@3.970.0':
+    resolution: {integrity: sha512-klpzObldOq8HXzDjDlY6K8rMhYZU6mXRz6P9F9N+tWnjoYFfeBMra8wYApydElTUYQKP1O7RLHwH1OKFfKcqIA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.947.0':
     resolution: {integrity: sha512-VR2V6dRELmzwAsCpK4GqxUi6UW5WNhAXS9F9AzWi5jvijwJo3nH92YNJUP4quMpgFZxJHEWyXLWgPjh9u0zYOA==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.970.0':
+    resolution: {integrity: sha512-rtVzXzEtAfZBfh+lq3DAvRar4c3jyptweOAJR2DweyXx71QSMY+O879hjpMwES7jl07a3O1zlnFIDo4KP/96kQ==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.947.0':
     resolution: {integrity: sha512-inF09lh9SlHj63Vmr5d+LmwPXZc2IbK8lAruhOr3KLsZAIHEgHgGPXWDC2ukTEMzg0pkexQ6FOhXXad6klK4RA==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.970.0':
+    resolution: {integrity: sha512-CjDbWL7JxjLc9ZxQilMusWSw05yRvUJKRpz59IxDpWUnSMHC9JMMUUkOy5Izk8UAtzi6gupRWArp4NG4labt9Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.948.0':
     resolution: {integrity: sha512-Cl//Qh88e8HBL7yYkJNpF5eq76IO6rq8GsatKcfVBm7RFVxCqYEPSSBtkHdbtNwQdRQqAMXc6E/lEB/CZUDxnA==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.971.0':
+    resolution: {integrity: sha512-c0TGJG4xyfTZz3SInXfGU8i5iOFRrLmy4Bo7lMyH+IpngohYMYGYl61omXqf2zdwMbDv+YJ9AviQTcCaEUKi8w==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.948.0':
     resolution: {integrity: sha512-gcKO2b6eeTuZGp3Vvgr/9OxajMrD3W+FZ2FCyJox363ZgMoYJsyNid1vuZrEuAGkx0jvveLXfwiVS0UXyPkgtw==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.971.0':
+    resolution: {integrity: sha512-yhbzmDOsk0RXD3rTPhZra4AWVnVAC4nFWbTp+sUty1hrOPurUmhuz8bjpLqYTHGnlMbJp+UqkQONhS2+2LzW2g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.948.0':
     resolution: {integrity: sha512-ep5vRLnrRdcsP17Ef31sNN4g8Nqk/4JBydcUJuFRbGuyQtrZZrVT81UeH2xhz6d0BK6ejafDB9+ZpBjXuWT5/Q==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.971.0':
+    resolution: {integrity: sha512-epUJBAKivtJqalnEBRsYIULKYV063o/5mXNJshZfyvkAgNIzc27CmmKRXTN4zaNOZg8g/UprFp25BGsi19x3nQ==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.947.0':
     resolution: {integrity: sha512-WpanFbHe08SP1hAJNeDdBDVz9SGgMu/gc0XJ9u3uNpW99nKZjDpvPRAdW7WLA4K6essMjxWkguIGNOpij6Do2Q==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.970.0':
+    resolution: {integrity: sha512-0XeT8OaT9iMA62DFV9+m6mZfJhrD0WNKf4IvsIpj2Z7XbaYfz3CoDDvNoALf3rPY9NzyMHgDxOspmqdvXP00mw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.948.0':
     resolution: {integrity: sha512-gqLhX1L+zb/ZDnnYbILQqJ46j735StfWV5PbDjxRzBKS7GzsiYoaf6MyHseEopmWrez5zl5l6aWzig7UpzSeQQ==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.971.0':
+    resolution: {integrity: sha512-dY0hMQ7dLVPQNJ8GyqXADxa9w5wNfmukgQniLxGVn+dMRx3YLViMp5ZpTSQpFhCWNF0oKQrYAI5cHhUJU1hETw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.948.0':
     resolution: {integrity: sha512-MvYQlXVoJyfF3/SmnNzOVEtANRAiJIObEUYYyjTqKZTmcRIVVky0tPuG26XnB8LmTYgtESwJIZJj/Eyyc9WURQ==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.971.0':
+    resolution: {integrity: sha512-F1AwfNLr7H52T640LNON/h34YDiMuIqW/ZreGzhRR6vnFGaSPtNSKAKB2ssAMkLM8EVg8MjEAYD3NCUiEo+t/w==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-bucket-endpoint@3.936.0':
     resolution: {integrity: sha512-XLSVVfAorUxZh6dzF+HTOp4R1B5EQcdpGcPliWr0KUj2jukgjZEcqbBmjyMF/p9bmyQsONX80iURF1HLAlW0qg==}
@@ -1295,6 +1345,10 @@ packages:
     resolution: {integrity: sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/middleware-host-header@3.969.0':
+    resolution: {integrity: sha512-AWa4rVsAfBR4xqm7pybQ8sUNJYnjyP/bJjfAw34qPuh3M9XrfGbAHG0aiAfQGrBnmS28jlO6Kz69o+c6PRw1dw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-location-constraint@3.936.0':
     resolution: {integrity: sha512-SCMPenDtQMd9o5da9JzkHz838w3327iqXk3cbNnXWqnNRx6unyW8FL0DZ84gIY12kAyVHz5WEqlWuekc15ehfw==}
     engines: {node: '>=18.0.0'}
@@ -1303,9 +1357,17 @@ packages:
     resolution: {integrity: sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/middleware-logger@3.969.0':
+    resolution: {integrity: sha512-xwrxfip7Y2iTtCMJ+iifN1E1XMOuhxIHY9DreMCvgdl4r7+48x2S1bCYPWH3eNY85/7CapBWdJ8cerpEl12sQQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-recursion-detection@3.948.0':
     resolution: {integrity: sha512-Qa8Zj+EAqA0VlAVvxpRnpBpIWJI9KUwaioY1vkeNVwXPlNaz9y9zCKVM9iU9OZ5HXpoUg6TnhATAHXHAE8+QsQ==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.969.0':
+    resolution: {integrity: sha512-2r3PuNquU3CcS1Am4vn/KHFwLi8QFjMdA/R+CRDXT4AFO/0qxevF/YStW3gAKntQIgWgQV8ZdEtKAoJvLI4UWg==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-sdk-s3@3.947.0':
     resolution: {integrity: sha512-DS2tm5YBKhPW2PthrRBDr6eufChbwXe0NjtTZcYDfUCXf0OR+W6cIqyKguwHMJ+IyYdey30AfVw9/Lb5KB8U8A==}
@@ -1323,13 +1385,25 @@ packages:
     resolution: {integrity: sha512-7rpKV8YNgCP2R4F9RjWZFcD2R+SO/0R4VHIbY9iZJdH2MzzJ8ZG7h8dZ2m8QkQd1fjx4wrFJGGPJUTYXPV3baA==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/middleware-user-agent@3.970.0':
+    resolution: {integrity: sha512-dnSJGGUGSFGEX2NzvjwSefH+hmZQ347AwbLhAsi0cdnISSge+pcGfOFrJt2XfBIypwFe27chQhlfuf/gWdzpZg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.948.0':
     resolution: {integrity: sha512-zcbJfBsB6h254o3NuoEkf0+UY1GpE9ioiQdENWv7odo69s8iaGBEQ4BDpsIMqcuiiUXw1uKIVNxCB1gUGYz8lw==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/nested-clients@3.971.0':
+    resolution: {integrity: sha512-TWaILL8GyYlhGrxxnmbkazM4QsXatwQgoWUvo251FXmUOsiXDFDVX3hoGIfB3CaJhV2pJPfebHUNJtY6TjZ11g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.936.0':
     resolution: {integrity: sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.969.0':
+    resolution: {integrity: sha512-scj9OXqKpcjJ4jsFLtqYWz3IaNvNOQTFFvEY8XMJXTv+3qF5I7/x9SJtKzTRJEBF3spjzBUYPtGFbs9sj4fisQ==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.947.0':
     resolution: {integrity: sha512-UaYmzoxf9q3mabIA2hc4T6x5YSFUG2BpNjAZ207EA1bnQMiK+d6vZvb83t7dIWL/U1de1sGV19c1C81Jf14rrA==}
@@ -1339,9 +1413,17 @@ packages:
     resolution: {integrity: sha512-V487/kM4Teq5dcr1t5K6eoUKuqlGr9FRWL3MIMukMERJXHZvio6kox60FZ/YtciRHRI75u14YUqm2Dzddcu3+A==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/token-providers@3.971.0':
+    resolution: {integrity: sha512-4hKGWZbmuDdONMJV0HJ+9jwTDb0zLfKxcCLx2GEnBY31Gt9GeyIQ+DZ97Bb++0voawj6pnZToFikXTyrEq2x+w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.936.0':
     resolution: {integrity: sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/types@3.969.0':
+    resolution: {integrity: sha512-7IIzM5TdiXn+VtgPdVLjmE6uUBUtnga0f4RiSEI1WW10RPuNvZ9U+pL3SwDiRDAdoGrOF9tSLJOFZmfuwYuVYQ==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.893.0':
     resolution: {integrity: sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==}
@@ -1351,6 +1433,10 @@ packages:
     resolution: {integrity: sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/util-endpoints@3.970.0':
+    resolution: {integrity: sha512-TZNZqFcMUtjvhZoZRtpEGQAdULYiy6rcGiXAbLU7e9LSpIYlRqpLa207oMNfgbzlL2PnHko+eVg8rajDiSOYCg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-locate-window@3.893.0':
     resolution: {integrity: sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==}
     engines: {node: '>=18.0.0'}
@@ -1358,9 +1444,21 @@ packages:
   '@aws-sdk/util-user-agent-browser@3.936.0':
     resolution: {integrity: sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==}
 
+  '@aws-sdk/util-user-agent-browser@3.969.0':
+    resolution: {integrity: sha512-bpJGjuKmFr0rA6UKUCmN8D19HQFMLXMx5hKBXqBlPFdalMhxJSjcxzX9DbQh0Fn6bJtxCguFmRGOBdQqNOt49g==}
+
   '@aws-sdk/util-user-agent-node@3.947.0':
     resolution: {integrity: sha512-+vhHoDrdbb+zerV4noQk1DHaUMNzWFWPpPYjVTwW2186k5BEJIecAMChYkghRrBVJ3KPWP1+JnZwOd72F3d4rQ==}
     engines: {node: '>=18.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/util-user-agent-node@3.971.0':
+    resolution: {integrity: sha512-Eygjo9mFzQYjbGY3MYO6CsIhnTwAMd3WmuFalCykqEmj2r5zf0leWrhPaqvA5P68V5JdGfPYgj7vhNOd6CtRBQ==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
     peerDependenciesMeta:
@@ -1373,6 +1471,10 @@ packages:
   '@aws-sdk/xml-builder@3.930.0':
     resolution: {integrity: sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/xml-builder@3.969.0':
+    resolution: {integrity: sha512-BSe4Lx/qdRQQdX8cSSI7Et20vqBspzAjBy8ZmXVoyLkol3y4sXBXzn+BiLtR+oh60ExQn6o2DU4QjdOZbXaKIQ==}
+    engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.2':
     resolution: {integrity: sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==}
@@ -3170,11 +3272,24 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@sinonjs/fake-timers@11.2.2':
+    resolution: {integrity: sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==}
+
   '@sinonjs/fake-timers@13.0.5':
     resolution: {integrity: sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==}
 
+  '@sinonjs/samsam@8.0.3':
+    resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
+
+  '@sinonjs/text-encoding@0.7.3':
+    resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
+
   '@smithy/abort-controller@4.2.5':
     resolution: {integrity: sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/abort-controller@4.2.8':
+    resolution: {integrity: sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/chunked-blob-reader-native@4.2.1':
@@ -3189,12 +3304,24 @@ packages:
     resolution: {integrity: sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/config-resolver@4.4.6':
+    resolution: {integrity: sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/core@3.18.7':
     resolution: {integrity: sha512-axG9MvKhMWOhFbvf5y2DuyTxQueO0dkedY9QC3mAfndLosRI/9LJv8WaL0mw7ubNhsO4IuXX9/9dYGPFvHrqlw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.20.7':
+    resolution: {integrity: sha512-aO7jmh3CtrmPsIJxUwYIzI5WVlMK8BMCPQ4D4nTzqTqBhbzvxHNzBMGcEg13yg/z9R2Qsz49NUFl0F0lVbTVFw==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.2.5':
     resolution: {integrity: sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.8':
+    resolution: {integrity: sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.5':
@@ -3221,6 +3348,10 @@ packages:
     resolution: {integrity: sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/fetch-http-handler@5.3.9':
+    resolution: {integrity: sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/hash-blob-browser@4.2.6':
     resolution: {integrity: sha512-8P//tA8DVPk+3XURk2rwcKgYwFvwGwmJH/wJqQiSKwXZtf/LiZK+hbUZmPj/9KzM+OVSwe4o85KTp5x9DUZTjw==}
     engines: {node: '>=18.0.0'}
@@ -3229,12 +3360,20 @@ packages:
     resolution: {integrity: sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/hash-node@4.2.8':
+    resolution: {integrity: sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/hash-stream-node@4.2.5':
     resolution: {integrity: sha512-6+do24VnEyvWcGdHXomlpd0m8bfZePpUKBy7m311n+JuRwug8J4dCanJdTymx//8mi0nlkflZBvJe+dEO/O12Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/invalid-dependency@4.2.5':
     resolution: {integrity: sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.8':
+    resolution: {integrity: sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -3253,60 +3392,124 @@ packages:
     resolution: {integrity: sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-content-length@4.2.8':
+    resolution: {integrity: sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-endpoint@4.3.14':
     resolution: {integrity: sha512-v0q4uTKgBM8dsqGjqsabZQyH85nFaTnFcgpWU1uydKFsdyyMzfvOkNum9G7VK+dOP01vUnoZxIeRiJ6uD0kjIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.8':
+    resolution: {integrity: sha512-TV44qwB/T0OMMzjIuI+JeS0ort3bvlPJ8XIH0MSlGADraXpZqmyND27ueuAL3E14optleADWqtd7dUgc2w+qhQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-retry@4.4.14':
     resolution: {integrity: sha512-Z2DG8Ej7FyWG1UA+7HceINtSLzswUgs2np3sZX0YBBxCt+CXG4QUxv88ZDS3+2/1ldW7LqtSY1UO/6VQ1pND8Q==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-retry@4.4.24':
+    resolution: {integrity: sha512-yiUY1UvnbUFfP5izoKLtfxDSTRv724YRRwyiC/5HYY6vdsVDcDOXKSXmkJl/Hovcxt5r+8tZEUAdrOaCJwrl9Q==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/middleware-serde@4.2.6':
     resolution: {integrity: sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.9':
+    resolution: {integrity: sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-stack@4.2.5':
     resolution: {integrity: sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/middleware-stack@4.2.8':
+    resolution: {integrity: sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-config-provider@4.3.5':
     resolution: {integrity: sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.8':
+    resolution: {integrity: sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.4.5':
     resolution: {integrity: sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.4.8':
+    resolution: {integrity: sha512-q9u+MSbJVIJ1QmJ4+1u+cERXkrhuILCBDsJUBAW1MPE6sFonbCNaegFuwW9ll8kh5UdyY3jOkoOGlc7BesoLpg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@4.2.5':
     resolution: {integrity: sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.8':
+    resolution: {integrity: sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/protocol-http@5.3.5':
     resolution: {integrity: sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/protocol-http@5.3.8':
+    resolution: {integrity: sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/querystring-builder@4.2.5':
     resolution: {integrity: sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.8':
+    resolution: {integrity: sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/querystring-parser@4.2.5':
     resolution: {integrity: sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/querystring-parser@4.2.8':
+    resolution: {integrity: sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/service-error-classification@4.2.5':
     resolution: {integrity: sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.8':
+    resolution: {integrity: sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/shared-ini-file-loader@4.4.0':
     resolution: {integrity: sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/shared-ini-file-loader@4.4.3':
+    resolution: {integrity: sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.3.5':
     resolution: {integrity: sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.3.8':
+    resolution: {integrity: sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.10.9':
+    resolution: {integrity: sha512-Je0EvGXVJ0Vrrr2lsubq43JGRIluJ/hX17aN/W/A0WfE+JpoMdI8kwk2t9F0zTX9232sJDGcoH4zZre6m6f/sg==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@4.9.10':
     resolution: {integrity: sha512-Jaoz4Jw1QYHc1EFww/E6gVtNjhoDU+gwRKqXP6C3LKYqqH2UQhP8tMP3+t/ePrhaze7fhLE8vS2q6vVxBANFTQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.12.0':
+    resolution: {integrity: sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.9.0':
@@ -3315,6 +3518,10 @@ packages:
 
   '@smithy/url-parser@4.2.5':
     resolution: {integrity: sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.8':
+    resolution: {integrity: sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-base64@4.3.0':
@@ -3345,12 +3552,24 @@ packages:
     resolution: {integrity: sha512-hlVLdAGrVfyNei+pKIgqDTxfu/ZI2NSyqj4IDxKd5bIsIqwR/dSlkxlPaYxFiIaDVrBy0he8orsFy+Cz119XvA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-defaults-mode-browser@4.3.23':
+    resolution: {integrity: sha512-mMg+r/qDfjfF/0psMbV4zd7F/i+rpyp7Hjh0Wry7eY15UnzTEId+xmQTGDU8IdZtDfbGQxuWNfgBZKBj+WuYbA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-defaults-mode-node@4.2.16':
     resolution: {integrity: sha512-F1t22IUiJLHrxW9W1CQ6B9PN+skZ9cqSuzB18Eh06HrJPbjsyZ7ZHecAKw80DQtyGTRcVfeukKaCRYebFwclbg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-defaults-mode-node@4.2.26':
+    resolution: {integrity: sha512-EQqe/WkbCinah0h1lMWh9ICl0Ob4lyl20/10WTB35SC9vDQfD8zWsOT+x2FIOXKAoZQ8z/y0EFMoodbcqWJY/w==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-endpoints@3.2.5':
     resolution: {integrity: sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.2.8':
+    resolution: {integrity: sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-hex-encoding@4.2.0':
@@ -3361,8 +3580,20 @@ packages:
     resolution: {integrity: sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/util-middleware@4.2.8':
+    resolution: {integrity: sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-retry@4.2.5':
     resolution: {integrity: sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.8':
+    resolution: {integrity: sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.10':
+    resolution: {integrity: sha512-jbqemy51UFSZSp2y0ZmRfckmrzuKww95zT9BYMmuJ8v3altGcqjwoV1tzpOwuHaKrwQrCjIzOib499ymr2f98g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-stream@4.5.6':
@@ -3742,6 +3973,12 @@ packages:
 
   '@types/serve-static@2.2.0':
     resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@types/sinon@17.0.4':
+    resolution: {integrity: sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==}
+
+  '@types/sinonjs__fake-timers@15.0.1':
+    resolution: {integrity: sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -4244,6 +4481,9 @@ packages:
 
   aws-crt@1.28.1:
     resolution: {integrity: sha512-3cu6kLKYlJbCeYUWsuFpbEFWLt5pIoRYqcpRC9YU5QcUh2nKCKFOn9vi1eyOSC55Sp6xOMgLNhwaN1CIMH8rLg==}
+
+  aws-sdk-client-mock@4.1.0:
+    resolution: {integrity: sha512-h/tOYTkXEsAcV3//6C1/7U4ifSpKyJvb6auveAepqqNJl6TdZaPFEtKjBQNf8UxQdDP850knB2i/whq4zlsxJw==}
 
   axe-core@3.5.6:
     resolution: {integrity: sha512-LEUDjgmdJoA3LqklSTwKYqkjcZ4HKc4ddIYGSAiSkr46NTjzg2L9RNB+lekO9P7Dlpa87+hBtzc2Fzn/+GUWMQ==}
@@ -4956,6 +5196,10 @@ packages:
 
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  diff@5.2.0:
+    resolution: {integrity: sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==}
     engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
@@ -6530,6 +6774,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  just-extend@6.2.0:
+    resolution: {integrity: sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==}
+
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
 
@@ -7040,6 +7287,9 @@ packages:
         optional: true
       sass:
         optional: true
+
+  nise@6.1.1:
+    resolution: {integrity: sha512-aMSAzLVY7LyeM60gvBS423nBmIPP+Wy7St7hsb+8/fc1HmeoHJfLO8CKse4u3BtOZvQLJghYPI2i/1WZrEj5/g==}
 
   node-abi@3.85.0:
     resolution: {integrity: sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==}
@@ -7949,6 +8199,9 @@ packages:
   simple-wcswidth@1.1.2:
     resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
 
+  sinon@18.0.1:
+    resolution: {integrity: sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -8429,6 +8682,10 @@ packages:
 
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
+    engines: {node: '>=4'}
+
+  type-detect@4.1.0:
+    resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
 
   type-fest@0.20.2:
@@ -9364,7 +9621,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.969.0
       '@aws-sdk/util-locate-window': 3.893.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -9372,7 +9629,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.969.0
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -9381,7 +9638,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.936.0
+      '@aws-sdk/types': 3.969.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -9491,6 +9748,50 @@ snapshots:
       - aws-crt
     optional: true
 
+  '@aws-sdk/client-secrets-manager@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/credential-provider-node': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/middleware-host-header': 3.969.0
+      '@aws-sdk/middleware-logger': 3.969.0
+      '@aws-sdk/middleware-recursion-detection': 3.969.0
+      '@aws-sdk/middleware-user-agent': 3.970.0
+      '@aws-sdk/region-config-resolver': 3.969.0
+      '@aws-sdk/types': 3.969.0
+      '@aws-sdk/util-endpoints': 3.970.0
+      '@aws-sdk/util-user-agent-browser': 3.969.0
+      '@aws-sdk/util-user-agent-node': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.20.7
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.8
+      '@smithy/middleware-retry': 4.4.24
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.10.9
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.23
+      '@smithy/util-defaults-mode-node': 4.2.26
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-sqs@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -9580,6 +9881,49 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-sso@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/middleware-host-header': 3.969.0
+      '@aws-sdk/middleware-logger': 3.969.0
+      '@aws-sdk/middleware-recursion-detection': 3.969.0
+      '@aws-sdk/middleware-user-agent': 3.970.0
+      '@aws-sdk/region-config-resolver': 3.969.0
+      '@aws-sdk/types': 3.969.0
+      '@aws-sdk/util-endpoints': 3.970.0
+      '@aws-sdk/util-user-agent-browser': 3.969.0
+      '@aws-sdk/util-user-agent-node': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.20.7
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.8
+      '@smithy/middleware-retry': 4.4.24
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.10.9
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.23
+      '@smithy/util-defaults-mode-node': 4.2.26
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-textract@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -9640,12 +9984,36 @@ snapshots:
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.970.0':
+    dependencies:
+      '@aws-sdk/types': 3.969.0
+      '@aws-sdk/xml-builder': 3.969.0
+      '@smithy/core': 3.20.7
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/signature-v4': 5.3.8
+      '@smithy/smithy-client': 4.10.9
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.947.0':
     dependencies:
       '@aws-sdk/core': 3.947.0
       '@aws-sdk/types': 3.936.0
       '@smithy/property-provider': 4.2.5
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.970.0':
+    dependencies:
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/types': 3.969.0
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.947.0':
@@ -9659,6 +10027,19 @@ snapshots:
       '@smithy/smithy-client': 4.9.10
       '@smithy/types': 4.9.0
       '@smithy/util-stream': 4.5.6
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.970.0':
+    dependencies:
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/types': 3.969.0
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.10.9
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.10
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.948.0(aws-crt@1.28.1)':
@@ -9680,6 +10061,25 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/credential-provider-env': 3.970.0
+      '@aws-sdk/credential-provider-http': 3.970.0
+      '@aws-sdk/credential-provider-login': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/credential-provider-process': 3.970.0
+      '@aws-sdk/credential-provider-sso': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/credential-provider-web-identity': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/nested-clients': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/types': 3.969.0
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-login@3.948.0(aws-crt@1.28.1)':
     dependencies:
       '@aws-sdk/core': 3.947.0
@@ -9689,6 +10089,19 @@ snapshots:
       '@smithy/protocol-http': 5.3.5
       '@smithy/shared-ini-file-loader': 4.4.0
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/nested-clients': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/types': 3.969.0
+      '@smithy/property-provider': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -9710,6 +10123,23 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.970.0
+      '@aws-sdk/credential-provider-http': 3.970.0
+      '@aws-sdk/credential-provider-ini': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/credential-provider-process': 3.970.0
+      '@aws-sdk/credential-provider-sso': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/credential-provider-web-identity': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/types': 3.969.0
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-process@3.947.0':
     dependencies:
       '@aws-sdk/core': 3.947.0
@@ -9717,6 +10147,15 @@ snapshots:
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.970.0':
+    dependencies:
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/types': 3.969.0
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.948.0(aws-crt@1.28.1)':
@@ -9732,6 +10171,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-sdk/client-sso': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/token-providers': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/types': 3.969.0
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-web-identity@3.948.0(aws-crt@1.28.1)':
     dependencies:
       '@aws-sdk/core': 3.947.0
@@ -9740,6 +10192,18 @@ snapshots:
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/nested-clients': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/types': 3.969.0
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -9787,6 +10251,13 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-host-header@3.969.0':
+    dependencies:
+      '@aws-sdk/types': 3.969.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-location-constraint@3.936.0':
     dependencies:
       '@aws-sdk/types': 3.936.0
@@ -9800,12 +10271,26 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-logger@3.969.0':
+    dependencies:
+      '@aws-sdk/types': 3.969.0
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-recursion-detection@3.948.0':
     dependencies:
       '@aws-sdk/types': 3.936.0
       '@aws/lambda-invoke-store': 0.2.2
       '@smithy/protocol-http': 5.3.5
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.969.0':
+    dependencies:
+      '@aws-sdk/types': 3.969.0
+      '@aws/lambda-invoke-store': 0.2.2
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.947.0':
@@ -9852,6 +10337,16 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-user-agent@3.970.0':
+    dependencies:
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/types': 3.969.0
+      '@aws-sdk/util-endpoints': 3.970.0
+      '@smithy/core': 3.20.7
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.948.0(aws-crt@1.28.1)':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -9895,12 +10390,63 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/middleware-host-header': 3.969.0
+      '@aws-sdk/middleware-logger': 3.969.0
+      '@aws-sdk/middleware-recursion-detection': 3.969.0
+      '@aws-sdk/middleware-user-agent': 3.970.0
+      '@aws-sdk/region-config-resolver': 3.969.0
+      '@aws-sdk/types': 3.969.0
+      '@aws-sdk/util-endpoints': 3.970.0
+      '@aws-sdk/util-user-agent-browser': 3.969.0
+      '@aws-sdk/util-user-agent-node': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/core': 3.20.7
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/hash-node': 4.2.8
+      '@smithy/invalid-dependency': 4.2.8
+      '@smithy/middleware-content-length': 4.2.8
+      '@smithy/middleware-endpoint': 4.4.8
+      '@smithy/middleware-retry': 4.4.24
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/node-http-handler': 4.4.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/smithy-client': 4.10.9
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.23
+      '@smithy/util-defaults-mode-node': 4.2.26
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/region-config-resolver@3.936.0':
     dependencies:
       '@aws-sdk/types': 3.936.0
       '@smithy/config-resolver': 4.4.3
       '@smithy/node-config-provider': 4.3.5
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@aws-sdk/region-config-resolver@3.969.0':
+    dependencies:
+      '@aws-sdk/types': 3.969.0
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.947.0':
@@ -9925,9 +10471,26 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-sdk/core': 3.970.0
+      '@aws-sdk/nested-clients': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/types': 3.969.0
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/types@3.936.0':
     dependencies:
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.969.0':
+    dependencies:
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.893.0':
@@ -9943,6 +10506,14 @@ snapshots:
       '@smithy/util-endpoints': 3.2.5
       tslib: 2.8.1
 
+  '@aws-sdk/util-endpoints@3.970.0':
+    dependencies:
+      '@aws-sdk/types': 3.969.0
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-endpoints': 3.2.8
+      tslib: 2.8.1
+
   '@aws-sdk/util-locate-window@3.893.0':
     dependencies:
       tslib: 2.8.1
@@ -9951,6 +10522,13 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.936.0
       '@smithy/types': 4.9.0
+      bowser: 2.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.969.0':
+    dependencies:
+      '@aws-sdk/types': 3.969.0
+      '@smithy/types': 4.12.0
       bowser: 2.13.1
       tslib: 2.8.1
 
@@ -9964,6 +10542,16 @@ snapshots:
     optionalDependencies:
       aws-crt: 1.28.1(bufferutil@4.0.9)
 
+  '@aws-sdk/util-user-agent-node@3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.970.0
+      '@aws-sdk/types': 3.969.0
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+    optionalDependencies:
+      aws-crt: 1.28.1(bufferutil@4.0.9)
+
   '@aws-sdk/util-utf8-browser@3.259.0':
     dependencies:
       tslib: 2.8.1
@@ -9972,6 +10560,12 @@ snapshots:
   '@aws-sdk/xml-builder@3.930.0':
     dependencies:
       '@smithy/types': 4.9.0
+      fast-xml-parser: 5.2.5
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.969.0':
+    dependencies:
+      '@smithy/types': 4.12.0
       fast-xml-parser: 5.2.5
       tslib: 2.8.1
 
@@ -11155,7 +11749,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.0(nxvvrexxi32o6afhxwucre4e7a)':
+  '@langchain/community@1.1.0(bmnf7ko662geybhoae7ww4ucxe)':
     dependencies:
       '@browserbasehq/stagehand': 3.0.6(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.0)(deepmerge@4.3.1)(dotenv@17.2.3)(encoding@0.1.13)(zod@4.1.13)
       '@ibm-cloud/watsonx-ai': 1.7.5
@@ -11173,7 +11767,7 @@ snapshots:
     optionalDependencies:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/client-s3': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
-      '@aws-sdk/credential-provider-node': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/credential-provider-node': 3.971.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@browserbasehq/sdk': 2.6.0(encoding@0.1.13)
       '@smithy/util-utf8': 2.3.0
       '@supabase/supabase-js': 2.87.1(bufferutil@4.0.9)
@@ -11795,13 +12389,29 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@sinonjs/fake-timers@11.2.2':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+
   '@sinonjs/fake-timers@13.0.5':
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@sinonjs/samsam@8.0.3':
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      type-detect: 4.1.0
+
+  '@sinonjs/text-encoding@0.7.3': {}
+
   '@smithy/abort-controller@4.2.5':
     dependencies:
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/abort-controller@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/chunked-blob-reader-native@4.2.1':
@@ -11824,6 +12434,15 @@ snapshots:
       '@smithy/util-middleware': 4.2.5
       tslib: 2.8.1
 
+  '@smithy/config-resolver@4.4.6':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-config-provider': 4.2.0
+      '@smithy/util-endpoints': 3.2.8
+      '@smithy/util-middleware': 4.2.8
+      tslib: 2.8.1
+
   '@smithy/core@3.18.7':
     dependencies:
       '@smithy/middleware-serde': 4.2.6
@@ -11837,12 +12456,33 @@ snapshots:
       '@smithy/uuid': 1.1.0
       tslib: 2.8.1
 
+  '@smithy/core@3.20.7':
+    dependencies:
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-stream': 4.5.10
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.2.5':
     dependencies:
       '@smithy/node-config-provider': 4.3.5
       '@smithy/property-provider': 4.2.5
       '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.5
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.5':
@@ -11888,6 +12528,14 @@ snapshots:
       '@smithy/util-base64': 4.3.0
       tslib: 2.8.1
 
+  '@smithy/fetch-http-handler@5.3.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
   '@smithy/hash-blob-browser@4.2.6':
     dependencies:
       '@smithy/chunked-blob-reader': 5.2.0
@@ -11903,6 +12551,13 @@ snapshots:
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
+  '@smithy/hash-node@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
   '@smithy/hash-stream-node@4.2.5':
     dependencies:
       '@smithy/types': 4.9.0
@@ -11913,6 +12568,11 @@ snapshots:
   '@smithy/invalid-dependency@4.2.5':
     dependencies:
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -11935,6 +12595,12 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@smithy/middleware-content-length@4.2.8':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/middleware-endpoint@4.3.14':
     dependencies:
       '@smithy/core': 3.18.7
@@ -11944,6 +12610,17 @@ snapshots:
       '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.5
       '@smithy/util-middleware': 4.2.5
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.8':
+    dependencies:
+      '@smithy/core': 3.20.7
+      '@smithy/middleware-serde': 4.2.9
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
+      '@smithy/url-parser': 4.2.8
+      '@smithy/util-middleware': 4.2.8
       tslib: 2.8.1
 
   '@smithy/middleware-retry@4.4.14':
@@ -11958,10 +12635,28 @@ snapshots:
       '@smithy/uuid': 1.1.0
       tslib: 2.8.1
 
+  '@smithy/middleware-retry@4.4.24':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/smithy-client': 4.10.9
+      '@smithy/types': 4.12.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-retry': 4.2.8
+      '@smithy/uuid': 1.1.0
+      tslib: 2.8.1
+
   '@smithy/middleware-serde@4.2.6':
     dependencies:
       '@smithy/protocol-http': 5.3.5
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.9':
+    dependencies:
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.2.5':
@@ -11969,11 +12664,23 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@smithy/middleware-stack@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/node-config-provider@4.3.5':
     dependencies:
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.8':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/shared-ini-file-loader': 4.4.3
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.4.5':
@@ -11984,14 +12691,32 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.4.8':
+    dependencies:
+      '@smithy/abort-controller': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/querystring-builder': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/property-provider@4.2.5':
     dependencies:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@smithy/property-provider@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/protocol-http@5.3.5':
     dependencies:
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.8':
+    dependencies:
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/querystring-builder@4.2.5':
@@ -12000,18 +12725,38 @@ snapshots:
       '@smithy/util-uri-escape': 4.2.0
       tslib: 2.8.1
 
+  '@smithy/querystring-builder@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      '@smithy/util-uri-escape': 4.2.0
+      tslib: 2.8.1
+
   '@smithy/querystring-parser@4.2.5':
     dependencies:
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/service-error-classification@4.2.5':
     dependencies:
       '@smithy/types': 4.9.0
 
+  '@smithy/service-error-classification@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+
   '@smithy/shared-ini-file-loader@4.4.0':
     dependencies:
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/shared-ini-file-loader@4.4.3':
+    dependencies:
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.3.5':
@@ -12025,6 +12770,27 @@ snapshots:
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.3.8':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.0
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-middleware': 4.2.8
+      '@smithy/util-uri-escape': 4.2.0
+      '@smithy/util-utf8': 4.2.0
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.10.9':
+    dependencies:
+      '@smithy/core': 3.20.7
+      '@smithy/middleware-endpoint': 4.4.8
+      '@smithy/middleware-stack': 4.2.8
+      '@smithy/protocol-http': 5.3.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-stream': 4.5.10
+      tslib: 2.8.1
+
   '@smithy/smithy-client@4.9.10':
     dependencies:
       '@smithy/core': 3.18.7
@@ -12035,6 +12801,10 @@ snapshots:
       '@smithy/util-stream': 4.5.6
       tslib: 2.8.1
 
+  '@smithy/types@4.12.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@smithy/types@4.9.0':
     dependencies:
       tslib: 2.8.1
@@ -12043,6 +12813,12 @@ snapshots:
     dependencies:
       '@smithy/querystring-parser': 4.2.5
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.8':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/util-base64@4.3.0':
@@ -12080,6 +12856,13 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@smithy/util-defaults-mode-browser@4.3.23':
+    dependencies:
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.10.9
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/util-defaults-mode-node@4.2.16':
     dependencies:
       '@smithy/config-resolver': 4.4.3
@@ -12090,10 +12873,26 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@smithy/util-defaults-mode-node@4.2.26':
+    dependencies:
+      '@smithy/config-resolver': 4.4.6
+      '@smithy/credential-provider-imds': 4.2.8
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/property-provider': 4.2.8
+      '@smithy/smithy-client': 4.10.9
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/util-endpoints@3.2.5':
     dependencies:
       '@smithy/node-config-provider': 4.3.5
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.2.8':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.8
+      '@smithy/types': 4.12.0
       tslib: 2.8.1
 
   '@smithy/util-hex-encoding@4.2.0':
@@ -12105,10 +12904,32 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@smithy/util-middleware@4.2.8':
+    dependencies:
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
   '@smithy/util-retry@4.2.5':
     dependencies:
       '@smithy/service-error-classification': 4.2.5
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.8':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.8
+      '@smithy/types': 4.12.0
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.10':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.9
+      '@smithy/node-http-handler': 4.4.8
+      '@smithy/types': 4.12.0
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-buffer-from': 4.2.0
+      '@smithy/util-hex-encoding': 4.2.0
+      '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.6':
@@ -12546,6 +13367,12 @@ snapshots:
     dependencies:
       '@types/http-errors': 2.0.5
       '@types/node': 25.0.1
+
+  '@types/sinon@17.0.4':
+    dependencies:
+      '@types/sinonjs__fake-timers': 15.0.1
+
+  '@types/sinonjs__fake-timers@15.0.1': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -13111,6 +13938,12 @@ snapshots:
       - supports-color
       - utf-8-validate
     optional: true
+
+  aws-sdk-client-mock@4.1.0:
+    dependencies:
+      '@types/sinon': 17.0.4
+      sinon: 18.0.1
+      tslib: 2.8.1
 
   axe-core@3.5.6: {}
 
@@ -13889,6 +14722,8 @@ snapshots:
   diff-sequences@29.6.3: {}
 
   diff@4.0.2: {}
+
+  diff@5.2.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -16323,6 +17158,8 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
+  just-extend@6.2.0: {}
+
   jwa@2.0.1:
     dependencies:
       buffer-equal-constant-time: 1.0.1
@@ -16816,6 +17653,14 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  nise@6.1.1:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 13.0.5
+      '@sinonjs/text-encoding': 0.7.3
+      just-extend: 6.2.0
+      path-to-regexp: 8.3.0
 
   node-abi@3.85.0:
     dependencies:
@@ -17899,6 +18744,15 @@ snapshots:
 
   simple-wcswidth@1.1.2: {}
 
+  sinon@18.0.1:
+    dependencies:
+      '@sinonjs/commons': 3.0.1
+      '@sinonjs/fake-timers': 11.2.2
+      '@sinonjs/samsam': 8.0.3
+      diff: 5.2.0
+      nise: 6.1.1
+      supports-color: 7.2.0
+
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
@@ -18523,6 +19377,8 @@ snapshots:
       prelude-ls: 1.2.1
 
   type-detect@4.0.8: {}
+
+  type-detect@4.1.0: {}
 
   type-fest@0.20.2: {}
 


### PR DESCRIPTION
## Summary

Implements federated secrets management for Issue #215 (INFRA-011):

- **EnvProvider** (default): Universal adapter that reads from `process.env` - works with Docker, Kubernetes, GCP Cloud Run, Azure App Service, and any platform that injects env vars
- **AWSSecretsProvider**: AWS Secrets Manager with local caching (configurable TTL)
- **SupabaseVaultProvider**: Existing provider retained for Supabase Cloud users

This design supports the starter kit use case where fork users choose their own infrastructure.

## Changes

- Add `EnvProvider` as new default (zero config for most deployments)
- Add `AWSSecretsProvider` with configurable TTL caching
- Update `SecretsModule` factory to support provider selection via `SECRETS_PROVIDER`
- Simplify backend config loading (remove complex Vault fallback logic)
- Add comprehensive tests for all providers (100% coverage on new code)
- Add `docs/guides/secrets-management.md` documentation

## Configuration

```bash
# Default - works everywhere
SECRETS_PROVIDER=env

# AWS Secrets Manager
SECRETS_PROVIDER=aws
AWS_REGION=us-east-1
SECRETS_CACHE_TTL=300

# Supabase Vault
SECRETS_PROVIDER=supabase
```

## Test plan

- [x] All 46 secrets-provider tests pass
- [x] All 987 backend tests pass
- [x] Lint passes
- [x] Build succeeds for all packages

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)