### PR TITLE
refactor: move shared utilities to @opuspopuli/common

### DIFF
--- a/packages/common/__tests__/memory-cache.spec.ts
+++ b/packages/common/__tests__/memory-cache.spec.ts
@@ -1,4 +1,4 @@
-import { MemoryCache } from "../../src/cache/memory-cache";
+import { MemoryCache } from "../src/providers/caching/memory-cache";
 
 describe("MemoryCache", () => {
   let cache: MemoryCache<string>;

--- a/packages/common/__tests__/rate-limiter.spec.ts
+++ b/packages/common/__tests__/rate-limiter.spec.ts
@@ -1,4 +1,4 @@
-import { RateLimiter } from "../../src/utils/rate-limiter";
+import { RateLimiter } from "../src/providers/rate-limiting/rate-limiter";
 
 describe("RateLimiter", () => {
   let limiter: RateLimiter;

--- a/packages/common/__tests__/retry.spec.ts
+++ b/packages/common/__tests__/retry.spec.ts
@@ -3,8 +3,8 @@ import {
   calculateDelay,
   RetryPredicates,
   DEFAULT_RETRY_CONFIG,
-} from "../../src/utils/retry";
-import { RetryExhaustedError } from "../../src/types";
+} from "../src/providers/retry/retry";
+import { RetryExhaustedError } from "../src/providers/retry/types";
 
 describe("retry utility", () => {
   beforeEach(() => {

--- a/packages/common/src/providers/caching/index.ts
+++ b/packages/common/src/providers/caching/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Caching Module
+ *
+ * Provides in-memory caching with TTL and LRU eviction support.
+ */
+
+export * from "./types.js";
+export * from "./memory-cache.js";

--- a/packages/common/src/providers/caching/memory-cache.ts
+++ b/packages/common/src/providers/caching/memory-cache.ts
@@ -5,7 +5,7 @@
  * Uses LRU-style eviction when max size is reached.
  */
 
-import { CacheOptions } from "../types.js";
+import { CacheOptions } from "./types.js";
 
 /**
  * Cache entry with value and expiration time

--- a/packages/common/src/providers/caching/types.ts
+++ b/packages/common/src/providers/caching/types.ts
@@ -1,9 +1,18 @@
 /**
- * Cache Interface
+ * Caching Types
  *
- * Common interface for cache implementations (Memory, Redis).
- * Enables switching between implementations without changing consumer code.
+ * Types and interfaces for cache implementations.
  */
+
+/**
+ * Configuration options for the in-memory cache
+ */
+export interface CacheOptions {
+  /** Time-to-live in milliseconds for cache entries (default: 300000 = 5 min) */
+  ttlMs?: number;
+  /** Maximum number of entries in the cache (default: 100) */
+  maxSize?: number;
+}
 
 /**
  * Cache interface for key-value storage with TTL support
@@ -57,37 +66,4 @@ export interface ICache<T = string> {
    * Cleanup resources (call on module destroy)
    */
   destroy(): Promise<void> | void;
-}
-
-/**
- * Rate limiter interface for distributed rate limiting
- */
-export interface IRateLimiter {
-  /**
-   * Acquire a token, waiting if necessary
-   * @returns Promise that resolves when a token is available
-   */
-  acquire(): Promise<void>;
-
-  /**
-   * Try to acquire a token without waiting
-   * @returns True if token was acquired, false otherwise
-   */
-  tryAcquire(): Promise<boolean> | boolean;
-
-  /**
-   * Get the time in milliseconds until the next token is available
-   * @returns 0 if a token is immediately available
-   */
-  getWaitTimeMs(): Promise<number> | number;
-
-  /**
-   * Get the current number of available tokens
-   */
-  getAvailableTokens(): Promise<number> | number;
-
-  /**
-   * Reset the limiter to its initial state
-   */
-  reset(): Promise<void> | void;
 }

--- a/packages/common/src/providers/index.ts
+++ b/packages/common/src/providers/index.ts
@@ -12,3 +12,6 @@ export * from "./email/index.js";
 export * from "./resilience/index.js";
 export * from "./http/index.js";
 export * from "./ocr/index.js";
+export * from "./rate-limiting/index.js";
+export * from "./retry/index.js";
+export * from "./caching/index.js";

--- a/packages/common/src/providers/rate-limiting/index.ts
+++ b/packages/common/src/providers/rate-limiting/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Rate Limiting Module
+ *
+ * Provides token bucket rate limiting for controlling request rates.
+ */
+
+export * from "./types.js";
+export * from "./rate-limiter.js";

--- a/packages/common/src/providers/rate-limiting/rate-limiter.ts
+++ b/packages/common/src/providers/rate-limiting/rate-limiter.ts
@@ -5,7 +5,7 @@
  * Tokens are added at a steady rate, and each request consumes one token.
  */
 
-import { RateLimitOptions } from "../types.js";
+import { RateLimitOptions } from "./types.js";
 
 /**
  * Token bucket rate limiter

--- a/packages/common/src/providers/rate-limiting/types.ts
+++ b/packages/common/src/providers/rate-limiting/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Rate Limiting Types
+ *
+ * Types and interfaces for rate limiting implementations.
+ */
+
+/**
+ * Configuration options for rate limiting
+ */
+export interface RateLimitOptions {
+  /** Maximum requests per second (default: 2) */
+  requestsPerSecond?: number;
+  /** Burst size for token bucket algorithm (default: 5) */
+  burstSize?: number;
+}
+
+/**
+ * Rate limiter interface for distributed rate limiting
+ */
+export interface IRateLimiter {
+  /**
+   * Acquire a token, waiting if necessary
+   * @returns Promise that resolves when a token is available
+   */
+  acquire(): Promise<void>;
+
+  /**
+   * Try to acquire a token without waiting
+   * @returns True if token was acquired, false otherwise
+   */
+  tryAcquire(): Promise<boolean> | boolean;
+
+  /**
+   * Get the time in milliseconds until the next token is available
+   * @returns 0 if a token is immediately available
+   */
+  getWaitTimeMs(): Promise<number> | number;
+
+  /**
+   * Get the current number of available tokens
+   */
+  getAvailableTokens(): Promise<number> | number;
+
+  /**
+   * Reset the limiter to its initial state
+   */
+  reset(): Promise<void> | void;
+}
+
+/**
+ * Error thrown when rate limit is exceeded
+ */
+export class RateLimitExceededError extends Error {
+  constructor(public readonly waitTimeMs: number) {
+    super(`Rate limit exceeded. Try again in ${waitTimeMs}ms`);
+    this.name = "RateLimitExceededError";
+  }
+}

--- a/packages/common/src/providers/retry/index.ts
+++ b/packages/common/src/providers/retry/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Retry Module
+ *
+ * Provides retry logic with exponential backoff and jitter
+ * for handling transient failures in external service calls.
+ */
+
+export * from "./types.js";
+export * from "./retry.js";

--- a/packages/common/src/providers/retry/retry.ts
+++ b/packages/common/src/providers/retry/retry.ts
@@ -7,7 +7,7 @@
 
 import { randomInt } from "node:crypto";
 
-import { RetryConfig, RetryExhaustedError } from "../types.js";
+import { RetryConfig, RetryExhaustedError } from "./types.js";
 
 /**
  * Default retry configuration

--- a/packages/common/src/providers/retry/types.ts
+++ b/packages/common/src/providers/retry/types.ts
@@ -1,0 +1,30 @@
+/**
+ * Retry Types
+ *
+ * Types and error classes for retry logic with exponential backoff.
+ */
+
+/**
+ * Retry configuration options
+ */
+export interface RetryConfig {
+  /** Maximum number of retry attempts */
+  maxAttempts: number;
+  /** Base delay in milliseconds for exponential backoff */
+  baseDelayMs: number;
+  /** Maximum delay in milliseconds between retries */
+  maxDelayMs: number;
+}
+
+/**
+ * Error thrown when all retry attempts are exhausted
+ */
+export class RetryExhaustedError extends Error {
+  constructor(
+    public readonly attempts: number,
+    public readonly lastError: Error,
+  ) {
+    super(`All ${attempts} retry attempts exhausted: ${lastError.message}`);
+    this.name = "RetryExhaustedError";
+  }
+}

--- a/packages/extraction-provider/src/cache/cache-factory.ts
+++ b/packages/extraction-provider/src/cache/cache-factory.ts
@@ -8,15 +8,18 @@
  */
 
 import { Logger } from "@nestjs/common";
-import type { ICache, IRateLimiter } from "./cache.interface.js";
-import { MemoryCache } from "./memory-cache.js";
+import type {
+  ICache,
+  IRateLimiter,
+  CacheOptions,
+  RateLimitOptions,
+} from "@opuspopuli/common";
+import { MemoryCache, RateLimiter } from "@opuspopuli/common";
 import { RedisCache, type RedisCacheOptions } from "./redis-cache.js";
-import { RateLimiter } from "../utils/rate-limiter.js";
 import {
   RedisRateLimiter,
   type RedisRateLimiterOptions,
 } from "../utils/redis-rate-limiter.js";
-import type { CacheOptions, RateLimitOptions } from "../types.js";
 
 /**
  * Cache provider type

--- a/packages/extraction-provider/src/cache/index.ts
+++ b/packages/extraction-provider/src/cache/index.ts
@@ -1,7 +1,13 @@
 /**
  * Cache module exports
+ *
+ * Core cache types (ICache, CacheOptions, MemoryCache) are now provided
+ * by @opuspopuli/common. Re-exported here for backwards compatibility.
  */
-export * from "./cache.interface.js";
-export * from "./memory-cache.js";
+
+// Re-export from common
+export { ICache, CacheOptions, MemoryCache } from "@opuspopuli/common";
+
+// Local implementations (Redis-specific, stays in extraction-provider)
 export * from "./redis-cache.js";
 export * from "./cache-factory.js";

--- a/packages/extraction-provider/src/cache/redis-cache.ts
+++ b/packages/extraction-provider/src/cache/redis-cache.ts
@@ -8,8 +8,7 @@
  */
 
 import Redis from "ioredis";
-import type { ICache } from "./cache.interface.js";
-import type { CacheOptions } from "../types.js";
+import type { ICache, CacheOptions } from "@opuspopuli/common";
 
 /**
  * Redis cache configuration options

--- a/packages/extraction-provider/src/extraction.provider.ts
+++ b/packages/extraction-provider/src/extraction.provider.ts
@@ -14,13 +14,15 @@ import type { CheerioAPI, Cheerio } from "cheerio";
 import type { Element } from "domhandler";
 import { PDFParse } from "pdf-parse";
 import {
+  type ICache,
+  type IRateLimiter,
+  type CircuitBreakerHealth,
   CircuitBreakerManager,
   createCircuitBreaker,
   DEFAULT_CIRCUIT_CONFIGS,
-  CircuitBreakerHealth,
+  withRetry,
+  RetryPredicates,
 } from "@opuspopuli/common";
-
-import type { ICache, IRateLimiter } from "./cache/cache.interface.js";
 import { CacheFactory } from "./cache/cache-factory.js";
 import {
   ExtractionConfig,
@@ -32,7 +34,6 @@ import {
   FetchError,
   FetchFunction,
 } from "./types.js";
-import { withRetry, RetryPredicates } from "./utils/retry.js";
 
 /**
  * Selected element from HTML parsing

--- a/packages/extraction-provider/src/types.ts
+++ b/packages/extraction-provider/src/types.ts
@@ -2,8 +2,23 @@
  * Extraction Provider Types
  *
  * Types and interfaces for the extraction provider infrastructure layer.
- * Includes configuration for caching, rate limiting, and retry logic.
+ * Shared types (CacheOptions, RateLimitOptions, RetryConfig, etc.) are
+ * re-exported from @opuspopuli/common for backwards compatibility.
  */
+
+// Re-export shared types from common for backwards compatibility
+export type { CacheOptions, ICache } from "@opuspopuli/common";
+export type { RateLimitOptions, IRateLimiter } from "@opuspopuli/common";
+export type { RetryConfig } from "@opuspopuli/common";
+export { RateLimitExceededError } from "@opuspopuli/common";
+export { RetryExhaustedError } from "@opuspopuli/common";
+
+// Local import for use in this file's interfaces
+import type {
+  CacheOptions,
+  RateLimitOptions,
+  RetryConfig,
+} from "@opuspopuli/common";
 
 /**
  * Options for HTTP fetch requests
@@ -27,38 +42,6 @@ export interface RetryOptions extends FetchOptions {
   baseDelayMs?: number;
   /** Maximum delay in milliseconds between retries (default: 30000) */
   maxDelayMs?: number;
-}
-
-/**
- * Configuration options for the in-memory cache
- */
-export interface CacheOptions {
-  /** Time-to-live in milliseconds for cache entries (default: 300000 = 5 min) */
-  ttlMs?: number;
-  /** Maximum number of entries in the cache (default: 100) */
-  maxSize?: number;
-}
-
-/**
- * Configuration options for rate limiting
- */
-export interface RateLimitOptions {
-  /** Maximum requests per second (default: 2) */
-  requestsPerSecond?: number;
-  /** Burst size for token bucket algorithm (default: 5) */
-  burstSize?: number;
-}
-
-/**
- * Retry configuration options
- */
-export interface RetryConfig {
-  /** Maximum number of retry attempts */
-  maxAttempts: number;
-  /** Base delay in milliseconds for exponential backoff */
-  baseDelayMs: number;
-  /** Maximum delay in milliseconds between retries */
-  maxDelayMs: number;
 }
 
 /**
@@ -144,29 +127,6 @@ export class FetchError extends Error {
   ) {
     super(`Failed to fetch ${url}: ${message}`);
     this.name = "FetchError";
-  }
-}
-
-/**
- * Error thrown when rate limit is exceeded
- */
-export class RateLimitExceededError extends Error {
-  constructor(public readonly waitTimeMs: number) {
-    super(`Rate limit exceeded. Try again in ${waitTimeMs}ms`);
-    this.name = "RateLimitExceededError";
-  }
-}
-
-/**
- * Error thrown when all retry attempts are exhausted
- */
-export class RetryExhaustedError extends Error {
-  constructor(
-    public readonly attempts: number,
-    public readonly lastError: Error,
-  ) {
-    super(`All ${attempts} retry attempts exhausted: ${lastError.message}`);
-    this.name = "RetryExhaustedError";
   }
 }
 

--- a/packages/extraction-provider/src/utils/index.ts
+++ b/packages/extraction-provider/src/utils/index.ts
@@ -1,6 +1,26 @@
 /**
  * Utils module exports
+ *
+ * Core utilities (RateLimiter, withRetry, RetryPredicates) are now provided
+ * by @opuspopuli/common. Re-exported here for backwards compatibility.
  */
-export * from "./rate-limiter.js";
+
+// Re-export from common
+export {
+  RateLimiter,
+  RateLimitOptions,
+  IRateLimiter,
+  RateLimitExceededError,
+} from "@opuspopuli/common";
+export {
+  withRetry,
+  calculateDelay,
+  RetryPredicates,
+  DEFAULT_RETRY_CONFIG,
+  RetryConfig,
+  RetryExhaustedError,
+} from "@opuspopuli/common";
+export type { WithRetryOptions } from "@opuspopuli/common";
+
+// Local implementations (Redis-specific, stays in extraction-provider)
 export * from "./redis-rate-limiter.js";
-export * from "./retry.js";

--- a/packages/extraction-provider/src/utils/redis-rate-limiter.ts
+++ b/packages/extraction-provider/src/utils/redis-rate-limiter.ts
@@ -10,8 +10,7 @@
  */
 
 import Redis from "ioredis";
-import type { IRateLimiter } from "../cache/cache.interface.js";
-import type { RateLimitOptions } from "../types.js";
+import type { IRateLimiter, RateLimitOptions } from "@opuspopuli/common";
 
 /**
  * Redis rate limiter configuration options


### PR DESCRIPTION
## Summary
- Move `RateLimiter`, `withRetry`/`RetryPredicates`, and `MemoryCache` from `extraction-provider` into `@opuspopuli/common` so all packages (including region plugins) can reuse them
- Add `ICache`, `IRateLimiter` interfaces and `CacheOptions`, `RateLimitOptions`, `RetryConfig` types to common
- Refactor `extraction-provider` to import from common; re-export for backwards compatibility
- Delete local copies from extraction-provider; move tests to common

## Test plan
- [x] All 3 new common modules build cleanly (`pnpm run build`)
- [x] 46 new tests pass in common (rate-limiter, retry, memory-cache)
- [x] Extraction-provider compiles with refactored imports
- [x] Full monorepo test suite passes (2,506 tests, 0 failures)
- [x] Backwards compatibility verified — no import changes needed in consuming packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)