### PR TITLE
Release: campaign finance GraphQL queries

### DIFF
--- a/apps/backend/src/apps/region/src/domains/models/committee.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/committee.model.ts
@@ -1,0 +1,92 @@
+import { ObjectType, Field, ID, Int, registerEnumType } from '@nestjs/graphql';
+
+/**
+ * Committee type enum for GraphQL
+ */
+export enum CommitteeTypeGQL {
+  CANDIDATE = 'candidate',
+  BALLOT_MEASURE = 'ballot_measure',
+  PAC = 'pac',
+  SUPER_PAC = 'super_pac',
+  PARTY = 'party',
+  SMALL_CONTRIBUTOR = 'small_contributor',
+  OTHER = 'other',
+}
+
+registerEnumType(CommitteeTypeGQL, {
+  name: 'CommitteeType',
+  description: 'Types of campaign finance committees',
+});
+
+/**
+ * Committee status enum for GraphQL
+ */
+export enum CommitteeStatusGQL {
+  ACTIVE = 'active',
+  TERMINATED = 'terminated',
+}
+
+registerEnumType(CommitteeStatusGQL, {
+  name: 'CommitteeStatus',
+  description: 'Status of a campaign committee',
+});
+
+/**
+ * Committee GraphQL model
+ */
+@ObjectType()
+export class CommitteeModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  externalId!: string;
+
+  @Field()
+  name!: string;
+
+  @Field()
+  type!: string;
+
+  @Field({ nullable: true })
+  candidateName?: string;
+
+  @Field({ nullable: true })
+  candidateOffice?: string;
+
+  @Field({ nullable: true })
+  propositionId?: string;
+
+  @Field({ nullable: true })
+  party?: string;
+
+  @Field()
+  status!: string;
+
+  @Field()
+  sourceSystem!: string;
+
+  @Field({ nullable: true })
+  sourceUrl?: string;
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  updatedAt!: Date;
+}
+
+/**
+ * Paginated committees response
+ */
+@ObjectType()
+export class PaginatedCommittees {
+  @Field(() => [CommitteeModel])
+  items!: CommitteeModel[];
+
+  @Field(() => Int)
+  total!: number;
+
+  @Field()
+  hasMore!: boolean;
+}

--- a/apps/backend/src/apps/region/src/domains/models/contribution.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/contribution.model.ts
@@ -1,0 +1,96 @@
+import {
+  ObjectType,
+  Field,
+  ID,
+  Int,
+  Float,
+  registerEnumType,
+} from '@nestjs/graphql';
+
+/**
+ * Donor type enum for GraphQL
+ */
+export enum DonorTypeGQL {
+  INDIVIDUAL = 'individual',
+  COMMITTEE = 'committee',
+  PARTY = 'party',
+  SELF = 'self',
+  OTHER = 'other',
+}
+
+registerEnumType(DonorTypeGQL, {
+  name: 'DonorType',
+  description: 'Types of campaign contribution donors',
+});
+
+/**
+ * Contribution GraphQL model
+ */
+@ObjectType()
+export class ContributionModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  externalId!: string;
+
+  @Field()
+  committeeId!: string;
+
+  @Field()
+  donorName!: string;
+
+  @Field()
+  donorType!: string;
+
+  @Field({ nullable: true })
+  donorEmployer?: string;
+
+  @Field({ nullable: true })
+  donorOccupation?: string;
+
+  @Field({ nullable: true })
+  donorCity?: string;
+
+  @Field({ nullable: true })
+  donorState?: string;
+
+  @Field({ nullable: true })
+  donorZip?: string;
+
+  @Field(() => Float)
+  amount!: number;
+
+  @Field()
+  date!: Date;
+
+  @Field({ nullable: true })
+  electionType?: string;
+
+  @Field({ nullable: true })
+  contributionType?: string;
+
+  @Field()
+  sourceSystem!: string;
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  updatedAt!: Date;
+}
+
+/**
+ * Paginated contributions response
+ */
+@ObjectType()
+export class PaginatedContributions {
+  @Field(() => [ContributionModel])
+  items!: ContributionModel[];
+
+  @Field(() => Int)
+  total!: number;
+
+  @Field()
+  hasMore!: boolean;
+}

