### PR TITLE
refactor: migrate vectordb-provider from TypeORM to Prisma

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ All documentation is located in the [`docs/`](docs/) directory:
 ### Backend (Microservices)
 - [NestJS](https://nestjs.com) - Node.js framework
 - [GraphQL Federation](https://www.apollographql.com/docs/federation/) - Unified API gateway
-- [TypeORM](https://typeorm.io) - Database ORM
+- [Prisma](https://www.prisma.io) - Database ORM
 
 ### AI/ML Stack (100% OSS)
 
@@ -111,6 +111,7 @@ opuspopuli/
 │   ├── email-provider/       # Transactional email (Resend)
 │   ├── logging-provider/     # Audit logging
 │   ├── ocr-provider/         # OCR functionality
+│   ├── scraping-pipeline/   # AI-powered web scraping (schema-on-read)
 │   └── region-provider/      # Civic data integration (declarative plugins)
 ├── apps/
 │   ├── backend/              # NestJS microservices
@@ -135,7 +136,7 @@ The `packages/` directory contains reusable workspace packages that provide plug
 | `@opuspopuli/common` | Shared types, interfaces, and HTTP connection pooling | - |
 | `@opuspopuli/llm-provider` | Ollama LLM integration | 16 |
 | `@opuspopuli/embeddings-provider` | Xenova/Ollama embeddings | 24 |
-| `@opuspopuli/vectordb-provider` | pgvector (PostgreSQL) | 19 |
+| `@opuspopuli/vectordb-provider` | pgvector (PostgreSQL) | 15 |
 | `@opuspopuli/relationaldb-provider` | PostgreSQL | 7 |
 | `@opuspopuli/extraction-provider` | Text extraction (URLs, PDFs) with caching & rate limiting | 116 |
 | `@opuspopuli/storage-provider` | Supabase Storage | 17 |
@@ -144,6 +145,7 @@ The `packages/` directory contains reusable workspace packages that provide plug
 | `@opuspopuli/email-provider` | Resend transactional email | - |
 | `@opuspopuli/logging-provider` | Audit logging | - |
 | `@opuspopuli/ocr-provider` | OCR functionality | - |
+| `@opuspopuli/scraping-pipeline` | AI-powered schema-on-read web scraping with structural manifests | - |
 | `@opuspopuli/region-provider` | Civic data integration (declarative plugins, propositions, meetings, representatives) | - |
 
 ## Development
@@ -195,6 +197,8 @@ docker-compose logs -f   # View logs
 - ✅ **Observability** - Prometheus metrics, Loki logging, Grafana dashboards
 - ✅ **Distributed Caching** - Redis for caching and rate limiting
 - ✅ **Internationalization** - English and Spanish with react-i18next
+- ✅ **Civic Data Integration** - Declarative region plugins for propositions, meetings, and representatives
+- ✅ **AI-Powered Scraping** - Schema-on-read pipeline with structural manifests and self-healing
 - ✅ **Accessibility** - WCAG 2.2 Level AA compliant
 - ✅ **100% Self-Hosted** - Complete data control and privacy
 
@@ -210,7 +214,7 @@ Opus Populi is the foundation for the Opus Populi Network - a collaborative ecos
 
 - **[Network Overview](NETWORK.md)** - Learn about the network and how to join
 - **[Network Terms](NETWORK-TERMS.md)** - Terms of service for network members
-- **[Region Provider Guide](docs/guides/region-provider.md)** - Create a custom region provider for your jurisdiction
+- **[Region Provider Guide](docs/guides/region-provider.md)** - Add civic data for your jurisdiction via declarative plugins
 
 ## Support
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -512,7 +512,7 @@ See [crypto.utils.ts](apps/backend/src/common/utils/crypto.utils.ts) for impleme
 ### Code Security
 
 - Input validation on all user inputs via class-validator
-- Parameterized queries (TypeORM)
+- Parameterized queries (Prisma)
 - Strict CORS configuration for API endpoints
 - Rate limiting on authentication endpoints
 - Error sanitization prevents information disclosure

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Practical guides for common tasks and workflows.
 - [**Database Migration**](guides/database-migration.md) - Migrating between database providers
 - [**Audit Logging**](guides/audit-logging.md) - Comprehensive audit logging for compliance and security
 - [**Email Integration**](guides/email-integration.md) - Transactional email with Resend
-- [**Region Provider**](guides/region-provider.md) - Creating custom region providers for civic data
+- [**Region Provider**](guides/region-provider.md) - Declarative region plugins for civic data
 - [**Observability**](guides/observability.md) - Prometheus metrics and Loki logging
 
 ## Quick Links
@@ -87,7 +87,7 @@ This platform is built on three core principles:
 
 ## Platform Packages
 
-The `packages/` directory contains reusable, publishable npm packages (`@opuspopuli/*`) that implement the pluggable provider architecture:
+The `packages/` directory contains workspace packages (`@opuspopuli/*`) that implement the pluggable provider architecture:
 
 | Package | Purpose |
 |---------|---------|
@@ -103,6 +103,7 @@ The `packages/` directory contains reusable, publishable npm packages (`@opuspop
 | `@opuspopuli/email-provider` | Resend transactional email |
 | `@opuspopuli/logging-provider` | Structured logging with PII redaction |
 | `@opuspopuli/ocr-provider` | Image text extraction (Tesseract.js) |
+| `@opuspopuli/scraping-pipeline` | AI-powered schema-on-read web scraping with structural manifests |
 | `@opuspopuli/region-provider` | Civic data integration (declarative plugins, propositions, meetings, representatives) |
 
 See [Provider Pattern](architecture/provider-pattern.md) and [Region Provider Guide](guides/region-provider.md) for implementation details.

--- a/docs/architecture/data-layer.md
+++ b/docs/architecture/data-layer.md
@@ -99,7 +99,7 @@ SELECT * FROM pg_extension WHERE extname = 'vector';
 
 ## Data Models
 
-### Relational Tables (TypeORM Entities)
+### Relational Tables (Prisma Models)
 
 #### User Entity
 ```typescript

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -90,7 +90,7 @@ Opus Populi is built on a modular, provider-based architecture with three core p
 
 ## Provider Architecture
 
-All external dependencies use the **Strategy Pattern + Dependency Injection** for maximum flexibility. Providers are implemented as reusable npm packages in the `packages/` directory.
+All external dependencies use the **Strategy Pattern + Dependency Injection** for maximum flexibility. Providers are implemented as workspace packages in the `packages/` directory.
 
 ### Platform Packages
 
@@ -107,7 +107,8 @@ All external dependencies use the **Strategy Pattern + Dependency Injection** fo
 | `@opuspopuli/email-provider` | Transactional email (Resend) | `EMAIL_PROVIDER` |
 | `@opuspopuli/logging-provider` | Audit logging | `LOGGING_PROVIDER` |
 | `@opuspopuli/ocr-provider` | OCR functionality | `OCR_PROVIDER` |
-| `@opuspopuli/region-provider` | Civic data integration | `REGION_PROVIDER` |
+| `@opuspopuli/scraping-pipeline` | AI-powered schema-on-read web scraping | `SCRAPING_PIPELINE` |
+| `@opuspopuli/region-provider` | Civic data integration (declarative plugins) | `REGION_PROVIDER` |
 
 ### Relational Database Provider
 **Package**: `@opuspopuli/relationaldb-provider`
@@ -442,11 +443,6 @@ See [Authentication Security Guide](../guides/auth-security.md) for implementati
 ### Planned Providers
 - **LLM**: vLLM, Text Generation Inference
 - **Embeddings**: Custom fine-tuned models
-
-### Recently Implemented
-- **Profile Enhancements**: Avatar upload, civic/demographic fields, profile completion tracking, visibility controls
-- **WCAG 2.2 AA Accessibility**: Keyboard navigation, screen reader support, focus management
-- **Internationalization**: English and Spanish translations with react-i18next
 
 ### Planned Features
 - Multi-modal RAG (images, PDFs)

--- a/docs/guides/backend-testing.md
+++ b/docs/guides/backend-testing.md
@@ -332,7 +332,7 @@ Coverage reports are uploaded to SonarCloud in CI.
 ### Excluded from Coverage
 
 - `src/db/migrations/` - Generated migration files
-- `src/db/entities/` - TypeORM entity definitions
+- `src/db/entities/` - Entity definitions
 - `main.ts` - Bootstrap files
 - `*.dto.ts` - Data transfer objects (type definitions)
 

--- a/docs/guides/region-provider.md
+++ b/docs/guides/region-provider.md
@@ -1,213 +1,195 @@
 # Region Provider Guide
 
-This guide explains how to create a custom region provider to integrate civic data from your jurisdiction into the platform.
+This guide explains how the declarative region plugin system works and how to add civic data for your jurisdiction.
 
 ## Overview
 
-The region framework follows the provider pattern used throughout the platform. The base platform includes:
+The platform uses **declarative region plugins** — JSON configuration that describes where civic data lives on the web and what to extract. There is no scraper code to write. The AI-powered scraping pipeline analyzes page structure, derives extraction rules, and maps raw data to typed domain models.
 
-- **Region microservice** (`apps/backend/src/apps/region/`) - Handles data sync, storage, and API
-- **Region provider package** (`packages/region-provider/`) - Contains the example provider and factory
-- **Provider interface** (`packages/common/src/providers/region/`) - TypeScript interfaces
+### Key Components
 
-Forks only need to create a new provider package that implements `IRegionProvider`.
+- **Region microservice** (`apps/backend/src/apps/region/`) — Data sync, storage, and GraphQL API
+- **Region provider package** (`packages/region-provider/`) — Plugin loader, registry, declarative plugin bridge, example provider
+- **Scraping pipeline** (`packages/scraping-pipeline/`) — AI structural analysis, manifest caching, Cheerio extraction, domain mapping
+- **Common types** (`packages/common/src/providers/`) — `DeclarativeRegionConfig`, `DataSourceConfig`, `DataType`, and domain models
 
 ## Architecture
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
-│                         BASE PLATFORM                               │
+│                         PLATFORM                                     │
 ├─────────────────────────────────────────────────────────────────────┤
-│  packages/common/src/providers/region/                              │
-│  └── types.ts (IRegionProvider, DataType)                           │
-│                                                                     │
-│  packages/extraction-provider/                                      │
-│  ├── src/extraction.provider.ts (fetch, parse, rate limit, cache)  │
-│  └── src/extraction.service.ts (text extraction orchestration)     │
-│                                                                     │
-│  packages/region-provider/                                          │
-│  ├── src/providers/example.provider.ts (mock/sample data)          │
-│  ├── src/region.service.ts (orchestrates sync)                     │
-│  └── src/region.module.ts (DI factory based on env)                │
-│                                                                     │
-│  apps/backend/src/apps/region/                                      │
-│  ├── Scheduler (cron jobs to sync data)                            │
-│  ├── Database entities (propositions, meetings, reps)              │
-│  └── GraphQL resolvers                                             │
-└─────────────────────────────────────────────────────────────────────┘
-
-┌─────────────────────────────────────────────────────────────────────┐
-│                         FORK ADDS ONLY                              │
-├─────────────────────────────────────────────────────────────────────┤
-│  packages/region-provider-california/  (or your jurisdiction)       │
-│  └── Implements IRegionProvider using ExtractionProvider            │
+│                                                                      │
+│  Database (region_plugins table)                                     │
+│  └── DeclarativeRegionConfig JSON (data sources + content goals)     │
+│                                                                      │
+│  packages/region-provider/                                           │
+│  ├── PluginLoaderService (loads config, creates plugin)              │
+│  ├── PluginRegistryService (tracks active plugin)                    │
+│  ├── DeclarativeRegionPlugin (bridges config → IRegionPlugin)        │
+│  └── ExampleRegionProvider (built-in mock data for development)      │
+│                                                                      │
+│  packages/scraping-pipeline/                                         │
+│  ├── StructuralAnalyzerService (AI analyzes page → manifest)         │
+│  ├── ManifestStoreService (caches versioned manifests in DB)         │
+│  ├── ManifestExtractorService (Cheerio extraction using rules)       │
+│  ├── DomainMapperService (raw records → typed models)                │
+│  ├── SelfHealingService (re-analyzes when extraction fails)          │
+│  └── PipelineService (orchestrates the above)                        │
+│                                                                      │
+│  apps/backend/src/apps/region/                                       │
+│  ├── RegionDomainService (loads plugin at startup, syncs data)       │
+│  ├── GraphQL resolvers (queries + mutations)                         │
+│  └── Database (propositions, meetings, representatives)              │
+│                                                                      │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-**Note**: Region providers should use `ExtractionProvider` from `@opuspopuli/extraction-provider` for fetching web content. This provides built-in rate limiting, caching, retry with exponential backoff, and HTML parsing via cheerio.
+## How It Works
 
-## Creating a Custom Provider
+1. **Startup**: `RegionDomainService.onModuleInit()` reads the `region_plugins` table for an enabled plugin
+2. **Loading**: `PluginLoaderService.loadPlugin()` validates the config and creates a `DeclarativeRegionPlugin`
+3. **Registration**: The plugin is registered in `PluginRegistryService` and wrapped in a `RegionService`
+4. **Sync**: When data sync runs, the plugin calls `pipeline.execute()` for each data source
+5. **Pipeline**: The scraping pipeline fetches the page, finds/creates a structural manifest via AI, extracts data with Cheerio, and maps it to typed domain models
+6. **Storage**: Extracted data is upserted into the database (propositions, meetings, representatives)
 
-### Step 1: Create the Provider Package
+If no plugin is configured in the database, the platform falls back to the built-in `ExampleRegionProvider` with mock data.
 
-Create a new package directory:
+## Adding a Region
 
-```bash
-mkdir -p packages/region-provider-california/src/providers
-```
+### Step 1: Define the Configuration
 
-Create `package.json`:
+Create a `DeclarativeRegionConfig` describing your region's data sources:
 
-```json
+```typescript
+// DeclarativeRegionConfig (from @opuspopuli/common)
 {
-  "name": "@opuspopuli/region-provider-california",
-  "version": "1.0.0",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "scripts": {
-    "build": "tsc",
-    "dev": "tsc --watch"
-  },
-  "dependencies": {
-    "@opuspopuli/common": "workspace:*"
-  },
-  "devDependencies": {
-    "typescript": "^5.7.2"
-  }
+  regionId: "california",
+  regionName: "California",
+  description: "Civic data for the State of California",
+  timezone: "America/Los_Angeles",
+  dataSources: [
+    {
+      url: "https://www.sos.ca.gov/elections/ballot-measures/qualified-ballot-measures",
+      dataType: "propositions",
+      contentGoal: "Extract qualified ballot measures with measure ID, title, and election date",
+      hints: ["Table with ballot measure details", "Look for measure numbers like 'Prop 1'"]
+    },
+    {
+      url: "https://assembly.ca.gov/schedules-publications/assembly-daily-file",
+      dataType: "meetings",
+      contentGoal: "Extract scheduled committee meetings with date, time, location, and committee name",
+      category: "Assembly"
+    },
+    {
+      url: "https://senate.ca.gov/publications/senate-daily-file",
+      dataType: "meetings",
+      contentGoal: "Extract scheduled committee meetings with date, time, location, and committee name",
+      category: "Senate"
+    },
+    {
+      url: "https://assembly.ca.gov/assemblymembers",
+      dataType: "representatives",
+      contentGoal: "Extract Assembly members with name, district number, party affiliation, and photo URL",
+      category: "Assembly"
+    },
+    {
+      url: "https://senate.ca.gov/senators",
+      dataType: "representatives",
+      contentGoal: "Extract Senators with name, district number, party affiliation, and photo URL",
+      category: "Senate"
+    }
+  ],
+  rateLimit: { requestsPerSecond: 1, burstSize: 3 },
+  cacheTtlMs: 3600000,
+  requestTimeoutMs: 30000
 }
 ```
 
-### Step 2: Implement IRegionProvider
+### Step 2: Insert into the Database
 
-Create `src/providers/california.provider.ts`:
+Add a row to the `region_plugins` table with your config as JSON:
+
+```sql
+INSERT INTO region_plugins (name, enabled, config, plugin_type)
+VALUES (
+  'california',
+  true,
+  '{ "regionId": "california", "regionName": "California", ... }',
+  'declarative'
+);
+```
+
+Or add it to a Prisma seed script:
 
 ```typescript
-import {
-  IRegionProvider,
-  RegionInfo,
-  DataType,
-  Proposition,
-  Meeting,
-  Representative,
-} from '@opuspopuli/common';
-
-export class CaliforniaRegionProvider implements IRegionProvider {
-  getName(): string {
-    return 'california';
-  }
-
-  getRegionInfo(): RegionInfo {
-    return {
-      id: 'california',
-      name: 'California',
+await prisma.regionPlugin.create({
+  data: {
+    name: 'california',
+    enabled: true,
+    pluginType: 'declarative',
+    config: {
+      regionId: 'california',
+      regionName: 'California',
       description: 'Civic data for the State of California',
       timezone: 'America/Los_Angeles',
-      dataSourceUrls: [
-        'https://leginfo.legislature.ca.gov/',
-        'https://www.sos.ca.gov/elections/',
+      dataSources: [
+        // ... data sources as above
       ],
-    };
-  }
+    },
+  },
+});
+```
 
-  getSupportedDataTypes(): DataType[] {
-    return [
-      DataType.PROPOSITIONS,
-      DataType.MEETINGS,
-      DataType.REPRESENTATIVES,
-    ];
-  }
+### Step 3: Restart and Sync
 
-  async fetchPropositions(): Promise<Proposition[]> {
-    // Implement scraping/API calls to fetch propositions
-    // Example: Fetch from California Secretary of State API
-    const propositions = await this.scrapePropositions();
-    return propositions;
-  }
+Restart the region service. It reads the enabled plugin from the database and loads it:
 
-  async fetchMeetings(): Promise<Meeting[]> {
-    // Implement scraping/API calls to fetch legislative meetings
-    const meetings = await this.scrapeMeetings();
-    return meetings;
-  }
+```bash
+pnpm start:region
+```
 
-  async fetchRepresentatives(): Promise<Representative[]> {
-    // Implement API calls to fetch state legislators
-    const reps = await this.fetchLegislators();
-    return reps;
-  }
+Trigger a sync via GraphQL:
 
-  // Private helper methods for scraping/fetching
-  private async scrapePropositions(): Promise<Proposition[]> {
-    // Your implementation here
-    return [];
-  }
-
-  private async scrapeMeetings(): Promise<Meeting[]> {
-    // Your implementation here
-    return [];
-  }
-
-  private async fetchLegislators(): Promise<Representative[]> {
-    // Your implementation here
-    return [];
+```graphql
+mutation {
+  syncAll {
+    dataType
+    itemsProcessed
+    itemsCreated
+    itemsUpdated
+    errors
+    syncedAt
   }
 }
 ```
 
-### Step 3: Export the Provider
+## DeclarativeRegionConfig Reference
 
-Create `src/index.ts`:
+### Top-Level Fields
 
-```typescript
-export { CaliforniaRegionProvider } from './providers/california.provider';
-```
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `regionId` | `string` | Yes | Unique identifier (e.g., `"california"`) |
+| `regionName` | `string` | Yes | Human-readable name (e.g., `"California"`) |
+| `description` | `string` | Yes | Short description of the region |
+| `timezone` | `string` | Yes | IANA timezone (e.g., `"America/Los_Angeles"`) |
+| `dataSources` | `DataSourceConfig[]` | Yes | Array of data source definitions |
+| `rateLimit` | `object` | No | `{ requestsPerSecond, burstSize }` |
+| `cacheTtlMs` | `number` | No | Cache TTL in milliseconds |
+| `requestTimeoutMs` | `number` | No | Request timeout in milliseconds |
 
-### Step 4: Register the Provider
+### DataSourceConfig Fields
 
-Update `packages/region-provider/src/region.module.ts` to include your provider:
-
-```typescript
-import { CaliforniaRegionProvider } from '@opuspopuli/region-provider-california';
-
-// In the factory function:
-switch (config.provider) {
-  case 'california':
-    return new CaliforniaRegionProvider();
-  case 'example':
-  default:
-    return new ExampleRegionProvider();
-}
-```
-
-### Step 5: Configure Environment
-
-Update your `.env` file:
-
-```bash
-REGION_PROVIDER=california
-REGION_PORT=3004
-REGION_SYNC_ENABLED=true
-REGION_SYNC_SCHEDULE='0 2 * * *'  # Daily at 2 AM
-
-# Provider-specific configuration
-CALIFORNIA_API_KEY=your-api-key
-```
-
-### Step 6: Add to Workspace
-
-Add to `pnpm-workspace.yaml`:
-
-```yaml
-packages:
-  - 'packages/*'
-  - 'apps/*'
-```
-
-Run install:
-
-```bash
-pnpm install
-```
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `url` | `string` | Yes | URL of the page to scrape |
+| `dataType` | `DataType` | Yes | `"propositions"`, `"meetings"`, or `"representatives"` |
+| `contentGoal` | `string` | Yes | Natural language description of what to extract |
+| `category` | `string` | No | Sub-grouping (e.g., `"Assembly"`, `"Senate"`) |
+| `hints` | `string[]` | No | Additional hints for the AI structural analyzer |
+| `rateLimitOverride` | `number` | No | Override the default rate limit for this source |
 
 ## Data Types
 
@@ -215,13 +197,13 @@ pnpm install
 
 ```typescript
 interface Proposition {
-  externalId: string;    // Unique ID from source (e.g., "prop-2024-1")
-  title: string;         // Proposition title
-  summary: string;       // Brief summary
-  fullText?: string;     // Full text of the proposition
-  status: PropositionStatus;  // 'pending' | 'passed' | 'failed' | 'withdrawn'
-  electionDate?: Date;   // Election date
-  sourceUrl?: string;    // Link to official source
+  externalId: string;           // Unique ID from source (e.g., "prop-2024-1")
+  title: string;                // Proposition title
+  summary: string;              // Brief summary
+  fullText?: string;            // Full text of the proposition
+  status: PropositionStatus;    // 'pending' | 'passed' | 'failed' | 'withdrawn'
+  electionDate?: Date;          // Election date
+  sourceUrl?: string;           // Link to official source
 }
 ```
 
@@ -243,13 +225,13 @@ interface Meeting {
 
 ```typescript
 interface Representative {
-  externalId: string;    // Unique ID from source
-  name: string;          // Full name
-  chamber: string;       // Legislative chamber
-  district: string;      // District identifier
-  party: string;         // Political party
-  photoUrl?: string;     // URL to photo
-  contactInfo?: ContactInfo;  // Contact details
+  externalId: string;           // Unique ID from source
+  name: string;                 // Full name
+  chamber: string;              // Legislative chamber
+  district: string;             // District identifier
+  party: string;                // Political party
+  photoUrl?: string;            // URL to photo
+  contactInfo?: ContactInfo;    // Contact details
 }
 
 interface ContactInfo {
@@ -260,16 +242,47 @@ interface ContactInfo {
 }
 ```
 
+## The Scraping Pipeline
+
+The `@opuspopuli/scraping-pipeline` package handles all data extraction using a **schema-on-read** pattern:
+
+1. **Structural Analysis** — AI (via Ollama LLM) analyzes a web page's HTML structure and produces a `StructuralManifest` containing CSS selectors and field mappings
+2. **Manifest Caching** — Manifests are versioned and stored in the database. If the page structure hasn't changed, the cached manifest is reused (no LLM call)
+3. **Cheerio Extraction** — The manifest's CSS selectors are applied with Cheerio to extract raw records from the page
+4. **Domain Mapping** — Raw records are mapped to typed domain models (`Proposition`, `Meeting`, `Representative`)
+5. **Self-Healing** — If extraction fails (e.g., the website changed its layout), the pipeline re-analyzes the page and creates a new manifest version
+
+### Writing Good Content Goals
+
+The `contentGoal` field in `DataSourceConfig` is the primary input to the AI structural analyzer. Good content goals are:
+
+- **Specific**: "Extract Assembly members with name, district number, party affiliation, and photo URL"
+- **Descriptive**: Mention the expected HTML structure if you know it (tables, lists, cards)
+- **Field-aware**: Name the fields you expect to find (matches the domain model)
+
+Use the `hints` array for additional context:
+
+```typescript
+{
+  url: "https://example.gov/members",
+  dataType: "representatives",
+  contentGoal: "Extract legislators with name, district, party, and photo",
+  hints: [
+    "Members are displayed in a card grid layout",
+    "District numbers are prefixed with 'District'",
+    "Party is shown as (D) or (R) after the name"
+  ]
+}
+```
+
 ## Data Sync
 
-The region microservice includes a scheduler that automatically syncs data:
+The region microservice syncs data from the plugin to the database using bulk upsert operations (batched in a database transaction for performance).
 
-- **Default schedule**: Daily at 2 AM (configurable via `REGION_SYNC_SCHEDULE`)
-- **On startup**: Syncs all data when the service starts (if `REGION_SYNC_ENABLED=true`)
-
-You can also trigger a manual sync via GraphQL:
+You can trigger a sync via GraphQL:
 
 ```graphql
+# Sync all data types
 mutation {
   syncAll {
     dataType
@@ -280,11 +293,8 @@ mutation {
     syncedAt
   }
 }
-```
 
-Or sync a specific data type:
-
-```graphql
+# Sync a specific data type
 mutation {
   syncDataType(dataType: PROPOSITIONS) {
     dataType
@@ -297,141 +307,74 @@ mutation {
 }
 ```
 
-## Best Practices
+## Querying Data
 
-### 1. Use External IDs
+Once synced, civic data is available via GraphQL:
 
-Always use stable external IDs from your data source. This allows the sync process to correctly update existing records.
-
-### 2. Use ExtractionProvider for Web Fetching
-
-**Always** use `ExtractionProvider` from `@opuspopuli/extraction-provider` for fetching web content. It provides:
-
-- **Rate Limiting**: Token bucket algorithm prevents overwhelming data sources
-- **Caching**: Automatic caching with configurable TTL
-- **Retry Logic**: Exponential backoff with jitter for transient failures
-- **HTML Parsing**: Built-in cheerio integration for DOM selection
-
-```typescript
-import { ExtractionProvider } from '@opuspopuli/extraction-provider';
-
-export class CaliforniaRegionProvider implements IRegionProvider {
-  constructor(private readonly extraction: ExtractionProvider) {}
-
-  async fetchPropositions(): Promise<Proposition[]> {
-    // Fetch with automatic rate limiting, caching, and retry
-    const result = await this.extraction.fetchUrl(
-      'https://www.sos.ca.gov/elections/ballot-measures'
-    );
-
-    // Parse HTML with cheerio
-    const $ = this.extraction.parseHtml(result.content);
-
-    // Select and parse elements
-    return $('table.ballot-measures tr')
-      .map((_, row) => ({
-        id: $(row).find('td:nth-child(1)').text().trim(),
-        title: $(row).find('td:nth-child(2)').text().trim(),
-        // ...
-      }))
-      .get();
-  }
-
-  async fetchPdfProposition(url: string): Promise<string> {
-    // Fetch PDF with retry logic
-    const result = await this.extraction.fetchWithRetry(url);
-    const buffer = Buffer.from(result.content);
-    return this.extraction.extractPdfText(buffer);
+```graphql
+# Region info
+query {
+  regionInfo {
+    id
+    name
+    description
+    timezone
+    supportedDataTypes
   }
 }
-```
 
-### 3. Configure Extraction for Your Needs
-
-Customize extraction settings via environment variables:
-
-```bash
-# Higher rate limit for APIs that allow it
-EXTRACTION_RATE_LIMIT_RPS=5
-
-# Longer cache for infrequently changing data
-EXTRACTION_CACHE_TTL_MS=3600000  # 1 hour
-
-# More retries for unreliable sources
-EXTRACTION_RETRY_MAX_ATTEMPTS=5
-```
-
-### 4. Log Progress
-
-Use the NestJS logger for sync progress:
-
-```typescript
-private readonly logger = new Logger(CaliforniaRegionProvider.name);
-
-async fetchPropositions(): Promise<Proposition[]> {
-  this.logger.log('Fetching California propositions...');
-  const props = await this.scrapePropositions();
-  this.logger.log(`Fetched ${props.length} propositions`);
-  return props;
+# Propositions with pagination
+query {
+  propositions(skip: 0, take: 10) {
+    items {
+      id
+      title
+      summary
+      status
+      electionDate
+    }
+    total
+    hasMore
+  }
 }
-```
 
-### 5. Test Your Scraper
-
-Create unit tests for your scraping logic:
-
-```typescript
-describe('CaliforniaRegionProvider', () => {
-  let provider: CaliforniaRegionProvider;
-
-  beforeEach(() => {
-    provider = new CaliforniaRegionProvider();
-  });
-
-  it('should return region info', () => {
-    const info = provider.getRegionInfo();
-    expect(info.id).toBe('california');
-    expect(info.name).toBe('California');
-  });
-
-  it('should fetch propositions', async () => {
-    const props = await provider.fetchPropositions();
-    expect(Array.isArray(props)).toBe(true);
-  });
-});
+# Representatives filtered by chamber
+query {
+  representatives(chamber: "Assembly", skip: 0, take: 20) {
+    items {
+      name
+      district
+      party
+      photoUrl
+    }
+    total
+    hasMore
+  }
+}
 ```
 
 ## Troubleshooting
 
-### Provider Not Loading
+### Plugin Not Loading
 
-1. Verify `REGION_PROVIDER` is set correctly in `.env`
-2. Check that the provider package is installed: `pnpm install`
-3. Verify the provider is exported correctly from the package
-4. Check the region service logs for errors
+1. Check that the `region_plugins` table has an enabled row
+2. Verify the config JSON has `regionId` and `dataSources` fields
+3. Check the region service logs for loader errors
+4. Ensure `ScrapingPipelineModule` is imported in the region module
 
-### Sync Failing
+### Sync Returning Empty Results
 
-1. Check the sync result for errors in the GraphQL response
-2. Review the region service logs: `pnpm start:region`
-3. Verify external API access (network, API keys, rate limits)
+1. Check the sync mutation response for errors
+2. Review the region service logs for pipeline errors
+3. Verify the data source URLs are accessible
+4. Check the structural manifest in the database — the AI may need better `contentGoal` or `hints`
 
-### Data Not Appearing
+### Data Not Appearing in Frontend
 
-1. Verify the sync completed successfully
-2. Check the database for the records
-3. Verify the GraphQL queries are returning data
-4. Check frontend console for GraphQL errors
+1. Verify the sync completed via the mutation response
+2. Query the data directly via GraphQL to confirm it's in the database
+3. Check the frontend console for GraphQL errors
 
-## Example Providers
+## Example Provider
 
-- **Example Provider** (`packages/region-provider/src/providers/example.provider.ts`) - Mock data for development
-
-## Contributing
-
-When contributing a new region provider:
-
-1. Follow the IRegionProvider interface strictly
-2. Include comprehensive tests
-3. Document data sources and any API requirements
-4. Update the plan file if adding new data types
+The built-in `ExampleRegionProvider` (`packages/region-provider/src/providers/example.provider.ts`) returns mock data for development. It is automatically used when no plugin is configured in the database.

--- a/docs/guides/supabase-setup.md
+++ b/docs/guides/supabase-setup.md
@@ -181,7 +181,7 @@ const tokens = await this.authProvider.authenticateUser(
 
 #### Passkey Database Schema
 
-Passkeys require two database tables (auto-created via TypeORM migrations):
+Passkeys require two database tables (auto-created via Prisma migrations):
 
 **passkey_credentials**:
 | Column | Type | Description |

--- a/packages/relationaldb-provider/prisma/seeds/region-plugins.seed.ts
+++ b/packages/relationaldb-provider/prisma/seeds/region-plugins.seed.ts
@@ -1,7 +1,7 @@
 /**
  * Seed script for region plugins.
  *
- * Creates the default example plugin and the California declarative plugin.
+ * Creates the California declarative plugin.
  *
  * Usage: npx ts-node prisma/seeds/region-plugins.seed.ts
  */
@@ -11,24 +11,6 @@ import { PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
 
 async function seedRegionPlugins() {
-  // Example plugin (code-based, for development/testing)
-  const example = await prisma.regionPlugin.upsert({
-    where: { name: "example" },
-    update: {},
-    create: {
-      name: "example",
-      displayName: "Example Region",
-      description:
-        "Sample region with mock civic data for development and testing",
-      packageName: "@opuspopuli/region-template",
-      pluginType: "code",
-      version: "0.1.0",
-      enabled: true,
-    },
-  });
-
-  console.log(`Seeded region plugin: ${example.name} (${example.id})`);
-
   // California plugin (declarative, uses scraping pipeline)
   const california = await prisma.regionPlugin.upsert({
     where: { name: "california" },

--- a/packages/vectordb-provider/package.json
+++ b/packages/vectordb-provider/package.json
@@ -25,25 +25,20 @@
   ],
   "license": "AGPL-3.0",
   "dependencies": {
-    "@opuspopuli/common": "workspace:*"
+    "@opuspopuli/common": "workspace:*",
+    "@opuspopuli/relationaldb-provider": "workspace:*"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",
-    "@nestjs/config": "^4.0.0",
-    "pg": "^8.0.0",
-    "typeorm": "^0.3.0"
+    "@nestjs/config": "^4.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "^11.1.9",
     "@nestjs/config": "^4.0.2",
-    "@nestjs/typeorm": "^11.0.0",
     "@types/jest": "^30.0.0",
     "jest": "^30.0.0",
-    "pg": "^8.13.1",
-    "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "ts-jest": "^29.2.5",
-    "typeorm": "^0.3.20",
     "typescript": "^5.7.2"
   }
 }

--- a/packages/vectordb-provider/src/index.ts
+++ b/packages/vectordb-provider/src/index.ts
@@ -2,7 +2,7 @@
  * @opuspopuli/vectordb-provider
  *
  * Vector database provider implementations for the Opus Populi platform.
- * Uses PostgreSQL with pgvector extension (consolidates with Supabase).
+ * Uses PostgreSQL with pgvector extension via the shared DbService connection.
  *
  * To add custom providers, implement IVectorDBProvider interface.
  */
@@ -14,6 +14,9 @@ export {
   IVectorQueryResult,
   VectorDBError,
 } from "@opuspopuli/common";
+
+// Types
+export type { IRawQueryClient } from "./types.js";
 
 // Provider implementations
 export { PgVectorProvider } from "./providers/pgvector.provider.js";

--- a/packages/vectordb-provider/src/types.ts
+++ b/packages/vectordb-provider/src/types.ts
@@ -1,0 +1,21 @@
+/**
+ * Minimal interface for raw SQL query execution.
+ * Compatible with PrismaClient.$queryRawUnsafe / $executeRawUnsafe.
+ * This keeps vectordb-provider decoupled from @prisma/client as a direct dependency.
+ */
+export interface IRawQueryClient {
+  /**
+   * Execute a raw SQL query that returns rows (SELECT).
+   * Parameters use positional placeholders ($1, $2, etc.).
+   */
+  $queryRawUnsafe<T = unknown>(
+    query: string,
+    ...values: unknown[]
+  ): Promise<T[]>;
+
+  /**
+   * Execute a raw SQL statement that does not return rows (INSERT, UPDATE, DELETE, DDL).
+   * Parameters use positional placeholders ($1, $2, etc.).
+   */
+  $executeRawUnsafe(query: string, ...values: unknown[]): Promise<number>;
+}

--- a/packages/vectordb-provider/src/vectordb.module.ts
+++ b/packages/vectordb-provider/src/vectordb.module.ts
@@ -1,14 +1,14 @@
 import { Module } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
-import { DataSource } from "typeorm";
 import { IVectorDBProvider } from "@opuspopuli/common";
+import { DbService } from "@opuspopuli/relationaldb-provider";
 import { PgVectorProvider } from "./providers/pgvector.provider.js";
 
 /**
  * Vector Database Module
  *
  * Configures Dependency Injection for vector database providers.
- * Uses PostgreSQL with pgvector extension (consolidates with Supabase).
+ * Uses PostgreSQL with pgvector extension via the shared DbService connection.
  *
  * To add custom providers, implement IVectorDBProvider interface.
  */
@@ -18,50 +18,15 @@ import { PgVectorProvider } from "./providers/pgvector.provider.js";
       provide: "VECTOR_DB_PROVIDER",
       useFactory: async (
         configService: ConfigService,
+        dbService: DbService,
       ): Promise<IVectorDBProvider> => {
         const dimensions =
           configService.get<number>("vectordb.dimensions") || 384;
         const project = configService.get<string>("project") || "default";
         const collectionName = `${project}_embeddings`;
 
-        // Use PostgreSQL with pgvector extension
-        // Uses vectordb.postgres.* config, falls back to relationaldb.postgres.* for convenience
-        const dataSource = new DataSource({
-          type: "postgres",
-          host:
-            configService.get<string>("vectordb.postgres.host") ||
-            configService.get<string>("relationaldb.postgres.host") ||
-            "localhost",
-          port:
-            configService.get<number>("vectordb.postgres.port") ||
-            configService.get<number>("relationaldb.postgres.port") ||
-            5432,
-          database:
-            configService.get<string>("vectordb.postgres.database") ||
-            configService.get<string>("relationaldb.postgres.database") ||
-            "postgres",
-          username:
-            configService.get<string>("vectordb.postgres.username") ||
-            configService.get<string>("relationaldb.postgres.username") ||
-            "postgres",
-          password:
-            configService.get<string>("vectordb.postgres.password") ||
-            configService.get<string>("relationaldb.postgres.password") ||
-            "postgres",
-          ssl:
-            (configService.get<boolean>("vectordb.postgres.ssl") ??
-            configService.get<boolean>("relationaldb.postgres.ssl"))
-              ? { rejectUnauthorized: false }
-              : false,
-          synchronize: false, // We handle schema ourselves
-          logging: configService.get<string>("NODE_ENV") !== "production",
-        });
-
-        // Initialize the data source
-        await dataSource.initialize();
-
         const vectorDBProvider = new PgVectorProvider(
-          dataSource,
+          dbService,
           collectionName,
           dimensions,
         );
@@ -71,7 +36,7 @@ import { PgVectorProvider } from "./providers/pgvector.provider.js";
 
         return vectorDBProvider;
       },
-      inject: [ConfigService],
+      inject: [ConfigService, DbService],
     },
   ],
   exports: ["VECTOR_DB_PROVIDER"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,7 +482,7 @@ importers:
         version: 4.1.18
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.0.1))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -976,6 +976,9 @@ importers:
       '@opuspopuli/common':
         specifier: workspace:*
         version: link:../common
+      '@opuspopuli/relationaldb-provider':
+        specifier: workspace:*
+        version: link:../relationaldb-provider
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -983,30 +986,18 @@ importers:
       '@nestjs/config':
         specifier: ^4.0.2
         version: 4.0.2(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)
-      '@nestjs/typeorm':
-        specifier: ^11.0.0
-        version: 11.0.0(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1))))
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.2.0(@types/node@25.0.1)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))
-      pg:
-        specifier: ^8.13.1
-        version: 8.16.3
-      reflect-metadata:
-        specifier: ^0.2.2
-        version: 0.2.2
+        version: 30.2.0(@types/node@25.0.1)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.0.1)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3)))(typescript@5.9.3)
-      typeorm:
-        specifier: ^0.3.20
-        version: 0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1)))
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -10152,12 +10143,12 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
-  '@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1)':
+  '@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.947.0
-      '@aws-sdk/credential-provider-node': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/credential-provider-node': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/middleware-host-header': 3.936.0
       '@aws-sdk/middleware-logger': 3.936.0
       '@aws-sdk/middleware-recursion-detection': 3.948.0
@@ -10166,7 +10157,7 @@ snapshots:
       '@aws-sdk/types': 3.936.0
       '@aws-sdk/util-endpoints': 3.936.0
       '@aws-sdk/util-user-agent-browser': 3.936.0
-      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1)
+      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.20.7
       '@smithy/fetch-http-handler': 5.3.9
