### PR TITLE
feat(frontend): add onboarding flow for first-time users (#302)

### DIFF
--- a/apps/frontend/__tests__/components/onboarding/OnboardingSteps.test.tsx
+++ b/apps/frontend/__tests__/components/onboarding/OnboardingSteps.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { OnboardingSteps } from "@/components/onboarding/OnboardingSteps";
+
+// Mock Next.js router
+const mockPush = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+// Mock onboarding context
+const mockNextStep = jest.fn();
+const mockPrevStep = jest.fn();
+const mockSkipOnboarding = jest.fn();
+const mockCompleteOnboarding = jest.fn();
+
+const defaultOnboardingContext = {
+  hasCompletedOnboarding: false,
+  currentStep: 0,
+  totalSteps: 4,
+  nextStep: mockNextStep,
+  prevStep: mockPrevStep,
+  skipOnboarding: mockSkipOnboarding,
+  completeOnboarding: mockCompleteOnboarding,
+  resetOnboarding: jest.fn(),
+};
+
+let mockOnboardingContextValue = { ...defaultOnboardingContext };
+
+jest.mock("@/lib/onboarding-context", () => ({
+  useOnboarding: () => mockOnboardingContextValue,
+}));
+
+describe("OnboardingSteps", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockOnboardingContextValue = { ...defaultOnboardingContext };
+  });
+
+  describe("rendering", () => {
+    it("should render welcome step initially", () => {
+      render(<OnboardingSteps />);
+
+      expect(screen.getByText("Welcome to OPUS")).toBeInTheDocument();
+    });
+
+    it("should render skip button", () => {
+      render(<OnboardingSteps />);
+
+      expect(screen.getByRole("button", { name: /skip/i })).toBeInTheDocument();
+    });
+
+    it("should render next button on first step", () => {
+      render(<OnboardingSteps />);
+
+      expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+    });
+
+    it("should render back button (disabled on first step)", () => {
+      render(<OnboardingSteps />);
+
+      const backButton = screen.getByRole("button", { name: /back/i });
+      expect(backButton).toBeInTheDocument();
+      expect(backButton).toBeDisabled();
+    });
+
+    it("should render progress dots", () => {
+      const { container } = render(<OnboardingSteps />);
+
+      const dots = container.querySelectorAll("[aria-hidden='true']");
+      expect(dots.length).toBe(4);
+    });
+  });
+
+  describe("step navigation", () => {
+    it("should call nextStep when Next is clicked", async () => {
+      render(<OnboardingSteps />);
+
+      await userEvent.click(screen.getByRole("button", { name: /next/i }));
+
+      expect(mockNextStep).toHaveBeenCalled();
+    });
+
+    it("should call prevStep when Back is clicked", async () => {
+      mockOnboardingContextValue = {
+        ...defaultOnboardingContext,
+        currentStep: 1,
+      };
+      render(<OnboardingSteps />);
+
+      await userEvent.click(screen.getByRole("button", { name: /back/i }));
+
+      expect(mockPrevStep).toHaveBeenCalled();
+    });
+
+    it("should render scan step on step 1", () => {
+      mockOnboardingContextValue = {
+        ...defaultOnboardingContext,
+        currentStep: 1,
+      };
+      render(<OnboardingSteps />);
+
+      expect(screen.getByText("Scan Petitions")).toBeInTheDocument();
+    });
+
+    it("should render analyze step on step 2", () => {
+      mockOnboardingContextValue = {
+        ...defaultOnboardingContext,
+        currentStep: 2,
+      };
+      render(<OnboardingSteps />);
+
+      expect(screen.getByText("Instant Analysis")).toBeInTheDocument();
+    });
+
+    it("should render track step on step 3", () => {
+      mockOnboardingContextValue = {
+        ...defaultOnboardingContext,
+        currentStep: 3,
+      };
+      render(<OnboardingSteps />);
+
+      expect(screen.getByText("Track Progress")).toBeInTheDocument();
+    });
+  });
+
+  describe("skip", () => {
+    it("should call skipOnboarding and redirect on skip", async () => {
+      render(<OnboardingSteps />);
+
+      await userEvent.click(screen.getByRole("button", { name: /skip/i }));
+
+      expect(mockSkipOnboarding).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith("/petition");
+    });
+  });
+
+  describe("completion", () => {
+    it("should show Get Started button on last step", () => {
+      mockOnboardingContextValue = {
+        ...defaultOnboardingContext,
+        currentStep: 3,
+      };
+      render(<OnboardingSteps />);
+
+      expect(
+        screen.getByRole("button", { name: /get started/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /^next$/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it("should call completeOnboarding and redirect on Get Started", async () => {
+      mockOnboardingContextValue = {
+        ...defaultOnboardingContext,
+        currentStep: 3,
+      };
+      render(<OnboardingSteps />);
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /get started/i }),
+      );
+
+      expect(mockCompleteOnboarding).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith("/petition");
+    });
+  });
+});

