### PR TITLE
Release: fix publish workflow auth token

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -56,7 +56,7 @@ jobs:
             echo "Skipping @opuspopuli/common — version $LOCAL_VERSION already published"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN }}
 
       - name: Check and publish @opuspopuli/region-plugin-sdk
         run: |
@@ -70,4 +70,4 @@ jobs:
             echo "Skipping @opuspopuli/region-plugin-sdk — version $LOCAL_VERSION already published"
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch publish workflow from `GITHUB_TOKEN` to `PACKAGES_TOKEN` (PAT) for package publish steps
- Fixes `403 permission_denied: write_package` error caused by org-level read-only restriction on `GITHUB_TOKEN`

## What triggers
Once merged, the publish workflow will auto-detect the version bump (0.1.0 → 0.2.0) and publish:
- `@opuspopuli/common@0.2.0`
- `@opuspopuli/region-plugin-sdk@0.2.0`

## Test plan
- [ ] Verify publish workflow completes successfully
- [ ] Confirm both packages appear at v0.2.0 on GitHub Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)