@@ -10203,7 +10194,7 @@ snapshots:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.947.0
-      '@aws-sdk/credential-provider-node': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/credential-provider-node': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/middleware-bucket-endpoint': 3.936.0
       '@aws-sdk/middleware-expect-continue': 3.936.0
       '@aws-sdk/middleware-flexible-checksums': 3.947.0
@@ -10219,7 +10210,7 @@ snapshots:
       '@aws-sdk/types': 3.936.0
       '@aws-sdk/util-endpoints': 3.936.0
       '@aws-sdk/util-user-agent-browser': 3.936.0
-      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1)
+      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@smithy/config-resolver': 4.4.6
       '@smithy/core': 3.20.7
       '@smithy/eventstream-serde-browser': 4.2.5
@@ -10307,7 +10298,7 @@ snapshots:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.947.0
-      '@aws-sdk/credential-provider-node': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/credential-provider-node': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/middleware-host-header': 3.936.0
       '@aws-sdk/middleware-logger': 3.936.0
       '@aws-sdk/middleware-recursion-detection': 3.948.0
@@ -10317,7 +10308,7 @@ snapshots:
       '@aws-sdk/types': 3.936.0
       '@aws-sdk/util-endpoints': 3.936.0
       '@aws-sdk/util-user-agent-browser': 3.936.0