--- a/apps/frontend/__tests__/onboarding-context.test.tsx
+++ b/apps/frontend/__tests__/onboarding-context.test.tsx
@@ -1,0 +1,189 @@
+import { act, renderHook } from "@testing-library/react";
+import { OnboardingProvider, useOnboarding } from "@/lib/onboarding-context";
+import "@testing-library/jest-dom";
+
+// Mock localStorage
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: jest.fn((key: string) => store[key] || null),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: jest.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+    _getStore: () => store,
+  };
+})();
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <OnboardingProvider>{children}</OnboardingProvider>
+);
+
+describe("OnboardingProvider", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorageMock.clear();
+  });
+
+  describe("initial state", () => {
+    it("should provide onboarding context", () => {
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      expect(result.current.hasCompletedOnboarding).toBe(false);
+      expect(result.current.currentStep).toBe(0);
+      expect(result.current.totalSteps).toBe(4);
+    });
+
+    it("should return completed when localStorage flag is set", () => {
+      localStorageMock.setItem("opus_onboarding_completed", "true");
+
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      expect(result.current.hasCompletedOnboarding).toBe(true);
+    });
+
+    it("should throw error when used outside provider", () => {
+      const consoleError = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      expect(() => {
+        renderHook(() => useOnboarding());
+      }).toThrow("useOnboarding must be used within OnboardingProvider");
+
+      consoleError.mockRestore();
+    });
+  });
+
+  describe("step navigation", () => {
+    it("should advance to next step", () => {
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      act(() => {
+        result.current.nextStep();
+      });
+
+      expect(result.current.currentStep).toBe(1);
+    });
+
+    it("should go back to previous step", () => {
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      act(() => {
+        result.current.nextStep();
+        result.current.nextStep();
+      });
+
+      expect(result.current.currentStep).toBe(2);
+
+      act(() => {
+        result.current.prevStep();
+      });
+
+      expect(result.current.currentStep).toBe(1);
+    });
+
+    it("should not go below step 0", () => {
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      act(() => {
+        result.current.prevStep();
+      });
+
+      expect(result.current.currentStep).toBe(0);
+    });
+
+    it("should not exceed totalSteps - 1", () => {
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      act(() => {
+        result.current.nextStep();
+        result.current.nextStep();
+        result.current.nextStep();
+        result.current.nextStep(); // Already at last step (3)
+        result.current.nextStep(); // Should not go beyond 3
+      });
+
+      expect(result.current.currentStep).toBe(3);
+    });
+  });
+
+  describe("completeOnboarding", () => {
+    it("should set localStorage flag on complete", () => {
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      act(() => {
+        result.current.completeOnboarding();
+      });
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "opus_onboarding_completed",
+        "true",
+      );
+    });
+
+    it("should update hasCompletedOnboarding after complete", () => {
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      expect(result.current.hasCompletedOnboarding).toBe(false);
+
+      act(() => {
+        result.current.completeOnboarding();
+      });
+
+      expect(result.current.hasCompletedOnboarding).toBe(true);
+    });
+  });
+
+  describe("skipOnboarding", () => {
+    it("should complete onboarding when skipped", () => {
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      act(() => {
+        result.current.skipOnboarding();
+      });
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "opus_onboarding_completed",
+        "true",
+      );
+      expect(result.current.hasCompletedOnboarding).toBe(true);
+    });
+  });
+
+  describe("resetOnboarding", () => {
+    it("should clear localStorage and reset step", () => {
+      const { result } = renderHook(() => useOnboarding(), { wrapper });
+
+      // First complete and advance
+      act(() => {
+        result.current.nextStep();
+        result.current.nextStep();
+        result.current.completeOnboarding();
+      });
+
+      expect(result.current.hasCompletedOnboarding).toBe(true);
+      expect(result.current.currentStep).toBe(2);
+
+      // Then reset
+      act(() => {
+        result.current.resetOnboarding();
+      });
+
+      expect(localStorageMock.removeItem).toHaveBeenCalledWith(
+        "opus_onboarding_completed",
+      );
+      expect(result.current.currentStep).toBe(0);
+      expect(result.current.hasCompletedOnboarding).toBe(false);
+    });
+  });
+});