--- a/apps/backend/src/apps/region/src/domains/models/expenditure.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/expenditure.model.ts
@@ -1,0 +1,85 @@
+import {
+  ObjectType,
+  Field,
+  ID,
+  Int,
+  Float,
+  registerEnumType,
+} from '@nestjs/graphql';
+
+/**
+ * Support or Oppose enum for GraphQL
+ * Shared by Expenditure and IndependentExpenditure
+ */
+export enum SupportOrOpposeGQL {
+  SUPPORT = 'support',
+  OPPOSE = 'oppose',
+}
+
+registerEnumType(SupportOrOpposeGQL, {
+  name: 'SupportOrOppose',
+  description: 'Whether spending supports or opposes a candidate/measure',
+});
+
+/**
+ * Expenditure GraphQL model
+ */
+@ObjectType()
+export class ExpenditureModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  externalId!: string;
+
+  @Field()
+  committeeId!: string;
+
+  @Field()
+  payeeName!: string;
+
+  @Field(() => Float)
+  amount!: number;
+
+  @Field()
+  date!: Date;
+
+  @Field({ nullable: true })
+  purposeDescription?: string;
+
+  @Field({ nullable: true })
+  expenditureCode?: string;
+
+  @Field({ nullable: true })
+  candidateName?: string;
+
+  @Field({ nullable: true })
+  propositionTitle?: string;
+
+  @Field({ nullable: true })
+  supportOrOppose?: string;
+
+  @Field()
+  sourceSystem!: string;
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  updatedAt!: Date;
+}
+
+/**
+ * Paginated expenditures response
+ */
+@ObjectType()
+export class PaginatedExpenditures {
+  @Field(() => [ExpenditureModel])
+  items!: ExpenditureModel[];
+
+  @Field(() => Int)
+  total!: number;
+
+  @Field()
+  hasMore!: boolean;
+}

--- a/apps/backend/src/apps/region/src/domains/models/independent-expenditure.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/independent-expenditure.model.ts
@@ -1,0 +1,64 @@
+import { ObjectType, Field, ID, Int, Float } from '@nestjs/graphql';
+
+/**
+ * Independent Expenditure GraphQL model
+ */
+@ObjectType()
+export class IndependentExpenditureModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  externalId!: string;
+
+  @Field()
+  committeeId!: string;
+
+  @Field()
+  committeeName!: string;
+
+  @Field({ nullable: true })
+  candidateName?: string;
+
+  @Field({ nullable: true })
+  propositionTitle?: string;
+
+  @Field()
+  supportOrOppose!: string;
+
+  @Field(() => Float)
+  amount!: number;
+
+  @Field()
+  date!: Date;
+
+  @Field({ nullable: true })
+  electionDate?: Date;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field()
+  sourceSystem!: string;
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  updatedAt!: Date;
+}
+
+/**
+ * Paginated independent expenditures response
+ */
+@ObjectType()
+export class PaginatedIndependentExpenditures {
+  @Field(() => [IndependentExpenditureModel])
+  items!: IndependentExpenditureModel[];
+
+  @Field(() => Int)
+  total!: number;
+
+  @Field()
+  hasMore!: boolean;
+}