-      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1)
+      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@smithy/config-resolver': 4.4.3
       '@smithy/core': 3.18.7
       '@smithy/fetch-http-handler': 5.3.6
@@ -10348,7 +10339,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso@3.948.0(aws-crt@1.28.1)':
+  '@aws-sdk/client-sso@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
@@ -10361,7 +10352,7 @@ snapshots:
       '@aws-sdk/types': 3.936.0
       '@aws-sdk/util-endpoints': 3.936.0
       '@aws-sdk/util-user-agent-browser': 3.936.0
-      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1)
+      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@smithy/config-resolver': 4.4.3
       '@smithy/core': 3.18.7
       '@smithy/fetch-http-handler': 5.3.6
@@ -10439,7 +10430,7 @@ snapshots:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/core': 3.947.0
-      '@aws-sdk/credential-provider-node': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/credential-provider-node': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/middleware-host-header': 3.936.0
       '@aws-sdk/middleware-logger': 3.936.0
       '@aws-sdk/middleware-recursion-detection': 3.948.0
@@ -10448,7 +10439,7 @@ snapshots:
       '@aws-sdk/types': 3.936.0
       '@aws-sdk/util-endpoints': 3.936.0
       '@aws-sdk/util-user-agent-browser': 3.936.0
-      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1)
+      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@smithy/config-resolver': 4.4.3
       '@smithy/core': 3.18.7
       '@smithy/fetch-http-handler': 5.3.6