--- a/apps/frontend/__tests__/pages/login.test.tsx
+++ b/apps/frontend/__tests__/pages/login.test.tsx
@@ -147,7 +147,7 @@ describe("LoginPage", () => {
       expect(mockLoginWithPasskey).toHaveBeenCalledWith("test@example.com");
     });
 
-    it("should redirect to rag-demo on successful passkey login", async () => {
+    it("should redirect to onboarding on successful passkey login", async () => {
       mockLoginWithPasskey.mockResolvedValue(undefined);
       render(<LoginPage />);
 
@@ -157,7 +157,7 @@ describe("LoginPage", () => {
       await userEvent.click(button);
 
       await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith("/rag-demo");
+        expect(mockPush).toHaveBeenCalledWith("/onboarding");
       });
     });
   });
@@ -337,7 +337,7 @@ describe("LoginPage", () => {
       expect(hideButton).toBeInTheDocument();
     });
 
-    it("should redirect to rag-demo on successful password login", async () => {
+    it("should redirect to onboarding on successful password login", async () => {
       mockLogin.mockResolvedValue(undefined);
       render(<LoginPage />);
 
@@ -354,7 +354,7 @@ describe("LoginPage", () => {
       await userEvent.click(submitButton);
 
       await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith("/rag-demo");
+        expect(mockPush).toHaveBeenCalledWith("/onboarding");
       });
     });
   });

