### PR TITLE
test(frontend): add unit tests for 5 untested components

### DIFF
--- a/apps/frontend/__tests__/components/Header.test.tsx
+++ b/apps/frontend/__tests__/components/Header.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { Header } from "@/components/Header";
+
+// Mock auth context
+const mockLogout = jest.fn();
+
+const defaultAuthContext = {
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  tokens: null,
+  login: jest.fn(),
+  loginWithPasskey: jest.fn(),
+  sendMagicLink: jest.fn(),
+  register: jest.fn(),
+  registerWithMagicLink: jest.fn(),
+  verifyMagicLink: jest.fn(),
+  registerPasskey: jest.fn(),
+  logout: mockLogout,
+  clearError: jest.fn(),
+  error: null,
+  supportsPasskeys: false,
+  magicLinkSent: false,
+  hasPlatformAuthenticator: false,
+};
+
+let mockAuthContextValue = { ...defaultAuthContext };
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockAuthContextValue,
+}));
+
+describe("Header", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthContextValue = { ...defaultAuthContext };
+  });
+
+  it("should render the brand name as a link to home", () => {
+    render(<Header />);
+
+    const brandLink = screen.getByRole("link", { name: /opus populi/i });
+    expect(brandLink).toHaveAttribute("href", "/");
+  });
+
+  describe("when loading", () => {
+    it("should show loading text", () => {
+      mockAuthContextValue = { ...defaultAuthContext, isLoading: true };
+      render(<Header />);
+
+      expect(screen.getByText("Loading...")).toBeInTheDocument();
+    });
+  });
+
+  describe("when not authenticated", () => {
+    it("should show sign in and get started links", () => {
+      render(<Header />);
+
+      expect(screen.getByRole("link", { name: /sign in/i })).toHaveAttribute(
+        "href",
+        "/login",
+      );
+      expect(
+        screen.getByRole("link", { name: /get started/i }),
+      ).toHaveAttribute("href", "/register");
+    });
+
+    it("should not show sign out button", () => {
+      render(<Header />);
+
+      expect(
+        screen.queryByRole("button", { name: /sign out/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("when authenticated", () => {
+    beforeEach(() => {
+      mockAuthContextValue = {
+        ...defaultAuthContext,
+        isAuthenticated: true,
+        user: { email: "test@example.com" },
+      };
+    });
+
+    it("should show user email", () => {
+      render(<Header />);
+
+      expect(screen.getByText("test@example.com")).toBeInTheDocument();
+    });
+
+    it("should show region link", () => {
+      render(<Header />);
+
+      expect(screen.getByRole("link", { name: /region/i })).toHaveAttribute(
+        "href",
+        "/region",
+      );
+    });
+
+    it("should show settings link with user email", () => {
+      render(<Header />);
+
+      expect(
+        screen.getByRole("link", { name: "test@example.com" }),
+      ).toHaveAttribute("href", "/settings");
+    });
+
+    it("should show sign out button", () => {
+      render(<Header />);
+
+      expect(
+        screen.getByRole("button", { name: /sign out/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("should call logout when sign out is clicked", async () => {
+      const user = userEvent.setup();
+      render(<Header />);
+
+      await user.click(screen.getByRole("button", { name: /sign out/i }));
+
+      expect(mockLogout).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not show sign in or get started links", () => {
+      render(<Header />);
+
+      expect(
+        screen.queryByRole("link", { name: /sign in/i }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("link", { name: /get started/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/__tests__/components/LoadingSpinner.test.tsx
+++ b/apps/frontend/__tests__/components/LoadingSpinner.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+
+describe("LoadingSpinner", () => {
+  it("should render an SVG element", () => {
+    const { container } = render(<LoadingSpinner />);
+
+    const svg = container.querySelector("svg");
+    expect(svg).toBeInTheDocument();
+  });
+
+  it("should be hidden from screen readers", () => {
+    const { container } = render(<LoadingSpinner />);
+
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("should apply animate-spin class", () => {
+    const { container } = render(<LoadingSpinner />);
+
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveClass("animate-spin");
+  });
+
+  describe("sizes", () => {
+    it("should default to small size", () => {
+      const { container } = render(<LoadingSpinner />);
+
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveClass("h-4", "w-4");
+    });
+
+    it("should render medium size", () => {
+      const { container } = render(<LoadingSpinner size="md" />);
+
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveClass("h-6", "w-6");
+    });
+
+    it("should render large size", () => {
+      const { container } = render(<LoadingSpinner size="lg" />);
+
+      const svg = container.querySelector("svg");
+      expect(svg).toHaveClass("h-10", "w-10");
+    });
+  });
+
+  it("should apply custom className", () => {
+    const { container } = render(<LoadingSpinner className="text-blue-500" />);
+
+    const svg = container.querySelector("svg");
+    expect(svg).toHaveClass("text-blue-500");
+  });
+});

--- a/apps/frontend/__tests__/components/OfflineIndicator.test.tsx
+++ b/apps/frontend/__tests__/components/OfflineIndicator.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { OfflineIndicator } from "@/components/OfflineIndicator";
+
+describe("OfflineIndicator", () => {
+  let onlineGetter: jest.SpyInstance;
+
+  beforeEach(() => {
+    onlineGetter = jest.spyOn(navigator, "onLine", "get");
+  });
+
+  afterEach(() => {
+    onlineGetter.mockRestore();
+  });
+
+  it("should render nothing when online", () => {
+    onlineGetter.mockReturnValue(true);
+    const { container } = render(<OfflineIndicator />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render offline banner when offline", () => {
+    onlineGetter.mockReturnValue(false);
+    render(<OfflineIndicator />);
+
+    expect(screen.getByText(/you're offline/i)).toBeInTheDocument();
+  });
+
+  it("should have correct accessibility attributes", () => {
+    onlineGetter.mockReturnValue(false);
+    render(<OfflineIndicator />);
+
+    const banner = screen.getByRole("status");
+    expect(banner).toHaveAttribute("aria-live", "polite");
+  });
+
+  it("should show banner when going offline", () => {
+    onlineGetter.mockReturnValue(true);
+    render(<OfflineIndicator />);
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+
+    // Simulate going offline
+    onlineGetter.mockReturnValue(false);
+    act(() => {
+      window.dispatchEvent(new Event("offline"));
+    });
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("should hide banner when coming back online", () => {
+    onlineGetter.mockReturnValue(false);
+    render(<OfflineIndicator />);
+
+    expect(screen.getByRole("status")).toBeInTheDocument();
+
+    // Simulate coming online
+    onlineGetter.mockReturnValue(true);
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/components/ProtectedRoute.test.tsx
+++ b/apps/frontend/__tests__/components/ProtectedRoute.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ProtectedRoute } from "@/components/ProtectedRoute";
+
+// Mock Next.js navigation
+const mockReplace = jest.fn();
+const mockPathname = "/settings";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+  usePathname: () => mockPathname,
+}));
+
+// Mock auth context
+const defaultAuthContext = {
+  isAuthenticated: false,
+  isLoading: false,
+  user: null,
+  tokens: null,
+  login: jest.fn(),
+  loginWithPasskey: jest.fn(),
+  sendMagicLink: jest.fn(),
+  register: jest.fn(),
+  registerWithMagicLink: jest.fn(),
+  verifyMagicLink: jest.fn(),
+  registerPasskey: jest.fn(),
+  logout: jest.fn(),
+  clearError: jest.fn(),
+  error: null,
+  supportsPasskeys: false,
+  magicLinkSent: false,
+  hasPlatformAuthenticator: false,
+};
+
+let mockAuthContextValue = { ...defaultAuthContext };
+
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => mockAuthContextValue,
+}));
+
+describe("ProtectedRoute", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthContextValue = { ...defaultAuthContext };
+  });
+
+  it("should show loading state when auth is loading", () => {
+    mockAuthContextValue = { ...defaultAuthContext, isLoading: true };
+    render(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>,
+    );
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+  });
+
+  it("should redirect to login when not authenticated", () => {
+    mockAuthContextValue = {
+      ...defaultAuthContext,
+      isAuthenticated: false,
+      isLoading: false,
+    };
+    render(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>,
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith("/login?redirect=%2Fsettings");
+    expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+  });
+
+  it("should render children when authenticated", () => {
+    mockAuthContextValue = {
+      ...defaultAuthContext,
+      isAuthenticated: true,
+      isLoading: false,
+    };
+    render(
+      <ProtectedRoute>
+        <div>Protected Content</div>
+      </ProtectedRoute>,
+    );
+
+    expect(screen.getByText("Protected Content")).toBeInTheDocument();
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("should use custom redirectTo path", () => {
+    mockAuthContextValue = {
+      ...defaultAuthContext,
+      isAuthenticated: false,
+      isLoading: false,
+    };
+    render(
+      <ProtectedRoute redirectTo="/signin">
+        <div>Protected Content</div>
+      </ProtectedRoute>,
+    );
+
+    expect(mockReplace).toHaveBeenCalledWith("/signin?redirect=%2Fsettings");
+  });
+});

--- a/apps/frontend/__tests__/components/auth/AuthUI.test.tsx
+++ b/apps/frontend/__tests__/components/auth/AuthUI.test.tsx
@@ -1,0 +1,290 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import {
+  AuthCard,
+  AuthHeader,
+  AuthErrorAlert,
+  AuthInput,
+  AuthSubmitButton,
+  AuthDivider,
+} from "@/components/auth/AuthUI";
+
+describe("AuthCard", () => {
+  it("should render children", () => {
+    render(
+      <AuthCard>
+        <p>Card content</p>
+      </AuthCard>,
+    );
+
+    expect(screen.getByText("Card content")).toBeInTheDocument();
+  });
+
+  it("should apply custom className", () => {
+    const { container } = render(
+      <AuthCard className="text-center">
+        <p>Content</p>
+      </AuthCard>,
+    );
+
+    expect(container.firstChild).toHaveClass("text-center");
+  });
+
+  it("should have base card styling", () => {
+    const { container } = render(
+      <AuthCard>
+        <p>Content</p>
+      </AuthCard>,
+    );
+
+    expect(container.firstChild).toHaveClass("bg-white", "rounded-2xl", "p-8");
+  });
+});
+
+describe("AuthHeader", () => {
+  it("should render title as heading", () => {
+    render(<AuthHeader title="Welcome" subtitle="Sign in below" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Welcome" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render subtitle", () => {
+    render(<AuthHeader title="Welcome" subtitle="Sign in below" />);
+
+    expect(screen.getByText("Sign in below")).toBeInTheDocument();
+  });
+});
+
+describe("AuthErrorAlert", () => {
+  it("should render nothing when error is null", () => {
+    const { container } = render(<AuthErrorAlert error={null} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render nothing when error is undefined", () => {
+    const { container } = render(<AuthErrorAlert error={undefined} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render nothing when error is empty string", () => {
+    const { container } = render(<AuthErrorAlert error="" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render error message", () => {
+    render(<AuthErrorAlert error="Something went wrong" />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("should have error styling", () => {
+    const { container } = render(<AuthErrorAlert error="Error" />);
+
+    expect(container.firstChild).toHaveClass("bg-red-50", "border-red-200");
+  });
+});
+
+describe("AuthInput", () => {
+  it("should render label and input", () => {
+    render(
+      <AuthInput id="email" label="Email" value="" onChange={jest.fn()} />,
+    );
+
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+  });
+
+  it("should display current value", () => {
+    render(
+      <AuthInput
+        id="email"
+        label="Email"
+        value="test@example.com"
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByDisplayValue("test@example.com")).toBeInTheDocument();
+  });
+
+  it("should call onChange with value when typing", async () => {
+    const handleChange = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <AuthInput id="email" label="Email" value="" onChange={handleChange} />,
+    );
+
+    await user.type(screen.getByLabelText("Email"), "a");
+
+    expect(handleChange).toHaveBeenCalledWith("a");
+  });
+
+  it("should apply placeholder", () => {
+    render(
+      <AuthInput
+        id="email"
+        label="Email"
+        value=""
+        onChange={jest.fn()}
+        placeholder="you@example.com"
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("you@example.com")).toBeInTheDocument();
+  });
+
+  it("should set input type", () => {
+    render(
+      <AuthInput
+        id="email"
+        label="Email"
+        type="email"
+        value=""
+        onChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText("Email")).toHaveAttribute("type", "email");
+  });
+
+  it("should default type to text", () => {
+    render(<AuthInput id="name" label="Name" value="" onChange={jest.fn()} />);
+
+    expect(screen.getByLabelText("Name")).toHaveAttribute("type", "text");
+  });
+
+  it("should apply custom className to input", () => {
+    render(
+      <AuthInput
+        id="code"
+        label="Code"
+        value=""
+        onChange={jest.fn()}
+        className="font-mono"
+      />,
+    );
+
+    expect(screen.getByLabelText("Code")).toHaveClass("font-mono");
+  });
+
+  it("should set required attribute", () => {
+    render(
+      <AuthInput
+        id="email"
+        label="Email"
+        value=""
+        onChange={jest.fn()}
+        required
+      />,
+    );
+
+    expect(screen.getByLabelText("Email")).toBeRequired();
+  });
+
+  it("should set autoComplete attribute", () => {
+    render(
+      <AuthInput
+        id="email"
+        label="Email"
+        value=""
+        onChange={jest.fn()}
+        autoComplete="email"
+      />,
+    );
+
+    expect(screen.getByLabelText("Email")).toHaveAttribute(
+      "autocomplete",
+      "email",
+    );
+  });
+});
+
+describe("AuthSubmitButton", () => {
+  it("should render children when not loading", () => {
+    render(
+      <AuthSubmitButton loadingText="Loading...">Submit</AuthSubmitButton>,
+    );
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument();
+  });
+
+  it("should show loading text when loading", () => {
+    render(
+      <AuthSubmitButton loading loadingText="Sending...">
+        Submit
+      </AuthSubmitButton>,
+    );
+
+    expect(screen.getByText("Sending...")).toBeInTheDocument();
+    expect(screen.queryByText("Submit")).not.toBeInTheDocument();
+  });
+
+  it("should be disabled when loading", () => {
+    render(
+      <AuthSubmitButton loading loadingText="Loading...">
+        Submit
+      </AuthSubmitButton>,
+    );
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("should be disabled when disabled prop is true", () => {
+    render(
+      <AuthSubmitButton disabled loadingText="Loading...">
+        Submit
+      </AuthSubmitButton>,
+    );
+
+    expect(screen.getByRole("button")).toBeDisabled();
+  });
+
+  it("should default to submit type", () => {
+    render(
+      <AuthSubmitButton loadingText="Loading...">Submit</AuthSubmitButton>,
+    );
+
+    expect(screen.getByRole("button")).toHaveAttribute("type", "submit");
+  });
+
+  it("should accept button type", () => {
+    render(
+      <AuthSubmitButton type="button" loadingText="Loading...">
+        Click
+      </AuthSubmitButton>,
+    );
+
+    expect(screen.getByRole("button")).toHaveAttribute("type", "button");
+  });
+
+  it("should call onClick when clicked", async () => {
+    const handleClick = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <AuthSubmitButton
+        type="button"
+        onClick={handleClick}
+        loadingText="Loading..."
+      >
+        Click me
+      </AuthSubmitButton>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Click me" }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("AuthDivider", () => {
+  it("should render 'or' text", () => {
+    render(<AuthDivider />);
+
+    expect(screen.getByText("or")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for 5 previously untested frontend components: **LoadingSpinner**, **OfflineIndicator**, **ProtectedRoute**, **Header**, and shared **AuthUI** components
- 53 new tests bringing the frontend total from 734 to 787

## Test plan
- [x] All 787 frontend tests pass
- [x] All backend tests pass (1079)
- [x] Frontend builds successfully (27 routes)
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)