### PR TITLE
Release: Document Analysis LLM Integration (#294)

### DIFF
--- a/apps/backend/src/apps/documents/src/domains/documents.module.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.module.ts
@@ -4,6 +4,7 @@ import { DocumentsResolver } from './documents.resolver';
 import { StorageModule } from '@qckstrt/storage-provider';
 import { OcrModule } from '@qckstrt/ocr-provider';
 import { ExtractionModule } from '@qckstrt/extraction-provider';
+import { LLMModule } from '@qckstrt/llm-provider';
 
 // RelationalDbModule is global, no need to import
 
@@ -13,9 +14,10 @@ import { ExtractionModule } from '@qckstrt/extraction-provider';
  * Provides document metadata management and file storage operations.
  * Manages documents in PostgreSQL and files in S3.
  * Supports text extraction from images (OCR) and PDFs.
+ * Supports AI analysis with type-specific prompts.
  */
 @Module({
-  imports: [StorageModule, OcrModule, ExtractionModule],
+  imports: [StorageModule, OcrModule, ExtractionModule, LLMModule],
   providers: [DocumentsService, DocumentsResolver],
   exports: [DocumentsService],
 })

--- a/apps/backend/src/apps/documents/src/domains/dto/analysis.dto.ts
+++ b/apps/backend/src/apps/documents/src/domains/dto/analysis.dto.ts
@@ -1,0 +1,122 @@
+import {
+  Field,
+  ObjectType,
+  InputType,
+  Int,
+  registerEnumType,
+} from '@nestjs/graphql';
+import { IsUUID, IsBoolean, IsOptional } from 'class-validator';
+import { DocumentType } from '@qckstrt/relationaldb-provider';
+
+// Register DocumentType enum for GraphQL
+registerEnumType(DocumentType, {
+  name: 'DocumentType',
+  description: 'Type of document for analysis routing',
+});
+
+/**
+ * Analysis result for all document types
+ * Common fields are always present; type-specific fields are nullable
+ */
+@ObjectType()
+export class DocumentAnalysis {
+  // Common fields (all document types)
+  @Field(() => DocumentType)
+  documentType!: DocumentType;
+
+  @Field()
+  summary!: string;
+
+  @Field(() => [String])
+  keyPoints!: string[];
+
+  @Field(() => [String])
+  entities!: string[];
+
+  @Field()
+  analyzedAt!: Date;
+
+  @Field()
+  provider!: string;
+
+  @Field()
+  model!: string;
+
+  @Field(() => Int, { nullable: true })
+  tokensUsed?: number;
+
+  @Field(() => Int)
+  processingTimeMs!: number;
+
+  @Field({ nullable: true })
+  cachedFrom?: string;
+
+  // Petition/Proposition fields
+  @Field({ nullable: true })
+  actualEffect?: string;
+
+  @Field(() => [String], { nullable: true })
+  potentialConcerns?: string[];
+
+  @Field(() => [String], { nullable: true })
+  beneficiaries?: string[];
+
+  @Field(() => [String], { nullable: true })
+  potentiallyHarmed?: string[];
+
+  @Field(() => [String], { nullable: true })
+  relatedMeasures?: string[];
+
+  // Contract fields
+  @Field(() => [String], { nullable: true })
+  parties?: string[];
+
+  @Field(() => [String], { nullable: true })
+  obligations?: string[];
+
+  @Field(() => [String], { nullable: true })
+  risks?: string[];
+
+  @Field({ nullable: true })
+  effectiveDate?: string;
+
+  @Field({ nullable: true })
+  terminationClause?: string;
+
+  // Form fields
+  @Field(() => [String], { nullable: true })
+  requiredFields?: string[];
+
+  @Field({ nullable: true })
+  purpose?: string;
+
+  @Field({ nullable: true })
+  submissionDeadline?: string;
+}
+
+/**
+ * Input for analyzing a document
+ */
+@InputType()
+export class AnalyzeDocumentInput {
+  @Field()
+  @IsUUID()
+  documentId!: string;
+
+  @Field({ nullable: true, defaultValue: false })
+  @IsOptional()
+  @IsBoolean()
+  forceReanalyze?: boolean;
+}
+
+/**
+ * Result of document analysis operation
+ */
+@ObjectType()
+export class AnalyzeDocumentResult {
+  @Field(() => DocumentAnalysis)
+  analysis!: DocumentAnalysis;
+
+  @Field()
+  fromCache!: boolean;
+}

--- a/apps/backend/src/apps/documents/src/domains/prompts/document-analysis.prompt.ts
+++ b/apps/backend/src/apps/documents/src/domains/prompts/document-analysis.prompt.ts
@@ -1,0 +1,121 @@
+import { DocumentType } from '@qckstrt/relationaldb-provider';
+
+const BASE_INSTRUCTIONS = `Respond with valid JSON only. No markdown, no explanations.`;
+
+const PROMPTS: Record<DocumentType, (text: string) => string> = {
+  [DocumentType.generic]: (
+    text,
+  ) => `Analyze this document and extract key information.
+
+DOCUMENT:
+${text}
+
+Respond with JSON:
+{
+  "summary": "2-3 sentence summary",
+  "keyPoints": ["Key point 1", "Key point 2"],
+  "entities": ["Person/org/place mentioned"]
+}
+${BASE_INSTRUCTIONS}`,
+
+  [DocumentType.petition]: (
+    text,
+  ) => `You are a nonpartisan civic analyst. Analyze this petition.
+
+PETITION:
+${text}
+
+Respond with JSON:
+{
+  "summary": "2-3 sentence summary",
+  "keyPoints": ["Key point 1", "Key point 2"],
+  "entities": ["Sponsors, officials, organizations mentioned"],
+  "actualEffect": "What this would actually do if passed",
+  "potentialConcerns": ["Concern 1", "Concern 2"],
+  "beneficiaries": ["Who benefits"],
+  "potentiallyHarmed": ["Who might be negatively affected"],
+  "relatedMeasures": ["Related ballot measures or 'None identified'"]
+}
+${BASE_INSTRUCTIONS}`,
+
+  [DocumentType.proposition]: (
+    text,
+  ) => `You are a nonpartisan civic analyst. Analyze this ballot proposition.
+
+PROPOSITION:
+${text}
+
+Respond with JSON:
+{
+  "summary": "2-3 sentence summary of what this proposition does",
+  "keyPoints": ["Key provision 1", "Key provision 2"],
+  "entities": ["Sponsors, officials, organizations mentioned"],
+  "actualEffect": "What this would actually change if passed",
+  "potentialConcerns": ["Potential concern 1", "Potential concern 2"],
+  "beneficiaries": ["Groups that would benefit"],
+  "potentiallyHarmed": ["Groups that might be negatively affected"],
+  "relatedMeasures": ["Related or conflicting measures"]
+}
+${BASE_INSTRUCTIONS}`,
+
+  [DocumentType.contract]: (text) => `Analyze this contract document.
+
+CONTRACT:
+${text}
+
+Respond with JSON:
+{
+  "summary": "Brief summary of the contract purpose",
+  "keyPoints": ["Key term 1", "Key term 2"],
+  "entities": ["Parties and stakeholders mentioned"],
+  "parties": ["Party 1 name", "Party 2 name"],
+  "obligations": ["Key obligation 1", "Key obligation 2"],
+  "risks": ["Potential risk 1", "Potential risk 2"],
+  "effectiveDate": "Contract effective date or 'Not specified'",
+  "terminationClause": "Summary of termination terms or 'Not specified'"
+}
+${BASE_INSTRUCTIONS}`,
+
+  [DocumentType.form]: (text) => `Analyze this form document.
+
+FORM:
+${text}
+
+Respond with JSON:
+{
+  "summary": "What this form is for",
+  "keyPoints": ["Important instruction 1", "Important instruction 2"],
+  "entities": ["Issuing organization, departments mentioned"],
+  "requiredFields": ["Required field 1", "Required field 2"],
+  "purpose": "The purpose of this form",
+  "submissionDeadline": "Any deadline mentioned or 'Not specified'"
+}
+${BASE_INSTRUCTIONS}`,
+};
+
+/**
+ * Build an analysis prompt for the given document type
+ */
+export function buildAnalysisPrompt(
+  text: string,
+  documentType: DocumentType,
+): string {
+  const promptBuilder = PROMPTS[documentType] || PROMPTS[DocumentType.generic];
+  return promptBuilder(text);
+}
+
+/**
+ * Parse LLM response, stripping any markdown code blocks
+ */
+export function parseAnalysisResponse(
+  response: string,
+): Record<string, unknown> {
+  // Strip markdown code blocks if present
+  const cleaned = response
+    .trim()
+    .replace(/^```json\n?/i, '')
+    .replace(/^```\n?/, '')
+    .replace(/\n?```$/, '');
+
+  return JSON.parse(cleaned);
+}

--- a/apps/backend/src/common/enums/document.status.enum.ts
+++ b/apps/backend/src/common/enums/document.status.enum.ts
@@ -8,6 +8,9 @@ export enum DocumentStatus {
   AIEMBEDDINGSSTARTED = 'AI Embeddings Started',
   AIEMBEDDINGSCOMPLETE = 'AI Embeddings Complete',
   AIEMBEDDINGSFAILED = 'AI Embeddings Failed',
+  AIANALYSISSTARTED = 'AI Analysis Started',
+  AIANALYSISCOMPLETE = 'AI Analysis Complete',
+  AIANALYSISFAILED = 'AI Analysis Failed',
   PROCESSINGNCOMPLETE = 'Complete',
 }
 

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -131,6 +131,9 @@ enum DocumentStatus {
   ai_embeddings_started    @map("AI Embeddings Started")
   ai_embeddings_complete   @map("AI Embeddings Complete")
   ai_embeddings_failed     @map("AI Embeddings Failed")
+  ai_analysis_started      @map("AI Analysis Started")
+  ai_analysis_complete     @map("AI Analysis Complete")
+  ai_analysis_failed       @map("AI Analysis Failed")
   processing_complete      @map("Complete")
 }
 


### PR DESCRIPTION
## Summary

Merge develop to main with Document Analysis feature.

## Changes Included

### feat(documents): add LLM-based document analysis with type-specific prompts (#294)
- Add document analysis using Ollama LLM provider
- Type-specific prompts for generic, petition, proposition, contract, form documents
- Analysis caching by contentHash + documentType
- GraphQL `analyzeDocument` mutation and `getDocumentAnalysis` query
- Status tracking: `ai_analysis_started`, `ai_analysis_complete`, `ai_analysis_failed`

## Test Results

- ✅ 1,061 unit tests passing
- ✅ 209 integration tests passing
- ✅ 100% statement coverage on documents service

## Files Changed

- `packages/relationaldb-provider/prisma/schema.prisma` - New status enum values
- `apps/backend/src/apps/documents/src/domains/dto/analysis.dto.ts` - New
- `apps/backend/src/apps/documents/src/domains/prompts/document-analysis.prompt.ts` - New
- `apps/backend/src/apps/documents/src/domains/documents.service.ts` - Analysis methods
- `apps/backend/src/apps/documents/src/domains/documents.resolver.ts` - GraphQL endpoints
- `apps/backend/src/apps/documents/src/domains/documents.module.ts` - LLMModule import

🤖 Generated with [Claude Code](https://claude.com/claude-code)