### PR TITLE
feat: petition scan results page with OCR and analysis pipeline (#301)

### DIFF
--- a/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
@@ -35,6 +35,7 @@ import {
   SetDocumentLocationInput,
   SetDocumentLocationResult,
 } from './dto/location.dto';
+import { ProcessScanInput, ProcessScanResult } from './dto/scan.dto';
 
 /**
  * Documents Resolver
@@ -87,6 +88,27 @@ export class DocumentsResolver {
   ): Promise<boolean> {
     const user = getUserFromContext(context);
     return this.documentsService.deleteFile(user.id, input.filename);
+  }
+
+  /**
+   * Process a camera scan: create document, store file, extract text via OCR
+   * Bridges the gap between camera capture and the analyzeDocument pipeline
+   */
+  @Mutation(() => ProcessScanResult)
+  @UseGuards(AuthGuard)
+  @Permissions({ action: Action.Create, subject: 'File' })
+  @Extensions({ complexity: 75 }) // Storage upload + OCR
+  async processScan(
+    @Args('input') input: ProcessScanInput,
+    @Context() context: GqlContext,
+  ): Promise<ProcessScanResult> {
+    const user = getUserFromContext(context);
+    return this.documentsService.processScan(
+      user.id,
+      input.data,
+      input.mimeType,
+      input.documentType,
+    );
   }
 
   @ResolveField(() => User)

--- a/apps/backend/src/apps/documents/src/domains/dto/scan.dto.ts
+++ b/apps/backend/src/apps/documents/src/domains/dto/scan.dto.ts
@@ -1,0 +1,60 @@
+import { Field, Float, InputType, Int, ObjectType } from '@nestjs/graphql';
+import {
+  IsNotEmpty,
+  IsString,
+  IsBase64,
+  Matches,
+  IsOptional,
+  IsEnum,
+} from 'class-validator';
+import { DocumentType } from '@opuspopuli/relationaldb-provider';
+
+/**
+ * Input for processing a camera scan
+ * Combines document creation, storage upload, and OCR text extraction
+ */
+@InputType()
+export class ProcessScanInput {
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  @IsBase64()
+  data!: string;
+
+  @Field()
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^(image\/(png|jpeg|jpg|webp|bmp|gif|tiff))$/, {
+    message: 'MIME type must be a supported image format',
+  })
+  mimeType!: string;
+
+  @Field(() => DocumentType, {
+    nullable: true,
+    defaultValue: DocumentType.petition,
+  })
+  @IsOptional()
+  @IsEnum(DocumentType)
+  documentType?: DocumentType;
+}
+
+/**
+ * Result of scan processing (document created + text extracted)
+ */
+@ObjectType()
+export class ProcessScanResult {
+  @Field()
+  documentId!: string;
+
+  @Field()
+  text!: string;
+
+  @Field(() => Float)
+  confidence!: number;
+
+  @Field()
+  provider!: string;
+
+  @Field(() => Int)
+  processingTimeMs!: number;
+}

