### PR TITLE
Release: develop → main

### DIFF
--- a/apps/backend/src/apps/documents/src/app.module.ts
+++ b/apps/backend/src/apps/documents/src/app.module.ts
@@ -11,7 +11,6 @@ import {
 import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ThrottlerModule } from '@nestjs/throttler';
-import { ApolloServerPluginInlineTrace } from '@apollo/server/plugin/inlineTrace';
 import { LoggingModule } from '@opuspopuli/logging-provider';
 import depthLimit from 'graphql-depth-limit';
 import { createQueryComplexityValidationRule } from 'src/common/graphql/query-complexity.plugin';
@@ -33,7 +32,9 @@ import { HMACMiddleware } from 'src/common/middleware/hmac.middleware';
 import {
   THROTTLER_CONFIG,
   SHARED_PROVIDERS,
+  GRAPHQL_INTROSPECTION_ENABLED,
   createLoggingConfig,
+  createSubgraphPlugins,
 } from 'src/common/config/shared-app.config';
 import { DbModule } from 'src/db/db.module';
 
@@ -74,11 +75,12 @@ import { MetricsModule } from 'src/common/metrics';
     GraphQLModule.forRoot<ApolloFederationDriverConfig>({
       driver: ApolloFederationDriver,
       autoSchemaFile: { path: 'documents-schema.gql', federation: 2 },
-      plugins: [ApolloServerPluginInlineTrace()],
+      plugins: createSubgraphPlugins('documents-service'),
       validationRules: [depthLimit(10), createQueryComplexityValidationRule()],
       buildSchemaOptions: {
         orphanedTypes: [User],
       },
+      introspection: GRAPHQL_INTROSPECTION_ENABLED,
       // Pass request/response to GraphQL context for guards to access headers
       context: ({ req, res }: { req: unknown; res: unknown }) => ({ req, res }),
     }),

--- a/apps/backend/src/apps/knowledge/src/app.module.ts
+++ b/apps/backend/src/apps/knowledge/src/app.module.ts
@@ -11,7 +11,6 @@ import {
 import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ThrottlerModule } from '@nestjs/throttler';
-import { ApolloServerPluginInlineTrace } from '@apollo/server/plugin/inlineTrace';
 import { LoggingModule } from '@opuspopuli/logging-provider';
 import depthLimit from 'graphql-depth-limit';
 import { createQueryComplexityValidationRule } from 'src/common/graphql/query-complexity.plugin';
@@ -31,7 +30,9 @@ import { HMACMiddleware } from 'src/common/middleware/hmac.middleware';
 import {
   THROTTLER_CONFIG,
   SHARED_PROVIDERS,
+  GRAPHQL_INTROSPECTION_ENABLED,
   createLoggingConfig,
+  createSubgraphPlugins,
 } from 'src/common/config/shared-app.config';
 import { DbModule } from 'src/db/db.module';
 import { AuditModule } from 'src/common/audit/audit.module';
@@ -67,8 +68,9 @@ import { MetricsModule } from 'src/common/metrics';
     GraphQLModule.forRoot<ApolloFederationDriverConfig>({
       driver: ApolloFederationDriver,
       autoSchemaFile: { path: 'knowledge-schema.gql', federation: 2 },
-      plugins: [ApolloServerPluginInlineTrace()],
+      plugins: createSubgraphPlugins('knowledge-service'),
       validationRules: [depthLimit(10), createQueryComplexityValidationRule()],
+      introspection: GRAPHQL_INTROSPECTION_ENABLED,
       context: ({ req, res }: { req: unknown; res: unknown }) => ({ req, res }),
     }),
     CaslModule.forRoot(),

--- a/apps/backend/src/apps/region/src/app.module.ts
+++ b/apps/backend/src/apps/region/src/app.module.ts
@@ -12,7 +12,6 @@ import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
-import { ApolloServerPluginInlineTrace } from '@apollo/server/plugin/inlineTrace';
 import { LoggingModule } from '@opuspopuli/logging-provider';
 import depthLimit from 'graphql-depth-limit';
 import { createQueryComplexityValidationRule } from 'src/common/graphql/query-complexity.plugin';