@@ -10552,16 +10543,16 @@ snapshots:
       '@smithy/util-stream': 4.5.10
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-ini@3.948.0(aws-crt@1.28.1)':
+  '@aws-sdk/credential-provider-ini@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-sdk/core': 3.947.0
       '@aws-sdk/credential-provider-env': 3.947.0
       '@aws-sdk/credential-provider-http': 3.947.0
-      '@aws-sdk/credential-provider-login': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/credential-provider-login': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/credential-provider-process': 3.947.0
-      '@aws-sdk/credential-provider-sso': 3.948.0(aws-crt@1.28.1)
-      '@aws-sdk/credential-provider-web-identity': 3.948.0(aws-crt@1.28.1)
-      '@aws-sdk/nested-clients': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/credential-provider-sso': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/credential-provider-web-identity': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/nested-clients': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/types': 3.936.0
       '@smithy/credential-provider-imds': 4.2.5
       '@smithy/property-provider': 4.2.5
@@ -10590,10 +10581,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.948.0(aws-crt@1.28.1)':
+  '@aws-sdk/credential-provider-login@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-sdk/core': 3.947.0
-      '@aws-sdk/nested-clients': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/nested-clients': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/types': 3.936.0
       '@smithy/property-provider': 4.2.5
       '@smithy/protocol-http': 5.3.5
