### PR TITLE
Release: campaign finance data models and test coverage

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -43,7 +43,21 @@ npm install @opuspopuli/common --registry https://npm.pkg.github.com
 | Module | Key Exports | Description |
 |--------|-------------|-------------|
 | **Region** | `IRegionProvider`, `RegionInfo`, `Proposition`, `Meeting`, `Representative` | Civic data types and region provider interface |
-| | `DataType`, `PropositionStatus`, `ContactInfo`, `SyncResult`, `RegionError` | Enums and supporting types |
+| | `Committee`, `Contribution`, `Expenditure`, `IndependentExpenditure` | Campaign finance domain models |
+| | `CommitteeType`, `DataType`, `PropositionStatus`, `ContactInfo`, `SyncResult`, `RegionError` | Enums and supporting types |
+
+### Scraping Pipeline
+
+| Module | Key Exports | Description |
+|--------|-------------|-------------|
+| **Scraping Pipeline** | `DeclarativeRegionConfig`, `DataSourceConfig`, `BulkDownloadConfig`, `ApiSourceConfig` | Declarative region config types |
+| | `ExtractionResult`, `RawExtractionResult`, `StructuralManifest`, `IPipelineService` | Pipeline interfaces and result types |
+
+### Config Utilities
+
+| Module | Key Exports | Description |
+|--------|-------------|-------------|
+| **Config** | `resolveConfigPlaceholders()` | Resolve `${variableName}` placeholders in config objects |
 
 ### Infrastructure Utilities
 