--- a/apps/backend/src/apps/region/src/domains/models/region-info.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/region-info.model.ts
@@ -7,6 +7,7 @@ export enum DataTypeGQL {
   PROPOSITIONS = 'propositions',
   MEETINGS = 'meetings',
   REPRESENTATIVES = 'representatives',
+  CAMPAIGN_FINANCE = 'campaign_finance',
 }
 
 registerEnumType(DataTypeGQL, {

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -24,6 +24,19 @@ import {
   RepresentativeModel,
   PaginatedRepresentatives,
 } from './models/representative.model';
+import { CommitteeModel, PaginatedCommittees } from './models/committee.model';
+import {
+  ContributionModel,
+  PaginatedContributions,
+} from './models/contribution.model';
+import {
+  ExpenditureModel,
+  PaginatedExpenditures,
+} from './models/expenditure.model';
+import {
+  IndependentExpenditureModel,
+  PaginatedIndependentExpenditures,
+} from './models/independent-expenditure.model';
 
 /**
  * Region Resolver
@@ -130,6 +143,163 @@ export class RegionResolver {
       ...result,
       photoUrl: result.photoUrl ?? undefined,
       contactInfo: (result.contactInfo as ContactInfoModel) ?? undefined,
+    };
+  }
+
+  // ==========================================
+  // CAMPAIGN FINANCE QUERIES
+  // ==========================================
+
+  /**
+   * Get paginated committees
+   */
+  @Query(() => PaginatedCommittees)
+  @Extensions({ complexity: 15 })
+  async committees(
+    @Args({ name: 'skip', type: () => Int, defaultValue: 0 }) skip: number,
+    @Args({ name: 'take', type: () => Int, defaultValue: 10 }) take: number,
+    @Args({ name: 'sourceSystem', nullable: true }) sourceSystem?: string,
+  ): Promise<PaginatedCommittees> {
+    return this.regionService.getCommittees(skip, take, sourceSystem);
+  }
+
+  /**
+   * Get a single committee by ID
+   */
+  @Query(() => CommitteeModel, { nullable: true })
+  async committee(
+    @Args({ name: 'id', type: () => ID }) id: string,
+  ): Promise<CommitteeModel | null> {
+    const result = await this.regionService.getCommittee(id);
+    if (!result) return null;
+    return {
+      ...result,
+      candidateName: result.candidateName ?? undefined,
+      candidateOffice: result.candidateOffice ?? undefined,
+      propositionId: result.propositionId ?? undefined,
+      party: result.party ?? undefined,
+      sourceUrl: result.sourceUrl ?? undefined,
+    };
+  }
+
+  /**
+   * Get paginated contributions
+   */
+  @Query(() => PaginatedContributions)
+  @Extensions({ complexity: 15 })
+  async contributions(
+    @Args({ name: 'skip', type: () => Int, defaultValue: 0 }) skip: number,
+    @Args({ name: 'take', type: () => Int, defaultValue: 10 }) take: number,
+    @Args({ name: 'committeeId', nullable: true }) committeeId?: string,
+    @Args({ name: 'sourceSystem', nullable: true }) sourceSystem?: string,
+  ): Promise<PaginatedContributions> {
+    return this.regionService.getContributions(
+      skip,
+      take,
+      committeeId,
+      sourceSystem,
+    );
+  }
+
+  /**
+   * Get a single contribution by ID
+   */
+  @Query(() => ContributionModel, { nullable: true })
+  async contribution(
+    @Args({ name: 'id', type: () => ID }) id: string,
+  ): Promise<ContributionModel | null> {
+    const result = await this.regionService.getContribution(id);
+    if (!result) return null;
+    return {
+      ...result,
+      amount: Number(result.amount),
+      donorEmployer: result.donorEmployer ?? undefined,
+      donorOccupation: result.donorOccupation ?? undefined,
+      donorCity: result.donorCity ?? undefined,
+      donorState: result.donorState ?? undefined,
+      donorZip: result.donorZip ?? undefined,
+      electionType: result.electionType ?? undefined,
+      contributionType: result.contributionType ?? undefined,
+    };
+  }
+
+  /**
+   * Get paginated expenditures
+   */
+  @Query(() => PaginatedExpenditures)
+  @Extensions({ complexity: 15 })
+  async expenditures(
+    @Args({ name: 'skip', type: () => Int, defaultValue: 0 }) skip: number,
+    @Args({ name: 'take', type: () => Int, defaultValue: 10 }) take: number,
+    @Args({ name: 'committeeId', nullable: true }) committeeId?: string,
+    @Args({ name: 'sourceSystem', nullable: true }) sourceSystem?: string,
+  ): Promise<PaginatedExpenditures> {
+    return this.regionService.getExpenditures(
+      skip,
+      take,
+      committeeId,
+      sourceSystem,
+    );
+  }
+
+  /**
+   * Get a single expenditure by ID
+   */
+  @Query(() => ExpenditureModel, { nullable: true })
+  async expenditure(
+    @Args({ name: 'id', type: () => ID }) id: string,
+  ): Promise<ExpenditureModel | null> {
+    const result = await this.regionService.getExpenditure(id);
+    if (!result) return null;
+    return {
+      ...result,
+      amount: Number(result.amount),
+      purposeDescription: result.purposeDescription ?? undefined,
+      expenditureCode: result.expenditureCode ?? undefined,
+      candidateName: result.candidateName ?? undefined,
+      propositionTitle: result.propositionTitle ?? undefined,
+      supportOrOppose: result.supportOrOppose ?? undefined,
+    };
+  }
+
+  /**
+   * Get paginated independent expenditures
+   */
+  @Query(() => PaginatedIndependentExpenditures)
+  @Extensions({ complexity: 15 })
+  async independentExpenditures(
+    @Args({ name: 'skip', type: () => Int, defaultValue: 0 }) skip: number,
+    @Args({ name: 'take', type: () => Int, defaultValue: 10 }) take: number,
+    @Args({ name: 'committeeId', nullable: true }) committeeId?: string,
+    @Args({ name: 'supportOrOppose', nullable: true })
+    supportOrOppose?: string,
+    @Args({ name: 'sourceSystem', nullable: true }) sourceSystem?: string,
+  ): Promise<PaginatedIndependentExpenditures> {
+    return this.regionService.getIndependentExpenditures(
+      skip,
+      take,
+      committeeId,
+      supportOrOppose,
+      sourceSystem,
+    );
+  }
+
+  /**
+   * Get a single independent expenditure by ID
+   */
+  @Query(() => IndependentExpenditureModel, { nullable: true })
+  async independentExpenditure(
+    @Args({ name: 'id', type: () => ID }) id: string,
+  ): Promise<IndependentExpenditureModel | null> {
+    const result = await this.regionService.getIndependentExpenditure(id);
+    if (!result) return null;
+    return {
+      ...result,
+      amount: Number(result.amount),
+      candidateName: result.candidateName ?? undefined,
+      propositionTitle: result.propositionTitle ?? undefined,
+      electionDate: result.electionDate ?? undefined,
+      description: result.description ?? undefined,
     };
   }
 

--- a/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
@@ -156,12 +156,12 @@ export class BulkDownloadHandler {
     const indices: Record<string, number> = {};
     for (const col of Object.keys(columns)) {
       const idx = headers.indexOf(col);
-      if (idx !== -1) {
-        indices[col] = idx;
-      } else {
+      if (idx === -1) {
         this.logger.warn(
           `Column '${col}' not found in file headers. Available: ${headers.slice(0, 10).join(", ")}`,
         );
+      } else {
+        indices[col] = idx;
       }
     }
     return indices;


### PR DESCRIPTION
## Summary
- Add GraphQL queries for all 4 campaign finance entity types (committees, contributions, expenditures, independent expenditures)
- Add paginated list queries with filtering support (sourceSystem, committeeId, supportOrOppose)
- Add single-entity lookup queries by ID
- Full unit test coverage for resolver and service layers

## Test plan
- [x] All 1118 backend unit tests pass
- [x] All 199 scraping pipeline tests pass
- [x] Clean build across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)