@@ -10616,14 +10607,14 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.948.0(aws-crt@1.28.1)':
+  '@aws-sdk/credential-provider-node@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.947.0
       '@aws-sdk/credential-provider-http': 3.947.0
-      '@aws-sdk/credential-provider-ini': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/credential-provider-ini': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/credential-provider-process': 3.947.0
-      '@aws-sdk/credential-provider-sso': 3.948.0(aws-crt@1.28.1)
-      '@aws-sdk/credential-provider-web-identity': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/credential-provider-sso': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
+      '@aws-sdk/credential-provider-web-identity': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/types': 3.936.0
       '@smithy/credential-provider-imds': 4.2.5
       '@smithy/property-provider': 4.2.5
@@ -10668,11 +10659,11 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-sso@3.948.0(aws-crt@1.28.1)':
+  '@aws-sdk/credential-provider-sso@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
-      '@aws-sdk/client-sso': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/client-sso': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/core': 3.947.0
-      '@aws-sdk/token-providers': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/token-providers': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/types': 3.936.0
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
@@ -10694,10 +10685,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.948.0(aws-crt@1.28.1)':
+  '@aws-sdk/credential-provider-web-identity@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-sdk/core': 3.947.0
-      '@aws-sdk/nested-clients': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/nested-clients': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/types': 3.936.0
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
@@ -10857,7 +10848,7 @@ snapshots:
       '@smithy/types': 4.12.0
       tslib: 2.8.1
 