@@ -68,6 +82,17 @@ import {
   Meeting,
   Representative,
   DataType,
+
+  // Campaign finance types
+  Committee,
+  Contribution,
+  Expenditure,
+  IndependentExpenditure,
+
+  // Config types and utilities
+  DeclarativeRegionConfig,
+  DataSourceConfig,
+  resolveConfigPlaceholders,
 
   // Infrastructure utilities
   RateLimiter,

--- a/packages/common/__tests__/config-placeholders.spec.ts
+++ b/packages/common/__tests__/config-placeholders.spec.ts
@@ -1,0 +1,196 @@
+import { resolveConfigPlaceholders } from "../src/providers/config/config-placeholders";
+
+describe("resolveConfigPlaceholders", () => {
+  it("should resolve a placeholder in a flat object", () => {
+    const config = { state: "${stateCode}", name: "Federal" };
+    const result = resolveConfigPlaceholders(config, { stateCode: "CA" });
+
+    expect(result.state).toBe("CA");
+    expect(result.name).toBe("Federal");
+  });
+
+  it("should resolve placeholders in deeply nested objects", () => {
+    const config = {
+      dataSources: [
+        {
+          api: {
+            queryParams: {
+              contributor_state: "${stateCode}",
+              sort: "-date",
+            },
+          },
+        },
+      ],
+    };
+
+    const result = resolveConfigPlaceholders(config, { stateCode: "TX" });
+
+    expect(result.dataSources[0].api.queryParams.contributor_state).toBe("TX");
+    expect(result.dataSources[0].api.queryParams.sort).toBe("-date");
+  });
+
+  it("should resolve placeholders in bulk download filters", () => {
+    const config = {
+      dataSources: [
+        {
+          bulk: {
+            format: "zip_csv",
+            filters: { STATE: "${stateCode}" },
+          },
+        },
+      ],
+    };
+
+    const result = resolveConfigPlaceholders(config, { stateCode: "NY" });
+
+    expect(result.dataSources[0].bulk.filters.STATE).toBe("NY");
+  });
+
+  it("should resolve placeholders in arrays of strings", () => {
+    const config = { hints: ["Filter by ${stateCode}", "No placeholder"] };
+    const result = resolveConfigPlaceholders(config, { stateCode: "CA" });
+
+    expect(result.hints[0]).toBe("Filter by CA");
+    expect(result.hints[1]).toBe("No placeholder");
+  });
+
+  it("should leave non-string values untouched", () => {
+    const config = {
+      count: 42,
+      enabled: true,
+      nothing: null,
+      state: "${stateCode}",
+    };
+    const result = resolveConfigPlaceholders(config, { stateCode: "CA" });
+
+    expect(result.count).toBe(42);
+    expect(result.enabled).toBe(true);
+    expect(result.nothing).toBeNull();
+    expect(result.state).toBe("CA");
+  });
+
+  it("should resolve multiple different placeholders", () => {
+    const config = {
+      state: "${stateCode}",
+      county: "${countyFips}",
+      label: "${stateCode}-${countyFips}",
+    };
+    const result = resolveConfigPlaceholders(config, {
+      stateCode: "CA",
+      countyFips: "06037",
+    });
+
+    expect(result.state).toBe("CA");
+    expect(result.county).toBe("06037");
+    expect(result.label).toBe("CA-06037");
+  });
+
+  it("should leave unresolved placeholders as-is", () => {
+    const config = { state: "${stateCode}", fips: "${unknownVar}" };
+    const result = resolveConfigPlaceholders(config, { stateCode: "CA" });
+
+    expect(result.state).toBe("CA");
+    expect(result.fips).toBe("${unknownVar}");
+  });
+
+  it("should return a deep clone (original not mutated)", () => {
+    const config = {
+      nested: { state: "${stateCode}" },
+      list: ["${stateCode}"],
+    };
+    const result = resolveConfigPlaceholders(config, { stateCode: "CA" });
+
+    expect(result.nested.state).toBe("CA");
+    expect(config.nested.state).toBe("${stateCode}");
+    expect(result.list[0]).toBe("CA");
+    expect(config.list[0]).toBe("${stateCode}");
+  });
+
+  it("should handle empty variables map (no-op, returns clone)", () => {
+    const config = { state: "${stateCode}" };
+    const result = resolveConfigPlaceholders(config, {});
+
+    expect(result.state).toBe("${stateCode}");
+    expect(result).not.toBe(config); // still a clone
+  });
+
+  it("should handle config with no placeholders", () => {
+    const config = { name: "Federal", count: 3 };
+    const result = resolveConfigPlaceholders(config, { stateCode: "CA" });
+
+    expect(result).toEqual(config);
+    expect(result).not.toBe(config);
+  });
+
+  it("should resolve a realistic federal.json config structure", () => {
+    const federalConfig = {
+      regionId: "federal",
+      regionName: "Federal",
+      dataSources: [
+        {
+          url: "https://api.open.fec.gov/v1/schedules/schedule_a/",
+          dataType: "campaign_finance",
+          sourceType: "api",
+          api: {
+            queryParams: {
+              sort: "-contribution_receipt_date",
+              is_individual: "true",
+              contributor_state: "${stateCode}",
+            },
+          },
+          hints: ["${stateCode} placeholder is resolved at runtime"],
+        },
+        {
+          url: "https://www.fec.gov/files/bulk-downloads/2026/indiv26.zip",
+          dataType: "campaign_finance",
+          sourceType: "bulk_download",
+          bulk: {
+            format: "zip_csv",
+            filePattern: "itcont.txt",
+            delimiter: "|",
+            filters: { STATE: "${stateCode}" },
+            columnMappings: { CMTE_ID: "committeeId" },
+          },
+          hints: ["${stateCode} placeholder is resolved at runtime"],
+        },
+        {
+          url: "https://api.open.fec.gov/v1/schedules/schedule_e/",
+          dataType: "campaign_finance",
+          sourceType: "api",
+          api: {
+            queryParams: { sort: "-expenditure_date" },
+          },
+        },
+      ],
+    };
+
+    const result = resolveConfigPlaceholders(federalConfig, {
+      stateCode: "CA",
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ds = result.dataSources as any[];
+
+    // API contributions: contributor_state resolved
+    expect(ds[0].api.queryParams.contributor_state).toBe("CA");
+    // API contributions: other params unchanged
+    expect(ds[0].api.queryParams.sort).toBe("-contribution_receipt_date");
+    // Hints resolved
+    expect(ds[0].hints[0]).toBe("CA placeholder is resolved at runtime");
+
+    // Bulk download: STATE filter resolved
+    expect(ds[1].bulk.filters.STATE).toBe("CA");
+    // Bulk download: other fields unchanged
+    expect(ds[1].bulk.delimiter).toBe("|");
+    expect(ds[1].bulk.columnMappings.CMTE_ID).toBe("committeeId");
+
+    // Independent expenditures: no placeholders, unchanged
+    expect(ds[2].api.queryParams.sort).toBe("-expenditure_date");
+
+    // Original not mutated
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const origDs = federalConfig.dataSources as any[];
+    expect(origDs[0].api.queryParams.contributor_state).toBe("${stateCode}");
+    expect(origDs[1].bulk.filters.STATE).toBe("${stateCode}");
+  });
+});

--- a/packages/common/src/providers/config/config-placeholders.ts
+++ b/packages/common/src/providers/config/config-placeholders.ts
@@ -1,0 +1,73 @@
+/**
+ * Config Placeholder Resolution
+ *
+ * Resolves ${variableName} placeholders in config objects.
+ * Used to inject runtime context (e.g., the active region's stateCode)
+ * into declarative config files before they are passed to plugins.
+ */
+
+const PLACEHOLDER_REGEX = /\$\{(\w+)\}/g;
+
+/**
+ * Resolve ${variableName} placeholders in a config object.
+ *
+ * Deep-clones the input, then recursively replaces ${varName} patterns
+ * in all string values using the provided variables map.
+ * Unresolved placeholders (no matching variable) are left as-is.
+ *
+ * @param config - The config object to resolve (will be deep-cloned)
+ * @param variables - Map of variable names to values (e.g., { stateCode: "CA" })
+ * @returns A new config object with placeholders resolved
+ */
+export function resolveConfigPlaceholders<T>(
+  config: T,
+  variables: Record<string, string>,
+): T {
+  if (Object.keys(variables).length === 0) {
+    // No variables to resolve — return a clone to maintain the contract
+    return structuredClone(config);
+  }
+
+  const cloned = structuredClone(config);
+  resolveRecursive(cloned, variables);
+  return cloned;
+}
+
+function resolveRecursive(
+  obj: unknown,
+  variables: Record<string, string>,
+): void {
+  if (obj === null || obj === undefined || typeof obj !== "object") {
+    return;
+  }
+
+  if (Array.isArray(obj)) {
+    for (let i = 0; i < obj.length; i++) {
+      if (typeof obj[i] === "string") {
+        obj[i] = resolveString(obj[i] as string, variables);
+      } else {
+        resolveRecursive(obj[i], variables);
+      }
+    }
+    return;
+  }
+
+  const record = obj as Record<string, unknown>;
+  for (const key of Object.keys(record)) {
+    const value = record[key];
+    if (typeof value === "string") {
+      record[key] = resolveString(value, variables);
+    } else {
+      resolveRecursive(value, variables);
+    }
+  }
+}
+
+function resolveString(
+  value: string,
+  variables: Record<string, string>,
+): string {
+  return value.replaceAll(PLACEHOLDER_REGEX, (match, varName: string) => {
+    return varName in variables ? variables[varName] : match;
+  });
+}

--- a/packages/common/src/providers/config/index.ts
+++ b/packages/common/src/providers/config/index.ts
@@ -1,0 +1,1 @@
+export { resolveConfigPlaceholders } from "./config-placeholders.js";

--- a/packages/common/src/providers/index.ts
+++ b/packages/common/src/providers/index.ts
@@ -16,3 +16,4 @@ export * from "./rate-limiting/index.js";
 export * from "./retry/index.js";
 export * from "./caching/index.js";
 export * from "./scraping-pipeline/index.js";
+export * from "./config/index.js";

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -13,6 +13,8 @@ export enum DataType {
   PROPOSITIONS = "propositions",
   MEETINGS = "meetings",
   REPRESENTATIVES = "representatives",
+  CAMPAIGN_FINANCE = "campaign_finance",
+  LOBBYING = "lobbying",
 }
 
 /**
@@ -85,6 +87,103 @@ export interface Representative {
   contactInfo?: ContactInfo;
 }
 
+// ============================================
+// CAMPAIGN FINANCE
+// ============================================
+
+/**
+ * Committee types for campaign finance tracking
+ */
+export enum CommitteeType {
+  CANDIDATE = "candidate",
+  BALLOT_MEASURE = "ballot_measure",
+  PAC = "pac",
+  SUPER_PAC = "super_pac",
+  PARTY = "party",
+  SMALL_CONTRIBUTOR = "small_contributor",
+  OTHER = "other",
+}
+
+/**
+ * Campaign committee (fundraising entity)
+ */
+export interface Committee {
+  externalId: string;
+  name: string;
+  type: CommitteeType;
+  candidateName?: string;
+  candidateOffice?: string;
+  propositionId?: string;
+  party?: string;
+  status: "active" | "terminated";
+  sourceSystem: "cal_access" | "fec";
+  sourceUrl?: string;
+}
+
+/**
+ * Campaign contribution (money received by a committee)
+ */
+export interface Contribution {
+  externalId: string;
+  committeeId: string;
+  donorName: string;
+  donorType: "individual" | "committee" | "party" | "self" | "other";
+  donorEmployer?: string;
+  donorOccupation?: string;
+  donorCity?: string;
+  donorState?: string;
+  donorZip?: string;
+  amount: number;
+  date: Date;
+  electionType?: string;
+  contributionType?: string;
+  sourceSystem: "cal_access" | "fec";
+}
+
+/**
+ * Campaign expenditure (money spent by a committee)
+ */
+export interface Expenditure {
+  externalId: string;
+  committeeId: string;
+  payeeName: string;
+  amount: number;
+  date: Date;
+  purposeDescription?: string;
+  expenditureCode?: string;
+  candidateName?: string;
+  propositionTitle?: string;
+  supportOrOppose?: "support" | "oppose";
+  sourceSystem: "cal_access" | "fec";
+}
+
+/**
+ * Independent expenditure (outside spending for/against candidate or measure)
+ */
+export interface IndependentExpenditure {
+  externalId: string;
+  committeeId: string;
+  committeeName: string;
+  candidateName?: string;
+  propositionTitle?: string;
+  supportOrOppose: "support" | "oppose";
+  amount: number;
+  date: Date;
+  electionDate?: Date;
+  description?: string;
+  sourceSystem: "cal_access" | "fec";
+}
+
+/**
+ * Aggregated result from campaign finance data fetch
+ */
+export interface CampaignFinanceResult {
+  committees: Committee[];
+  contributions: Contribution[];
+  expenditures: Expenditure[];
+  independentExpenditures: IndependentExpenditure[];
+}
+
 /**
  * Sync result metadata
  */
@@ -130,6 +229,12 @@ export interface IRegionProvider {
    * Fetch representatives from the region's data sources
    */
   fetchRepresentatives(): Promise<Representative[]>;
+
+  /**
+   * Fetch campaign finance data from the region's data sources.
+   * Optional — only implemented by plugins with campaign_finance data sources.
+   */
+  fetchCampaignFinance?(): Promise<CampaignFinanceResult>;
 }
 
 /**

--- a/packages/region-provider/regions/california.json
+++ b/packages/region-provider/regions/california.json
@@ -1,33 +1,36 @@
 {
   "name": "california",
   "displayName": "California",
-  "description": "California civic data from official state government websites",
-  "version": "1.0.0",
+  "description": "California civic and campaign finance data from official state government websites",
+  "version": "1.1.0",
   "config": {
     "regionId": "california",
     "regionName": "California",
-    "description": "California civic data from official state government websites",
+    "description": "California civic and campaign finance data from official state government websites",
     "timezone": "America/Los_Angeles",
+    "stateCode": "CA",
     "dataSources": [
       {
         "url": "https://www.sos.ca.gov/elections/ballot-measures/qualified-ballot-measures",
         "dataType": "propositions",
-        "contentGoal": "Extract qualified ballot measures with measure ID, title, description, and election date",
+        "contentGoal": "Extract qualified ballot measures with measure ID, title, brief description, and election date",
         "category": "Secretary of State",
         "hints": [
           "Measures are grouped under election date headings",
           "Each measure has an identifier like ACA 13 or SB 1234",
-          "Link text contains the measure title"
+          "Link text contains the measure title",
+          "Full descriptions are in linked PDFs; the page only shows brief titles and legislative designations"
         ]
       },
       {
-        "url": "https://www.assembly.ca.gov/schedules-publications/assembly-daily-file",
+        "url": "https://www.assembly.ca.gov/dailyfile",
         "dataType": "meetings",
         "contentGoal": "Extract scheduled Assembly committee meetings with date, time, location, and committee name",
         "category": "Assembly",
         "hints": [
-          "Daily file contains committee hearing schedules",
-          "Look for tables or structured lists with date, time, and room info"
+          "Data is in structured HTML tables with embedded JSON metadata",
+          "Content is divided into committee hearings and floor calendar sections",
+          "Tables include date, time, committee name, and room location columns"
         ]
       },
       {
@@ -36,8 +39,9 @@
         "contentGoal": "Extract scheduled Senate committee meetings with date, time, location, and committee name",
         "category": "Senate",
         "hints": [
-          "Senate daily file format may differ from Assembly",
-          "Look for committee names, dates, times, and locations"
+          "This is a gateway page — actual schedule data is in a linked PDF download, not inline HTML",
+          "The page provides a link to the current Senate Daily File PDF",
+          "Alternative: https://www.senate.ca.gov/committees may have HTML committee schedules"
         ]
       },
       {
@@ -54,12 +58,101 @@
       {
         "url": "https://www.senate.ca.gov/senators",
         "dataType": "representatives",
-        "contentGoal": "Extract Senators with name, district number, party affiliation, and photo",
+        "contentGoal": "Extract Senators with name, district number, party affiliation, photo, and Capitol/district office contact information",
         "category": "Senate",
         "hints": [
-          "Senator cards with expandable details",
-          "Each has name, district, party, and photo",
-          "40 Senators total"
+          "Senator cards with expandable details including office addresses and phone numbers",
+          "Each has name, district, party, photo, Capitol office, and district office(s)",
+          "40 Senators total",
+          "Page uses lazy-loading for images"
+        ]
+      },
+      {
+        "url": "https://campaignfinance.cdn.sos.ca.gov/dbwebexport.zip",
+        "dataType": "campaign_finance",
+        "sourceType": "bulk_download",
+        "contentGoal": "Extract campaign contributions from the RCPT_CD table: donor name, employer, occupation, amount, date, recipient committee, candidate/measure info",
+        "category": "CAL-ACCESS Contributions",
+        "bulk": {
+          "format": "zip_tsv",
+          "filePattern": "RCPT_CD.TSV",
+          "columnMappings": {
+            "FILING_ID": "externalId",
+            "FILER_ID": "committeeId",
+            "ENTITY_CD": "donorType",
+            "CTRIB_NAMF": "donorFirstName",
+            "CTRIB_NAML": "donorLastName",
+            "CTRIB_EMP": "donorEmployer",
+            "CTRIB_OCC": "donorOccupation",
+            "CTRIB_CITY": "donorCity",
+            "CTRIB_ST": "donorState",
+            "CTRIB_ZIP4": "donorZip",
+            "AMOUNT": "amount",
+            "RCPT_DATE": "date",
+            "CAND_NAML": "candidateName",
+            "OFFICE_CD": "candidateOffice",
+            "BAL_NAME": "propositionTitle",
+            "SUP_OPP_CD": "supportOrOppose"
+          }
+        },
+        "hints": [
+          "ZIP file updated daily from CA Secretary of State, ~1GB uncompressed",
+          "RCPT_CD has 64 columns; map only the essential ones",
+          "ENTITY_CD values: IND=individual, COM=committee, OTH=other, PTY=party, SCC=small contributor",
+          "Filter to recent election cycles to manage data volume"
+        ]
+      },
+      {
+        "url": "https://campaignfinance.cdn.sos.ca.gov/dbwebexport.zip",
+        "dataType": "campaign_finance",
+        "sourceType": "bulk_download",
+        "contentGoal": "Extract campaign expenditures from the EXPN_CD table: payee, amount, date, purpose, candidate/measure info",
+        "category": "CAL-ACCESS Expenditures",
+        "bulk": {
+          "format": "zip_tsv",
+          "filePattern": "EXPN_CD.TSV",
+          "columnMappings": {
+            "FILING_ID": "externalId",
+            "FILER_ID": "committeeId",
+            "PAYEE_NAML": "payeeName",
+            "AMOUNT": "amount",
+            "EXPN_DATE": "date",
+            "EXPN_DSCR": "purposeDescription",
+            "EXPN_CODE": "expenditureCode",
+            "CAND_NAML": "candidateName",
+            "BAL_NAME": "propositionTitle",
+            "SUP_OPP_CD": "supportOrOppose"
+          }
+        },
+        "hints": [
+          "Same ZIP archive as contributions — download once, extract both tables",
+          "EXPN_CODE values: CMP=campaign paraphernalia, CNS=consulting, CTB=contribution to other committee, FIL=candidate filing fees, FND=fundraising, LIT=campaign literature, etc."
+        ]
+      },
+      {
+        "url": "https://campaignfinance.cdn.sos.ca.gov/dbwebexport.zip",
+        "dataType": "campaign_finance",
+        "sourceType": "bulk_download",
+        "contentGoal": "Extract late independent expenditures from S496_CD: committee spending for/against candidates and measures near elections",
+        "category": "CAL-ACCESS Independent Expenditures",
+        "bulk": {
+          "format": "zip_tsv",
+          "filePattern": "S496_CD.TSV",
+          "columnMappings": {
+            "FILING_ID": "externalId",
+            "FILER_ID": "committeeId",
+            "FILER_NAML": "committeeName",
+            "CAND_NAML": "candidateName",
+            "BAL_NAME": "propositionTitle",
+            "SUP_OPP_CD": "supportOrOppose",
+            "AMOUNT": "amount",
+            "EXP_DATE": "date",
+            "ELEC_DATE": "electionDate"
+          }
+        },
+        "hints": [
+          "S496 = Form 496 late independent expenditure reports",
+          "Filed within 24 hours of making an IE of $1,000+ in the 90 days before an election"
         ]
       }
     ],

--- a/packages/region-provider/regions/federal.json
+++ b/packages/region-provider/regions/federal.json
@@ -1,0 +1,106 @@
+{
+  "name": "federal",
+  "displayName": "Federal",
+  "description": "US federal campaign finance data from the Federal Election Commission (FEC), scoped to the active local region",
+  "version": "1.0.0",
+  "config": {
+    "regionId": "federal",
+    "regionName": "Federal",
+    "description": "US federal campaign finance data from the Federal Election Commission, filtered to the active local region's state",
+    "timezone": "America/New_York",
+    "dataSources": [
+      {
+        "url": "https://api.open.fec.gov/v1/schedules/schedule_a/",
+        "dataType": "campaign_finance",
+        "sourceType": "api",
+        "contentGoal": "Fetch itemized individual contributions to federal candidates and committees within the local region's state",
+        "category": "FEC Contributions",
+        "api": {
+          "apiKeyEnvVar": "FEC_API_KEY",
+          "apiKeyHeader": "api_key",
+          "pagination": {
+            "type": "cursor",
+            "limitParam": "per_page",
+            "limit": 100
+          },
+          "resultsPath": "results",
+          "queryParams": {
+            "sort": "-contribution_receipt_date",
+            "is_individual": "true",
+            "contributor_state": "${stateCode}"
+          }
+        },
+        "hints": [
+          "Free API key from api.open.fec.gov/developers (DEMO_KEY for testing)",
+          "1,000 calls/hour default rate limit; 7,200/hr available on request",
+          "${stateCode} placeholder is resolved at runtime from the active local region's stateCode",
+          "Use two_year_transaction_period to scope by election cycle"
+        ]
+      },
+      {
+        "url": "https://api.open.fec.gov/v1/schedules/schedule_e/",
+        "dataType": "campaign_finance",
+        "sourceType": "api",
+        "contentGoal": "Fetch independent expenditures for/against federal candidates by PACs and Super PACs",
+        "category": "FEC Independent Expenditures",
+        "api": {
+          "apiKeyEnvVar": "FEC_API_KEY",
+          "apiKeyHeader": "api_key",
+          "pagination": {
+            "type": "cursor",
+            "limitParam": "per_page",
+            "limit": 100
+          },
+          "resultsPath": "results",
+          "queryParams": {
+            "sort": "-expenditure_date"
+          }
+        },
+        "hints": [
+          "Schedule E = independent expenditures by PACs/Super PACs",
+          "support_oppose_indicator: S=support, O=oppose",
+          "Note: IEs are harder to filter by state — they target candidates who represent a state"
+        ]
+      },
+      {
+        "url": "https://www.fec.gov/files/bulk-downloads/2026/indiv26.zip",
+        "dataType": "campaign_finance",
+        "sourceType": "bulk_download",
+        "contentGoal": "Bulk download of individual contributions for the 2025-2026 election cycle, filtered to the local region's state",
+        "category": "FEC Bulk Contributions",
+        "bulk": {
+          "format": "zip_csv",
+          "filePattern": "itcont.txt",
+          "delimiter": "|",
+          "columnMappings": {
+            "CMTE_ID": "committeeId",
+            "NAME": "donorName",
+            "CITY": "donorCity",
+            "STATE": "donorState",
+            "ZIP_CODE": "donorZip",
+            "EMPLOYER": "donorEmployer",
+            "OCCUPATION": "donorOccupation",
+            "TRANSACTION_DT": "date",
+            "TRANSACTION_AMT": "amount",
+            "SUB_ID": "externalId"
+          },
+          "filters": {
+            "STATE": "${stateCode}"
+          }
+        },
+        "hints": [
+          "Very large file (~4GB for a full cycle) but filtered by STATE during parse",
+          "Pipe-delimited, not comma-delimited",
+          "${stateCode} placeholder is resolved at runtime from the active local region's stateCode",
+          "SUB_ID is the unique transaction identifier"
+        ]
+      }
+    ],
+    "rateLimit": {
+      "requestsPerSecond": 0.25,
+      "burstSize": 1
+    },
+    "cacheTtlMs": 86400000,
+    "requestTimeoutMs": 120000
+  }
+}

--- a/packages/region-provider/src/loader/region-config-discovery.ts
+++ b/packages/region-provider/src/loader/region-config-discovery.ts
@@ -51,7 +51,7 @@ export async function discoverRegionConfigs(
     try {
       parsed = JSON.parse(raw);
     } catch {
-      throw new Error(`Invalid JSON in region config file: ${file}`);
+      throw new TypeError(`Invalid JSON in region config file: ${file}`);
     }
 
     const pluginFile = validateRegionPluginFile(parsed, file);
@@ -66,7 +66,7 @@ function validateRegionPluginFile(
   fileName: string,
 ): RegionPluginFile {
   if (typeof data !== "object" || data === null || Array.isArray(data)) {
-    throw new Error(`Region config "${fileName}" must be a JSON object`);
+    throw new TypeError(`Region config "${fileName}" must be a JSON object`);
   }
 
   const obj = data as Record<string, unknown>;
@@ -74,21 +74,21 @@ function validateRegionPluginFile(
   // Validate outer fields
   for (const field of ["name", "displayName", "version"] as const) {
     if (typeof obj[field] !== "string" || (obj[field] as string).length === 0) {
-      throw new Error(
+      throw new TypeError(
         `Region config "${fileName}" is missing required field "${field}"`,
       );
     }
   }
 
   if (typeof obj.description !== "string") {
-    throw new Error(
+    throw new TypeError(
       `Region config "${fileName}" is missing required field "description"`,
     );
   }
 
   // Validate config object
   if (typeof obj.config !== "object" || obj.config === null) {
-    throw new Error(
+    throw new TypeError(
       `Region config "${fileName}" is missing required field "config"`,
     );
   }
@@ -96,13 +96,13 @@ function validateRegionPluginFile(
   const config = obj.config as Record<string, unknown>;
 
   if (typeof config.regionId !== "string" || config.regionId.length === 0) {
-    throw new Error(
+    throw new TypeError(
       `Region config "${fileName}" is missing required field "config.regionId"`,
     );
   }
 
   if (!Array.isArray(config.dataSources) || config.dataSources.length === 0) {
-    throw new Error(
+    throw new TypeError(
       `Region config "${fileName}" must have at least one entry in "config.dataSources"`,
     );
   }
@@ -112,7 +112,7 @@ function validateRegionPluginFile(
     const ds = config.dataSources[i] as Record<string, unknown>;
     for (const field of ["url", "dataType", "contentGoal"] as const) {
       if (typeof ds[field] !== "string" || (ds[field] as string).length === 0) {
-        throw new Error(
+        throw new TypeError(
           `Region config "${fileName}" dataSources[${i}] is missing required field "${field}"`,
         );
       }

--- a/packages/relationaldb-provider/prisma/migrations/20260215000000_add_campaign_finance_tables/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260215000000_add_campaign_finance_tables/migration.sql
@@ -1,0 +1,123 @@
+-- Campaign Finance Tables
+-- Supports both California (CAL-ACCESS) and Federal (FEC) data sources
+
+-- Committees: the entities that raise and spend money
+CREATE TABLE "committees" (
+    "id" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "type" VARCHAR(50) NOT NULL,
+    "candidate_name" TEXT,
+    "candidate_office" TEXT,
+    "proposition_id" TEXT,
+    "party" VARCHAR(50),
+    "status" VARCHAR(20) NOT NULL DEFAULT 'active',
+    "source_system" VARCHAR(20) NOT NULL,
+    "source_url" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMPTZ,
+
+    CONSTRAINT "committees_pkey" PRIMARY KEY ("id")
+);
+
+-- Contributions: money received by a committee
+CREATE TABLE "contributions" (
+    "id" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "committee_id" TEXT NOT NULL,
+    "donor_name" TEXT NOT NULL,
+    "donor_type" VARCHAR(20) NOT NULL,
+    "donor_employer" TEXT,
+    "donor_occupation" TEXT,
+    "donor_city" VARCHAR(100),
+    "donor_state" VARCHAR(2),
+    "donor_zip" VARCHAR(10),
+    "amount" DECIMAL(12,2) NOT NULL,
+    "date" DATE NOT NULL,
+    "election_type" VARCHAR(20),
+    "contribution_type" VARCHAR(30),
+    "source_system" VARCHAR(20) NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "contributions_pkey" PRIMARY KEY ("id")
+);
+
+-- Expenditures: money spent by a committee
+CREATE TABLE "expenditures" (
+    "id" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "committee_id" TEXT NOT NULL,
+    "payee_name" TEXT NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "date" DATE NOT NULL,
+    "purpose_description" TEXT,
+    "expenditure_code" VARCHAR(10),
+    "candidate_name" TEXT,
+    "proposition_title" TEXT,
+    "support_or_oppose" VARCHAR(10),
+    "source_system" VARCHAR(20) NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "expenditures_pkey" PRIMARY KEY ("id")
+);
+
+-- Independent Expenditures: outside spending for/against candidates or measures
+CREATE TABLE "independent_expenditures" (
+    "id" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "committee_id" TEXT NOT NULL,
+    "committee_name" TEXT NOT NULL,
+    "candidate_name" TEXT,
+    "proposition_title" TEXT,
+    "support_or_oppose" VARCHAR(10) NOT NULL,
+    "amount" DECIMAL(12,2) NOT NULL,
+    "date" DATE NOT NULL,
+    "election_date" DATE,
+    "description" TEXT,
+    "source_system" VARCHAR(20) NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "independent_expenditures_pkey" PRIMARY KEY ("id")
+);
+
+-- Unique constraints
+CREATE UNIQUE INDEX "committees_external_id_key" ON "committees"("external_id");
+CREATE UNIQUE INDEX "contributions_external_id_key" ON "contributions"("external_id");
+CREATE UNIQUE INDEX "expenditures_external_id_key" ON "expenditures"("external_id");
+CREATE UNIQUE INDEX "independent_expenditures_external_id_key" ON "independent_expenditures"("external_id");
+
+-- Committee indexes
+CREATE INDEX "committees_name_idx" ON "committees"("name");
+CREATE INDEX "committees_type_idx" ON "committees"("type");
+CREATE INDEX "committees_source_system_idx" ON "committees"("source_system");
+CREATE INDEX "committees_proposition_id_idx" ON "committees"("proposition_id");
+
+-- Contribution indexes
+CREATE INDEX "contributions_committee_id_idx" ON "contributions"("committee_id");
+CREATE INDEX "contributions_donor_name_idx" ON "contributions"("donor_name");
+CREATE INDEX "contributions_date_idx" ON "contributions"("date");
+CREATE INDEX "contributions_amount_idx" ON "contributions"("amount");
+CREATE INDEX "contributions_source_system_idx" ON "contributions"("source_system");
+
+-- Expenditure indexes
+CREATE INDEX "expenditures_committee_id_idx" ON "expenditures"("committee_id");
+CREATE INDEX "expenditures_payee_name_idx" ON "expenditures"("payee_name");
+CREATE INDEX "expenditures_date_idx" ON "expenditures"("date");
+CREATE INDEX "expenditures_source_system_idx" ON "expenditures"("source_system");
+
+-- Independent expenditure indexes
+CREATE INDEX "independent_expenditures_committee_id_idx" ON "independent_expenditures"("committee_id");
+CREATE INDEX "independent_expenditures_candidate_name_idx" ON "independent_expenditures"("candidate_name");
+CREATE INDEX "independent_expenditures_proposition_title_idx" ON "independent_expenditures"("proposition_title");
+CREATE INDEX "independent_expenditures_date_idx" ON "independent_expenditures"("date");
+CREATE INDEX "independent_expenditures_support_or_oppose_idx" ON "independent_expenditures"("support_or_oppose");
+CREATE INDEX "independent_expenditures_source_system_idx" ON "independent_expenditures"("source_system");
+
+-- Foreign keys
+ALTER TABLE "contributions" ADD CONSTRAINT "contributions_committee_id_fkey" FOREIGN KEY ("committee_id") REFERENCES "committees"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "expenditures" ADD CONSTRAINT "expenditures_committee_id_fkey" FOREIGN KEY ("committee_id") REFERENCES "committees"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "independent_expenditures" ADD CONSTRAINT "independent_expenditures_committee_id_fkey" FOREIGN KEY ("committee_id") REFERENCES "committees"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -595,6 +595,124 @@ model RegionPlugin {
 }
 
 // ============================================
+// CAMPAIGN FINANCE
+// ============================================
+
+/// Campaign committee — the entity that raises and spends money.
+/// Covers candidate committees, ballot measure committees, PACs, Super PACs, and party committees.
+model Committee {
+  id              String    @id @default(uuid())
+  externalId      String    @unique @map("external_id")
+  name            String
+  type            String    @db.VarChar(50) /// candidate, ballot_measure, pac, super_pac, party, small_contributor, other
+  candidateName   String?   @map("candidate_name")
+  candidateOffice String?   @map("candidate_office")
+  propositionId   String?   @map("proposition_id")
+  party           String?   @db.VarChar(50)
+  status          String    @default("active") @db.VarChar(20)
+  sourceSystem    String    @map("source_system") @db.VarChar(20) /// cal_access, fec
+  sourceUrl       String?   @map("source_url")
+  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt       DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+  deletedAt       DateTime? @map("deleted_at") @db.Timestamptz
+
+  contributions           Contribution[]
+  expenditures            Expenditure[]
+  independentExpenditures IndependentExpenditure[]
+
+  @@index([name])
+  @@index([type])
+  @@index([sourceSystem])
+  @@index([propositionId])
+  @@map("committees")
+}
+
+/// Campaign contribution — money received by a committee from a donor.
+model Contribution {
+  id               String   @id @default(uuid())
+  externalId       String   @unique @map("external_id")
+  committeeId      String   @map("committee_id")
+  donorName        String   @map("donor_name")
+  donorType        String   @map("donor_type") @db.VarChar(20) /// individual, committee, party, self, other
+  donorEmployer    String?  @map("donor_employer")
+  donorOccupation  String?  @map("donor_occupation")
+  donorCity        String?  @map("donor_city") @db.VarChar(100)
+  donorState       String?  @map("donor_state") @db.VarChar(2)
+  donorZip         String?  @map("donor_zip") @db.VarChar(10)
+  amount           Decimal  @db.Decimal(12, 2)
+  date             DateTime @db.Date
+  electionType     String?  @map("election_type") @db.VarChar(20)
+  contributionType String?  @map("contribution_type") @db.VarChar(30)
+  sourceSystem     String   @map("source_system") @db.VarChar(20)
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  committee Committee @relation(fields: [committeeId], references: [id])
+
+  @@index([committeeId])
+  @@index([donorName])
+  @@index([date])
+  @@index([amount])
+  @@index([sourceSystem])
+  @@map("contributions")
+}
+
+/// Campaign expenditure — money spent by a committee.
+model Expenditure {
+  id                 String   @id @default(uuid())
+  externalId         String   @unique @map("external_id")
+  committeeId        String   @map("committee_id")
+  payeeName          String   @map("payee_name")
+  amount             Decimal  @db.Decimal(12, 2)
+  date               DateTime @db.Date
+  purposeDescription String?  @map("purpose_description") @db.Text
+  expenditureCode    String?  @map("expenditure_code") @db.VarChar(10)
+  candidateName      String?  @map("candidate_name")
+  propositionTitle   String?  @map("proposition_title")
+  supportOrOppose    String?  @map("support_or_oppose") @db.VarChar(10)
+  sourceSystem       String   @map("source_system") @db.VarChar(20)
+  createdAt          DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt          DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  committee Committee @relation(fields: [committeeId], references: [id])
+
+  @@index([committeeId])
+  @@index([payeeName])
+  @@index([date])
+  @@index([sourceSystem])
+  @@map("expenditures")
+}
+
+/// Independent expenditure — outside spending for/against a candidate or ballot measure.
+/// Typically by Super PACs and other independent committees.
+model IndependentExpenditure {
+  id               String    @id @default(uuid())
+  externalId       String    @unique @map("external_id")
+  committeeId      String    @map("committee_id")
+  committeeName    String    @map("committee_name")
+  candidateName    String?   @map("candidate_name")
+  propositionTitle String?   @map("proposition_title")
+  supportOrOppose  String    @map("support_or_oppose") @db.VarChar(10)
+  amount           Decimal   @db.Decimal(12, 2)
+  date             DateTime  @db.Date
+  electionDate     DateTime? @map("election_date") @db.Date
+  description      String?   @db.Text
+  sourceSystem     String    @map("source_system") @db.VarChar(20)
+  createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  committee Committee @relation(fields: [committeeId], references: [id])
+
+  @@index([committeeId])
+  @@index([candidateName])
+  @@index([propositionTitle])
+  @@index([date])
+  @@index([supportOrOppose])
+  @@index([sourceSystem])
+  @@map("independent_expenditures")
+}
+
+// ============================================
 // SCRAPING PIPELINE - STRUCTURAL MANIFESTS
 // ============================================
 

--- a/packages/scraping-pipeline/__tests__/api-ingest.handler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/api-ingest.handler.spec.ts
@@ -1,0 +1,428 @@
+import { ApiIngestHandler } from "../src/handlers/api-ingest.handler";
+import type { DomainMapperService } from "../src/mapping/domain-mapper.service";
+import {
+  DataType,
+  type DataSourceConfig,
+  type ExtractionResult,
+} from "@opuspopuli/common";
+
+// Mock NestJS decorators
+jest.mock("@nestjs/common", () => ({
+  Injectable: () => (target: any) => target,
+  Logger: jest.fn().mockImplementation(() => ({
+    log: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+function createSource(
+  overrides: Partial<DataSourceConfig> = {},
+): DataSourceConfig {
+  return {
+    url: "https://api.example.com/v1/items",
+    dataType: DataType.CAMPAIGN_FINANCE,
+    contentGoal: "Extract items",
+    sourceType: "api",
+    api: {
+      resultsPath: "results",
+    },
+    ...overrides,
+  };
+}
+
+function createMockMapper(): jest.Mocked<DomainMapperService> {
+  return {
+    map: jest.fn().mockImplementation((raw, _source) => ({
+      items: raw.items,
+      manifestVersion: 0,
+      success: raw.items.length > 0,
+      warnings: raw.warnings,
+      errors: raw.errors,
+      extractionTimeMs: 1,
+    })),
+  } as unknown as jest.Mocked<DomainMapperService>;
+}
+
+function mockFetchResponse(
+  body: Record<string, unknown>,
+  ok = true,
+  status = 200,
+) {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Internal Server Error",
+    json: jest.fn().mockResolvedValue(body),
+  };
+}
+
+describe("ApiIngestHandler", () => {
+  let handler: ApiIngestHandler;
+  let mapper: jest.Mocked<DomainMapperService>;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    mapper = createMockMapper();
+    handler = new ApiIngestHandler(mapper);
+    originalFetch = global.fetch;
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("execute — successful single-page response", () => {
+    it("should fetch items and map them through the domain mapper", async () => {
+      const items = [
+        { externalId: "C1", name: "Committee 1" },
+        { externalId: "C2", name: "Committee 2" },
+      ];
+
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: items }),
+      );
+
+      const result = await handler.execute(createSource(), "california");
+
+      expect(result.success).toBe(true);
+      expect(result.items).toHaveLength(2);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(mapper.map).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("execute — HTTP error", () => {
+    it("should return success: false with error message", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({}, false, 500),
+      );
+
+      const result = await handler.execute(createSource(), "california");
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining("500")]),
+      );
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  describe("execute — offset pagination", () => {
+    it("should fetch multiple pages until items < limit", async () => {
+      const page1 = Array.from({ length: 10 }, (_, i) => ({
+        id: `item-${i}`,
+      }));
+      const page2 = Array.from({ length: 5 }, (_, i) => ({
+        id: `item-${10 + i}`,
+      }));
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(mockFetchResponse({ results: page1 }))
+        .mockResolvedValueOnce(mockFetchResponse({ results: page2 }));
+
+      const source = createSource({
+        api: {
+          resultsPath: "results",
+          pagination: {
+            type: "offset",
+            limit: 10,
+            pageParam: "offset",
+            limitParam: "per_page",
+          },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.items).toHaveLength(15);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("execute — cursor pagination", () => {
+    it("should extract cursor from FEC-style response and stop when no cursor", async () => {
+      const page1Items = [{ id: "1" }, { id: "2" }];
+      const page2Items = [{ id: "3" }];
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            results: page1Items,
+            pagination: {
+              last_indexes: { last_index: "cursor-abc" },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            results: page2Items,
+            pagination: { last_indexes: {} },
+          }),
+        );
+
+      const source = createSource({
+        api: {
+          resultsPath: "results",
+          pagination: {
+            type: "cursor",
+            limit: 100,
+          },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.items).toHaveLength(3);
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("execute — page pagination at MAX_PAGES", () => {
+    it("should stop at MAX_PAGES (10) and add a warning", async () => {
+      // Always return full pages to trigger MAX_PAGES
+      (global.fetch as jest.Mock).mockImplementation(() =>
+        Promise.resolve(
+          mockFetchResponse({
+            results: Array.from({ length: 100 }, (_, i) => ({ id: `${i}` })),
+          }),
+        ),
+      );
+
+      const source = createSource({
+        api: {
+          resultsPath: "results",
+          pagination: {
+            type: "page",
+            limit: 100,
+            pageParam: "page",
+            limitParam: "per_page",
+          },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(global.fetch).toHaveBeenCalledTimes(10);
+      // Warnings should contain the max page limit warning
+      expect(mapper.map).toHaveBeenCalledWith(
+        expect.objectContaining({
+          warnings: expect.arrayContaining([
+            expect.stringContaining("max page limit"),
+          ]),
+        }),
+        source,
+      );
+    });
+  });
+
+  describe("buildPageUrl", () => {
+    it("should add queryParams and API key to URL", async () => {
+      const envKey = "TEST_API_KEY_12345";
+      process.env.FEC_API_KEY = envKey;
+
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: [] }),
+      );
+
+      const source = createSource({
+        api: {
+          resultsPath: "results",
+          queryParams: {
+            sort: "-date",
+            is_individual: "true",
+          },
+          apiKeyEnvVar: "FEC_API_KEY",
+          apiKeyHeader: "api_key",
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
+      const url = new URL(fetchUrl);
+      expect(url.searchParams.get("sort")).toBe("-date");
+      expect(url.searchParams.get("is_individual")).toBe("true");
+      expect(url.searchParams.get("api_key")).toBe(envKey);
+
+      delete process.env.FEC_API_KEY;
+    });
+
+    it("should add offset pagination params correctly", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: [] }),
+      );
+
+      const source = createSource({
+        api: {
+          resultsPath: "results",
+          pagination: {
+            type: "offset",
+            limit: 50,
+            pageParam: "offset",
+            limitParam: "per_page",
+          },
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
+      const url = new URL(fetchUrl);
+      expect(url.searchParams.get("per_page")).toBe("50");
+      expect(url.searchParams.get("offset")).toBe("0");
+    });
+  });
+
+  describe("extractItems", () => {
+    it("should navigate dot-separated resultsPath", async () => {
+      const items = [{ id: "1" }];
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ data: { items } }),
+      );
+
+      const source = createSource({
+        api: { resultsPath: "data.items" },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.items).toHaveLength(1);
+    });
+
+    it("should return empty array for missing path", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ data: {} }),
+      );
+
+      const source = createSource({
+        api: { resultsPath: "data.items.nested" },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.items).toEqual([]);
+    });
+  });
+
+  describe("inferSourceSystem", () => {
+    it("should inject fec sourceSystem for FEC category", async () => {
+      const items = [{ id: "1" }];
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: items }),
+      );
+
+      const source = createSource({ category: "fec-contributions" });
+
+      await handler.execute(source, "california");
+
+      const rawResult = mapper.map.mock.calls[0][0];
+      expect(rawResult.items[0].sourceSystem).toBe("fec");
+    });
+
+    it("should inject cal_access sourceSystem for CAL-ACCESS category", async () => {
+      const items = [{ id: "1" }];
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: items }),
+      );
+
+      const source = createSource({ category: "cal-access-contributions" });
+
+      await handler.execute(source, "california");
+
+      const rawResult = mapper.map.mock.calls[0][0];
+      expect(rawResult.items[0].sourceSystem).toBe("cal_access");
+    });
+
+    it("should not inject sourceSystem for unknown category", async () => {
+      const items = [{ id: "1" }];
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: items }),
+      );
+
+      const source = createSource({ category: "other" });
+
+      await handler.execute(source, "california");
+
+      const rawResult = mapper.map.mock.calls[0][0];
+      expect(rawResult.items[0].sourceSystem).toBeUndefined();
+    });
+  });
+
+  describe("resolveApiKey", () => {
+    it("should read API key from environment variable", async () => {
+      process.env.MY_API_KEY = "secret-key";
+
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: [] }),
+      );
+
+      const source = createSource({
+        api: {
+          resultsPath: "results",
+          apiKeyEnvVar: "MY_API_KEY",
+          apiKeyHeader: "api_key",
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
+      expect(fetchUrl).toContain("secret-key");
+
+      delete process.env.MY_API_KEY;
+    });
+
+    it("should not add api_key param when env var is not set", async () => {
+      delete process.env.NONEXISTENT_KEY;
+
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: [] }),
+      );
+
+      const source = createSource({
+        api: {
+          resultsPath: "results",
+          apiKeyEnvVar: "NONEXISTENT_KEY",
+          apiKeyHeader: "api_key",
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const fetchUrl = (global.fetch as jest.Mock).mock.calls[0][0];
+      const url = new URL(fetchUrl);
+      expect(url.searchParams.has("api_key")).toBe(false);
+    });
+  });
+
+  describe("execute — no pagination config", () => {
+    it("should fetch a single page when pagination is not configured", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: [{ id: "1" }] }),
+      );
+
+      const result = await handler.execute(createSource(), "california");
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(result.items).toHaveLength(1);
+    });
+  });
+
+  describe("execute — network error", () => {
+    it("should return error result when fetch throws", async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(
+        new TypeError("Failed to fetch"),
+      );
+
+      const result = await handler.execute(createSource(), "california");
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining("Failed to fetch")]),
+      );
+    });
+  });
+});

--- a/packages/scraping-pipeline/__tests__/bulk-download.handler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/bulk-download.handler.spec.ts
@@ -1,0 +1,526 @@
+import { BulkDownloadHandler } from "../src/handlers/bulk-download.handler";
+import type { DomainMapperService } from "../src/mapping/domain-mapper.service";
+import {
+  DataType,
+  type DataSourceConfig,
+  type BulkDownloadConfig,
+} from "@opuspopuli/common";
+
+// Mock NestJS decorators
+jest.mock("@nestjs/common", () => ({
+  Injectable: () => (target: any) => target,
+  Logger: jest.fn().mockImplementation(() => ({
+    log: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+// Mock AdmZip
+const mockGetData = jest.fn();
+const mockGetEntries = jest.fn();
+jest.mock("adm-zip", () => {
+  return jest.fn().mockImplementation(() => ({
+    getEntries: mockGetEntries,
+  }));
+});
+
+function createSource(
+  overrides: Partial<DataSourceConfig> = {},
+): DataSourceConfig {
+  return {
+    url: "https://example.com/data.csv",
+    dataType: DataType.CAMPAIGN_FINANCE,
+    contentGoal: "Extract campaign finance",
+    sourceType: "bulk_download",
+    bulk: {
+      format: "csv",
+      columnMappings: {
+        CMTE_ID: "committeeId",
+        NAME: "donorName",
+        AMOUNT: "amount",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function createMockMapper(): jest.Mocked<DomainMapperService> {
+  return {
+    map: jest.fn().mockImplementation((raw, _source) => ({
+      items: raw.items,
+      manifestVersion: 0,
+      success: raw.items.length > 0,
+      warnings: raw.warnings,
+      errors: raw.errors,
+      extractionTimeMs: 1,
+    })),
+  } as unknown as jest.Mocked<DomainMapperService>;
+}
+
+/**
+ * Convert a string to a clean ArrayBuffer.
+ * Buffer.from(str).buffer returns the shared pool buffer which is too large,
+ * so we need to slice it to the exact byte range.
+ */
+function toArrayBuffer(str: string): ArrayBuffer {
+  const buf = Buffer.from(str, "utf-8");
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+}
+
+describe("BulkDownloadHandler", () => {
+  let handler: BulkDownloadHandler;
+  let mapper: jest.Mocked<DomainMapperService>;
+  let originalFetch: typeof global.fetch;
+
+  beforeEach(() => {
+    mapper = createMockMapper();
+    handler = new BulkDownloadHandler(mapper);
+    originalFetch = global.fetch;
+    global.fetch = jest.fn();
+    mockGetEntries.mockReset();
+    mockGetData.mockReset();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("execute — successful CSV download", () => {
+    it("should download CSV, parse rows, apply column mappings, and map through domain mapper", async () => {
+      const csvContent =
+        "CMTE_ID,NAME,AMOUNT\nC001,Jane Doe,500\nC002,John Smith,1000";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(csvContent)),
+      });
+
+      const result = await handler.execute(createSource(), "california");
+
+      expect(result.success).toBe(true);
+      expect(result.items).toHaveLength(2);
+      expect(mapper.map).toHaveBeenCalledTimes(1);
+
+      // Verify mapped field names
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0]).toMatchObject({
+        committeeId: "C001",
+        donorName: "Jane Doe",
+        amount: "500",
+      });
+      expect(rawItems[1]).toMatchObject({
+        committeeId: "C002",
+        donorName: "John Smith",
+        amount: "1000",
+      });
+    });
+  });
+
+  describe("execute — HTTP error", () => {
+    it("should return success: false with error message", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+      });
+
+      const result = await handler.execute(createSource(), "california");
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining("404")]),
+      );
+    });
+  });
+
+  describe("extractFromZip — file found by exact name", () => {
+    it("should extract file matching exact filePattern from ZIP", async () => {
+      const csvContent = "CMTE_ID|NAME|AMOUNT\nC001|Jane|500";
+
+      mockGetData.mockReturnValue(Buffer.from(csvContent));
+      mockGetEntries.mockReturnValue([
+        {
+          entryName: "itcont.txt",
+          isDirectory: false,
+          header: { size: csvContent.length },
+          getData: mockGetData,
+        },
+      ]);
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer("zip")),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "zip_csv",
+          filePattern: "itcont.txt",
+          delimiter: "|",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("extractFromZip — case-insensitive match", () => {
+    it("should find file by case-insensitive match", async () => {
+      const csvContent = "CMTE_ID\nC001";
+
+      mockGetData.mockReturnValue(Buffer.from(csvContent));
+      mockGetEntries.mockReturnValue([
+        {
+          entryName: "ITCONT.TXT",
+          isDirectory: false,
+          header: { size: csvContent.length },
+          getData: mockGetData,
+        },
+      ]);
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer("zip")),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "zip_csv",
+          filePattern: "itcont.txt",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe("extractFromZip — file not found", () => {
+    it("should return error when filePattern not found in ZIP", async () => {
+      mockGetEntries.mockReturnValue([
+        {
+          entryName: "other-file.csv",
+          isDirectory: false,
+        },
+      ]);
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer("zip")),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "zip_csv",
+          filePattern: "itcont.txt",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining("not found in ZIP")]),
+      );
+    });
+  });
+
+  describe("extractFromZip — no filePattern for ZIP", () => {
+    it("should return error when no filePattern provided for ZIP format", async () => {
+      mockGetEntries.mockReturnValue([]);
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer("zip")),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "zip_csv",
+          columnMappings: { CMTE_ID: "committeeId" },
+        } as BulkDownloadConfig,
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining("filePattern")]),
+      );
+    });
+  });
+
+  describe("parseDelimited — pipe delimiter with column mappings", () => {
+    it("should parse pipe-delimited content and apply column mappings", async () => {
+      const content = "CMTE_ID|NAME|STATE\nC001|Jane|CA\nC002|John|NY";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "csv",
+          delimiter: "|",
+          columnMappings: {
+            CMTE_ID: "committeeId",
+            NAME: "donorName",
+            STATE: "donorState",
+          },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.items).toHaveLength(2);
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0]).toMatchObject({
+        committeeId: "C001",
+        donorName: "Jane",
+        donorState: "CA",
+      });
+    });
+  });
+
+  describe("parseDelimited — applies filters", () => {
+    it("should skip rows that don't match filter criteria", async () => {
+      const content =
+        "CMTE_ID,NAME,STATE\nC001,Jane,CA\nC002,John,NY\nC003,Bob,CA";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "csv",
+          columnMappings: {
+            CMTE_ID: "committeeId",
+            NAME: "donorName",
+          },
+          filters: { STATE: "CA" },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems).toHaveLength(2);
+      expect(rawItems[0]).toMatchObject({ committeeId: "C001" });
+      expect(rawItems[1]).toMatchObject({ committeeId: "C003" });
+    });
+  });
+
+  describe("parseDelimited — skips empty lines", () => {
+    it("should skip empty lines in the content", async () => {
+      const content = "CMTE_ID,NAME\nC001,Jane\n\n\nC002,John\n";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "csv",
+          columnMappings: { CMTE_ID: "committeeId", NAME: "donorName" },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems).toHaveLength(2);
+    });
+  });
+
+  describe("getDelimiter", () => {
+    it("should use config delimiter when provided", async () => {
+      const content = "CMTE_ID|NAME\nC001|Jane";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "csv",
+          delimiter: "|",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0]).toMatchObject({ committeeId: "C001" });
+    });
+
+    it("should default to tab for TSV format", async () => {
+      const content = "CMTE_ID\tNAME\nC001\tJane";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "tsv",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0]).toMatchObject({ committeeId: "C001" });
+    });
+
+    it("should default to comma for CSV format", async () => {
+      const content = "CMTE_ID,NAME\nC001,Jane";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "csv",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0]).toMatchObject({ committeeId: "C001" });
+    });
+  });
+
+  describe("inferSourceSystem", () => {
+    it("should inject cal_access sourceSystem for cal-access category", async () => {
+      const content = "CMTE_ID,NAME\nC001,Jane";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      const source = createSource({
+        category: "cal-access-contributions",
+        bulk: {
+          format: "csv",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0].sourceSystem).toBe("cal_access");
+    });
+
+    it("should inject fec sourceSystem for FEC category", async () => {
+      const content = "CMTE_ID,NAME\nC001,Jane";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      const source = createSource({
+        category: "fec-individual-contributions",
+        bulk: {
+          format: "csv",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0].sourceSystem).toBe("fec");
+    });
+  });
+
+  describe("parseDelimited — warns on missing column headers", () => {
+    it("should still parse available columns when some headers are missing", async () => {
+      const content = "CMTE_ID,NAME\nC001,Jane";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      // Map a column that doesn't exist in the CSV
+      const source = createSource({
+        bulk: {
+          format: "csv",
+          columnMappings: {
+            CMTE_ID: "committeeId",
+            NONEXISTENT: "missing",
+          },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0]).toMatchObject({ committeeId: "C001" });
+      expect(rawItems[0].missing).toBeUndefined();
+    });
+  });
+
+  describe("execute — network error", () => {
+    it("should return error result when fetch throws", async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(
+        new TypeError("Failed to fetch"),
+      );
+
+      const result = await handler.execute(createSource(), "california");
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining("Failed to fetch")]),
+      );
+    });
+  });
+
+  describe("execute — headerLines skip", () => {
+    it("should skip specified number of header lines", async () => {
+      const content = "# Comment line\nCMTE_ID,NAME\nC001,Jane";
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "csv",
+          headerLines: 1,
+          columnMappings: { CMTE_ID: "committeeId", NAME: "donorName" },
+        },
+      });
+
+      await handler.execute(source, "california");
+
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems).toHaveLength(1);
+      expect(rawItems[0]).toMatchObject({ committeeId: "C001" });
+    });
+  });
+});

