### PR TITLE
feat: harden CORS configuration for production (#381)

### DIFF
--- a/apps/backend/src/config/cors.config.spec.ts
+++ b/apps/backend/src/config/cors.config.spec.ts
@@ -2,6 +2,8 @@ import { ConfigService } from '@nestjs/config';
 import {
   getCorsConfig,
   getGraphQLCorsConfig,
+  parseAllowedOrigins,
+  isValidProductionOrigin,
   CORS_ALLOWED_HEADERS,
   CORS_ALLOWED_METHODS,
   CORS_MAX_AGE,
@@ -20,7 +22,6 @@ describe('CORS Configuration', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    // Restore original environment
     process.env.NODE_ENV = originalNodeEnv;
   });
 
@@ -43,14 +44,135 @@ describe('CORS Configuration', () => {
     });
   });
 
+  describe('isValidProductionOrigin', () => {
+    it('should accept HTTPS origins', () => {
+      expect(isValidProductionOrigin('https://app.example.com')).toBe(true);
+      expect(isValidProductionOrigin('https://example.com')).toBe(true);
+      expect(isValidProductionOrigin('https://sub.domain.example.com')).toBe(
+        true,
+      );
+    });
+
+    it('should reject HTTP origins', () => {
+      expect(isValidProductionOrigin('http://app.example.com')).toBe(false);
+      expect(isValidProductionOrigin('http://localhost:3000')).toBe(false);
+    });
+
+    it('should reject invalid URLs', () => {
+      expect(isValidProductionOrigin('not-a-url')).toBe(false);
+      expect(isValidProductionOrigin('')).toBe(false);
+      expect(isValidProductionOrigin('ftp://example.com')).toBe(false);
+    });
+  });
+
+  describe('parseAllowedOrigins', () => {
+    describe('in development mode', () => {
+      beforeEach(() => {
+        process.env.NODE_ENV = 'development';
+      });
+
+      it('should return null when ALLOWED_ORIGINS is unset', () => {
+        mockConfigService.get.mockReturnValue(undefined);
+        expect(parseAllowedOrigins(mockConfigService)).toBeNull();
+      });
+
+      it('should return parsed origins when ALLOWED_ORIGINS is set', () => {
+        mockConfigService.get.mockReturnValue(
+          'http://localhost:3000,http://localhost:3200',
+        );
+        expect(parseAllowedOrigins(mockConfigService)).toEqual([
+          'http://localhost:3000',
+          'http://localhost:3200',
+        ]);
+      });
+    });
+
+    describe('in production mode', () => {
+      beforeEach(() => {
+        process.env.NODE_ENV = 'production';
+      });
+
+      it('should throw if ALLOWED_ORIGINS is unset', () => {
+        mockConfigService.get.mockReturnValue(undefined);
+        expect(() => parseAllowedOrigins(mockConfigService)).toThrow(
+          'ALLOWED_ORIGINS must be set in production',
+        );
+      });
+
+      it('should throw if ALLOWED_ORIGINS is empty string', () => {
+        mockConfigService.get.mockReturnValue('');
+        expect(() => parseAllowedOrigins(mockConfigService)).toThrow(
+          'ALLOWED_ORIGINS must be set in production',
+        );
+      });
+
+      it('should throw if ALLOWED_ORIGINS contains only whitespace', () => {
+        mockConfigService.get.mockReturnValue('   ');
+        expect(() => parseAllowedOrigins(mockConfigService)).toThrow(
+          'ALLOWED_ORIGINS must be set in production',
+        );
+      });
+
+      it('should throw if ALLOWED_ORIGINS contains only commas', () => {
+        mockConfigService.get.mockReturnValue(',,,');
+        expect(() => parseAllowedOrigins(mockConfigService)).toThrow(
+          'ALLOWED_ORIGINS must contain at least one valid origin',
+        );
+      });
+
+      it('should throw if any origin is not HTTPS', () => {
+        mockConfigService.get.mockReturnValue(
+          'https://app.example.com,http://admin.example.com',
+        );
+        expect(() => parseAllowedOrigins(mockConfigService)).toThrow(
+          'Invalid origins in ALLOWED_ORIGINS: http://admin.example.com',
+        );
+      });
+
+      it('should throw if origin is not a valid URL', () => {
+        mockConfigService.get.mockReturnValue('not-a-url');
+        expect(() => parseAllowedOrigins(mockConfigService)).toThrow(
+          'Invalid origins in ALLOWED_ORIGINS: not-a-url',
+        );
+      });
+
+      it('should return valid HTTPS origins', () => {
+        mockConfigService.get.mockReturnValue(
+          'https://app.example.com,https://admin.example.com',
+        );
+        expect(parseAllowedOrigins(mockConfigService)).toEqual([
+          'https://app.example.com',
+          'https://admin.example.com',
+        ]);
+      });
+
+      it('should trim whitespace from origins', () => {
+        mockConfigService.get.mockReturnValue(
+          '  https://app.example.com  ,  https://admin.example.com  ',
+        );
+        expect(parseAllowedOrigins(mockConfigService)).toEqual([
+          'https://app.example.com',
+          'https://admin.example.com',
+        ]);
+      });
+
+      it('should filter out empty entries from trailing commas', () => {
+        mockConfigService.get.mockReturnValue(
+          'https://app.example.com,,https://admin.example.com,',
+        );
+        expect(parseAllowedOrigins(mockConfigService)).toEqual([
+          'https://app.example.com',
+          'https://admin.example.com',
+        ]);
+      });
+    });
+  });
+
   describe('getCorsConfig', () => {
     describe('in development mode', () => {
       beforeEach(() => {
         process.env.NODE_ENV = 'development';
-        mockConfigService.get.mockImplementation((key: string) => {
-          if (key === 'ALLOWED_ORIGINS') return undefined;
-          return undefined;
-        });
+        mockConfigService.get.mockReturnValue(undefined);
       });
 
       it('should allow all origins', () => {
@@ -74,24 +196,90 @@ describe('CORS Configuration', () => {
       });
     });
 
+    describe('in development mode with ALLOWED_ORIGINS set', () => {
+      beforeEach(() => {
+        process.env.NODE_ENV = 'development';
+        mockConfigService.get.mockReturnValue(
+          'http://localhost:3000,http://localhost:3200',
+        );
+      });
+
+      it('should use callback-based origin validation', () => {
+        const config = getCorsConfig(mockConfigService);
+        expect(typeof config.origin).toBe('function');
+      });
+
+      it('should allow listed origins', () => {
+        const config = getCorsConfig(mockConfigService);
+        const originFn = config.origin as (
+          origin: string | undefined,
+          callback: (err: Error | null, allow?: boolean) => void,
+        ) => void;
+        const callback = jest.fn();
+        originFn('http://localhost:3000', callback);
+        expect(callback).toHaveBeenCalledWith(null, true);
+      });
+
+      it('should reject unlisted origins', () => {
+        const config = getCorsConfig(mockConfigService);
+        const originFn = config.origin as (
+          origin: string | undefined,
+          callback: (err: Error | null, allow?: boolean) => void,
+        ) => void;
+        const callback = jest.fn();
+        originFn('http://evil.com', callback);
+        expect(callback).toHaveBeenCalledWith(expect.any(Error));
+      });
+    });
+
     describe('in production mode', () => {
       const allowedOrigins =
         'https://app.example.com,https://admin.example.com';
 
       beforeEach(() => {
         process.env.NODE_ENV = 'production';
-        mockConfigService.get.mockImplementation((key: string) => {
-          if (key === 'ALLOWED_ORIGINS') return allowedOrigins;
-          return undefined;
-        });
+        mockConfigService.get.mockReturnValue(allowedOrigins);
       });
 
-      it('should restrict to allowed origins', () => {
+      it('should use callback-based origin validation', () => {
         const config = getCorsConfig(mockConfigService);
-        expect(config.origin).toEqual([
-          'https://app.example.com',
-          'https://admin.example.com',
-        ]);
+        expect(typeof config.origin).toBe('function');
+      });
+
+      it('should allow listed origins via callback', () => {
+        const config = getCorsConfig(mockConfigService);
+        const originFn = config.origin as (
+          origin: string | undefined,
+          callback: (err: Error | null, allow?: boolean) => void,
+        ) => void;
+        const callback = jest.fn();
+
+        originFn('https://app.example.com', callback);
+        expect(callback).toHaveBeenCalledWith(null, true);
+      });
+
+      it('should reject unlisted origins via callback', () => {
+        const config = getCorsConfig(mockConfigService);
+        const originFn = config.origin as (
+          origin: string | undefined,
+          callback: (err: Error | null, allow?: boolean) => void,
+        ) => void;
+        const callback = jest.fn();
+
+        originFn('https://evil.example.com', callback);
+        expect(callback).toHaveBeenCalledWith(expect.any(Error));
+      });
+
+      it('should allow requests with no origin (server-to-server)', () => {
+        const config = getCorsConfig(mockConfigService);
+        const originFn = config.origin as (
+          origin: string | undefined,
+          callback: (err: Error | null, allow?: boolean) => void,
+        ) => void;
+        const callback = jest.fn();
+
+        originFn(undefined, callback);
+        expect(callback).toHaveBeenCalledWith(null, true);
       });
 
       it('should include credentials', () => {
@@ -118,34 +306,13 @@ describe('CORS Configuration', () => {
     describe('in production without ALLOWED_ORIGINS', () => {
       beforeEach(() => {
         process.env.NODE_ENV = 'production';
-        mockConfigService.get.mockImplementation((key: string) => {
-          if (key === 'ALLOWED_ORIGINS') return undefined;
-          return undefined;
-        });
+        mockConfigService.get.mockReturnValue(undefined);
       });
 
-      it('should fall back to allowing all origins', () => {
-        const config = getCorsConfig(mockConfigService);
-        expect(config.origin).toBe(true);
-      });
-    });
-
-    describe('origin trimming', () => {
-      beforeEach(() => {
-        process.env.NODE_ENV = 'production';
-        mockConfigService.get.mockImplementation((key: string) => {
-          if (key === 'ALLOWED_ORIGINS')
-            return '  https://app.example.com  ,  https://admin.example.com  ';
-          return undefined;
-        });
-      });
-
-      it('should trim whitespace from origins', () => {
-        const config = getCorsConfig(mockConfigService);
-        expect(config.origin).toEqual([
-          'https://app.example.com',
-          'https://admin.example.com',
-        ]);
+      it('should throw an error', () => {
+        expect(() => getCorsConfig(mockConfigService)).toThrow(
+          'ALLOWED_ORIGINS must be set in production',
+        );
       });
     });
   });
@@ -154,10 +321,7 @@ describe('CORS Configuration', () => {
     describe('in development mode', () => {
       beforeEach(() => {
         process.env.NODE_ENV = 'development';
-        mockConfigService.get.mockImplementation((key: string) => {
-          if (key === 'ALLOWED_ORIGINS') return undefined;
-          return undefined;
-        });
+        mockConfigService.get.mockReturnValue(undefined);
       });
 
       it('should allow all origins', () => {
@@ -187,10 +351,7 @@ describe('CORS Configuration', () => {
 
       beforeEach(() => {
         process.env.NODE_ENV = 'production';
-        mockConfigService.get.mockImplementation((key: string) => {
-          if (key === 'ALLOWED_ORIGINS') return allowedOrigins;
-          return undefined;
-        });
+        mockConfigService.get.mockReturnValue(allowedOrigins);
       });
 
       it('should restrict to allowed origins', () => {
@@ -220,15 +381,13 @@ describe('CORS Configuration', () => {
     describe('in production without ALLOWED_ORIGINS', () => {
       beforeEach(() => {
         process.env.NODE_ENV = 'production';
-        mockConfigService.get.mockImplementation((key: string) => {
-          if (key === 'ALLOWED_ORIGINS') return undefined;
-          return undefined;
-        });
+        mockConfigService.get.mockReturnValue(undefined);
       });
 
-      it('should fall back to allowing all origins', () => {
-        const config = getGraphQLCorsConfig(mockConfigService);
-        expect(config.origin).toBe(true);
+      it('should throw an error', () => {
+        expect(() => getGraphQLCorsConfig(mockConfigService)).toThrow(
+          'ALLOWED_ORIGINS must be set in production',
+        );
       });
     });
   });

--- a/apps/backend/src/config/cors.config.ts
+++ b/apps/backend/src/config/cors.config.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { ConfigService } from '@nestjs/config';
 import { isProduction } from './environment.config';
@@ -8,16 +9,20 @@ import { isProduction } from './environment.config';
  * Provides environment-aware CORS settings for the API gateway and GraphQL endpoints.
  *
  * Production Mode:
- * - Restricts origins to ALLOWED_ORIGINS environment variable
- * - Validates origin against whitelist
- * - Blocks requests from unauthorized domains
+ * - Requires ALLOWED_ORIGINS to be set (throws on startup if missing)
+ * - Validates each origin is a valid HTTPS URL
+ * - Logs CORS rejections for security auditing
+ * - Applies to both HTTP and WebSocket connections
  *
  * Development Mode:
  * - Allows all origins for easier local development
  * - Still enforces credentials and method restrictions
  *
  * @see https://github.com/OpusPopuli/opuspopuli/issues/189
+ * @see https://github.com/OpusPopuli/opuspopuli/issues/381
  */
+
+const logger = new Logger('CorsConfig');
 
 /**
  * Standard allowed headers for CORS requests
@@ -40,19 +45,109 @@ export const CORS_ALLOWED_METHODS = ['GET', 'POST', 'OPTIONS'];
 export const CORS_MAX_AGE = 86400;
 
 /**
+ * Validate that an origin is a valid HTTPS URL (required in production).
+ * Allows http://localhost for development convenience, though in production
+ * mode HTTPS is enforced.
+ */
+export function isValidProductionOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse and validate the ALLOWED_ORIGINS environment variable.
+ *
+ * In production:
+ * - Throws if ALLOWED_ORIGINS is unset or empty
+ * - Throws if any origin is not a valid HTTPS URL
+ *
+ * In development:
+ * - Returns null (all origins allowed)
+ */
+export function parseAllowedOrigins(
+  configService: ConfigService,
+): string[] | null {
+  const allowedOrigins = configService.get<string>('ALLOWED_ORIGINS');
+  const isProd = isProduction();
+
+  if (!isProd) {
+    return allowedOrigins
+      ? allowedOrigins
+          .split(',')
+          .map((o) => o.trim())
+          .filter(Boolean)
+      : null;
+  }
+
+  // Production: ALLOWED_ORIGINS is required (defense in depth — env.validation.ts also enforces this)
+  if (!allowedOrigins || allowedOrigins.trim() === '') {
+    throw new Error(
+      'ALLOWED_ORIGINS must be set in production. Provide a comma-separated list of HTTPS origins.',
+    );
+  }
+
+  const origins = allowedOrigins
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  if (origins.length === 0) {
+    throw new Error(
+      'ALLOWED_ORIGINS must contain at least one valid origin in production.',
+    );
+  }
+
+  const invalidOrigins = origins.filter((o) => !isValidProductionOrigin(o));
+  if (invalidOrigins.length > 0) {
+    throw new Error(
+      `Invalid origins in ALLOWED_ORIGINS: ${invalidOrigins.join(', ')}. All production origins must use HTTPS.`,
+    );
+  }
+
+  logger.log(
+    `Production CORS configured with ${origins.length} allowed origin(s)`,
+  );
+  return origins;
+}
+
+/**
  * Get CORS configuration based on environment
+ *
+ * In production, uses a callback function to validate each request origin
+ * and log rejections for security auditing.
  *
  * @param configService - NestJS ConfigService for reading environment variables
  * @returns CorsOptions for NestJS CORS configuration
  */
 export function getCorsConfig(configService: ConfigService): CorsOptions {
-  const allowedOrigins = configService.get<string>('ALLOWED_ORIGINS');
-  const isProd = isProduction();
+  const origins = parseAllowedOrigins(configService);
 
-  if (isProd && allowedOrigins) {
-    const origins = allowedOrigins.split(',').map((o) => o.trim());
+  if (origins) {
+    const originSet = new Set(origins);
     return {
-      origin: origins,
+      origin: (
+        requestOrigin: string | undefined,
+        callback: (err: Error | null, allow?: boolean) => void,
+      ) => {
+        // Allow requests with no origin (e.g., server-to-server, curl)
+        if (!requestOrigin) {
+          callback(null, true);
+          return;
+        }
+
+        if (originSet.has(requestOrigin)) {
+          callback(null, true);
+        } else {
+          logger.warn(
+            `CORS rejection: origin="${requestOrigin}" is not in the allowed list`,
+          );
+          callback(new Error('Not allowed by CORS'));
+        }
+      },
       methods: CORS_ALLOWED_METHODS,
       allowedHeaders: CORS_ALLOWED_HEADERS,
       credentials: true,
@@ -84,11 +179,9 @@ export function getGraphQLCorsConfig(configService: ConfigService): {
   methods: string[];
   allowedHeaders: string[];
 } {
-  const allowedOrigins = configService.get<string>('ALLOWED_ORIGINS');
-  const isProd = isProduction();
+  const origins = parseAllowedOrigins(configService);
 
-  if (isProd && allowedOrigins) {
-    const origins = allowedOrigins.split(',').map((o) => o.trim());
+  if (origins) {
     return {
       origin: origins,
       credentials: true,


### PR DESCRIPTION
## Summary
- Production mode now **throws on startup** if `ALLOWED_ORIGINS` is unset or empty (defense in depth alongside env validation)
- All production origins are **validated for HTTPS protocol** — HTTP origins are rejected with a descriptive error
- CORS uses **callback-based origin checking** that logs rejections via `Logger.warn` for security auditing
- **WebSocket subscription connections** now enforce the same origin restrictions as HTTP CORS
- 42 tests covering all validation, rejection, and edge case behavior

Closes #381

## Test plan
- [x] 42 CORS config tests pass (up from 22)
- [x] Full backend suite: 1160 tests pass
- [x] Production throws on missing/empty `ALLOWED_ORIGINS`
- [x] Production throws on non-HTTPS origins
- [x] CORS rejections logged with origin detail
- [x] WebSocket `onConnect` validates origin against allowed list
- [x] Development mode unchanged (allows all origins when unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)