-  '@aws-sdk/nested-clients@3.948.0(aws-crt@1.28.1)':
+  '@aws-sdk/nested-clients@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
@@ -10870,7 +10861,7 @@ snapshots:
       '@aws-sdk/types': 3.936.0
       '@aws-sdk/util-endpoints': 3.936.0
       '@aws-sdk/util-user-agent-browser': 3.936.0
-      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1)
+      '@aws-sdk/util-user-agent-node': 3.947.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@smithy/config-resolver': 4.4.3
       '@smithy/core': 3.18.7
       '@smithy/fetch-http-handler': 5.3.6
@@ -10969,10 +10960,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/token-providers@3.948.0(aws-crt@1.28.1)':
+  '@aws-sdk/token-providers@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-sdk/core': 3.947.0
-      '@aws-sdk/nested-clients': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/nested-clients': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       '@aws-sdk/types': 3.936.0
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
@@ -11042,7 +11033,7 @@ snapshots:
       bowser: 2.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/util-user-agent-node@3.947.0(aws-crt@1.28.1)':
+  '@aws-sdk/util-user-agent-node@3.947.0(aws-crt@1.28.1(bufferutil@4.0.9))':
     dependencies:
       '@aws-sdk/middleware-user-agent': 3.947.0
       '@aws-sdk/types': 3.936.0