@@ -32,7 +31,9 @@ import { LoggerMiddleware } from 'src/common/middleware/logger.middleware';
 import {
   THROTTLER_CONFIG,
   SHARED_PROVIDERS,
+  GRAPHQL_INTROSPECTION_ENABLED,
   createLoggingConfig,
+  createSubgraphPlugins,
 } from 'src/common/config/shared-app.config';
 import { DbModule } from 'src/db/db.module';
 import { AuditModule } from 'src/common/audit/audit.module';
@@ -70,8 +71,9 @@ import { MetricsModule } from 'src/common/metrics';
     GraphQLModule.forRoot<ApolloFederationDriverConfig>({
       driver: ApolloFederationDriver,
       autoSchemaFile: { path: 'region-schema.gql', federation: 2 },
-      plugins: [ApolloServerPluginInlineTrace()],
+      plugins: createSubgraphPlugins('region-service'),
       validationRules: [depthLimit(10), createQueryComplexityValidationRule()],
+      introspection: GRAPHQL_INTROSPECTION_ENABLED,
       context: ({ req, res }: { req: unknown; res: unknown }) => ({ req, res }),
     }),
     CaslModule.forRoot(),

--- a/apps/backend/src/apps/users/src/app.module.ts
+++ b/apps/backend/src/apps/users/src/app.module.ts
@@ -11,7 +11,6 @@ import {
 import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
 import { ThrottlerModule } from '@nestjs/throttler';
-import { ApolloServerPluginInlineTrace } from '@apollo/server/plugin/inlineTrace';
 import { LoggingModule } from '@opuspopuli/logging-provider';
 import depthLimit from 'graphql-depth-limit';
 import { createQueryComplexityValidationRule } from 'src/common/graphql/query-complexity.plugin';
@@ -37,7 +36,9 @@ import { HMACMiddleware } from 'src/common/middleware/hmac.middleware';
 import {
   THROTTLER_CONFIG,
   SHARED_PROVIDERS,
+  GRAPHQL_INTROSPECTION_ENABLED,
   createLoggingConfig,
+  createSubgraphPlugins,
 } from 'src/common/config/shared-app.config';
 import { DbModule } from 'src/db/db.module';
 import { AuditModule } from 'src/common/audit/audit.module';
@@ -69,8 +70,9 @@ import { MetricsModule } from 'src/common/metrics';
     GraphQLModule.forRoot<ApolloFederationDriverConfig>({
       driver: ApolloFederationDriver,
       autoSchemaFile: { path: 'schema.gql', federation: 2 },
-      plugins: [ApolloServerPluginInlineTrace()],
+      plugins: createSubgraphPlugins('users-service'),
       validationRules: [depthLimit(10), createQueryComplexityValidationRule()],
+      introspection: GRAPHQL_INTROSPECTION_ENABLED,
       // Pass request/response to GraphQL context for guards to access headers
       context: ({ req, res }: { req: unknown; res: unknown }) => ({ req, res }),
     }),

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -41,8 +41,10 @@ sonar.javascript.lcov.reportPaths=coverage-reports/apps/frontend/coverage/lcov.i
 # TypeScript configuration
 sonar.typescript.tsconfigPaths=apps/frontend/tsconfig.json,apps/backend/tsconfig.json
 
-# Duplication exclusions (seed data files have repetitive structure by design)
-sonar.cpd.exclusions=**/prisma/seed-*.ts
+# Duplication exclusions
+# - Seed data files have repetitive structure by design
+# - NestJS module files are declarative DI configuration with inherently similar structure
+sonar.cpd.exclusions=**/prisma/seed-*.ts,**/app.module.ts
 
 # Encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
## Summary
- feat: disable GraphQL introspection on subgraphs in production (#378)
- Shared `createSubgraphPlugins()` and `GRAPHQL_INTROSPECTION_ENABLED` in shared-app.config.ts
- Add `**/app.module.ts` to SonarCloud CPD exclusions (NestJS module config)

## Test plan
- [x] All CI checks passed on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)