--- a/apps/frontend/__tests__/pages/petition/results.test.tsx
+++ b/apps/frontend/__tests__/pages/petition/results.test.tsx
@@ -1,0 +1,307 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import PetitionResultsPage from "@/app/petition/results/page";
+
+// Mock next/navigation
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
+
+// Mock react-i18next
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, string>) => {
+      if (params) {
+        let result = key;
+        for (const [k, v] of Object.entries(params)) {
+          result = result.replace(`{{${k}}}`, v);
+        }
+        return result;
+      }
+      return key;
+    },
+  }),
+}));
+
+// Mock Apollo Client mutations
+const mockProcessScan = jest.fn();
+const mockAnalyzeDocument = jest.fn();
+const mockSetDocumentLocation = jest.fn();
+
+jest.mock("@apollo/client/react", () => ({
+  ...jest.requireActual("@apollo/client/react"),
+  useMutation: jest.fn((mutation) => {
+    const mutationName = mutation?.definitions?.[0]?.name?.value;
+    if (mutationName === "ProcessScan") {
+      return [mockProcessScan, { loading: false }];
+    }
+    if (mutationName === "AnalyzeDocument") {
+      return [mockAnalyzeDocument, { loading: false }];
+    }
+    if (mutationName === "SetDocumentLocation") {
+      return [mockSetDocumentLocation, { loading: false }];
+    }
+    return [jest.fn(), { loading: false }];
+  }),
+}));
+
+const mockScanResult = {
+  data: {
+    processScan: {
+      documentId: "doc-123",
+      text: "We the undersigned petition for change",
+      confidence: 95.5,
+      provider: "Tesseract",
+      processingTimeMs: 1200,
+    },
+  },
+};
+
+const mockAnalysisResult = {
+  data: {
+    analyzeDocument: {
+      analysis: {
+        documentType: "petition",
+        summary: "A petition calling for policy change",
+        keyPoints: ["Requests new regulation", "Requires 10000 signatures"],
+        entities: ["City Council", "Department of Parks"],
+        analyzedAt: "2025-02-21T00:00:00.000Z",
+        provider: "Ollama",
+        model: "mistral:7b",
+        tokensUsed: 500,
+        processingTimeMs: 3000,
+        actualEffect: "Would mandate new park maintenance standards",
+        potentialConcerns: ["Budget impact unclear"],
+        beneficiaries: ["Local residents"],
+        potentiallyHarmed: ["Tax payers"],
+        relatedMeasures: ["Proposition 15"],
+      },
+      fromCache: false,
+    },
+  },
+};
+
+describe("PetitionResultsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    sessionStorage.clear();
+    mockProcessScan.mockResolvedValue(mockScanResult);
+    mockAnalyzeDocument.mockResolvedValue(mockAnalysisResult);
+    mockSetDocumentLocation.mockResolvedValue({
+      data: {
+        setDocumentLocation: {
+          success: true,
+          fuzzedLocation: { latitude: 37.77, longitude: -122.42 },
+        },
+      },
+    });
+  });
+
+  it("should redirect to /petition when no scan data in sessionStorage", () => {
+    render(<PetitionResultsPage />);
+
+    expect(mockReplace).toHaveBeenCalledWith("/petition");
+  });
+
+  it("should show extraction loading state initially", () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+
+    render(<PetitionResultsPage />);
+
+    expect(screen.getByText("results.extractingText")).toBeInTheDocument();
+  });
+
+  it("should show OCR text after extraction completes", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("We the undersigned petition for change"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should show confidence badge", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/96%/)).toBeInTheDocument();
+    });
+  });
+
+  it("should show analysis after completion", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("A petition calling for policy change"),
+      ).toBeInTheDocument();
+    });
+
+    // Check key points
+    expect(screen.getByText("Requests new regulation")).toBeInTheDocument();
+    expect(screen.getByText("Requires 10000 signatures")).toBeInTheDocument();
+
+    // Check actual effect
+    expect(
+      screen.getByText("Would mandate new park maintenance standards"),
+    ).toBeInTheDocument();
+
+    // Check concerns
+    expect(screen.getByText("Budget impact unclear")).toBeInTheDocument();
+
+    // Check beneficiaries
+    expect(screen.getByText(/Local residents/)).toBeInTheDocument();
+
+    // Check entities
+    expect(screen.getByText("City Council")).toBeInTheDocument();
+    expect(screen.getByText("Department of Parks")).toBeInTheDocument();
+  });
+
+  it("should show action buttons when complete", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("results.share")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("results.saveToTrack")).toBeInTheDocument();
+  });
+
+  it("should show error state when processScan fails", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+    mockProcessScan.mockRejectedValue(new Error("Network error"));
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("results.errorTitle")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+    expect(screen.getByText("results.backToHome")).toBeInTheDocument();
+    expect(screen.getByText("results.tryAgain")).toBeInTheDocument();
+  });
+
+  it("should show error state when analyzeDocument fails", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+    mockAnalyzeDocument.mockRejectedValue(new Error("Analysis timeout"));
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("results.errorTitle")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Analysis timeout")).toBeInTheDocument();
+  });
+
+  it("should clean up sessionStorage after reading", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+    sessionStorage.setItem(
+      "petition-scan-location",
+      JSON.stringify({ latitude: 37.7749, longitude: -122.4194 }),
+    );
+
+    render(<PetitionResultsPage />);
+
+    // sessionStorage should be cleared immediately
+    await waitFor(() => {
+      expect(sessionStorage.getItem("petition-scan-data")).toBeNull();
+      expect(sessionStorage.getItem("petition-scan-location")).toBeNull();
+    });
+  });
+
+  it("should allow editing OCR text", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("We the undersigned petition for change"),
+      ).toBeInTheDocument();
+    });
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "Edited text" } });
+
+    expect(screen.getByDisplayValue("Edited text")).toBeInTheDocument();
+  });
+
+  it("should call setDocumentLocation when location is provided", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+    sessionStorage.setItem(
+      "petition-scan-location",
+      JSON.stringify({ latitude: 37.7749, longitude: -122.4194 }),
+    );
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(mockSetDocumentLocation).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            documentId: "doc-123",
+            location: { latitude: 37.7749, longitude: -122.4194 },
+          },
+        },
+      });
+    });
+  });
+
+  it("should not call setDocumentLocation when no location", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByDisplayValue("We the undersigned petition for change"),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockSetDocumentLocation).not.toHaveBeenCalled();
+  });
+
+  it("should navigate to /petition when back button is clicked", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+
+    const user = userEvent.setup();
+
+    render(<PetitionResultsPage />);
+
+    const backButton = screen.getByLabelText("results.back");
+    await user.click(backButton);
+
+    expect(mockPush).toHaveBeenCalledWith("/petition");
+  });
+
+  it("should navigate to /petition/capture when try again is clicked", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+    mockProcessScan.mockRejectedValue(new Error("Failed"));
+
+    const user = userEvent.setup();
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("results.tryAgain")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("results.tryAgain"));
+
+    expect(mockPush).toHaveBeenCalledWith("/petition/capture");
+  });
+});