--- a/apps/frontend/__tests__/pages/onboarding.test.tsx
+++ b/apps/frontend/__tests__/pages/onboarding.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import OnboardingPage from "@/app/onboarding/page";
+
+// Mock Next.js router
+const mockReplace = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}));
+
+// Mock auth context
+const defaultAuthContext = {
+  isAuthenticated: true,
+  isLoading: false,
+  user: { id: "user-123", email: "test@example.com", roles: ["user"] },
+  tokens: null,
+  login: jest.fn(),
+  loginWithPasskey: jest.fn(),
+  sendMagicLink: jest.fn(),
+  clearError: jest.fn(),
+  error: null,
+  supportsPasskeys: true,
+  magicLinkSent: false,
+  register: jest.fn(),
+  registerWithMagicLink: jest.fn(),
+  verifyMagicLink: jest.fn(),
+  registerPasskey: jest.fn(),
+  logout: jest.fn(),
+  hasPlatformAuthenticator: true,
+};
+
+let mockAuthContextValue = { ...defaultAuthContext };
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockAuthContextValue,
+}));
+
+// Mock onboarding context
+const defaultOnboardingContext = {
+  hasCompletedOnboarding: false,
+  currentStep: 0,
+  totalSteps: 4,
+  nextStep: jest.fn(),
+  prevStep: jest.fn(),
+  skipOnboarding: jest.fn(),
+  completeOnboarding: jest.fn(),
+  resetOnboarding: jest.fn(),
+};
+
+let mockOnboardingContextValue = { ...defaultOnboardingContext };
+
+jest.mock("@/lib/onboarding-context", () => ({
+  useOnboarding: () => mockOnboardingContextValue,
+}));
+
+// Mock OnboardingSteps component
+jest.mock("@/components/onboarding/OnboardingSteps", () => ({
+  OnboardingSteps: () => <div data-testid="onboarding-steps">Steps</div>,
+}));
+
+describe("OnboardingPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthContextValue = { ...defaultAuthContext };
+    mockOnboardingContextValue = { ...defaultOnboardingContext };
+  });
+
+  it("should render OnboardingSteps when authenticated and not completed", () => {
+    render(<OnboardingPage />);
+
+    expect(screen.getByTestId("onboarding-steps")).toBeInTheDocument();
+  });
+
+  it("should redirect to /login when not authenticated", async () => {
+    mockAuthContextValue = {
+      ...defaultAuthContext,
+      isAuthenticated: false,
+    };
+
+    render(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("should redirect to /petition when onboarding is completed", async () => {
+    mockOnboardingContextValue = {
+      ...defaultOnboardingContext,
+      hasCompletedOnboarding: true,
+    };
+
+    render(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/petition");
+    });
+  });
+
+  it("should render nothing when auth is loading", () => {
+    mockAuthContextValue = {
+      ...defaultAuthContext,
+      isLoading: true,
+    };
+
+    const { container } = render(<OnboardingPage />);
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("should render nothing when onboarding is already completed", () => {
+    mockOnboardingContextValue = {
+      ...defaultOnboardingContext,
+      hasCompletedOnboarding: true,
+    };
+
+    const { container } = render(<OnboardingPage />);
+
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/apps/frontend/app/(auth)/login/page.tsx
+++ b/apps/frontend/app/(auth)/login/page.tsx
@@ -32,7 +32,7 @@ export default function LoginPage() {
     clearError();
     try {
       await loginWithPasskey(email || undefined);
-      router.push("/rag-demo");
+      router.push("/onboarding");
     } catch {
       // Error is handled in context
     }
@@ -49,7 +49,7 @@ export default function LoginPage() {
     clearError();
     try {
       await login({ email, password });
-      router.push("/rag-demo");
+      router.push("/onboarding");
     } catch {
       // Error is handled in context
     }

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -3,6 +3,7 @@ import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
 import "./globals.css";
 import { ApolloProvider } from "@/lib/apollo-provider";
 import { ToastProvider } from "@/lib/toast";
+import { OnboardingProvider } from "@/lib/onboarding-context";
 import { OfflineIndicator } from "@/components/OfflineIndicator";
 
 const ibmPlexSans = IBM_Plex_Sans({
@@ -52,7 +53,7 @@ export default function RootLayout({
       >
         <ApolloProvider>
           <ToastProvider>
-            {children}
+            <OnboardingProvider>{children}</OnboardingProvider>
             <OfflineIndicator />
           </ToastProvider>
         </ApolloProvider>

--- a/apps/frontend/app/onboarding/page.tsx
+++ b/apps/frontend/app/onboarding/page.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth-context";
+import { useOnboarding } from "@/lib/onboarding-context";
+import { OnboardingSteps } from "@/components/onboarding/OnboardingSteps";
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { isAuthenticated, isLoading: authLoading } = useAuth();
+  const { hasCompletedOnboarding } = useOnboarding();
+
+  useEffect(() => {
+    if (!authLoading && !isAuthenticated) {
+      router.replace("/login");
+    }
+    if (!authLoading && hasCompletedOnboarding) {
+      router.replace("/petition");
+    }
+  }, [authLoading, isAuthenticated, hasCompletedOnboarding, router]);
+
+  if (authLoading || hasCompletedOnboarding) {
+    return null;
+  }
+
+  return <OnboardingSteps />;
+}

--- a/apps/frontend/components/onboarding/OnboardingSteps.tsx
+++ b/apps/frontend/components/onboarding/OnboardingSteps.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useTranslation } from "react-i18next";
+import { useOnboarding } from "@/lib/onboarding-context";
+import { WelcomeStep } from "./steps/WelcomeStep";
+import { ScanStep } from "./steps/ScanStep";
+import { AnalyzeStep } from "./steps/AnalyzeStep";
+import { TrackStep } from "./steps/TrackStep";
+
+export function OnboardingSteps() {
+  const router = useRouter();
+  const { t } = useTranslation("onboarding");
+  const {
+    currentStep,
+    totalSteps,
+    nextStep,
+    prevStep,
+    skipOnboarding,
+    completeOnboarding,
+  } = useOnboarding();
+
+  const handleComplete = () => {
+    completeOnboarding();
+    router.push("/petition");
+  };
+
+  const handleSkip = () => {
+    skipOnboarding();
+    router.push("/petition");
+  };
+
+  const steps = [
+    <WelcomeStep key="welcome" />,
+    <ScanStep key="scan" />,
+    <AnalyzeStep key="analyze" />,
+    <TrackStep key="track" />,
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-[#6f42c1] to-[#4c1d95] flex flex-col">
+      {/* Skip button */}
+      <div className="absolute top-4 right-4 z-10">
+        <button
+          onClick={handleSkip}
+          className="text-white/70 hover:text-white text-sm transition-colors px-3 py-1"
+        >
+          {t("skip")}
+        </button>
+      </div>
+
+      {/* Progress dots */}
+      <div className="flex justify-center gap-2 pt-8 pb-4">
+        {Array.from({ length: totalSteps }).map((_, i) => (
+          <div
+            key={i}
+            className={`w-2 h-2 rounded-full transition-colors ${
+              i === currentStep ? "bg-white" : "bg-white/30"
+            }`}
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+
+      {/* Step content */}
+      <div className="flex-1 flex items-center justify-center px-6">
+        {steps[currentStep]}
+      </div>
+
+      {/* Navigation */}
+      <div className="p-6 flex justify-between items-center">
+        <button
+          onClick={prevStep}
+          disabled={currentStep === 0}
+          className="px-6 py-3 text-white/70 hover:text-white disabled:opacity-0 transition-all"
+        >
+          {t("back")}
+        </button>
+
+        {currentStep === totalSteps - 1 ? (
+          <button
+            onClick={handleComplete}
+            className="px-8 py-3 bg-white text-[#6f42c1] rounded-full font-semibold hover:bg-white/90 transition-colors"
+          >
+            {t("getStarted")}
+          </button>
+        ) : (
+          <button
+            onClick={nextStep}
+            className="px-8 py-3 bg-white/20 text-white rounded-full font-semibold hover:bg-white/30 transition-colors"
+          >
+            {t("next")}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/onboarding/steps/AnalyzeStep.tsx
+++ b/apps/frontend/components/onboarding/steps/AnalyzeStep.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+export function AnalyzeStep() {
+  const { t } = useTranslation("onboarding");
+
+  return (
+    <div className="text-center text-white max-w-md">
+      <div className="w-20 h-20 bg-white/20 rounded-2xl mx-auto mb-8 flex items-center justify-center">
+        <svg
+          className="w-10 h-10"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+          />
+        </svg>
+      </div>
+
+      <h2 className="text-2xl font-bold mb-4">{t("analyze.title")}</h2>
+      <p className="text-white/80">{t("analyze.description")}</p>
+    </div>
+  );
+}

--- a/apps/frontend/components/onboarding/steps/ScanStep.tsx
+++ b/apps/frontend/components/onboarding/steps/ScanStep.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+export function ScanStep() {
+  const { t } = useTranslation("onboarding");
+
+  return (
+    <div className="text-center text-white max-w-md">
+      <div className="w-20 h-20 bg-white/20 rounded-2xl mx-auto mb-8 flex items-center justify-center">
+        <svg
+          className="w-10 h-10"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+        </svg>
+      </div>
+
+      <h2 className="text-2xl font-bold mb-4">{t("scan.title")}</h2>
+      <p className="text-white/80 mb-6">{t("scan.description")}</p>
+
+      <div className="bg-white/10 rounded-xl p-4 text-sm text-white/70">
+        <p>{t("scan.permissionNote")}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/onboarding/steps/TrackStep.tsx
+++ b/apps/frontend/components/onboarding/steps/TrackStep.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+export function TrackStep() {
+  const { t } = useTranslation("onboarding");
+
+  return (
+    <div className="text-center text-white max-w-md">
+      <div className="w-20 h-20 bg-white/20 rounded-2xl mx-auto mb-8 flex items-center justify-center">
+        <svg
+          className="w-10 h-10"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7"
+          />
+        </svg>
+      </div>
+
+      <h2 className="text-2xl font-bold mb-4">{t("track.title")}</h2>
+      <p className="text-white/80">{t("track.description")}</p>
+    </div>
+  );
+}

--- a/apps/frontend/components/onboarding/steps/WelcomeStep.tsx
+++ b/apps/frontend/components/onboarding/steps/WelcomeStep.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+export function WelcomeStep() {
+  const { t } = useTranslation("onboarding");
+
+  return (
+    <div className="text-center text-white max-w-md">
+      <div className="w-24 h-24 bg-white/20 rounded-3xl mx-auto mb-8 flex items-center justify-center">
+        <span className="text-4xl font-bold">O</span>
+      </div>
+
+      <h1 className="text-3xl font-bold mb-4">{t("welcome.title")}</h1>
+      <p className="text-white/80 text-lg">{t("welcome.subtitle")}</p>
+    </div>
+  );
+}

--- a/apps/frontend/e2e/onboarding.spec.ts
+++ b/apps/frontend/e2e/onboarding.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * Onboarding Flow E2E Tests
+ *
+ * Tests for the first-time user onboarding experience:
+ * Welcome → Scan → Analyze → Track → redirect to /petition
+ */
+import { test, expect } from "@playwright/test";
+import {
+  setupAuthSession,
+  checkAccessibility,
+  viewports,
+} from "./utils/test-helpers";
+
+/**
+ * Set up an authenticated session WITHOUT onboarding completed.
+ * Must be called BEFORE page.goto().
+ */
+async function setupNewUserSession(page: import("@playwright/test").Page) {
+  await setupAuthSession(page);
+  // Ensure onboarding flag is NOT set (new user)
+  await page.addInitScript(() => {
+    localStorage.removeItem("opus_onboarding_completed");
+  });
+}
+
+/**
+ * Set up an authenticated session WITH onboarding already completed.
+ * Must be called BEFORE page.goto().
+ */
+async function setupReturningUserSession(
+  page: import("@playwright/test").Page,
+) {
+  await setupAuthSession(page);
+  await page.addInitScript(() => {
+    localStorage.setItem("opus_onboarding_completed", "true");
+  });
+}
+
+test.describe("Onboarding Flow", () => {
+  test("should display welcome step for new user", async ({ page }) => {
+    await setupNewUserSession(page);
+    await page.goto("/onboarding");
+
+    await expect(page.getByText("Welcome to OPUS")).toBeVisible();
+    await expect(page.getByText(/civic engagement companion/i)).toBeVisible();
+  });
+
+  test("should navigate through all steps", async ({ page }) => {
+    await setupNewUserSession(page);
+    await page.goto("/onboarding");
+
+    // Step 1: Welcome
+    await expect(page.getByText("Welcome to OPUS")).toBeVisible();
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // Step 2: Scan
+    await expect(page.getByText("Scan Petitions")).toBeVisible();
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // Step 3: Analyze
+    await expect(page.getByText("Instant Analysis")).toBeVisible();
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // Step 4: Track
+    await expect(page.getByText("Track Progress")).toBeVisible();
+
+    // Should show Get Started button on last step
+    await expect(
+      page.getByRole("button", { name: /get started/i }),
+    ).toBeVisible();
+  });
+
+  test("should complete onboarding and redirect to /petition", async ({
+    page,
+  }) => {
+    await setupNewUserSession(page);
+    await page.goto("/onboarding");
+
+    // Navigate through all steps
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+
+    // Click Get Started
+    await page.getByRole("button", { name: /get started/i }).click();
+
+    // Should redirect to /petition
+    await expect(page).toHaveURL(/\/petition/);
+  });
+
+  test("should skip onboarding and redirect to /petition", async ({ page }) => {
+    await setupNewUserSession(page);
+    await page.goto("/onboarding");
+
+    await page.getByRole("button", { name: /skip/i }).click();
+
+    // Should redirect to /petition
+    await expect(page).toHaveURL(/\/petition/);
+  });
+
+  test("should navigate back to previous step", async ({ page }) => {
+    await setupNewUserSession(page);
+    await page.goto("/onboarding");
+
+    // Go to step 2
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+    await expect(page.getByText("Scan Petitions")).toBeVisible();
+
+    // Go back to step 1
+    await page.getByRole("button", { name: /back/i }).click();
+    await expect(page.getByText("Welcome to OPUS")).toBeVisible();
+  });
+
+  test("back button should be disabled on first step", async ({ page }) => {
+    await setupNewUserSession(page);
+    await page.goto("/onboarding");
+
+    const backButton = page.getByRole("button", { name: /back/i });
+    await expect(backButton).toBeDisabled();
+  });
+
+  test("should persist completion in localStorage", async ({ page }) => {
+    await setupNewUserSession(page);
+    await page.goto("/onboarding");
+
+    // Verify localStorage is empty before skip
+    const before = await page.evaluate(() =>
+      localStorage.getItem("opus_onboarding_completed"),
+    );
+    expect(before).toBeNull();
+
+    // Listen for localStorage change before clicking
+    await page.evaluate(() => {
+      (globalThis as unknown as Record<string, string>).__onboardingSet =
+        "false";
+      const origSetItem = localStorage.setItem.bind(localStorage);
+      localStorage.setItem = (key: string, value: string) => {
+        origSetItem(key, value);
+        if (key === "opus_onboarding_completed") {
+          (globalThis as unknown as Record<string, string>).__onboardingSet =
+            value;
+        }
+      };
+    });
+
+    // Skip onboarding
+    await page.getByRole("button", { name: /skip/i }).click();
+
+    // Verify the flag was set before navigation
+    const completed = await page.evaluate(
+      () => (globalThis as unknown as Record<string, string>).__onboardingSet,
+    );
+    expect(completed).toBe("true");
+  });
+});
+
+test.describe("Onboarding - Returning User", () => {
+  test("should redirect completed user to /petition", async ({ page }) => {
+    await setupReturningUserSession(page);
+    await page.goto("/onboarding");
+
+    await expect(page).toHaveURL(/\/petition/);
+  });
+});
+
+test.describe("Onboarding - Unauthenticated", () => {
+  test("should redirect to /login when not authenticated", async ({ page }) => {
+    // Don't set up auth session
+    await page.goto("/onboarding");
+
+    await expect(page).toHaveURL(/\/login/);
+  });
+});
+
+test.describe("Onboarding - Responsive Design", () => {
+  test("should display correctly on mobile", async ({ page }) => {
+    await setupNewUserSession(page);
+    await page.setViewportSize(viewports.mobile);
+    await page.goto("/onboarding");
+
+    await expect(page.getByText("Welcome to OPUS")).toBeVisible();
+    await expect(page.getByRole("button", { name: /skip/i })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Next", exact: true }),
+    ).toBeVisible();
+  });
+
+  test("should display correctly on tablet", async ({ page }) => {
+    await setupNewUserSession(page);
+    await page.setViewportSize(viewports.tablet);
+    await page.goto("/onboarding");
+
+    await expect(page.getByText("Welcome to OPUS")).toBeVisible();
+  });
+});
+
+test.describe("Onboarding - Accessibility", () => {
+  test("should have no WCAG 2.2 AA violations on welcome step", async ({
+    page,
+  }) => {
+    await setupNewUserSession(page);
+    await page.goto("/onboarding");
+    await expect(page.getByText("Welcome to OPUS")).toBeVisible();
+
+    const violations = await checkAccessibility(page);
+    expect(violations).toEqual([]);
+  });
+
+  test("should have no WCAG 2.2 AA violations on scan step", async ({
+    page,
+  }) => {
+    await setupNewUserSession(page);
+    await page.goto("/onboarding");
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+    await expect(page.getByText("Scan Petitions")).toBeVisible();
+
+    const violations = await checkAccessibility(page);
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/frontend/lib/i18n/index.ts
+++ b/apps/frontend/lib/i18n/index.ts
@@ -3,8 +3,10 @@ import { initReactI18next } from "react-i18next";
 
 import enCommon from "@/locales/en/common.json";
 import enSettings from "@/locales/en/settings.json";
+import enOnboarding from "@/locales/en/onboarding.json";
 import esCommon from "@/locales/es/common.json";
 import esSettings from "@/locales/es/settings.json";
+import esOnboarding from "@/locales/es/onboarding.json";
 
 export const defaultNS = "common";
 export const supportedLanguages = ["en", "es"] as const;
@@ -14,10 +16,12 @@ export const resources = {
   en: {
     common: enCommon,
     settings: enSettings,
+    onboarding: enOnboarding,
   },
   es: {
     common: esCommon,
     settings: esSettings,
+    onboarding: esOnboarding,
   },
 } as const;
 

--- a/apps/frontend/lib/onboarding-context.tsx
+++ b/apps/frontend/lib/onboarding-context.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useSyncExternalStore,
+  useCallback,
+  ReactNode,
+} from "react";
+
+interface OnboardingContextType {
+  hasCompletedOnboarding: boolean;
+  currentStep: number;
+  totalSteps: number;
+  nextStep: () => void;
+  prevStep: () => void;
+  skipOnboarding: () => void;
+  completeOnboarding: () => void;
+  resetOnboarding: () => void;
+}
+
+const OnboardingContext = createContext<OnboardingContextType | undefined>(
+  undefined,
+);
+
+const STORAGE_KEY = "opus_onboarding_completed";
+
+function getSnapshot(): boolean {
+  return localStorage.getItem(STORAGE_KEY) === "true";
+}
+
+function getServerSnapshot(): boolean {
+  return true;
+}
+
+function subscribe(callback: () => void): () => void {
+  globalThis.addEventListener("storage", callback);
+  return () => globalThis.removeEventListener("storage", callback);
+}
+
+export function OnboardingProvider({ children }: { children: ReactNode }) {
+  const hasCompletedOnboarding = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+  const [currentStep, setCurrentStep] = useState(0);
+  const totalSteps = 4;
+
+  const completeOnboarding = useCallback(() => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    globalThis.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+  }, []);
+
+  const skipOnboarding = useCallback(() => {
+    completeOnboarding();
+  }, [completeOnboarding]);
+
+  const resetOnboarding = useCallback(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    globalThis.dispatchEvent(new StorageEvent("storage", { key: STORAGE_KEY }));
+    setCurrentStep(0);
+  }, []);
+
+  const nextStep = useCallback(
+    () => setCurrentStep((s) => Math.min(s + 1, totalSteps - 1)),
+    [totalSteps],
+  );
+  const prevStep = useCallback(
+    () => setCurrentStep((s) => Math.max(s - 1, 0)),
+    [],
+  );
+
+  return (
+    <OnboardingContext.Provider
+      value={{
+        hasCompletedOnboarding,
+        currentStep,
+        totalSteps,
+        nextStep,
+        prevStep,
+        skipOnboarding,
+        completeOnboarding,
+        resetOnboarding,
+      }}
+    >
+      {children}
+    </OnboardingContext.Provider>
+  );
+}
+
+export function useOnboarding() {
+  const context = useContext(OnboardingContext);
+  if (!context) {
+    throw new Error("useOnboarding must be used within OnboardingProvider");
+  }
+  return context;
+}

--- a/apps/frontend/locales/en/onboarding.json
+++ b/apps/frontend/locales/en/onboarding.json
@@ -1,0 +1,23 @@
+{
+  "skip": "Skip",
+  "back": "Back",
+  "next": "Next",
+  "getStarted": "Get Started",
+  "welcome": {
+    "title": "Welcome to OPUS",
+    "subtitle": "Your civic engagement companion for tracking petitions and ballot measures"
+  },
+  "scan": {
+    "title": "Scan Petitions",
+    "description": "Use your camera to quickly scan and verify petition signatures in seconds",
+    "permissionNote": "We'll ask for camera access when you're ready to scan. No images are saved to your device."
+  },
+  "analyze": {
+    "title": "Instant Analysis",
+    "description": "Our AI verifies signatures and extracts key information automatically"
+  },
+  "track": {
+    "title": "Track Progress",
+    "description": "See petition activity in your area and follow measures through to the ballot"
+  }
+}

--- a/apps/frontend/locales/es/onboarding.json
+++ b/apps/frontend/locales/es/onboarding.json
@@ -1,0 +1,23 @@
+{
+  "skip": "Omitir",
+  "back": "Atrás",
+  "next": "Siguiente",
+  "getStarted": "Comenzar",
+  "welcome": {
+    "title": "Bienvenido a OPUS",
+    "subtitle": "Tu compañero de participación cívica para seguir peticiones y medidas electorales"
+  },
+  "scan": {
+    "title": "Escanear Peticiones",
+    "description": "Usa tu cámara para escanear y verificar firmas de peticiones en segundos",
+    "permissionNote": "Te pediremos acceso a la cámara cuando estés listo para escanear. No se guardan imágenes en tu dispositivo."
+  },
+  "analyze": {
+    "title": "Análisis Instantáneo",
+    "description": "Nuestra IA verifica firmas y extrae información clave automáticamente"
+  },
+  "track": {
+    "title": "Seguir Progreso",
+    "description": "Ve la actividad de peticiones en tu área y sigue las medidas hasta la votación"
+  }
+}


### PR DESCRIPTION
## Summary

- Implement a 4-step onboarding experience (Welcome → Scan → Analyze → Track) for first-time users
- Add skip option with localStorage persistence so returning users bypass onboarding
- Login now redirects to `/onboarding` which checks completion status before forwarding to `/petition`
- Full i18n support (English + Spanish) using existing react-i18next setup
- Mobile-first purple gradient UI matching OPUS branding

## Test plan

- [x] Unit tests: onboarding-context (11 tests), OnboardingSteps component (11 tests), onboarding page (5 tests)
- [x] Login test updated: redirect assertions changed from `/rag-demo` to `/onboarding`
- [x] E2E tests: 13 Playwright tests covering full flow, skip, back navigation, localStorage persistence, responsive design, and WCAG 2.2 AA accessibility
- [x] Full unit suite: 611 frontend + 1,079 backend tests passing
- [x] Docker integration tests: 215 passed
- [x] Docker E2E tests (CI mode): 171 passed

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)