@@ -11528,7 +11519,7 @@ snapshots:
       '@types/ws': 8.18.1
       duplexify: 3.7.1
       inherits: 2.0.4
-      isomorphic-ws: 4.0.1(ws@8.18.3)
+      isomorphic-ws: 4.0.1(ws@8.18.3(bufferutil@4.0.9))
       readable-stream: 2.3.8
       safe-buffer: 5.2.1
       ws: 8.18.3(bufferutil@4.0.9)
@@ -12301,7 +12292,7 @@ snapshots:
     optionalDependencies:
       cheerio: 1.1.2
       langsmith: 0.3.87(@opentelemetry/api@1.9.0)(openai@6.10.0(ws@8.18.3(bufferutil@4.0.9))(zod@4.1.13))
-      typeorm: 0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1)))
+      typeorm: 0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))))
     transitivePeerDependencies:
       - '@opentelemetry/api'
       - '@opentelemetry/exporter-trace-otlp-proto'
@@ -12347,7 +12338,7 @@ snapshots:
       mysql2: 3.15.3
       pg: 8.16.3
       playwright: 1.57.0
-      typeorm: 0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1)))
+      typeorm: 0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))))
       ws: 8.18.3(bufferutil@4.0.9)
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -12695,9 +12686,9 @@ snapshots:
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
     optionalDependencies:
-      '@nestjs/typeorm': 11.0.0(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1))))
+      '@nestjs/typeorm': 11.0.0(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9)))))
       '@prisma/client': 5.22.0(prisma@5.22.0)
-      typeorm: 0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1)))
+      typeorm: 0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))))
 
   '@nestjs/testing@11.1.9(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(@nestjs/platform-express@11.1.9)':
     dependencies:
@@ -12713,13 +12704,14 @@ snapshots:
       '@nestjs/core': 11.1.9(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
 
-  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1))))':
+  '@nestjs/typeorm@11.0.0(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9)))))':
     dependencies:
       '@nestjs/common': 11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.9(@nestjs/common@11.1.9(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.9)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
-      typeorm: 0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1)))
+      typeorm: 0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))))
+    optional: true
 
   '@next/env@16.1.6': {}
 
@@ -13631,7 +13623,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@sqltools/formatter@1.2.5': {}
+  '@sqltools/formatter@1.2.5':
+    optional: true
 
   '@standard-schema/spec@1.0.0': {}
 
@@ -14477,7 +14470,8 @@ snapshots:
     dependencies:
       '@apollo/client': 4.0.10(graphql-ws@6.0.6(graphql@16.12.0)(ws@8.18.3(bufferutil@4.0.9)))(graphql@16.12.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(bufferutil@4.0.9)(graphql@16.12.0))
 
-  app-root-path@3.1.0: {}
+  app-root-path@3.1.0:
+    optional: true
 
   append-field@1.0.0: {}
 
@@ -15308,7 +15302,8 @@ snapshots:
 
   dateformat@4.6.3: {}
 
-  dayjs@1.11.19: {}
+  dayjs@1.11.19:
+    optional: true
 
   debug@2.6.9:
     dependencies:
@@ -16837,7 +16832,7 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@4.0.1(ws@8.18.3):
+  isomorphic-ws@4.0.1(ws@8.18.3(bufferutil@4.0.9)):
     dependencies:
       ws: 8.18.3(bufferutil@4.0.9)
     optional: true
@@ -17353,7 +17348,7 @@ snapshots:
   jest-mock-extended@4.0.0(@jest/globals@30.2.0)(jest@30.2.0)(typescript@5.9.3):
     dependencies:
       '@jest/globals': 30.2.0
-      jest: 30.2.0(@types/node@25.0.1)
+      jest: 30.2.0
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -17664,6 +17659,19 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@30.2.0:
+    dependencies:
+      '@jest/core': 30.2.0(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))
+      '@jest/types': 30.2.0
+      import-local: 3.2.0
+      jest-cli: 30.2.0(@types/node@25.0.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
       - supports-color
       - ts-node
 
@@ -19635,7 +19643,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  sql-highlight@6.1.0: {}
+  sql-highlight@6.1.0:
+    optional: true
 
   sqlstring@2.3.3:
     optional: true
@@ -20116,12 +20125,32 @@ snapshots:
       babel-jest: 30.2.0(@babel/core@7.28.5)
       jest-util: 30.2.0
 
-  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0)(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@25.0.1))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
       jest: 30.2.0(@types/node@25.0.1)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.3
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.5
+      '@jest/transform': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.5)
+      jest-util: 30.2.0
+
+  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0)(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 30.2.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -20275,13 +20304,13 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1)):
+  typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))):
     dependencies:
-      '@aws-sdk/client-rds-data': 3.948.0(aws-crt@1.28.1)
+      '@aws-sdk/client-rds-data': 3.948.0(aws-crt@1.28.1(bufferutil@4.0.9))
       sqlstring: 2.3.3
     optional: true
 
-  typeorm@0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1))):
+  typeorm@0.3.28(better-sqlite3@12.5.0)(ioredis@5.9.2)(mysql2@3.15.3)(pg@8.16.3)(ts-node@10.9.2(@types/node@25.0.1)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9)))):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.2.0
@@ -20304,10 +20333,11 @@ snapshots:
       mysql2: 3.15.3
       pg: 8.16.3
       ts-node: 10.9.2(@types/node@25.0.1)(typescript@5.9.3)
-      typeorm-aurora-data-api-driver: 3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1))
+      typeorm-aurora-data-api-driver: 3.0.2(@aws-sdk/client-rds-data@3.948.0(aws-crt@1.28.1(bufferutil@4.0.9)))
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   typescript-eslint@8.49.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

- **Eliminate TypeORM** from the codebase entirely — vectordb-provider was the only package using it, and only for raw SQL (zero ORM features)
- **Introduce `IRawQueryClient` interface** that `DbService` (PrismaClient) already satisfies, keeping vectordb-provider decoupled from Prisma as a direct dependency
- **Simplify `VectorDBModule`** — removed ~30 lines of standalone DataSource connection config; now injects the shared `DbService` via NestJS DI
- **Update all documentation** to reflect Prisma-only architecture (removed 6 stale TypeORM references across docs)
- **Clean up region plugin seed** — removed stale example entry, kept only California declarative plugin

## Test plan

- [x] `pnpm --filter @opuspopuli/vectordb-provider build` — compiles clean
- [x] `pnpm --filter @opuspopuli/vectordb-provider test` — 15 tests pass, 99.3% coverage
- [x] `pnpm --filter backend build` — all 5 services compile clean
- [x] `pnpm --filter backend test` — 1079 tests pass
- [x] `./scripts/test-integration-docker.sh` — 215 integration tests pass (12 skipped: Supabase auth)
- [x] `grep -r "typeorm" packages/ apps/` — zero source references (1 test string literal in error-sanitizer.spec.ts)
- [x] Pre-commit hooks pass (lint + format + full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)