--- a/apps/frontend/app/petition/capture/page.tsx
+++ b/apps/frontend/app/petition/capture/page.tsx
@@ -4,6 +4,22 @@ import { useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { CameraCapture } from "@/components/camera";
 
+/**
+ * Convert ImageData (raw pixels from camera) to a base64-encoded PNG string.
+ * Uses an offscreen canvas to re-encode the pixel data.
+ */
+function imageDataToBase64(imageData: ImageData): string {
+  const canvas = document.createElement("canvas");
+  canvas.width = imageData.width;
+  canvas.height = imageData.height;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("Canvas 2D context not available");
+  ctx.putImageData(imageData, 0, 0);
+  const dataUrl = canvas.toDataURL("image/png");
+  // Strip the data URL prefix to get raw base64
+  return dataUrl.replace(/^data:image\/png;base64,/, "");
+}
+
 export default function PetitionCapturePage() {
   const router = useRouter();
 
@@ -12,14 +28,22 @@ export default function PetitionCapturePage() {
       imageData: ImageData,
       location?: { latitude: number; longitude: number },
     ) => {
-      // TODO: Pass imageData to OCR processing pipeline (Issue #288+)
-      // TODO: Call setDocumentLocation mutation with documentId + location (Issue #296)
-      // For now, navigate back to petition home
-      console.log("Captured image:", imageData.width, "x", imageData.height);
-      if (location) {
-        console.log("Location:", location.latitude, location.longitude);
+      try {
+        const base64 = imageDataToBase64(imageData);
+        sessionStorage.setItem("petition-scan-data", base64);
+        if (location) {
+          sessionStorage.setItem(
+            "petition-scan-location",
+            JSON.stringify(location),
+          );
+        } else {
+          sessionStorage.removeItem("petition-scan-location");
+        }
+        router.push("/petition/results");
+      } catch (error) {
+        console.error("Failed to process captured image:", error);
+        router.push("/petition");
       }
-      router.push("/petition");
     },
     [router],
   );

--- a/apps/frontend/app/petition/results/page.tsx
+++ b/apps/frontend/app/petition/results/page.tsx
@@ -1,0 +1,431 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { useMutation } from "@apollo/client/react";
+import { useTranslation } from "react-i18next";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+import {
+  PROCESS_SCAN,
+  ANALYZE_DOCUMENT,
+  SET_DOCUMENT_LOCATION,
+  type ProcessScanData,
+  type AnalyzeDocumentData,
+  type SetDocumentLocationData,
+  type DocumentAnalysis,
+} from "@/lib/graphql/documents";
+
+type ProcessingStep = "extracting" | "analyzing" | "complete" | "error";
+
+function getConfidenceBadgeClass(confidence: number): string {
+  if (confidence >= 90) return "bg-green-900 text-green-300";
+  if (confidence >= 70) return "bg-yellow-900 text-yellow-300";
+  return "bg-red-900 text-red-300";
+}
+
+export default function PetitionResultsPage() {
+  const router = useRouter();
+  const { t } = useTranslation("petition");
+  const hasStarted = useRef(false);
+
+  const [step, setStep] = useState<ProcessingStep>("extracting");
+  const [ocrText, setOcrText] = useState("");
+  const [ocrConfidence, setOcrConfidence] = useState(0);
+  const [analysis, setAnalysis] = useState<DocumentAnalysis | null>(null);
+  const [fromCache, setFromCache] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [processScan] = useMutation<ProcessScanData>(PROCESS_SCAN);
+  const [analyzeDocument] = useMutation<AnalyzeDocumentData>(ANALYZE_DOCUMENT);
+  const [setDocumentLocation] = useMutation<SetDocumentLocationData>(
+    SET_DOCUMENT_LOCATION,
+  );
+
+  const runPipeline = useCallback(
+    async (
+      base64: string,
+      location: { latitude: number; longitude: number } | null,
+    ) => {
+      try {
+        // Step 1: Process scan (OCR + persist)
+        setStep("extracting");
+        const scanResult = await processScan({
+          variables: {
+            input: {
+              data: base64,
+              mimeType: "image/png",
+              documentType: "petition",
+            },
+          },
+        });
+
+        const scan = scanResult.data?.processScan;
+        if (!scan) throw new Error("Scan processing failed");
+
+        setOcrText(scan.text);
+        setOcrConfidence(scan.confidence);
+
+        // Step 2: Set location (fire-and-forget)
+        if (location) {
+          setDocumentLocation({
+            variables: {
+              input: {
+                documentId: scan.documentId,
+                location: {
+                  latitude: location.latitude,
+                  longitude: location.longitude,
+                },
+              },
+            },
+          }).catch((err) => console.warn("Location save failed:", err));
+        }
+
+        // Step 3: Analyze document
+        setStep("analyzing");
+        const analysisResult = await analyzeDocument({
+          variables: {
+            input: { documentId: scan.documentId },
+          },
+        });
+
+        const analysisData = analysisResult.data?.analyzeDocument;
+        if (!analysisData) throw new Error("Analysis failed");
+
+        setAnalysis(analysisData.analysis);
+        setFromCache(analysisData.fromCache);
+        setStep("complete");
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Processing failed";
+        setError(message);
+        setStep("error");
+      }
+    },
+    [processScan, analyzeDocument, setDocumentLocation],
+  );
+
+  useEffect(() => {
+    if (hasStarted.current) return;
+    hasStarted.current = true;
+
+    const base64 = sessionStorage.getItem("petition-scan-data");
+    if (!base64) {
+      router.replace("/petition");
+      return;
+    }
+
+    const locationStr = sessionStorage.getItem("petition-scan-location");
+    const location = locationStr
+      ? (JSON.parse(locationStr) as { latitude: number; longitude: number })
+      : null;
+
+    // Clean up sessionStorage
+    sessionStorage.removeItem("petition-scan-data");
+    sessionStorage.removeItem("petition-scan-location");
+
+    runPipeline(base64, location);
+  }, [router, runPipeline]);
+
+  const handleShare = useCallback(async () => {
+    let shareText = ocrText;
+    if (analysis) {
+      const keyPointsList = analysis.keyPoints.map((p) => "- " + p).join("\n");
+      shareText = analysis.summary + "\n\nKey Points:\n" + keyPointsList;
+    }
+
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "Petition Analysis", text: shareText });
+      } catch {
+        // User cancelled or share failed — no action needed
+      }
+    } else {
+      await navigator.clipboard.writeText(shareText);
+    }
+  }, [analysis, ocrText]);
+
+  const confidenceBadgeClass = getConfidenceBadgeClass(ocrConfidence);
+
+  return (
+    <div className="h-full overflow-y-auto">
+      {/* Header */}
+      <div className="sticky top-0 z-10 bg-black/90 backdrop-blur-sm px-4 py-4 flex items-center gap-3 border-b border-gray-800">
+        <button
+          onClick={() => router.push("/petition")}
+          className="text-gray-400 hover:text-white transition-colors"
+          aria-label={t("results.back")}
+        >
+          <svg
+            className="w-6 h-6"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        </button>
+        <h1 className="text-lg font-semibold text-white">
+          {t("results.title")}
+        </h1>
+      </div>
+
+      {/* Processing Indicator */}
+      {(step === "extracting" || step === "analyzing") && !ocrText && (
+        <div className="flex flex-col items-center justify-center py-16">
+          <LoadingSpinner size="lg" className="text-blue-500 mb-4" />
+          <p className="text-white text-lg font-medium">
+            {step === "extracting"
+              ? t("results.extractingText")
+              : t("results.analyzingDocument")}
+          </p>
+          <p className="text-gray-400 text-sm mt-2">
+            {step === "extracting"
+              ? t("results.extractingDescription")
+              : t("results.analyzingDescription")}
+          </p>
+        </div>
+      )}
+
+      {/* OCR Text Section */}
+      {ocrText && (
+        <section className="px-4 py-6">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-lg font-semibold text-white">
+              {t("results.extractedText")}
+            </h2>
+            <span
+              className={`text-xs px-2 py-1 rounded-full ${confidenceBadgeClass}`}
+            >
+              {ocrConfidence.toFixed(0)}% {t("results.confidence")}
+            </span>
+          </div>
+          <textarea
+            value={ocrText}
+            onChange={(e) => setOcrText(e.target.value)}
+            className="w-full bg-gray-900 text-gray-200 rounded-lg p-4 text-sm leading-relaxed border border-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none resize-y min-h-[120px]"
+            rows={6}
+            aria-label={t("results.extractedTextLabel")}
+          />
+        </section>
+      )}
+
+      {/* Analysis Loading (shown while analyzing, after OCR text is visible) */}
+      {step === "analyzing" && ocrText && (
+        <div className="flex items-center gap-3 px-4 py-4">
+          <LoadingSpinner size="sm" className="text-blue-500" />
+          <p className="text-gray-400 text-sm">
+            {t("results.analyzingDocument")}
+          </p>
+        </div>
+      )}
+
+      {/* Analysis Section */}
+      {analysis && (
+        <section className="px-4 py-6 space-y-6">
+          {/* Summary */}
+          <div>
+            <h2 className="text-lg font-semibold text-white mb-2">
+              {t("results.summary")}
+            </h2>
+            <p className="text-gray-300 leading-relaxed">{analysis.summary}</p>
+          </div>
+
+          {/* Key Points */}
+          {analysis.keyPoints.length > 0 && (
+            <div>
+              <h3 className="text-md font-semibold text-white mb-2">
+                {t("results.keyPoints")}
+              </h3>
+              <ul className="space-y-2">
+                {analysis.keyPoints.map((point) => (
+                  <li
+                    key={point}
+                    className="flex items-start gap-2 text-gray-300"
+                  >
+                    <span className="text-blue-400 mt-1 flex-shrink-0">
+                      &#8226;
+                    </span>
+                    <span>{point}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Actual Effect */}
+          {analysis.actualEffect && (
+            <div>
+              <h3 className="text-md font-semibold text-white mb-2">
+                {t("results.actualEffect")}
+              </h3>
+              <p className="text-gray-300">{analysis.actualEffect}</p>
+            </div>
+          )}
+
+          {/* Potential Concerns */}
+          {analysis.potentialConcerns &&
+            analysis.potentialConcerns.length > 0 && (
+              <div>
+                <h3 className="text-md font-semibold text-amber-400 mb-2">
+                  {t("results.concerns")}
+                </h3>
+                <ul className="space-y-1">
+                  {analysis.potentialConcerns.map((concern) => (
+                    <li
+                      key={concern}
+                      className="flex items-start gap-2 text-gray-300"
+                    >
+                      <span className="text-amber-400 mt-1 flex-shrink-0">
+                        &#9888;
+                      </span>
+                      <span>{concern}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+          {/* Beneficiaries */}
+          {analysis.beneficiaries && analysis.beneficiaries.length > 0 && (
+            <div>
+              <h3 className="text-md font-semibold text-green-400 mb-2">
+                {t("results.beneficiaries")}
+              </h3>
+              <ul className="space-y-1">
+                {analysis.beneficiaries.map((b) => (
+                  <li key={b} className="text-gray-300">
+                    &#8226; {b}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Potentially Harmed */}
+          {analysis.potentiallyHarmed &&
+            analysis.potentiallyHarmed.length > 0 && (
+              <div>
+                <h3 className="text-md font-semibold text-red-400 mb-2">
+                  {t("results.potentiallyHarmed")}
+                </h3>
+                <ul className="space-y-1">
+                  {analysis.potentiallyHarmed.map((h) => (
+                    <li key={h} className="text-gray-300">
+                      &#8226; {h}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+          {/* Related Measures */}
+          {analysis.relatedMeasures && analysis.relatedMeasures.length > 0 && (
+            <div>
+              <h3 className="text-md font-semibold text-gray-400 mb-2">
+                {t("results.relatedMeasures")}
+              </h3>
+              <ul className="space-y-1">
+                {analysis.relatedMeasures.map((m) => (
+                  <li key={m} className="text-gray-300">
+                    &#8226; {m}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Entities */}
+          {analysis.entities.length > 0 && (
+            <div>
+              <h3 className="text-md font-semibold text-gray-400 mb-2">
+                {t("results.entities")}
+              </h3>
+              <div className="flex flex-wrap gap-2">
+                {analysis.entities.map((entity) => (
+                  <span
+                    key={entity}
+                    className="bg-gray-800 text-gray-300 px-3 py-1 rounded-full text-sm"
+                  >
+                    {entity}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Provider info footer */}
+          <div className="text-xs text-gray-500 pt-4 border-t border-gray-800">
+            {t("results.analyzedBy", {
+              provider: analysis.provider,
+              model: analysis.model,
+            })}
+            {fromCache && ` (${t("results.cachedResult")})`}
+          </div>
+        </section>
+      )}
+
+      {/* Action Buttons */}
+      {step === "complete" && (
+        <div className="px-4 py-6 flex gap-3">
+          <button
+            onClick={handleShare}
+            className="flex-1 py-3 bg-white/10 text-white font-medium rounded-lg hover:bg-white/20 transition-colors"
+          >
+            {t("results.share")}
+          </button>
+          <button
+            disabled
+            className="flex-1 py-3 bg-blue-600/50 text-white/50 font-medium rounded-lg cursor-not-allowed"
+            title={t("results.saveComingSoon")}
+          >
+            {t("results.saveToTrack")}
+          </button>
+        </div>
+      )}
+
+      {/* Error State */}
+      {step === "error" && (
+        <div className="flex flex-col items-center justify-center py-16 px-6 text-center">
+          <svg
+            className="w-16 h-16 mb-4 text-red-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
+            />
+          </svg>
+          <h2 className="text-xl font-semibold text-white mb-2">
+            {t("results.errorTitle")}
+          </h2>
+          <p className="text-gray-400 mb-6">{error}</p>
+          <div className="flex gap-3">
+            <button
+              onClick={() => router.push("/petition")}
+              className="px-6 py-3 bg-gray-700 text-white font-medium rounded-lg hover:bg-gray-600 transition-colors"
+            >
+              {t("results.backToHome")}
+            </button>
+            <button
+              onClick={() => router.push("/petition/capture")}
+              className="px-6 py-3 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              {t("results.tryAgain")}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/lib/graphql/documents.ts
+++ b/apps/frontend/lib/graphql/documents.ts
@@ -24,6 +24,49 @@ export interface SetDocumentLocationResult {
   fuzzedLocation?: GeoLocation;
 }
 
+export interface ProcessScanInput {
+  data: string;
+  mimeType: string;
+  documentType?: string;
+}
+
+export interface ProcessScanResult {
+  documentId: string;
+  text: string;
+  confidence: number;
+  provider: string;
+  processingTimeMs: number;
+}
+
+export interface AnalyzeDocumentInput {
+  documentId: string;
+  forceReanalyze?: boolean;
+}
+
+export interface DocumentAnalysis {
+  documentType: string;
+  summary: string;
+  keyPoints: string[];
+  entities: string[];
+  analyzedAt: string;
+  provider: string;
+  model: string;
+  tokensUsed?: number;
+  processingTimeMs: number;
+  cachedFrom?: string;
+  // Petition/proposition fields
+  actualEffect?: string;
+  potentialConcerns?: string[];
+  beneficiaries?: string[];
+  potentiallyHarmed?: string[];
+  relatedMeasures?: string[];
+}
+
+export interface AnalyzeDocumentResult {
+  analysis: DocumentAnalysis;
+  fromCache: boolean;
+}
+
 // ============================================
 // Mutations
 // ============================================
@@ -40,10 +83,55 @@ export const SET_DOCUMENT_LOCATION = gql`
   }
 `;
 
+export const PROCESS_SCAN = gql`
+  mutation ProcessScan($input: ProcessScanInput!) {
+    processScan(input: $input) {
+      documentId
+      text
+      confidence
+      provider
+      processingTimeMs
+    }
+  }
+`;
+
+export const ANALYZE_DOCUMENT = gql`
+  mutation AnalyzeDocument($input: AnalyzeDocumentInput!) {
+    analyzeDocument(input: $input) {
+      analysis {
+        documentType
+        summary
+        keyPoints
+        entities
+        analyzedAt
+        provider
+        model
+        tokensUsed
+        processingTimeMs
+        cachedFrom
+        actualEffect
+        potentialConcerns
+        beneficiaries
+        potentiallyHarmed
+        relatedMeasures
+      }
+      fromCache
+    }
+  }
+`;
+
 // ============================================
 // Response Types
 // ============================================
 
 export interface SetDocumentLocationData {
   setDocumentLocation: SetDocumentLocationResult;
+}
+
+export interface ProcessScanData {
+  processScan: ProcessScanResult;
+}
+
+export interface AnalyzeDocumentData {
+  analyzeDocument: AnalyzeDocumentResult;
 }

--- a/apps/frontend/locales/en/petition.json
+++ b/apps/frontend/locales/en/petition.json
@@ -62,5 +62,33 @@
       "title": "Location Unavailable",
       "continueWithout": "Continue Without Location"
     }
+  },
+  "results": {
+    "title": "Scan Results",
+    "back": "Go back",
+    "extractingText": "Reading your petition...",
+    "extractingDescription": "Using AI to extract text from your image",
+    "analyzingDocument": "Analyzing petition...",
+    "analyzingDescription": "Our AI is reviewing the petition content",
+    "extractedText": "Extracted Text",
+    "extractedTextLabel": "Extracted petition text (editable if OCR errors)",
+    "confidence": "confidence",
+    "summary": "Summary",
+    "keyPoints": "Key Points",
+    "actualEffect": "What This Actually Does",
+    "concerns": "Potential Concerns",
+    "beneficiaries": "Who Benefits",
+    "potentiallyHarmed": "Who May Be Affected",
+    "relatedMeasures": "Related Measures",
+    "entities": "Mentioned Entities",
+    "analyzedBy": "Analyzed by {{provider}} ({{model}})",
+    "cachedResult": "cached result",
+    "share": "Share Analysis",
+    "saveToTrack": "Save to Track",
+    "saveComingSoon": "Coming soon: Save to your ballot tracker",
+    "errorTitle": "Processing Failed",
+    "backToHome": "Back to Home",
+    "tryAgain": "Scan Again",
+    "copiedToClipboard": "Analysis copied to clipboard"
   }
 }


### PR DESCRIPTION
## Summary
- Adds new `processScan` compound GraphQL mutation (backend) that creates a document record, uploads to storage, and extracts text via OCR in one call
- Creates `/petition/results` page (frontend) with progressive pipeline: OCR extraction → LLM analysis → interactive results display
- Wires camera capture page to store base64 image in sessionStorage and navigate to results page
- Adds i18n translations for all results page strings

## Changes

### Backend
- **New** `scan.dto.ts` — `ProcessScanInput` (validated base64 + mimeType) and `ProcessScanResult` DTOs
- **Modified** `documents.service.ts` — `processScan()` method: decode base64 → create document → upload via signed URL → OCR extract → update document with text/hash/confidence
- **Modified** `documents.resolver.ts` — `processScan` mutation with `AuthGuard` + CASL `File:Create` permission
- **Modified** `documents.service.spec.ts` — 7 new tests (happy path, document types, filename extensions, OCR/storage error handling)

### Frontend
- **New** `results/page.tsx` — State machine (`extracting → analyzing → complete | error`), editable OCR textarea with confidence badge, analysis sections (summary, key points, actual effect, concerns, beneficiaries, entities), share via Web Share API with clipboard fallback
- **Modified** `capture/page.tsx` — `imageDataToBase64()` via canvas, sessionStorage transfer, navigation to `/petition/results`
- **Modified** `documents.ts` — Added `PROCESS_SCAN`, `ANALYZE_DOCUMENT` mutations + TypeScript interfaces
- **Modified** `petition.json` — Added `results` i18n section (20+ keys)
- **New** `results.test.tsx` — 14 tests (redirect, loading states, OCR display, analysis, errors, editing, location, navigation)
- **Modified** `capture.test.tsx` — Updated for sessionStorage/navigation flow (6 tests)

## Test plan
- [x] Backend unit tests: 63 passed (7 new processScan tests)
- [x] Frontend unit tests: 20 passed (6 capture + 14 results)
- [x] Coverage: capture 100%, results 96%/78%/80%, documents.ts 100%, service 100%/97%
- [x] Backend builds (all 5 microservices)
- [x] Frontend builds (lint + Next.js build clean, `/petition/results` route included)
- [x] Docker integration tests: 249 passed

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)