--- a/packages/scraping-pipeline/package.json
+++ b/packages/scraping-pipeline/package.json
@@ -27,6 +27,7 @@
   "license": "AGPL-3.0",
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
+    "adm-zip": "^0.5.16",
     "cheerio": "^1.1.2",
     "zod": "^3.23.0"
   },
@@ -42,6 +43,7 @@
     "@opuspopuli/extraction-provider": "workspace:*",
     "@opuspopuli/llm-provider": "workspace:*",
     "@opuspopuli/relationaldb-provider": "workspace:*",
+    "@types/adm-zip": "^0.5.7",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.0.0",
     "domhandler": "^5.0.3",

--- a/packages/scraping-pipeline/src/handlers/api-ingest.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/api-ingest.handler.ts
@@ -1,0 +1,342 @@
+/**
+ * API Ingest Handler
+ *
+ * Makes paginated REST API requests, extracts items from JSON responses,
+ * and maps to domain types. No AI analysis needed — the response structure
+ * is defined declaratively in the config.
+ *
+ * Supports pagination strategies: offset, cursor, page.
+ * API keys are resolved from environment variables at runtime.
+ */
+
+import { Injectable, Logger } from "@nestjs/common";
+import type {
+  ApiSourceConfig,
+  DataSourceConfig,
+  ExtractionResult,
+  RawExtractionResult,
+} from "@opuspopuli/common";
+import { DomainMapperService } from "../mapping/domain-mapper.service.js";
+
+/** Maximum pages to fetch in a single pipeline run (safety limit) */
+const MAX_PAGES = 10;
+
+/** Request timeout in milliseconds */
+const REQUEST_TIMEOUT_MS = 60_000;
+
+/** Delay between paginated requests in milliseconds */
+const PAGE_DELAY_MS = 250;
+
+@Injectable()
+export class ApiIngestHandler {
+  private readonly logger = new Logger(ApiIngestHandler.name);
+
+  constructor(private readonly mapper: DomainMapperService) {}
+
+  async execute<T>(
+    source: DataSourceConfig,
+    _regionId: string,
+  ): Promise<ExtractionResult<T>> {
+    const pipelineStart = Date.now();
+    const api = source.api!;
+    const warnings: string[] = [];
+    const errors: string[] = [];
+
+    try {
+      // 1. Resolve API key
+      const apiKey = this.resolveApiKey(api);
+
+      // 2. Fetch all pages
+      const allItems = await this.fetchAllPages(
+        source.url,
+        api,
+        apiKey,
+        warnings,
+      );
+
+      this.logger.log(
+        `Fetched ${allItems.length} items from API ${source.url}`,
+      );
+
+      // 3. Inject sourceSystem based on category
+      const sourceSystem = this.inferSourceSystem(source);
+      if (sourceSystem) {
+        for (const item of allItems) {
+          if (!item["sourceSystem"]) {
+            item["sourceSystem"] = sourceSystem;
+          }
+        }
+      }
+
+      // 4. Map through domain mapper
+      const rawResult: RawExtractionResult = {
+        items: allItems,
+        success: allItems.length > 0,
+        warnings,
+        errors,
+      };
+
+      const result = this.mapper.map<T>(rawResult, source);
+      result.extractionTimeMs = Date.now() - pipelineStart;
+      return result;
+    } catch (error) {
+      errors.push((error as Error).message);
+      return {
+        items: [],
+        manifestVersion: 0,
+        success: false,
+        warnings,
+        errors,
+        extractionTimeMs: Date.now() - pipelineStart,
+      };
+    }
+  }
+
+  /**
+   * Resolve API key from environment variable.
+   */
+  private resolveApiKey(api: ApiSourceConfig): string | undefined {
+    if (!api.apiKeyEnvVar) return undefined;
+
+    const key = process.env[api.apiKeyEnvVar];
+    if (!key) {
+      this.logger.warn(`API key env var '${api.apiKeyEnvVar}' not set`);
+    }
+    return key;
+  }
+
+  /**
+   * Fetch all pages from a paginated API endpoint.
+   */
+  private async fetchAllPages(
+    baseUrl: string,
+    api: ApiSourceConfig,
+    apiKey: string | undefined,
+    warnings: string[],
+  ): Promise<Record<string, unknown>[]> {
+    const allItems: Record<string, unknown>[] = [];
+    let page = 0;
+    let cursor: string | undefined;
+
+    while (page < MAX_PAGES) {
+      const { items, body } = await this.fetchPage(
+        baseUrl,
+        api,
+        apiKey,
+        page,
+        cursor,
+      );
+
+      if (items.length === 0) {
+        this.logger.debug(`No more items on page ${page + 1}`);
+        break;
+      }
+
+      allItems.push(...items);
+      page++;
+
+      const nextCursor = this.shouldContinue(api, items, body);
+      if (nextCursor === false) break;
+      cursor = nextCursor || undefined;
+
+      await this.delay(PAGE_DELAY_MS);
+    }
+
+    if (page >= MAX_PAGES) {
+      warnings.push(
+        `Reached max page limit (${MAX_PAGES}). More data may be available.`,
+      );
+    }
+
+    return allItems;
+  }
+
+  /**
+   * Fetch a single page from the API.
+   */
+  private async fetchPage(
+    baseUrl: string,
+    api: ApiSourceConfig,
+    apiKey: string | undefined,
+    page: number,
+    cursor: string | undefined,
+  ): Promise<{
+    items: Record<string, unknown>[];
+    body: Record<string, unknown>;
+  }> {
+    const url = this.buildPageUrl(baseUrl, api, apiKey, page, cursor);
+    this.logger.debug(`Fetching page ${page + 1}: ${url.toString()}`);
+
+    const response = await fetch(url.toString(), {
+      method: api.method ?? "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `API error HTTP ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    const body = (await response.json()) as Record<string, unknown>;
+    const resultsPath = api.resultsPath ?? "results";
+    const items = this.extractItems(body, resultsPath);
+
+    return { items, body };
+  }
+
+  /**
+   * Determine whether to continue pagination.
+   * Returns false to stop, or the cursor string for cursor-based pagination.
+   */
+  private shouldContinue(
+    api: ApiSourceConfig,
+    items: Record<string, unknown>[],
+    body: Record<string, unknown>,
+  ): string | false {
+    const pagination = api.pagination;
+    if (!pagination) return false;
+
+    if (pagination.type === "cursor") {
+      const cursor = this.extractCursor(body);
+      return cursor || false;
+    }
+
+    // For offset/page pagination, stop if we got fewer items than the limit
+    const limit = pagination.limit ?? 100;
+    return items.length < limit ? false : "";
+  }
+
+  /**
+   * Build the URL for a specific page of results.
+   */
+  private buildPageUrl(
+    baseUrl: string,
+    api: ApiSourceConfig,
+    apiKey: string | undefined,
+    page: number,
+    cursor: string | undefined,
+  ): URL {
+    const url = new URL(baseUrl);
+
+    // Add static query parameters from config
+    if (api.queryParams) {
+      for (const [key, value] of Object.entries(api.queryParams)) {
+        url.searchParams.set(key, value);
+      }
+    }
+
+    // Add API key (as query parameter)
+    if (apiKey && api.apiKeyHeader) {
+      url.searchParams.set(api.apiKeyHeader, apiKey);
+    }
+
+    // Add pagination parameters
+    if (api.pagination) {
+      const { type, pageParam, limitParam, limit } = api.pagination;
+      const effectiveLimit = limit ?? 100;
+
+      // Always send the limit/per_page parameter
+      url.searchParams.set(limitParam ?? "per_page", String(effectiveLimit));
+
+      switch (type) {
+        case "offset": {
+          const offset = page * effectiveLimit;
+          url.searchParams.set(pageParam ?? "offset", String(offset));
+          break;
+        }
+        case "page": {
+          if (page > 0) {
+            url.searchParams.set(pageParam ?? "page", String(page + 1));
+          }
+          break;
+        }
+        case "cursor": {
+          if (cursor) {
+            url.searchParams.set("last_index", cursor);
+          }
+          break;
+        }
+      }
+    }
+
+    return url;
+  }
+
+  /**
+   * Extract items array from a JSON response using a dot-separated path.
+   * e.g., "results" → body.results, "data.items" → body.data.items
+   */
+  private extractItems(
+    body: Record<string, unknown>,
+    resultsPath: string,
+  ): Record<string, unknown>[] {
+    const parts = resultsPath.split(".");
+    let current: unknown = body;
+
+    for (const part of parts) {
+      if (
+        current &&
+        typeof current === "object" &&
+        !Array.isArray(current) &&
+        part in (current as Record<string, unknown>)
+      ) {
+        current = (current as Record<string, unknown>)[part];
+      } else {
+        return [];
+      }
+    }
+
+    if (!Array.isArray(current)) return [];
+    return current as Record<string, unknown>[];
+  }
+
+  /**
+   * Extract cursor value for next page from API response.
+   * Handles FEC-style pagination: { pagination: { last_indexes: { last_index: "..." } } }
+   */
+  private extractCursor(body: Record<string, unknown>): string | undefined {
+    const pagination = body["pagination"] as
+      | Record<string, unknown>
+      | undefined;
+    if (!pagination) return undefined;
+
+    // FEC style: pagination.last_indexes.last_index
+    const lastIndexes = pagination["last_indexes"] as
+      | Record<string, unknown>
+      | undefined;
+    if (lastIndexes) {
+      const cursor = lastIndexes["last_index"];
+      if (typeof cursor === "string" || typeof cursor === "number") {
+        return String(cursor);
+      }
+    }
+
+    // Generic: pagination.last_index or pagination.cursor or pagination.next_cursor
+    for (const key of ["last_index", "cursor", "next_cursor", "next"]) {
+      const val = pagination[key];
+      if (typeof val === "string" || typeof val === "number") {
+        return String(val);
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Infer the sourceSystem value from the data source category.
+   */
+  private inferSourceSystem(source: DataSourceConfig): string | undefined {
+    const cat = (source.category ?? "").toLowerCase();
+    if (cat.includes("cal-access") || cat.includes("cal_access")) {
+      return "cal_access";
+    }
+    if (cat.includes("fec")) return "fec";
+    return undefined;
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
@@ -1,0 +1,273 @@
+/**
+ * Bulk Download Handler
+ *
+ * Downloads ZIP/CSV/TSV files, extracts target files from archives,
+ * parses rows using column mappings, applies filters, and maps to domain types.
+ *
+ * No AI analysis needed — the schema is defined declaratively in the config.
+ */
+
+import { Injectable, Logger } from "@nestjs/common";
+import AdmZip from "adm-zip";
+import type {
+  BulkDownloadConfig,
+  DataSourceConfig,
+  ExtractionResult,
+  RawExtractionResult,
+} from "@opuspopuli/common";
+import { DomainMapperService } from "../mapping/domain-mapper.service.js";
+
+@Injectable()
+export class BulkDownloadHandler {
+  private readonly logger = new Logger(BulkDownloadHandler.name);
+
+  constructor(private readonly mapper: DomainMapperService) {}
+
+  async execute<T>(
+    source: DataSourceConfig,
+    _regionId: string,
+  ): Promise<ExtractionResult<T>> {
+    const pipelineStart = Date.now();
+    const bulk = source.bulk!;
+    const warnings: string[] = [];
+    const errors: string[] = [];
+
+    try {
+      // 1. Download the file
+      this.logger.log(`Downloading ${source.url}...`);
+      const response = await fetch(source.url, {
+        signal: AbortSignal.timeout(300_000), // 5 min timeout for large files
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const buffer = Buffer.from(await response.arrayBuffer());
+      this.logger.log(
+        `Downloaded ${(buffer.length / 1024 / 1024).toFixed(1)}MB`,
+      );
+
+      // 2. Get the target file content
+      let content: string;
+      const isZip = bulk.format.startsWith("zip_");
+
+      if (isZip) {
+        content = this.extractFromZip(buffer, bulk);
+      } else {
+        content = buffer.toString("utf-8");
+      }
+
+      // 3. Parse delimited rows and apply column mappings + filters
+      const delimiter = this.getDelimiter(bulk);
+      const rawRecords = this.parseDelimited(content, delimiter, bulk, source);
+
+      this.logger.log(
+        `Parsed ${rawRecords.length} records from ${bulk.filePattern ?? source.url}`,
+      );
+
+      // 4. Map through domain mapper
+      const rawResult: RawExtractionResult = {
+        items: rawRecords,
+        success: rawRecords.length > 0,
+        warnings,
+        errors,
+      };
+
+      const result = this.mapper.map<T>(rawResult, source);
+      result.extractionTimeMs = Date.now() - pipelineStart;
+      return result;
+    } catch (error) {
+      errors.push((error as Error).message);
+      return {
+        items: [],
+        manifestVersion: 0,
+        success: false,
+        warnings,
+        errors,
+        extractionTimeMs: Date.now() - pipelineStart,
+      };
+    }
+  }
+
+  /**
+   * Extract a target file from a ZIP archive.
+   */
+  private extractFromZip(buffer: Buffer, bulk: BulkDownloadConfig): string {
+    const pattern = bulk.filePattern;
+    if (!pattern) {
+      throw new Error("ZIP format requires filePattern in bulk config");
+    }
+
+    const zip = new AdmZip(buffer);
+    const entries = zip.getEntries();
+
+    // Find entry matching the file pattern (exact match or path suffix)
+    const entry = entries.find(
+      (e) =>
+        e.entryName === pattern ||
+        e.entryName.endsWith(`/${pattern}`) ||
+        e.entryName.toUpperCase() === pattern.toUpperCase(),
+    );
+
+    if (!entry) {
+      const available = entries
+        .filter((e) => !e.isDirectory)
+        .map((e) => e.entryName)
+        .slice(0, 20)
+        .join(", ");
+      throw new Error(
+        `File '${pattern}' not found in ZIP. Available: ${available}${entries.length > 20 ? "..." : ""}`,
+      );
+    }
+
+    const uncompressedSize = entry.header.size;
+    this.logger.log(
+      `Extracting ${entry.entryName} (${(uncompressedSize / 1024 / 1024).toFixed(1)}MB uncompressed)`,
+    );
+
+    return entry.getData().toString("utf-8");
+  }
+
+  /**
+   * Determine the column delimiter from the config.
+   */
+  private getDelimiter(bulk: BulkDownloadConfig): string {
+    if (bulk.delimiter) return bulk.delimiter;
+    const format = bulk.format.replaceAll("zip_", "");
+    return format === "tsv" ? "\t" : ",";
+  }
+
+  /**
+   * Strip surrounding double quotes and trim whitespace from a CSV cell value.
+   */
+  private static stripQuotes(val: string): string {
+    return val.trim().replaceAll(/(^"|"$)/g, "");
+  }
+
+  /**
+   * Build a column-index lookup map from headers.
+   * Logs warnings for mapped columns not found in the file.
+   */
+  private buildColumnIndices(
+    headers: string[],
+    columns: Record<string, string>,
+  ): Record<string, number> {
+    const indices: Record<string, number> = {};
+    for (const col of Object.keys(columns)) {
+      const idx = headers.indexOf(col);
+      if (idx !== -1) {
+        indices[col] = idx;
+      } else {
+        this.logger.warn(
+          `Column '${col}' not found in file headers. Available: ${headers.slice(0, 10).join(", ")}`,
+        );
+      }
+    }
+    return indices;
+  }
+
+  /**
+   * Check if a row passes all filter criteria.
+   */
+  private passesFilters(
+    values: string[],
+    filters: Record<string, string>,
+    filterIndices: Record<string, number>,
+  ): boolean {
+    for (const [filterCol, filterVal] of Object.entries(filters)) {
+      const idx = filterIndices[filterCol];
+      if (idx === undefined) continue;
+      const cellVal = BulkDownloadHandler.stripQuotes(values[idx] ?? "");
+      if (cellVal !== filterVal) return false;
+    }
+    return true;
+  }
+
+  /**
+   * Map a row's values to a domain record using column mappings.
+   */
+  private mapRow(
+    values: string[],
+    mappings: Record<string, string>,
+    colIndices: Record<string, number>,
+  ): Record<string, unknown> {
+    const record: Record<string, unknown> = {};
+    for (const [sourceCol, targetField] of Object.entries(mappings)) {
+      const idx = colIndices[sourceCol];
+      if (idx === undefined) continue;
+      const val = BulkDownloadHandler.stripQuotes(values[idx] ?? "");
+      if (val) record[targetField] = val;
+    }
+    return record;
+  }
+
+  /**
+   * Parse delimited text into records using column mappings.
+   * Applies filters to skip irrelevant rows.
+   */
+  private parseDelimited(
+    content: string,
+    delimiter: string,
+    bulk: BulkDownloadConfig,
+    source: DataSourceConfig,
+  ): Record<string, unknown>[] {
+    const lines = content.split("\n");
+    if (lines.length === 0) return [];
+
+    // Get header line (skip any leading header lines as configured)
+    const headerSkip = bulk.headerLines ?? 0;
+    const headerLine = lines[headerSkip];
+    if (!headerLine) return [];
+
+    const headers = headerLine
+      .split(delimiter)
+      .map((h) => BulkDownloadHandler.stripQuotes(h));
+
+    const mappings = bulk.columnMappings;
+    const filters = bulk.filters ?? {};
+    const colIndices = this.buildColumnIndices(headers, mappings);
+    const filterIndices = this.buildColumnIndices(
+      headers,
+      filters as Record<string, string>,
+    );
+    const sourceSystem = this.inferSourceSystem(source);
+
+    const records: Record<string, unknown>[] = [];
+
+    for (let i = headerSkip + 1; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line?.trim()) continue;
+
+      const values = line.split(delimiter);
+
+      if (!this.passesFilters(values, filters, filterIndices)) continue;
+
+      const record = this.mapRow(values, mappings, colIndices);
+
+      if (sourceSystem && !record["sourceSystem"]) {
+        record["sourceSystem"] = sourceSystem;
+      }
+
+      const fieldCount = Object.keys(record).length;
+      const minFields = sourceSystem ? 2 : 1;
+      if (fieldCount >= minFields) {
+        records.push(record);
+      }
+    }
+
+    return records;
+  }
+
+  /**
+   * Infer the sourceSystem value from the data source category.
+   */
+  private inferSourceSystem(source: DataSourceConfig): string | undefined {
+    const cat = (source.category ?? "").toLowerCase();
+    if (cat.includes("cal-access") || cat.includes("cal_access")) {
+      return "cal_access";
+    }
+    if (cat.includes("fec")) return "fec";
+    return undefined;
+  }
+}

--- a/packages/scraping-pipeline/src/index.ts
+++ b/packages/scraping-pipeline/src/index.ts
@@ -36,6 +36,10 @@ export { DomainMapperService } from "./mapping/domain-mapper.service.js";
 // Self-healing
 export { SelfHealingService } from "./healing/self-healing.service.js";
 
+// Source type handlers
+export { BulkDownloadHandler } from "./handlers/bulk-download.handler.js";
+export { ApiIngestHandler } from "./handlers/api-ingest.handler.js";
+
 // Validation
 export { ConfigValidator } from "./validation/config-validator.js";
 

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -11,9 +11,14 @@ import { z } from "zod";
 import {
   DataType,
   PropositionStatus,
+  CommitteeType,
   type Proposition,
   type Meeting,
   type Representative,
+  type Committee,
+  type Contribution,
+  type Expenditure,
+  type IndependentExpenditure,
   type RawExtractionResult,
   type ExtractionResult,
   type DataSourceConfig,
@@ -65,7 +70,15 @@ export class DomainMapperService {
   private mapItem(
     record: Record<string, unknown>,
     source: DataSourceConfig,
-  ): Proposition | Meeting | Representative | null {
+  ):
+    | Proposition
+    | Meeting
+    | Representative
+    | Committee
+    | Contribution
+    | Expenditure
+    | IndependentExpenditure
+    | null {
     switch (source.dataType) {
       case DataType.PROPOSITIONS:
         return this.mapProposition(record);
@@ -73,9 +86,34 @@ export class DomainMapperService {
         return this.mapMeeting(record, source.category);
       case DataType.REPRESENTATIVES:
         return this.mapRepresentative(record, source.category);
+      case DataType.CAMPAIGN_FINANCE:
+        return this.mapCampaignFinanceItem(record, source.category);
       default:
         return null;
     }
+  }
+
+  /**
+   * Route campaign finance records to the correct sub-mapper based on category.
+   */
+  private mapCampaignFinanceItem(
+    record: Record<string, unknown>,
+    category?: string,
+  ): Committee | Contribution | Expenditure | IndependentExpenditure | null {
+    const cat = (category ?? "").toLowerCase();
+
+    if (cat.includes("committee")) {
+      return this.mapCommittee(record);
+    } else if (cat.includes("independent") || cat.includes("s496")) {
+      return this.mapIndependentExpenditure(record);
+    } else if (cat.includes("expenditure")) {
+      return this.mapExpenditure(record);
+    } else if (cat.includes("contribution")) {
+      return this.mapContribution(record);
+    }
+
+    // Default: try contribution (most common campaign finance record type)
+    return this.mapContribution(record);
   }
 
   private mapProposition(record: Record<string, unknown>): Proposition | null {
@@ -121,6 +159,63 @@ export class DomainMapperService {
     if (!result.success) {
       this.logger.debug(
         `Representative validation failed: ${result.error.message}`,
+      );
+      return null;
+    }
+    return result.data;
+  }
+
+  private mapCommittee(record: Record<string, unknown>): Committee | null {
+    const result = CommitteeSchema.safeParse(record);
+    if (!result.success) {
+      this.logger.debug(`Committee validation failed: ${result.error.message}`);
+      return null;
+    }
+    return result.data;
+  }
+
+  private mapContribution(
+    record: Record<string, unknown>,
+  ): Contribution | null {
+    // Combine first/last name fields if donorName not already set
+    const enriched = { ...record };
+    if (
+      !enriched.donorName &&
+      (enriched.donorLastName || enriched.donorFirstName)
+    ) {
+      const last = (enriched.donorLastName as string) ?? "";
+      const first = (enriched.donorFirstName as string) ?? "";
+      enriched.donorName = first ? `${last}, ${first}`.trim() : last;
+    }
+
+    const result = ContributionSchema.safeParse(enriched);
+    if (!result.success) {
+      this.logger.debug(
+        `Contribution validation failed: ${result.error.message}`,
+      );
+      return null;
+    }
+    return result.data;
+  }
+
+  private mapExpenditure(record: Record<string, unknown>): Expenditure | null {
+    const result = ExpenditureSchema.safeParse(record);
+    if (!result.success) {
+      this.logger.debug(
+        `Expenditure validation failed: ${result.error.message}`,
+      );
+      return null;
+    }
+    return result.data;
+  }
+
+  private mapIndependentExpenditure(
+    record: Record<string, unknown>,
+  ): IndependentExpenditure | null {
+    const result = IndependentExpenditureSchema.safeParse(record);
+    if (!result.success) {
+      this.logger.debug(
+        `IndependentExpenditure validation failed: ${result.error.message}`,
       );
       return null;
     }
@@ -172,4 +267,88 @@ const RepresentativeSchema = z.object({
       website: z.string().optional(),
     })
     .optional(),
+});
+
+// ============================================
+// Zod Schemas for Campaign Finance Models
+// ============================================
+
+const supportOpposeTransform = (val: string | undefined) => {
+  if (!val) return undefined;
+  const upper = val.toUpperCase();
+  if (upper === "S" || upper === "SUPPORT") return "support" as const;
+  if (upper === "O" || upper === "OPPOSE") return "oppose" as const;
+  return undefined;
+};
+
+const donorTypeTransform = (val: string | undefined) => {
+  if (!val) return "other" as const;
+  const upper = val.toUpperCase();
+  if (upper === "IND") return "individual" as const;
+  if (upper === "COM") return "committee" as const;
+  if (upper === "PTY") return "party" as const;
+  if (upper === "SCC") return "individual" as const; // small contributor → individual
+  if (upper === "OTH") return "other" as const;
+  return "other" as const;
+};
+
+const CommitteeSchema = z.object({
+  externalId: z.string().min(1),
+  name: z.string().min(1),
+  type: z.nativeEnum(CommitteeType).default(CommitteeType.OTHER),
+  candidateName: z.string().optional(),
+  candidateOffice: z.string().optional(),
+  propositionId: z.string().optional(),
+  party: z.string().optional(),
+  status: z.enum(["active", "terminated"]).default("active"),
+  sourceSystem: z.enum(["cal_access", "fec"]),
+  sourceUrl: z.string().optional(),
+});
+
+const ContributionSchema = z.object({
+  externalId: z.string().min(1),
+  committeeId: z.string().min(1),
+  donorName: z.string().min(1),
+  donorType: z.string().transform(donorTypeTransform).default("other"),
+  donorEmployer: z.string().optional(),
+  donorOccupation: z.string().optional(),
+  donorCity: z.string().optional(),
+  donorState: z.string().optional(),
+  donorZip: z.string().optional(),
+  amount: z.coerce.number(),
+  date: z.coerce.date(),
+  electionType: z.string().optional(),
+  contributionType: z.string().optional(),
+  sourceSystem: z.enum(["cal_access", "fec"]),
+});
+
+const ExpenditureSchema = z.object({
+  externalId: z.string().min(1),
+  committeeId: z.string().min(1),
+  payeeName: z.string().min(1),
+  amount: z.coerce.number(),
+  date: z.coerce.date(),
+  purposeDescription: z.string().optional(),
+  expenditureCode: z.string().optional(),
+  candidateName: z.string().optional(),
+  propositionTitle: z.string().optional(),
+  supportOrOppose: z.string().transform(supportOpposeTransform).optional(),
+  sourceSystem: z.enum(["cal_access", "fec"]),
+});
+
+const IndependentExpenditureSchema = z.object({
+  externalId: z.string().min(1),
+  committeeId: z.string().min(1),
+  committeeName: z.string().min(1),
+  candidateName: z.string().optional(),
+  propositionTitle: z.string().optional(),
+  supportOrOppose: z
+    .string()
+    .transform((val) => supportOpposeTransform(val) ?? "support")
+    .default("support"),
+  amount: z.coerce.number(),
+  date: z.coerce.date(),
+  electionDate: z.coerce.date().optional(),
+  description: z.string().optional(),
+  sourceSystem: z.enum(["cal_access", "fec"]),
 });

--- a/packages/scraping-pipeline/src/scraping-pipeline.module.ts
+++ b/packages/scraping-pipeline/src/scraping-pipeline.module.ts
@@ -20,6 +20,8 @@ import { ManifestExtractorService } from "./extraction/manifest-extractor.servic
 import { ExtractionValidator } from "./extraction/extraction-validator.js";
 import { DomainMapperService } from "./mapping/domain-mapper.service.js";
 import { SelfHealingService } from "./healing/self-healing.service.js";
+import { BulkDownloadHandler } from "./handlers/bulk-download.handler.js";
+import { ApiIngestHandler } from "./handlers/api-ingest.handler.js";
 
 export interface ScrapingPipelineModuleOptions {
   /** Configuration for the prompt client (remote or local) */
@@ -65,6 +67,9 @@ export class ScrapingPipelineModule {
         ExtractionValidator,
         DomainMapperService,
         SelfHealingService,
+        // Source type handlers
+        BulkDownloadHandler,
+        ApiIngestHandler,
         ScrapingPipelineService,
       ],
       exports: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -844,6 +844,9 @@ importers:
       '@opuspopuli/common':
         specifier: workspace:*
         version: link:../common
+      adm-zip:
+        specifier: ^0.5.16
+        version: 0.5.16
       cheerio:
         specifier: ^1.1.2
         version: 1.1.2
@@ -866,6 +869,9 @@ importers:
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../relationaldb-provider
+      '@types/adm-zip':
+        specifier: ^0.5.7
+        version: 0.5.7
       '@types/jest':
         specifier: ^30.0.0
         version: 30.0.0
@@ -4117,6 +4123,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/adm-zip@0.5.7':
+    resolution: {integrity: sha512-DNEs/QvmyRLurdQPChqq0Md4zGvPwHerAJYWk9l2jCbD1VPpnzRJorOdiq4zsw09NFbYnhfsoEhWtxIzXpn2yw==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -4611,6 +4620,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -13801,6 +13814,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/adm-zip@0.5.7':
+    dependencies:
+      '@types/node': 25.0.1
+
   '@types/aria-query@5.0.4': {}
 
   '@types/aws-lambda@8.10.159': {}
@@ -14376,6 +14393,8 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  adm-zip@0.5.16: {}
 
   agent-base@6.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Campaign finance data models (Committee, Contribution, Expenditure, IndependentExpenditure) with Prisma schema and migration
- Multi-plugin loading: dual-slot registry (federal + local) with `${stateCode}` placeholder resolution
- `sourceType` routing: `api` (paginated REST/FEC), `bulk_download` (ZIP/CSV/TSV/CAL-ACCESS), `html_scrape` (default)
- API ingest handler with offset/cursor/page pagination strategies
- Bulk download handler with ZIP extraction, column mappings, and row filters
- Domain mapper for campaign finance types with Zod validation
- Comprehensive test coverage (~60 new tests) across 8 files
- SonarQube fixes: reduced cognitive complexity, structuredClone, replaceAll

## Test plan
- [x] All 129 common tests pass
- [x] All 191 scraping-pipeline tests pass
- [x] All 128 region-provider tests pass
- [x] All 1085 backend tests pass
- [x] Clean build across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)