### PR TITLE
fix(ci): use PACKAGES_TOKEN for publish workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -56,7 +56,7 @@ jobs:
             echo "Skipping @opuspopuli/common — version $LOCAL_VERSION already published"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
 
       - name: Check and publish @opuspopuli/region-plugin-sdk
         run: |
@@ -70,4 +70,4 @@ jobs:
             echo "Skipping @opuspopuli/region-plugin-sdk — version $LOCAL_VERSION already published"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch publish workflow from `GITHUB_TOKEN` to `PACKAGES_TOKEN` (PAT) for the publish steps
- Org-level settings restrict `GITHUB_TOKEN` to read-only, causing `403 permission_denied: write_package` on publish
- Install step still uses `GITHUB_TOKEN` (only needs read access)

## Test plan
- [ ] Merge to develop, then to main
- [ ] Verify publish workflow succeeds with `PACKAGES_TOKEN` secret
- [ ] Confirm `@opuspopuli/common@0.2.0` and `@opuspopuli/region-plugin-sdk@0.2.0` appear on GitHub Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)