### PR TITLE
feat: add interactive petition map view with clustering and filters (#297)

### DIFF
--- a/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
@@ -34,6 +34,9 @@ import {
   GeoLocation,
   SetDocumentLocationInput,
   SetDocumentLocationResult,
+  PetitionMapMarker,
+  PetitionMapStats,
+  MapFiltersInput,
 } from './dto/location.dto';
 import { ProcessScanInput, ProcessScanResult } from './dto/scan.dto';
 
@@ -216,5 +219,29 @@ export class DocumentsResolver {
   ): Promise<GeoLocation | null> {
     const user = getUserFromContext(context);
     return this.documentsService.getDocumentLocation(user.id, documentId);
+  }
+
+  /**
+   * Get petition locations for map display
+   * Returns fuzzed coordinates for all documents with scan locations
+   */
+  @Query(() => [PetitionMapMarker])
+  @UseGuards(AuthGuard)
+  @Permissions({ action: Action.Read, subject: 'File' })
+  @Extensions({ complexity: 25 })
+  async petitionMapLocations(
+    @Args('filters', { nullable: true }) filters?: MapFiltersInput,
+  ): Promise<PetitionMapMarker[]> {
+    return this.documentsService.getPetitionMapLocations(filters);
+  }
+
+  /**
+   * Get aggregated stats for the petition map sidebar
+   */
+  @Query(() => PetitionMapStats)
+  @UseGuards(AuthGuard)
+  @Permissions({ action: Action.Read, subject: 'File' })
+  async petitionMapStats(): Promise<PetitionMapStats> {
+    return this.documentsService.getPetitionMapStats();
   }
 }

--- a/apps/backend/src/apps/documents/src/domains/dto/location.dto.ts
+++ b/apps/backend/src/apps/documents/src/domains/dto/location.dto.ts
@@ -1,5 +1,5 @@
-import { Field, Float, InputType, ObjectType } from '@nestjs/graphql';
-import { IsUUID, IsNumber, Min, Max } from 'class-validator';
+import { Field, Float, InputType, Int, ObjectType } from '@nestjs/graphql';
+import { IsUUID, IsNumber, IsOptional, Min, Max } from 'class-validator';
 
 /**
  * Geographic coordinate types for location tracking
@@ -50,6 +50,82 @@ export class SetDocumentLocationResult {
 
   @Field(() => GeoLocation, { nullable: true })
   fuzzedLocation?: GeoLocation;
+}
+
+@ObjectType()
+export class PetitionMapMarker {
+  @Field()
+  id!: string;
+
+  @Field(() => Float)
+  latitude!: number;
+
+  @Field(() => Float)
+  longitude!: number;
+
+  @Field({ nullable: true })
+  documentType?: string;
+
+  @Field()
+  createdAt!: Date;
+}
+
+@ObjectType()
+export class PetitionMapStats {
+  @Field(() => Int)
+  totalPetitions!: number;
+
+  @Field(() => Int)
+  totalWithLocation!: number;
+
+  @Field(() => Int)
+  recentPetitions!: number;
+}
+
+@InputType()
+export class MapBoundsInput {
+  @Field(() => Float)
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  swLat!: number;
+
+  @Field(() => Float)
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  swLng!: number;
+
+  @Field(() => Float)
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  neLat!: number;
+
+  @Field(() => Float)
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  neLng!: number;
+}
+
+@InputType()
+export class MapFiltersInput {
+  @Field(() => MapBoundsInput, { nullable: true })
+  @IsOptional()
+  bounds?: MapBoundsInput;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  documentType?: string;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  startDate?: Date;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  endDate?: Date;
 }
 
 /**

--- a/apps/frontend/__tests__/components/map/MapFilters.test.tsx
+++ b/apps/frontend/__tests__/components/map/MapFilters.test.tsx
@@ -1,0 +1,176 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { MapFilters } from "@/components/map/MapFilters";
+
+describe("MapFilters", () => {
+  const defaultProps = {
+    filters: {},
+    onUpdateFilters: jest.fn(),
+    onNearMe: jest.fn(),
+    locationLoading: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders document type select", () => {
+    render(<MapFilters {...defaultProps} />);
+
+    expect(
+      screen.getByRole("combobox", { name: "Filter by document type" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders date inputs", () => {
+    render(<MapFilters {...defaultProps} />);
+
+    expect(screen.getByLabelText("Start date")).toBeInTheDocument();
+    expect(screen.getByLabelText("End date")).toBeInTheDocument();
+  });
+
+  it("renders Near me button", () => {
+    render(<MapFilters {...defaultProps} />);
+
+    expect(
+      screen.getByRole("button", { name: "Center map on my location" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Near me")).toBeInTheDocument();
+  });
+
+  it("calls onUpdateFilters when document type changes", async () => {
+    const user = userEvent.setup();
+    const onUpdateFilters = jest.fn();
+
+    render(<MapFilters {...defaultProps} onUpdateFilters={onUpdateFilters} />);
+
+    const select = screen.getByRole("combobox", {
+      name: "Filter by document type",
+    });
+    await user.selectOptions(select, "petition");
+
+    expect(onUpdateFilters).toHaveBeenCalledWith({
+      documentType: "petition",
+    });
+  });
+
+  it("calls onUpdateFilters with undefined when selecting 'All types'", async () => {
+    const user = userEvent.setup();
+    const onUpdateFilters = jest.fn();
+
+    render(
+      <MapFilters
+        {...defaultProps}
+        filters={{ documentType: "petition" }}
+        onUpdateFilters={onUpdateFilters}
+      />,
+    );
+
+    const select = screen.getByRole("combobox", {
+      name: "Filter by document type",
+    });
+    await user.selectOptions(select, "");
+
+    expect(onUpdateFilters).toHaveBeenCalledWith({
+      documentType: undefined,
+    });
+  });
+
+  it("calls onUpdateFilters when start date changes", async () => {
+    const user = userEvent.setup();
+    const onUpdateFilters = jest.fn();
+
+    render(<MapFilters {...defaultProps} onUpdateFilters={onUpdateFilters} />);
+
+    const startDate = screen.getByLabelText("Start date");
+    await user.type(startDate, "2024-01-01");
+
+    expect(onUpdateFilters).toHaveBeenCalledWith({
+      startDate: expect.any(String),
+    });
+  });
+
+  it("calls onUpdateFilters when end date changes", async () => {
+    const user = userEvent.setup();
+    const onUpdateFilters = jest.fn();
+
+    render(<MapFilters {...defaultProps} onUpdateFilters={onUpdateFilters} />);
+
+    const endDate = screen.getByLabelText("End date");
+    await user.type(endDate, "2024-12-31");
+
+    expect(onUpdateFilters).toHaveBeenCalledWith({
+      endDate: expect.any(String),
+    });
+  });
+
+  it("calls onNearMe when button is clicked", async () => {
+    const user = userEvent.setup();
+    const onNearMe = jest.fn();
+
+    render(<MapFilters {...defaultProps} onNearMe={onNearMe} />);
+
+    await user.click(
+      screen.getByRole("button", { name: "Center map on my location" }),
+    );
+
+    expect(onNearMe).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows Locating... text when location is loading", () => {
+    render(<MapFilters {...defaultProps} locationLoading={true} />);
+
+    expect(screen.getByText("Locating...")).toBeInTheDocument();
+    expect(screen.queryByText("Near me")).not.toBeInTheDocument();
+  });
+
+  it("disables Near me button when loading", () => {
+    render(<MapFilters {...defaultProps} locationLoading={true} />);
+
+    const button = screen.getByRole("button", {
+      name: "Center map on my location",
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it("shows all document type options", () => {
+    render(<MapFilters {...defaultProps} />);
+
+    const select = screen.getByRole("combobox", {
+      name: "Filter by document type",
+    });
+    const options = select.querySelectorAll("option");
+
+    expect(options).toHaveLength(5); // All types + 4 specific types
+    expect(options[0]).toHaveTextContent("All types");
+    expect(options[1]).toHaveTextContent("Petition");
+    expect(options[2]).toHaveTextContent("Proposition");
+    expect(options[3]).toHaveTextContent("Contract");
+    expect(options[4]).toHaveTextContent("Report");
+  });
+
+  it("reflects current filter values in inputs", () => {
+    render(
+      <MapFilters
+        {...defaultProps}
+        filters={{
+          documentType: "proposition",
+          startDate: "2024-01-01",
+          endDate: "2024-12-31",
+        }}
+      />,
+    );
+
+    const select = screen.getByRole("combobox", {
+      name: "Filter by document type",
+    }) as HTMLSelectElement;
+    expect(select.value).toBe("proposition");
+
+    const startDate = screen.getByLabelText("Start date") as HTMLInputElement;
+    expect(startDate.value).toBe("2024-01-01");
+
+    const endDate = screen.getByLabelText("End date") as HTMLInputElement;
+    expect(endDate.value).toBe("2024-12-31");
+  });
+});

--- a/apps/frontend/__tests__/components/map/MapLegend.test.tsx
+++ b/apps/frontend/__tests__/components/map/MapLegend.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MapLegend } from "@/components/map/MapLegend";
+
+describe("MapLegend", () => {
+  it("renders legend title", () => {
+    render(<MapLegend />);
+
+    expect(screen.getByText("Legend")).toBeInTheDocument();
+  });
+
+  it("renders petition location indicator", () => {
+    render(<MapLegend />);
+
+    expect(screen.getByText("Petition location")).toBeInTheDocument();
+  });
+
+  it("renders selected petition indicator", () => {
+    render(<MapLegend />);
+
+    expect(screen.getByText("Selected petition")).toBeInTheDocument();
+  });
+
+  it("renders cluster indicator", () => {
+    render(<MapLegend />);
+
+    expect(screen.getByText("Cluster (count)")).toBeInTheDocument();
+  });
+
+  it("renders cluster count example", () => {
+    render(<MapLegend />);
+
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/components/map/PetitionMarkers.test.tsx
+++ b/apps/frontend/__tests__/components/map/PetitionMarkers.test.tsx
@@ -1,0 +1,289 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// Mock supercluster (ESM module that Jest can't parse natively)
+const mockLoad = jest.fn();
+const mockGetClusters = jest.fn().mockReturnValue([]);
+const mockGetLeaves = jest.fn().mockReturnValue([]);
+jest.mock("supercluster", () => {
+  return jest.fn().mockImplementation(() => ({
+    load: mockLoad,
+    getClusters: mockGetClusters,
+    getLeaves: mockGetLeaves,
+  }));
+});
+
+// Mock react-map-gl Marker to render children directly
+jest.mock("react-map-gl/maplibre", () => ({
+  Marker: ({
+    children,
+    latitude,
+    longitude,
+    onClick,
+  }: {
+    children: React.ReactNode;
+    latitude: number;
+    longitude: number;
+    anchor: string;
+    onClick?: (e: { originalEvent: { stopPropagation: () => void } }) => void;
+  }) => (
+    <div
+      data-testid={`marker-${latitude.toFixed(2)}-${longitude.toFixed(2)}`}
+      data-lat={latitude}
+      data-lng={longitude}
+      onClick={() =>
+        onClick?.({
+          originalEvent: { stopPropagation: jest.fn() },
+        })
+      }
+    >
+      {children}
+    </div>
+  ),
+}));
+
+// Must import after mocks
+import { PetitionMarkers } from "@/components/map/PetitionMarkers";
+import type { PetitionMapMarker } from "@/lib/graphql/documents";
+
+// Mock requestAnimationFrame — do NOT invoke callback synchronously
+// (invoking it would cause infinite recursion via setPulse -> re-render -> rAF)
+jest.spyOn(window, "requestAnimationFrame").mockImplementation(() => 1);
+jest.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+const mockMarkers: PetitionMapMarker[] = [
+  {
+    id: "doc-1",
+    latitude: 37.77,
+    longitude: -122.42,
+    documentType: "petition",
+    createdAt: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: "doc-2",
+    latitude: 37.78,
+    longitude: -122.41,
+    documentType: "petition",
+    createdAt: "2024-06-02T00:00:00Z",
+  },
+  {
+    id: "doc-3",
+    latitude: 34.05,
+    longitude: -118.24,
+    documentType: "proposition",
+    createdAt: "2024-06-03T00:00:00Z",
+  },
+];
+
+const wideBounds = {
+  swLat: 30,
+  swLng: -125,
+  neLat: 40,
+  neLng: -115,
+};
+
+describe("PetitionMarkers", () => {
+  const defaultProps = {
+    markers: mockMarkers,
+    zoom: 6,
+    bounds: wideBounds,
+    selectedId: null,
+    onSelect: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: return individual markers (no clustering)
+    mockGetClusters.mockReturnValue(
+      mockMarkers.map((m) => ({
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [m.longitude, m.latitude] },
+        properties: { marker: m },
+      })),
+    );
+  });
+
+  it("renders markers when given data and bounds", () => {
+    const { container } = render(<PetitionMarkers {...defaultProps} />);
+
+    const markers = container.querySelectorAll("[data-testid^='marker-']");
+    expect(markers.length).toBe(3);
+  });
+
+  it("renders nothing when bounds are undefined", () => {
+    const { container } = render(
+      <PetitionMarkers {...defaultProps} bounds={undefined} />,
+    );
+
+    const markers = container.querySelectorAll("[data-testid^='marker-']");
+    expect(markers.length).toBe(0);
+  });
+
+  it("renders nothing when markers are empty", () => {
+    // Set getClusters to return empty BEFORE render
+    mockGetClusters.mockReturnValue([]);
+
+    const { container } = render(
+      <PetitionMarkers {...defaultProps} markers={[]} />,
+    );
+
+    const markers = container.querySelectorAll("[data-testid^='marker-']");
+    expect(markers.length).toBe(0);
+  });
+
+  it("renders count text in marker SVGs", () => {
+    render(<PetitionMarkers {...defaultProps} />);
+
+    // Each individual marker should show count "1"
+    const ones = screen.getAllByText("1");
+    expect(ones.length).toBe(3);
+  });
+
+  it("renders cluster with count when supercluster returns cluster feature", () => {
+    mockGetClusters.mockReturnValue([
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-122.42, 37.77] },
+        properties: {
+          cluster: true,
+          cluster_id: 0,
+          point_count: 5,
+        },
+      },
+    ]);
+    mockGetLeaves.mockReturnValue(
+      mockMarkers.map((m) => ({
+        properties: { marker: m },
+      })),
+    );
+
+    render(<PetitionMarkers {...defaultProps} />);
+
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+
+  it("calls onSelect when clicking a marker", () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <PetitionMarkers {...defaultProps} onSelect={onSelect} />,
+    );
+
+    const markers = container.querySelectorAll("[data-testid^='marker-']");
+    (markers[0] as HTMLElement).click();
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "doc-1" }),
+    );
+  });
+
+  it("calls onSelect with null when clicking already-selected marker", () => {
+    const onSelect = jest.fn();
+    const { container } = render(
+      <PetitionMarkers
+        {...defaultProps}
+        selectedId="doc-3"
+        onSelect={onSelect}
+      />,
+    );
+
+    // Find the LA marker
+    const laMarker = container.querySelector(
+      "[data-testid='marker-34.05--118.24']",
+    );
+    expect(laMarker).toBeTruthy();
+    (laMarker as HTMLElement).click();
+
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("selects first marker when clicking a cluster", () => {
+    const onSelect = jest.fn();
+
+    mockGetClusters.mockReturnValue([
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-122.42, 37.77] },
+        properties: {
+          cluster: true,
+          cluster_id: 0,
+          point_count: 3,
+        },
+      },
+    ]);
+    mockGetLeaves.mockReturnValue([
+      { properties: { marker: mockMarkers[0] } },
+      { properties: { marker: mockMarkers[1] } },
+    ]);
+
+    const { container } = render(
+      <PetitionMarkers {...defaultProps} onSelect={onSelect} />,
+    );
+
+    const markers = container.querySelectorAll("[data-testid^='marker-']");
+    (markers[0] as HTMLElement).click();
+
+    // Should select the first marker in the cluster
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "doc-1" }),
+    );
+  });
+
+  it("loads supercluster index with marker points", () => {
+    render(<PetitionMarkers {...defaultProps} />);
+
+    expect(mockLoad).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: [-122.42, 37.77],
+          },
+        }),
+      ]),
+    );
+  });
+
+  it("calls getClusters with correct bbox and zoom", () => {
+    render(<PetitionMarkers {...defaultProps} />);
+
+    expect(mockGetClusters).toHaveBeenCalledWith(
+      [-125, 30, -115, 40], // [swLng, swLat, neLng, neLat]
+      6, // zoom
+    );
+  });
+
+  it("starts animation loop on mount", () => {
+    render(<PetitionMarkers {...defaultProps} />);
+
+    expect(window.requestAnimationFrame).toHaveBeenCalled();
+  });
+
+  it("cancels animation on unmount", () => {
+    const { unmount } = render(<PetitionMarkers {...defaultProps} />);
+
+    unmount();
+
+    expect(window.cancelAnimationFrame).toHaveBeenCalled();
+  });
+
+  it("formats large cluster counts with k suffix", () => {
+    mockGetClusters.mockReturnValue([
+      {
+        type: "Feature",
+        geometry: { type: "Point", coordinates: [-122.42, 37.77] },
+        properties: {
+          cluster: true,
+          cluster_id: 0,
+          point_count: 2500,
+        },
+      },
+    ]);
+    mockGetLeaves.mockReturnValue([]);
+
+    render(<PetitionMarkers {...defaultProps} />);
+
+    expect(screen.getByText("2.5k")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/components/map/PetitionSidebar.test.tsx
+++ b/apps/frontend/__tests__/components/map/PetitionSidebar.test.tsx
@@ -1,0 +1,209 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { PetitionSidebar } from "@/components/map/PetitionSidebar";
+import type {
+  PetitionMapMarker,
+  PetitionMapStats,
+} from "@/lib/graphql/documents";
+
+const mockMarkers: PetitionMapMarker[] = [
+  {
+    id: "doc-1",
+    latitude: 37.7749,
+    longitude: -122.4194,
+    documentType: "petition",
+    createdAt: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: "doc-2",
+    latitude: 34.0522,
+    longitude: -118.2437,
+    documentType: "proposition",
+    createdAt: "2024-06-15T00:00:00Z",
+  },
+  {
+    id: "doc-3",
+    latitude: 36.7783,
+    longitude: -119.4179,
+    createdAt: "2024-06-10T00:00:00Z",
+  },
+];
+
+const mockStats: PetitionMapStats = {
+  totalPetitions: 42,
+  totalWithLocation: 35,
+  recentPetitions: 8,
+};
+
+describe("PetitionSidebar", () => {
+  const defaultProps = {
+    markers: mockMarkers,
+    stats: mockStats,
+    selectedMarker: null,
+    onSelect: jest.fn(),
+    loading: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders petition count in header", () => {
+    render(<PetitionSidebar {...defaultProps} />);
+
+    expect(
+      screen.getByText(`All Petitions (${mockMarkers.length})`),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all petition list items", () => {
+    render(<PetitionSidebar {...defaultProps} />);
+
+    expect(screen.getAllByRole("option")).toHaveLength(mockMarkers.length);
+  });
+
+  it("renders petition type and truncated ID", () => {
+    render(<PetitionSidebar {...defaultProps} />);
+
+    // doc-1 has documentType "petition"
+    expect(screen.getByText(/petition · doc-1/)).toBeInTheDocument();
+    // doc-2 has documentType "proposition"
+    expect(screen.getByText(/proposition · doc-2/)).toBeInTheDocument();
+  });
+
+  it("renders fallback type for markers without documentType", () => {
+    render(<PetitionSidebar {...defaultProps} />);
+
+    // doc-3 has no documentType, should show "Petition"
+    expect(screen.getByText(/Petition · doc-3/)).toBeInTheDocument();
+  });
+
+  it("renders stats footer with correct values", () => {
+    render(<PetitionSidebar {...defaultProps} />);
+
+    expect(screen.getByText("42")).toBeInTheDocument();
+    expect(screen.getByText("35")).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument(); // In View count
+    expect(screen.getByText("Total Petitions")).toBeInTheDocument();
+    expect(screen.getByText("With Location")).toBeInTheDocument();
+    expect(screen.getByText("Recent (7d)")).toBeInTheDocument();
+    expect(screen.getByText("In View")).toBeInTheDocument();
+  });
+
+  it("renders dash for stats when null", () => {
+    render(<PetitionSidebar {...defaultProps} stats={null} />);
+
+    const dashes = screen.getAllByText("—");
+    expect(dashes.length).toBe(3); // totalPetitions, totalWithLocation, recentPetitions
+  });
+
+  it("shows selected petition detail when marker is selected", () => {
+    render(
+      <PetitionSidebar {...defaultProps} selectedMarker={mockMarkers[0]} />,
+    );
+
+    expect(screen.getByText("Selected Petition")).toBeInTheDocument();
+    expect(screen.getByText("doc-1...")).toBeInTheDocument();
+    expect(screen.getByText("DOCUMENT ID")).toBeInTheDocument();
+    expect(screen.getByText("SCANNED")).toBeInTheDocument();
+  });
+
+  it("does not show selected detail when no marker selected", () => {
+    render(<PetitionSidebar {...defaultProps} />);
+
+    expect(screen.queryByText("Selected Petition")).not.toBeInTheDocument();
+  });
+
+  it("calls onSelect when clicking a petition item", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+
+    render(<PetitionSidebar {...defaultProps} onSelect={onSelect} />);
+
+    const items = screen.getAllByRole("option");
+    await user.click(items[0]);
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.any(String) }),
+    );
+  });
+
+  it("calls onSelect with null when clicking already-selected item", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+
+    render(
+      <PetitionSidebar
+        {...defaultProps}
+        selectedMarker={mockMarkers[0]}
+        onSelect={onSelect}
+      />,
+    );
+
+    // Find the option for doc-1 and click it
+    const items = screen.getAllByRole("option");
+    const selectedItem = items.find(
+      (item) => item.getAttribute("aria-selected") === "true",
+    );
+    expect(selectedItem).toBeTruthy();
+
+    await user.click(selectedItem!);
+
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("handles keyboard selection with Enter", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+
+    render(<PetitionSidebar {...defaultProps} onSelect={onSelect} />);
+
+    const items = screen.getAllByRole("option");
+    items[0].focus();
+    await user.keyboard("{Enter}");
+
+    expect(onSelect).toHaveBeenCalled();
+  });
+
+  it("handles keyboard selection with Space", async () => {
+    const user = userEvent.setup();
+    const onSelect = jest.fn();
+
+    render(<PetitionSidebar {...defaultProps} onSelect={onSelect} />);
+
+    const items = screen.getAllByRole("option");
+    items[0].focus();
+    await user.keyboard(" ");
+
+    expect(onSelect).toHaveBeenCalled();
+  });
+
+  it("shows loading state when loading with no markers", () => {
+    render(<PetitionSidebar {...defaultProps} markers={[]} loading={true} />);
+
+    expect(screen.getByText("Loading petitions...")).toBeInTheDocument();
+  });
+
+  it("shows empty state when not loading with no markers", () => {
+    render(<PetitionSidebar {...defaultProps} markers={[]} loading={false} />);
+
+    expect(
+      screen.getByText("No petitions scanned in this area yet"),
+    ).toBeInTheDocument();
+  });
+
+  it("marks selected item with aria-selected true", () => {
+    render(
+      <PetitionSidebar {...defaultProps} selectedMarker={mockMarkers[0]} />,
+    );
+
+    const items = screen.getAllByRole("option");
+    const selectedItems = items.filter(
+      (item) => item.getAttribute("aria-selected") === "true",
+    );
+    expect(selectedItems).toHaveLength(1);
+  });
+});

--- a/apps/frontend/__tests__/hooks/useMapPetitions.test.ts
+++ b/apps/frontend/__tests__/hooks/useMapPetitions.test.ts
@@ -1,0 +1,319 @@
+import { renderHook, act } from "@testing-library/react";
+import { useMapPetitions } from "@/lib/hooks/useMapPetitions";
+
+const mockUseQuery = jest.fn();
+jest.mock("@apollo/client/react", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+}));
+
+const mockMarkers = [
+  {
+    id: "doc-1",
+    latitude: 37.7749,
+    longitude: -122.4194,
+    documentType: "petition",
+    createdAt: "2024-06-01T00:00:00Z",
+  },
+  {
+    id: "doc-2",
+    latitude: 34.0522,
+    longitude: -118.2437,
+    documentType: "proposition",
+    createdAt: "2024-06-02T00:00:00Z",
+  },
+];
+
+const mockStats = {
+  totalPetitions: 42,
+  totalWithLocation: 35,
+  recentPetitions: 8,
+};
+
+describe("useMapPetitions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("initializes with empty markers and null stats", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    expect(result.current.markers).toEqual([]);
+    expect(result.current.stats).toBeNull();
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns markers from locations query", () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: { petitionMapLocations: mockMarkers },
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: { petitionMapStats: mockStats },
+        loading: false,
+        error: undefined,
+      });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    expect(result.current.markers).toEqual(mockMarkers);
+    expect(result.current.markers).toHaveLength(2);
+    expect(result.current.markers[0].id).toBe("doc-1");
+  });
+
+  it("returns stats from stats query", () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: { petitionMapLocations: mockMarkers },
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: { petitionMapStats: mockStats },
+        loading: false,
+        error: undefined,
+      });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    expect(result.current.stats).toEqual(mockStats);
+    expect(result.current.stats?.totalPetitions).toBe(42);
+  });
+
+  it("reports loading when either query is loading", () => {
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: undefined,
+        loading: true,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: { petitionMapStats: mockStats },
+        loading: false,
+        error: undefined,
+      });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("reports not loading when both queries complete", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("returns error from locations query", () => {
+    const locError = new Error("Network error");
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: undefined,
+        loading: false,
+        error: locError,
+      })
+      .mockReturnValueOnce({
+        data: undefined,
+        loading: false,
+        error: undefined,
+      });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    expect(result.current.error).toBe(locError);
+  });
+
+  it("returns error from stats query when locations succeeds", () => {
+    const statsError = new Error("Stats failed");
+    mockUseQuery
+      .mockReturnValueOnce({
+        data: { petitionMapLocations: [] },
+        loading: false,
+        error: undefined,
+      })
+      .mockReturnValueOnce({
+        data: undefined,
+        loading: false,
+        error: statsError,
+      });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    expect(result.current.error).toBe(statsError);
+  });
+
+  it("debounces bounds updates", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    act(() => {
+      result.current.updateBounds({
+        swLat: 34,
+        swLng: -119,
+        neLat: 38,
+        neLng: -117,
+      });
+    });
+
+    // Filters should not include bounds yet (debounce pending)
+    expect(result.current.filters.bounds).toBeUndefined();
+
+    // Fast-forward past debounce
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(result.current.filters.bounds).toEqual({
+      swLat: 34,
+      swLng: -119,
+      neLat: 38,
+      neLng: -117,
+    });
+  });
+
+  it("cancels pending debounce on rapid bounds updates", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    act(() => {
+      result.current.updateBounds({
+        swLat: 34,
+        swLng: -119,
+        neLat: 38,
+        neLng: -117,
+      });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(100);
+    });
+
+    // Send a second update before debounce fires
+    act(() => {
+      result.current.updateBounds({
+        swLat: 35,
+        swLng: -120,
+        neLat: 39,
+        neLng: -118,
+      });
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    // Should have the second bounds, not the first
+    expect(result.current.filters.bounds).toEqual({
+      swLat: 35,
+      swLng: -120,
+      neLat: 39,
+      neLng: -118,
+    });
+  });
+
+  it("updates filters immediately (no debounce)", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    act(() => {
+      result.current.updateFilters({ documentType: "petition" });
+    });
+
+    expect(result.current.filters.documentType).toBe("petition");
+  });
+
+  it("merges filter updates with existing filters", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useMapPetitions());
+
+    act(() => {
+      result.current.updateFilters({ documentType: "petition" });
+    });
+
+    act(() => {
+      result.current.updateFilters({ startDate: "2024-01-01" });
+    });
+
+    expect(result.current.filters.documentType).toBe("petition");
+    expect(result.current.filters.startDate).toBe("2024-01-01");
+  });
+
+  it("accepts initial filters", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() =>
+      useMapPetitions({ documentType: "proposition" }),
+    );
+
+    expect(result.current.filters.documentType).toBe("proposition");
+  });
+
+  it("cleans up debounce timer on unmount", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    const { result, unmount } = renderHook(() => useMapPetitions());
+
+    act(() => {
+      result.current.updateBounds({
+        swLat: 34,
+        swLng: -119,
+        neLat: 38,
+        neLng: -117,
+      });
+    });
+
+    unmount();
+
+    // Should not throw when timer fires after unmount
+    expect(() => {
+      jest.advanceTimersByTime(300);
+    }).not.toThrow();
+  });
+});

--- a/apps/frontend/__tests__/pages/petition/map.test.tsx
+++ b/apps/frontend/__tests__/pages/petition/map.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { MapPageClient } from "@/app/petition/map/MapPageClient";
+
+// Mock map components to avoid maplibre-gl/WebGL issues in test env
+jest.mock("@/components/map/MapView", () => ({
+  MapView: ({
+    children,
+    onMoveEnd,
+  }: {
+    children: React.ReactNode;
+    onMoveEnd?: (bounds: {
+      swLat: number;
+      swLng: number;
+      neLat: number;
+      neLng: number;
+    }) => void;
+  }) => (
+    <div data-testid="map-view">
+      {children}
+      <button
+        data-testid="trigger-move"
+        onClick={() =>
+          onMoveEnd?.({ swLat: 34, swLng: -119, neLat: 38, neLng: -117 })
+        }
+      >
+        Trigger Move
+      </button>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/map/PetitionMarkers", () => ({
+  PetitionMarkers: () => <div data-testid="petition-markers" />,
+}));
+
+jest.mock("@/components/map/PetitionSidebar", () => ({
+  PetitionSidebar: ({
+    markers,
+    loading,
+  }: {
+    markers: unknown[];
+    loading: boolean;
+  }) => (
+    <div data-testid="petition-sidebar">
+      <span data-testid="marker-count">{markers.length}</span>
+      <span data-testid="loading-state">{String(loading)}</span>
+    </div>
+  ),
+}));
+
+jest.mock("@/components/map/MapLegend", () => ({
+  MapLegend: () => <div data-testid="map-legend" />,
+}));
+
+jest.mock("@/components/map/MapFilters", () => ({
+  MapFilters: ({
+    onNearMe,
+    locationLoading,
+  }: {
+    onNearMe: () => void;
+    locationLoading: boolean;
+  }) => (
+    <div data-testid="map-filters">
+      <button data-testid="near-me-btn" onClick={onNearMe}>
+        {locationLoading ? "Locating..." : "Near me"}
+      </button>
+    </div>
+  ),
+}));
+
+// Mock hooks
+const mockUpdateBounds = jest.fn();
+const mockUpdateFilters = jest.fn();
+jest.mock("@/lib/hooks/useMapPetitions", () => ({
+  useMapPetitions: () => ({
+    markers: [],
+    stats: null,
+    loading: false,
+    error: null,
+    updateBounds: mockUpdateBounds,
+    updateFilters: mockUpdateFilters,
+    filters: {},
+  }),
+}));
+
+const mockRequestLocation = jest.fn();
+jest.mock("@/lib/hooks/useGeolocation", () => ({
+  useGeolocation: () => ({
+    requestLocation: mockRequestLocation,
+    isLoading: false,
+  }),
+}));
+
+describe("MapPageClient", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Clear hash
+    window.location.hash = "";
+  });
+
+  it("renders header with branding", () => {
+    render(<MapPageClient />);
+
+    expect(screen.getByText("Opus Populi")).toBeInTheDocument();
+    expect(screen.getByText("Civic Petition Map")).toBeInTheDocument();
+  });
+
+  it("renders layer toggle buttons", () => {
+    render(<MapPageClient />);
+
+    expect(
+      screen.getByRole("button", { name: "Show clusters layer" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show both layer" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders map view", () => {
+    render(<MapPageClient />);
+
+    expect(screen.getByTestId("map-view")).toBeInTheDocument();
+  });
+
+  it("renders petition markers inside map", () => {
+    render(<MapPageClient />);
+
+    expect(screen.getByTestId("petition-markers")).toBeInTheDocument();
+  });
+
+  it("renders sidebar", () => {
+    render(<MapPageClient />);
+
+    expect(screen.getByTestId("petition-sidebar")).toBeInTheDocument();
+  });
+
+  it("renders map legend", () => {
+    render(<MapPageClient />);
+
+    expect(screen.getByTestId("map-legend")).toBeInTheDocument();
+  });
+
+  it("renders map filters", () => {
+    render(<MapPageClient />);
+
+    expect(screen.getByTestId("map-filters")).toBeInTheDocument();
+  });
+
+  it("toggles active layer on button click", async () => {
+    const user = userEvent.setup();
+    render(<MapPageClient />);
+
+    const bothBtn = screen.getByRole("button", { name: "Show both layer" });
+    await user.click(bothBtn);
+
+    // "both" button should now be active (aria-pressed=true)
+    expect(bothBtn).toHaveAttribute("aria-pressed", "true");
+
+    const clustersBtn = screen.getByRole("button", {
+      name: "Show clusters layer",
+    });
+    // clusters should not be active
+    expect(clustersBtn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("calls updateBounds on map move", async () => {
+    const user = userEvent.setup();
+    render(<MapPageClient />);
+
+    await user.click(screen.getByTestId("trigger-move"));
+
+    expect(mockUpdateBounds).toHaveBeenCalledWith({
+      swLat: 34,
+      swLng: -119,
+      neLat: 38,
+      neLng: -117,
+    });
+  });
+
+  it("has clusters as default active layer", () => {
+    render(<MapPageClient />);
+
+    const clustersBtn = screen.getByRole("button", {
+      name: "Show clusters layer",
+    });
+    expect(clustersBtn).toHaveAttribute("aria-pressed", "true");
+  });
+});

--- a/apps/frontend/app/petition/map/MapPageClient.tsx
+++ b/apps/frontend/app/petition/map/MapPageClient.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import { MapView } from "@/components/map/MapView";
+import { PetitionMarkers } from "@/components/map/PetitionMarkers";
+import { PetitionSidebar } from "@/components/map/PetitionSidebar";
+import { MapLegend } from "@/components/map/MapLegend";
+import { MapFilters } from "@/components/map/MapFilters";
+import { useMapPetitions } from "@/lib/hooks/useMapPetitions";
+import { useGeolocation } from "@/lib/hooks/useGeolocation";
+import type {
+  PetitionMapMarker,
+  MapBoundsInput,
+} from "@/lib/graphql/documents";
+
+type ActiveLayer = "clusters" | "both";
+
+export function MapPageClient() {
+  const [selectedMarker, setSelectedMarker] =
+    useState<PetitionMapMarker | null>(null);
+  const [activeLayer, setActiveLayer] = useState<ActiveLayer>("clusters");
+  const [zoom, setZoom] = useState(4);
+  const [currentBounds, setCurrentBounds] = useState<
+    MapBoundsInput | undefined
+  >();
+
+  const {
+    markers,
+    stats,
+    loading,
+    error,
+    updateBounds,
+    updateFilters,
+    filters,
+  } = useMapPetitions();
+  const { requestLocation, isLoading: locationLoading } = useGeolocation();
+
+  const mapCenterRef = useRef<{ latitude: number; longitude: number } | null>(
+    null,
+  );
+
+  const handleMoveEnd = useCallback(
+    (bounds: MapBoundsInput) => {
+      setCurrentBounds(bounds);
+      updateBounds(bounds);
+      // Estimate zoom from bounds span
+      const latSpan = bounds.neLat - bounds.swLat;
+      if (latSpan > 0) {
+        const estimatedZoom = Math.max(
+          1,
+          Math.min(18, Math.log2(180 / latSpan)),
+        );
+        setZoom(estimatedZoom);
+      }
+    },
+    [updateBounds],
+  );
+
+  const handleSelect = useCallback((marker: PetitionMapMarker | null) => {
+    setSelectedMarker(marker);
+  }, []);
+
+  const handleNearMe = useCallback(async () => {
+    const coords = await requestLocation();
+    if (coords) {
+      mapCenterRef.current = {
+        latitude: coords.latitude,
+        longitude: coords.longitude,
+      };
+      // Force re-render with new center by using window location
+      // For now, we reload the map component with new initial center
+      globalThis.location.hash = `#${coords.latitude},${coords.longitude},12`;
+      globalThis.location.reload();
+    }
+  }, [requestLocation]);
+
+  // Parse hash for initial center
+  let initialCenter: { latitude: number; longitude: number } | undefined;
+  let initialZoom: number | undefined;
+  if (typeof globalThis !== "undefined" && globalThis.location?.hash) {
+    const parts = globalThis.location.hash.substring(1).split(",");
+    if (parts.length >= 2) {
+      initialCenter = {
+        latitude: Number.parseFloat(parts[0]),
+        longitude: Number.parseFloat(parts[1]),
+      };
+      if (parts.length >= 3) {
+        initialZoom = Number.parseFloat(parts[2]);
+      }
+    }
+  }
+
+  return (
+    <div
+      style={{
+        fontFamily: "'Georgia', serif",
+        background: "#0a0f1a",
+        height: "100vh",
+        color: "#e8dcc8",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      {/* Header */}
+      <header
+        style={{
+          borderBottom: "1px solid #1e2d45",
+          padding: "16px 28px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          background: "rgba(10,15,26,0.95)",
+          backdropFilter: "blur(12px)",
+          position: "sticky",
+          top: 0,
+          zIndex: 100,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+          <span
+            style={{
+              fontSize: 22,
+              fontWeight: 700,
+              letterSpacing: "-0.5px",
+              color: "#e8dcc8",
+            }}
+          >
+            Opus Populi
+          </span>
+          <span
+            style={{
+              fontSize: 12,
+              color: "#4a6080",
+              letterSpacing: "2px",
+              textTransform: "uppercase",
+            }}
+          >
+            Civic Petition Map
+          </span>
+        </div>
+        <div style={{ display: "flex", gap: 8 }}>
+          {(["clusters", "both"] as const).map((l) => (
+            <button
+              key={l}
+              onClick={() => setActiveLayer(l)}
+              aria-label={`Show ${l} layer`}
+              aria-pressed={activeLayer === l}
+              style={{
+                padding: "5px 14px",
+                borderRadius: 4,
+                border:
+                  activeLayer === l ? "1px solid #c8a84b" : "1px solid #1e2d45",
+                background:
+                  activeLayer === l ? "rgba(200,168,75,0.15)" : "transparent",
+                color: activeLayer === l ? "#c8a84b" : "#4a6080",
+                fontSize: 11,
+                letterSpacing: "1px",
+                textTransform: "uppercase",
+                cursor: "pointer",
+                fontFamily: "inherit",
+              }}
+            >
+              {l}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      {/* Error banner */}
+      {error && (
+        <div
+          style={{
+            padding: "8px 28px",
+            background: "rgba(200,50,50,0.15)",
+            color: "#ff8888",
+            fontSize: 12,
+            borderBottom: "1px solid #3a1515",
+          }}
+        >
+          Failed to load petition data: {error.message}
+        </div>
+      )}
+
+      {/* Main content */}
+      <div style={{ display: "flex", flex: 1, overflow: "hidden" }}>
+        {/* Map Area */}
+        <div style={{ flex: 1, position: "relative", overflow: "hidden" }}>
+          <MapView
+            initialCenter={initialCenter}
+            initialZoom={initialZoom}
+            onMoveEnd={handleMoveEnd}
+          >
+            {(activeLayer === "clusters" || activeLayer === "both") && (
+              <PetitionMarkers
+                markers={markers}
+                zoom={zoom}
+                bounds={currentBounds}
+                selectedId={selectedMarker?.id ?? null}
+                onSelect={handleSelect}
+              />
+            )}
+          </MapView>
+
+          {/* Overlays */}
+          <MapFilters
+            filters={filters}
+            onUpdateFilters={updateFilters}
+            onNearMe={handleNearMe}
+            locationLoading={locationLoading}
+          />
+          <MapLegend />
+        </div>
+
+        {/* Sidebar */}
+        <PetitionSidebar
+          markers={markers}
+          stats={stats}
+          selectedMarker={selectedMarker}
+          onSelect={handleSelect}
+          loading={loading}
+        />
+      </div>
+
+      <style>{`
+        @keyframes fadeIn {
+          from { opacity: 0; transform: translateY(-4px); }
+          to { opacity: 1; transform: none; }
+        }
+        ::-webkit-scrollbar { width: 4px; }
+        ::-webkit-scrollbar-track { background: #080d16; }
+        ::-webkit-scrollbar-thumb { background: #1e2d45; border-radius: 2px; }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/frontend/app/petition/map/page.tsx
+++ b/apps/frontend/app/petition/map/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { MapPageClient } from "./MapPageClient";
+
+export default function MapPage() {
+  return <MapPageClient />;
+}

--- a/apps/frontend/app/petition/page.tsx
+++ b/apps/frontend/app/petition/page.tsx
@@ -31,6 +31,12 @@ export default function PetitionPage() {
         Start Scanning
       </Link>
       <Link
+        href="/petition/map"
+        className="mt-4 px-8 py-3 border border-gray-600 hover:border-gray-400 text-gray-300 font-medium rounded-lg transition-colors"
+      >
+        View Map
+      </Link>
+      <Link
         href="/"
         className="mt-4 text-sm text-gray-400 hover:text-gray-300 transition-colors"
       >

--- a/apps/frontend/components/map/MapFilters.tsx
+++ b/apps/frontend/components/map/MapFilters.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback } from "react";
+import type { MapFiltersInput } from "../../lib/graphql/documents";
+
+interface MapFiltersProps {
+  filters: MapFiltersInput;
+  onUpdateFilters: (filters: Partial<MapFiltersInput>) => void;
+  onNearMe: () => void;
+  locationLoading: boolean;
+}
+
+export function MapFilters({
+  filters,
+  onUpdateFilters,
+  onNearMe,
+  locationLoading,
+}: MapFiltersProps) {
+  const handleTypeChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = e.target.value;
+      onUpdateFilters({ documentType: value || undefined });
+    },
+    [onUpdateFilters],
+  );
+
+  const handleStartDateChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      onUpdateFilters({ startDate: value || undefined });
+    },
+    [onUpdateFilters],
+  );
+
+  const handleEndDateChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value;
+      onUpdateFilters({ endDate: value || undefined });
+    },
+    [onUpdateFilters],
+  );
+
+  const inputStyle: React.CSSProperties = {
+    background: "rgba(10,15,26,0.8)",
+    border: "1px solid #1e2d45",
+    borderRadius: 4,
+    color: "#e8dcc8",
+    padding: "4px 8px",
+    fontSize: 11,
+    fontFamily: "'Georgia', serif",
+    outline: "none",
+  };
+
+  const buttonStyle: React.CSSProperties = {
+    padding: "5px 14px",
+    borderRadius: 4,
+    border: "1px solid #1e2d45",
+    background: "transparent",
+    color: "#4a8fa8",
+    fontSize: 11,
+    letterSpacing: "1px",
+    textTransform: "uppercase",
+    cursor: "pointer",
+    fontFamily: "'Georgia', serif",
+    whiteSpace: "nowrap",
+  };
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: 12,
+        left: 12,
+        display: "flex",
+        gap: 8,
+        zIndex: 20,
+        flexWrap: "wrap",
+      }}
+    >
+      <select
+        value={filters.documentType ?? ""}
+        onChange={handleTypeChange}
+        style={inputStyle}
+        aria-label="Filter by document type"
+      >
+        <option value="">All types</option>
+        <option value="petition">Petition</option>
+        <option value="proposition">Proposition</option>
+        <option value="contract">Contract</option>
+        <option value="report">Report</option>
+      </select>
+
+      <input
+        type="date"
+        value={filters.startDate ?? ""}
+        onChange={handleStartDateChange}
+        style={inputStyle}
+        aria-label="Start date"
+        placeholder="From"
+      />
+
+      <input
+        type="date"
+        value={filters.endDate ?? ""}
+        onChange={handleEndDateChange}
+        style={inputStyle}
+        aria-label="End date"
+        placeholder="To"
+      />
+
+      <button
+        onClick={onNearMe}
+        disabled={locationLoading}
+        style={{
+          ...buttonStyle,
+          opacity: locationLoading ? 0.5 : 1,
+        }}
+        aria-label="Center map on my location"
+      >
+        {locationLoading ? "Locating..." : "Near me"}
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend/components/map/MapLegend.tsx
+++ b/apps/frontend/components/map/MapLegend.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+export function MapLegend() {
+  return (
+    <div
+      style={{
+        position: "absolute",
+        bottom: 28,
+        left: 28,
+        background: "rgba(10,15,26,0.88)",
+        border: "1px solid #1e2d45",
+        borderRadius: 6,
+        padding: "12px 16px",
+        fontSize: 11,
+        fontFamily: "'Georgia', serif",
+        zIndex: 20,
+      }}
+    >
+      <div
+        style={{
+          color: "#4a6080",
+          letterSpacing: "1.5px",
+          textTransform: "uppercase",
+          marginBottom: 10,
+        }}
+      >
+        Legend
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 6,
+        }}
+      >
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            background: "rgba(74,143,168,0.85)",
+            border: "1px solid #8fcfe8",
+          }}
+        />
+        <span style={{ color: "#8a9db5" }}>Petition location</span>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          marginBottom: 6,
+        }}
+      >
+        <div
+          style={{
+            width: 10,
+            height: 10,
+            borderRadius: "50%",
+            background: "rgba(200,168,75,0.85)",
+            border: "1px solid #f0d070",
+          }}
+        />
+        <span style={{ color: "#8a9db5" }}>Selected petition</span>
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
+        <div
+          style={{
+            width: 18,
+            height: 18,
+            borderRadius: "50%",
+            background: "rgba(74,143,168,0.4)",
+            border: "1px solid #4a8fa8",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 8,
+            color: "white",
+            fontWeight: "bold",
+            fontFamily: "sans-serif",
+          }}
+        >
+          5
+        </div>
+        <span style={{ color: "#8a9db5" }}>Cluster (count)</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/map/MapView.tsx
+++ b/apps/frontend/components/map/MapView.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useRef, useEffect, useCallback, useState } from "react";
+import Map, { MapRef, ViewStateChangeEvent } from "react-map-gl/maplibre";
+import type { StyleSpecification } from "maplibre-gl";
+import type { MapLayerMouseEvent } from "maplibre-gl";
+import "maplibre-gl/dist/maplibre-gl.css";
+import { Protocol } from "pmtiles";
+
+// Dark basemap style matching the midnight navy aesthetic
+const DARK_STYLE: StyleSpecification = {
+  version: 8,
+  name: "Opus Dark",
+  sources: {
+    protomaps: {
+      type: "vector",
+      url: "pmtiles://https://build.protomaps.com/20240701.pmtiles",
+      attribution:
+        '<a href="https://protomaps.com">Protomaps</a> | <a href="https://openstreetmap.org">OpenStreetMap</a>',
+    },
+  },
+  layers: [
+    {
+      id: "background",
+      type: "background",
+      paint: { "background-color": "#0a0f1a" },
+    },
+    {
+      id: "water",
+      type: "fill",
+      source: "protomaps",
+      "source-layer": "water",
+      paint: { "fill-color": "#0d1825" },
+    },
+    {
+      id: "landuse-park",
+      type: "fill",
+      source: "protomaps",
+      "source-layer": "landuse",
+      filter: ["==", "pmap:kind", "park"],
+      paint: { "fill-color": "#0e1a24", "fill-opacity": 0.5 },
+    },
+    {
+      id: "roads-highway",
+      type: "line",
+      source: "protomaps",
+      "source-layer": "roads",
+      filter: ["==", "pmap:kind", "highway"],
+      paint: {
+        "line-color": "#1a2d42",
+        "line-width": 1.5,
+        "line-opacity": 0.6,
+      },
+    },
+    {
+      id: "roads-major",
+      type: "line",
+      source: "protomaps",
+      "source-layer": "roads",
+      filter: ["==", "pmap:kind", "major_road"],
+      paint: {
+        "line-color": "#152235",
+        "line-width": 0.8,
+        "line-opacity": 0.4,
+      },
+    },
+    {
+      id: "roads-minor",
+      type: "line",
+      source: "protomaps",
+      "source-layer": "roads",
+      filter: ["==", "pmap:kind", "minor_road"],
+      paint: {
+        "line-color": "#121d2d",
+        "line-width": 0.5,
+        "line-opacity": 0.3,
+      },
+    },
+    {
+      id: "boundaries",
+      type: "line",
+      source: "protomaps",
+      "source-layer": "boundaries",
+      paint: {
+        "line-color": "#1e3a5a",
+        "line-width": 1,
+        "line-opacity": 0.5,
+      },
+    },
+    {
+      id: "place-labels",
+      type: "symbol",
+      source: "protomaps",
+      "source-layer": "places",
+      filter: ["<=", "pmap:min_zoom", 8],
+      layout: {
+        "text-field": "{name}",
+        "text-size": 12,
+        "text-font": ["Noto Sans Regular"],
+      },
+      paint: {
+        "text-color": "#2a4060",
+        "text-halo-color": "#0a0f1a",
+        "text-halo-width": 1,
+      },
+    },
+  ],
+  glyphs: "https://cdn.protomaps.com/fonts/pbf/{fontstack}/{range}.pbf",
+};
+
+// Default to center of continental US
+const DEFAULT_VIEW = {
+  longitude: -98.5,
+  latitude: 39.8,
+  zoom: 4,
+};
+
+export interface MapViewProps {
+  initialCenter?: { latitude: number; longitude: number };
+  initialZoom?: number;
+  onMoveEnd?: (bounds: {
+    swLat: number;
+    swLng: number;
+    neLat: number;
+    neLng: number;
+  }) => void;
+  onClick?: (event: { latitude: number; longitude: number }) => void;
+  children?: React.ReactNode;
+}
+
+export function MapView({
+  initialCenter,
+  initialZoom,
+  onMoveEnd,
+  onClick,
+  children,
+}: MapViewProps) {
+  const mapRef = useRef<MapRef>(null);
+  const [protocolAdded, setProtocolAdded] = useState(false);
+
+  useEffect(() => {
+    const protocol = new Protocol();
+    // maplibregl addProtocol is imported via react-map-gl/maplibre
+    // The Protocol registers itself globally
+    import("maplibre-gl").then((maplibregl) => {
+      maplibregl.addProtocol("pmtiles", protocol.tile);
+      setProtocolAdded(true);
+    });
+    return () => {
+      import("maplibre-gl").then((maplibregl) => {
+        maplibregl.removeProtocol("pmtiles");
+      });
+    };
+  }, []);
+
+  const handleMoveEnd = useCallback(
+    (evt: ViewStateChangeEvent) => {
+      if (!onMoveEnd || !mapRef.current) return;
+      const map = mapRef.current.getMap();
+      const bounds = map.getBounds();
+      onMoveEnd({
+        swLat: bounds.getSouth(),
+        swLng: bounds.getWest(),
+        neLat: bounds.getNorth(),
+        neLng: bounds.getEast(),
+      });
+    },
+    [onMoveEnd],
+  );
+
+  const handleClick = useCallback(
+    (event: MapLayerMouseEvent) => {
+      if (!onClick) return;
+      onClick({
+        latitude: event.lngLat.lat,
+        longitude: event.lngLat.lng,
+      });
+    },
+    [onClick],
+  );
+
+  if (!protocolAdded) {
+    return (
+      <div
+        style={{
+          flex: 1,
+          background: "#0a0f1a",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#4a6080",
+          fontFamily: "Georgia, serif",
+        }}
+      >
+        Loading map...
+      </div>
+    );
+  }
+
+  return (
+    <Map
+      ref={mapRef}
+      initialViewState={{
+        longitude: initialCenter?.longitude ?? DEFAULT_VIEW.longitude,
+        latitude: initialCenter?.latitude ?? DEFAULT_VIEW.latitude,
+        zoom: initialZoom ?? DEFAULT_VIEW.zoom,
+      }}
+      style={{ flex: 1 }}
+      mapStyle={DARK_STYLE}
+      onMoveEnd={handleMoveEnd}
+      onClick={handleClick}
+      attributionControl={false}
+    >
+      {children}
+    </Map>
+  );
+}

--- a/apps/frontend/components/map/PetitionLayer.tsx
+++ b/apps/frontend/components/map/PetitionLayer.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useMemo, useRef, useEffect, useState, useCallback } from "react";
+import Supercluster from "supercluster";
+import type { PetitionMapMarker } from "../../lib/graphql/documents";
+
+export interface ClusterFeature {
+  id: string;
+  latitude: number;
+  longitude: number;
+  count: number;
+  isCluster: boolean;
+  markers: PetitionMapMarker[];
+}
+
+interface PetitionLayerProps {
+  markers: PetitionMapMarker[];
+  zoom: number;
+  bounds?: { swLat: number; swLng: number; neLat: number; neLng: number };
+  selectedId: string | null;
+  onSelect: (marker: PetitionMapMarker | null) => void;
+}
+
+function formatCount(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function markerSize(count: number): number {
+  return Math.max(14, Math.min(48, 14 + (count / 100) * 34));
+}
+
+export function PetitionLayer({
+  markers,
+  zoom,
+  bounds,
+  selectedId,
+  onSelect,
+}: PetitionLayerProps) {
+  const [pulse, setPulse] = useState(0);
+  const rafRef = useRef<number>(0);
+
+  useEffect(() => {
+    let frame = 0;
+    const tick = () => {
+      frame++;
+      setPulse(Math.sin(frame * 0.04) * 0.5 + 0.5);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, []);
+
+  const index = useMemo(() => {
+    const sc = new Supercluster<{ marker: PetitionMapMarker }>({
+      radius: 60,
+      maxZoom: 16,
+    });
+    const points = markers.map((m) => ({
+      type: "Feature" as const,
+      geometry: {
+        type: "Point" as const,
+        coordinates: [m.longitude, m.latitude] as [number, number],
+      },
+      properties: { marker: m },
+    }));
+    sc.load(points);
+    return sc;
+  }, [markers]);
+
+  const clusters = useMemo((): ClusterFeature[] => {
+    if (!bounds) return [];
+    const bbox: [number, number, number, number] = [
+      bounds.swLng,
+      bounds.swLat,
+      bounds.neLng,
+      bounds.neLat,
+    ];
+    const raw = index.getClusters(bbox, Math.floor(zoom));
+    return raw.map((feature) => {
+      const [lng, lat] = feature.geometry.coordinates;
+      const props = feature.properties as Record<string, unknown>;
+      if (props.cluster) {
+        const clusterId = props.cluster_id as number;
+        const leaves = index.getLeaves(clusterId, Infinity);
+        return {
+          id: `cluster-${clusterId}`,
+          latitude: lat,
+          longitude: lng,
+          count: props.point_count as number,
+          isCluster: true,
+          markers: leaves.map(
+            (l) => (l.properties as { marker: PetitionMapMarker }).marker,
+          ),
+        };
+      }
+      const marker = (props as { marker: PetitionMapMarker }).marker;
+      return {
+        id: marker.id,
+        latitude: lat,
+        longitude: lng,
+        count: 1,
+        isCluster: false,
+        markers: [marker],
+      };
+    });
+  }, [index, bounds, zoom]);
+
+  const handleClick = useCallback(
+    (cluster: ClusterFeature) => {
+      if (cluster.isCluster) {
+        // For clusters, select the first marker (or could zoom in)
+        onSelect(cluster.markers[0]);
+      } else {
+        const marker = cluster.markers[0];
+        onSelect(selectedId === marker.id ? null : marker);
+      }
+    },
+    [onSelect, selectedId],
+  );
+
+  return (
+    <svg
+      style={{
+        position: "absolute",
+        inset: 0,
+        width: "100%",
+        height: "100%",
+        pointerEvents: "none",
+        zIndex: 10,
+      }}
+    >
+      {clusters.map((cluster) => {
+        const isSelected =
+          !cluster.isCluster && cluster.markers[0].id === selectedId;
+        const size = markerSize(cluster.count);
+        const r = size / 2;
+        const glowR = r * (1 + pulse * 0.25);
+
+        // We use CSS transform for positioning via the parent MapView
+        // For the SVG overlay approach, coordinates are managed by the map
+        return (
+          <g
+            key={cluster.id}
+            data-marker-id={cluster.id}
+            data-lat={cluster.latitude}
+            data-lng={cluster.longitude}
+            style={{ pointerEvents: "auto", cursor: "pointer" }}
+            onClick={() => handleClick(cluster)}
+          >
+            {/* Glow ring */}
+            <circle
+              r={glowR * 2.2}
+              fill="none"
+              stroke={isSelected ? "#c8a84b" : "#4a8fa8"}
+              strokeWidth="1"
+              opacity={0.3 + pulse * 0.3}
+            />
+            {/* Outer ring */}
+            <circle
+              r={r * 1.6}
+              fill="none"
+              stroke={isSelected ? "#c8a84b" : "#4a8fa8"}
+              strokeWidth="1.5"
+              opacity={0.5}
+            />
+            {/* Main circle */}
+            <circle
+              r={r}
+              fill={
+                isSelected ? "rgba(200,168,75,0.9)" : "rgba(74,143,168,0.85)"
+              }
+              stroke={isSelected ? "#f0d070" : "#8fcfe8"}
+              strokeWidth="1.5"
+            />
+            {/* Count text */}
+            <text
+              textAnchor="middle"
+              dominantBaseline="central"
+              fontSize={r * 0.7}
+              fill="white"
+              fontWeight="bold"
+              style={{ fontFamily: "sans-serif" }}
+            >
+              {formatCount(cluster.count)}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+export { type PetitionMapMarker };

--- a/apps/frontend/components/map/PetitionMarkers.tsx
+++ b/apps/frontend/components/map/PetitionMarkers.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { useMemo, useRef, useEffect, useState, useCallback } from "react";
+import { Marker } from "react-map-gl/maplibre";
+import Supercluster from "supercluster";
+import type { PetitionMapMarker } from "../../lib/graphql/documents";
+
+export interface ClusterFeature {
+  id: string;
+  latitude: number;
+  longitude: number;
+  count: number;
+  isCluster: boolean;
+  clusterId?: number;
+  markers: PetitionMapMarker[];
+}
+
+function formatCount(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+function markerSize(count: number): number {
+  return Math.max(24, Math.min(56, 24 + (count / 50) * 32));
+}
+
+interface PetitionMarkersProps {
+  markers: PetitionMapMarker[];
+  zoom: number;
+  bounds?: { swLat: number; swLng: number; neLat: number; neLng: number };
+  selectedId: string | null;
+  onSelect: (marker: PetitionMapMarker | null) => void;
+}
+
+export function PetitionMarkers({
+  markers,
+  zoom,
+  bounds,
+  selectedId,
+  onSelect,
+}: PetitionMarkersProps) {
+  const [pulse, setPulse] = useState(0);
+  const rafRef = useRef<number>(0);
+
+  useEffect(() => {
+    let frame = 0;
+    const tick = () => {
+      frame++;
+      setPulse(Math.sin(frame * 0.04) * 0.5 + 0.5);
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, []);
+
+  const index = useMemo(() => {
+    const sc = new Supercluster<{ marker: PetitionMapMarker }>({
+      radius: 60,
+      maxZoom: 16,
+    });
+    const points = markers.map((m) => ({
+      type: "Feature" as const,
+      geometry: {
+        type: "Point" as const,
+        coordinates: [m.longitude, m.latitude] as [number, number],
+      },
+      properties: { marker: m },
+    }));
+    sc.load(points);
+    return sc;
+  }, [markers]);
+
+  const clusters = useMemo((): ClusterFeature[] => {
+    if (!bounds) return [];
+    const bbox: [number, number, number, number] = [
+      bounds.swLng,
+      bounds.swLat,
+      bounds.neLng,
+      bounds.neLat,
+    ];
+    const raw = index.getClusters(bbox, Math.floor(zoom));
+    return raw.map((feature) => {
+      const [lng, lat] = feature.geometry.coordinates;
+      const props = feature.properties as Record<string, unknown>;
+      if (props.cluster) {
+        const clusterId = props.cluster_id as number;
+        const leaves = index.getLeaves(clusterId, Infinity);
+        return {
+          id: `cluster-${clusterId}`,
+          latitude: lat,
+          longitude: lng,
+          count: props.point_count as number,
+          isCluster: true,
+          clusterId,
+          markers: leaves.map(
+            (l) => (l.properties as { marker: PetitionMapMarker }).marker,
+          ),
+        };
+      }
+      const marker = (props as { marker: PetitionMapMarker }).marker;
+      return {
+        id: marker.id,
+        latitude: lat,
+        longitude: lng,
+        count: 1,
+        isCluster: false,
+        markers: [marker],
+      };
+    });
+  }, [index, bounds, zoom]);
+
+  const handleClick = useCallback(
+    (cluster: ClusterFeature) => {
+      if (cluster.isCluster) {
+        onSelect(cluster.markers[0]);
+      } else {
+        const marker = cluster.markers[0];
+        onSelect(selectedId === marker.id ? null : marker);
+      }
+    },
+    [onSelect, selectedId],
+  );
+
+  return (
+    <>
+      {clusters.map((cluster) => {
+        const isSelected =
+          !cluster.isCluster && cluster.markers[0].id === selectedId;
+        const size = markerSize(cluster.count);
+        const r = size / 2;
+        const glowR = r * (1 + pulse * 0.25);
+
+        return (
+          <Marker
+            key={cluster.id}
+            latitude={cluster.latitude}
+            longitude={cluster.longitude}
+            anchor="center"
+            onClick={(e) => {
+              e.originalEvent.stopPropagation();
+              handleClick(cluster);
+            }}
+          >
+            <svg
+              width={glowR * 4.4 + 4}
+              height={glowR * 4.4 + 4}
+              viewBox={`${-(glowR * 2.2 + 2)} ${-(glowR * 2.2 + 2)} ${glowR * 4.4 + 4} ${glowR * 4.4 + 4}`}
+              style={{ cursor: "pointer", overflow: "visible" }}
+            >
+              {/* Glow ring */}
+              <circle
+                cx={0}
+                cy={0}
+                r={glowR * 2.2}
+                fill="none"
+                stroke={isSelected ? "#c8a84b" : "#4a8fa8"}
+                strokeWidth="1"
+                opacity={0.3 + pulse * 0.3}
+              />
+              {/* Outer ring */}
+              <circle
+                cx={0}
+                cy={0}
+                r={r * 1.6}
+                fill="none"
+                stroke={isSelected ? "#c8a84b" : "#4a8fa8"}
+                strokeWidth="1.5"
+                opacity={0.5}
+              />
+              {/* Main circle */}
+              <circle
+                cx={0}
+                cy={0}
+                r={r}
+                fill={
+                  isSelected ? "rgba(200,168,75,0.9)" : "rgba(74,143,168,0.85)"
+                }
+                stroke={isSelected ? "#f0d070" : "#8fcfe8"}
+                strokeWidth="1.5"
+              />
+              {/* Count text */}
+              <text
+                x={0}
+                y={0}
+                textAnchor="middle"
+                dominantBaseline="central"
+                fontSize={Math.max(10, r * 0.65)}
+                fill="white"
+                fontWeight="bold"
+                style={{ fontFamily: "sans-serif", pointerEvents: "none" }}
+              >
+                {formatCount(cluster.count)}
+              </text>
+            </svg>
+          </Marker>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/frontend/components/map/PetitionSidebar.tsx
+++ b/apps/frontend/components/map/PetitionSidebar.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import type {
+  PetitionMapMarker,
+  PetitionMapStats,
+} from "../../lib/graphql/documents";
+
+interface PetitionSidebarProps {
+  markers: PetitionMapMarker[];
+  stats: PetitionMapStats | null;
+  selectedMarker: PetitionMapMarker | null;
+  onSelect: (marker: PetitionMapMarker | null) => void;
+  loading: boolean;
+}
+
+export function PetitionSidebar({
+  markers,
+  stats,
+  selectedMarker,
+  onSelect,
+  loading,
+}: PetitionSidebarProps) {
+  const sorted = [...markers].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+
+  return (
+    <div
+      style={{
+        width: 320,
+        background: "rgba(8,13,22,0.95)",
+        borderLeft: "1px solid #1e2d45",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        fontFamily: "'Georgia', serif",
+      }}
+    >
+      {/* Selected Petition Detail */}
+      {selectedMarker && (
+        <div
+          style={{
+            padding: 20,
+            borderBottom: "1px solid #1e2d45",
+            background: "rgba(200,168,75,0.05)",
+            animation: "fadeIn 0.2s ease",
+          }}
+        >
+          <div
+            style={{
+              fontSize: 10,
+              color: "#c8a84b",
+              letterSpacing: "2px",
+              textTransform: "uppercase",
+              marginBottom: 8,
+            }}
+          >
+            Selected Petition
+          </div>
+          <div
+            style={{
+              fontSize: 15,
+              color: "#e8dcc8",
+              lineHeight: 1.4,
+              marginBottom: 12,
+            }}
+          >
+            {selectedMarker.documentType ?? "Petition"}
+          </div>
+          <div style={{ display: "flex", gap: 16 }}>
+            <div>
+              <div
+                style={{
+                  fontSize: 13,
+                  color: "#c8a84b",
+                  fontFamily: "monospace",
+                }}
+              >
+                {selectedMarker.id.substring(0, 8)}...
+              </div>
+              <div
+                style={{
+                  fontSize: 10,
+                  color: "#4a6080",
+                  letterSpacing: "1px",
+                }}
+              >
+                DOCUMENT ID
+              </div>
+            </div>
+            <div>
+              <div style={{ fontSize: 13, color: "#4a8fa8" }}>
+                {new Date(selectedMarker.createdAt).toLocaleDateString()}
+              </div>
+              <div
+                style={{
+                  fontSize: 10,
+                  color: "#4a6080",
+                  letterSpacing: "1px",
+                }}
+              >
+                SCANNED
+              </div>
+            </div>
+          </div>
+          <div style={{ marginTop: 10, fontSize: 11, color: "#4a6080" }}>
+            {selectedMarker.latitude.toFixed(4)},{" "}
+            {selectedMarker.longitude.toFixed(4)}
+          </div>
+        </div>
+      )}
+
+      {/* Petition List */}
+      <div style={{ overflowY: "auto", flex: 1 }}>
+        <div
+          style={{
+            padding: "16px 20px 8px",
+            fontSize: 10,
+            color: "#4a6080",
+            letterSpacing: "2px",
+            textTransform: "uppercase",
+          }}
+        >
+          All Petitions ({markers.length})
+        </div>
+
+        {loading && markers.length === 0 && (
+          <div
+            style={{
+              padding: "40px 20px",
+              textAlign: "center",
+              color: "#4a6080",
+              fontSize: 13,
+            }}
+          >
+            Loading petitions...
+          </div>
+        )}
+
+        {!loading && markers.length === 0 && (
+          <div
+            style={{
+              padding: "40px 20px",
+              textAlign: "center",
+              color: "#4a6080",
+              fontSize: 13,
+            }}
+          >
+            No petitions scanned in this area yet
+          </div>
+        )}
+
+        {sorted.map((marker) => {
+          const isSelected = selectedMarker?.id === marker.id;
+          return (
+            <div
+              key={marker.id}
+              role="option"
+              aria-selected={isSelected}
+              tabIndex={0}
+              onClick={() => onSelect(isSelected ? null : marker)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onSelect(isSelected ? null : marker);
+                }
+              }}
+              style={{
+                padding: "12px 20px",
+                borderBottom: "1px solid #111a28",
+                cursor: "pointer",
+                background: isSelected
+                  ? "rgba(200,168,75,0.08)"
+                  : "transparent",
+                borderLeft: isSelected
+                  ? "2px solid #c8a84b"
+                  : "2px solid transparent",
+                transition: "all 0.15s",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "flex-start",
+                  gap: 8,
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 12,
+                    color: isSelected ? "#e8dcc8" : "#8a9db5",
+                    lineHeight: 1.4,
+                    flex: 1,
+                  }}
+                >
+                  {marker.documentType ?? "Petition"} &middot;{" "}
+                  {marker.id.substring(0, 8)}
+                </div>
+                <div
+                  style={{
+                    fontSize: 11,
+                    color: "#c8a84b",
+                    whiteSpace: "nowrap",
+                    fontVariantNumeric: "tabular-nums",
+                  }}
+                >
+                  {new Date(marker.createdAt).toLocaleDateString()}
+                </div>
+              </div>
+              <div
+                style={{
+                  marginTop: 4,
+                  display: "flex",
+                  justifyContent: "space-between",
+                }}
+              >
+                <span style={{ fontSize: 10, color: "#2a4060" }}>
+                  {marker.latitude.toFixed(3)}, {marker.longitude.toFixed(3)}
+                </span>
+              </div>
+              {/* Subtle activity bar */}
+              <div
+                style={{
+                  marginTop: 6,
+                  height: 2,
+                  background: "#1a2535",
+                  borderRadius: 1,
+                }}
+              >
+                <div
+                  style={{
+                    height: "100%",
+                    width: "60%",
+                    background: isSelected ? "#c8a84b" : "#4a8fa8",
+                    borderRadius: 1,
+                    transition: "width 0.3s ease",
+                  }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Stats Footer */}
+      <div
+        style={{
+          padding: "14px 20px",
+          borderTop: "1px solid #1e2d45",
+          display: "grid",
+          gridTemplateColumns: "1fr 1fr",
+          gap: 12,
+        }}
+      >
+        {[
+          {
+            label: "Total Petitions",
+            value: stats?.totalPetitions?.toLocaleString() ?? "—",
+          },
+          {
+            label: "With Location",
+            value: stats?.totalWithLocation?.toLocaleString() ?? "—",
+          },
+          {
+            label: "Recent (7d)",
+            value: stats?.recentPetitions?.toLocaleString() ?? "—",
+          },
+          {
+            label: "In View",
+            value: markers.length.toLocaleString(),
+          },
+        ].map((s) => (
+          <div key={s.label}>
+            <div style={{ fontSize: 14, color: "#c8a84b", fontWeight: 600 }}>
+              {s.value}
+            </div>
+            <div
+              style={{
+                fontSize: 10,
+                color: "#2a4060",
+                letterSpacing: "0.5px",
+              }}
+            >
+              {s.label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/map/index.ts
+++ b/apps/frontend/components/map/index.ts
@@ -1,0 +1,5 @@
+export { MapView } from "./MapView";
+export { PetitionMarkers } from "./PetitionMarkers";
+export { PetitionSidebar } from "./PetitionSidebar";
+export { MapLegend } from "./MapLegend";
+export { MapFilters } from "./MapFilters";

--- a/apps/frontend/lib/graphql/documents.ts
+++ b/apps/frontend/lib/graphql/documents.ts
@@ -67,6 +67,34 @@ export interface AnalyzeDocumentResult {
   fromCache: boolean;
 }
 
+export interface PetitionMapMarker {
+  id: string;
+  latitude: number;
+  longitude: number;
+  documentType?: string;
+  createdAt: string;
+}
+
+export interface PetitionMapStats {
+  totalPetitions: number;
+  totalWithLocation: number;
+  recentPetitions: number;
+}
+
+export interface MapBoundsInput {
+  swLat: number;
+  swLng: number;
+  neLat: number;
+  neLng: number;
+}
+
+export interface MapFiltersInput {
+  bounds?: MapBoundsInput;
+  documentType?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
 // ============================================
 // Mutations
 // ============================================
@@ -121,6 +149,32 @@ export const ANALYZE_DOCUMENT = gql`
 `;
 
 // ============================================
+// Queries
+// ============================================
+
+export const GET_PETITION_MAP_LOCATIONS = gql`
+  query PetitionMapLocations($filters: MapFiltersInput) {
+    petitionMapLocations(filters: $filters) {
+      id
+      latitude
+      longitude
+      documentType
+      createdAt
+    }
+  }
+`;
+
+export const GET_PETITION_MAP_STATS = gql`
+  query PetitionMapStats {
+    petitionMapStats {
+      totalPetitions
+      totalWithLocation
+      recentPetitions
+    }
+  }
+`;
+
+// ============================================
 // Response Types
 // ============================================
 
@@ -134,4 +188,12 @@ export interface ProcessScanData {
 
 export interface AnalyzeDocumentData {
   analyzeDocument: AnalyzeDocumentResult;
+}
+
+export interface PetitionMapLocationsData {
+  petitionMapLocations: PetitionMapMarker[];
+}
+
+export interface PetitionMapStatsData {
+  petitionMapStats: PetitionMapStats;
 }

--- a/apps/frontend/lib/hooks/index.ts
+++ b/apps/frontend/lib/hooks/index.ts
@@ -3,3 +3,4 @@ export { useMagicLink } from "./useMagicLink";
 export { useCamera } from "./useCamera";
 export { useLightingAnalysis } from "./useLightingAnalysis";
 export { useGeolocation } from "./useGeolocation";
+export { useMapPetitions } from "./useMapPetitions";

--- a/apps/frontend/lib/hooks/useMapPetitions.ts
+++ b/apps/frontend/lib/hooks/useMapPetitions.ts
@@ -1,0 +1,85 @@
+"use client";
+
+import { useQuery } from "@apollo/client/react";
+import { useState, useCallback, useRef, useEffect } from "react";
+import {
+  GET_PETITION_MAP_LOCATIONS,
+  GET_PETITION_MAP_STATS,
+  PetitionMapLocationsData,
+  PetitionMapStatsData,
+  MapFiltersInput,
+  MapBoundsInput,
+  PetitionMapMarker,
+  PetitionMapStats,
+} from "../graphql/documents";
+
+export interface UseMapPetitionsReturn {
+  markers: PetitionMapMarker[];
+  stats: PetitionMapStats | null;
+  loading: boolean;
+  error: Error | null;
+  updateBounds: (bounds: MapBoundsInput) => void;
+  updateFilters: (filters: Partial<MapFiltersInput>) => void;
+  filters: MapFiltersInput;
+}
+
+const DEBOUNCE_MS = 300;
+
+export function useMapPetitions(
+  initialFilters?: Partial<MapFiltersInput>,
+): UseMapPetitionsReturn {
+  const [filters, setFilters] = useState<MapFiltersInput>({
+    ...initialFilters,
+  });
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const {
+    data: locationsData,
+    loading: locationsLoading,
+    error: locationsError,
+  } = useQuery<PetitionMapLocationsData>(GET_PETITION_MAP_LOCATIONS, {
+    variables: {
+      filters: Object.keys(filters).length > 0 ? filters : undefined,
+    },
+    fetchPolicy: "cache-and-network",
+  });
+
+  const {
+    data: statsData,
+    loading: statsLoading,
+    error: statsError,
+  } = useQuery<PetitionMapStatsData>(GET_PETITION_MAP_STATS, {
+    fetchPolicy: "cache-and-network",
+  });
+
+  const updateBounds = useCallback((bounds: MapBoundsInput) => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    debounceRef.current = setTimeout(() => {
+      setFilters((prev) => ({ ...prev, bounds }));
+    }, DEBOUNCE_MS);
+  }, []);
+
+  const updateFilters = useCallback((newFilters: Partial<MapFiltersInput>) => {
+    setFilters((prev) => ({ ...prev, ...newFilters }));
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, []);
+
+  return {
+    markers: locationsData?.petitionMapLocations ?? [],
+    stats: statsData?.petitionMapStats ?? null,
+    loading: locationsLoading || statsLoading,
+    error: locationsError ?? statsError ?? null,
+    updateBounds,
+    updateFilters,
+    filters,
+  };
+}

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -29,6 +29,9 @@
   },
   "dependencies": {
     "@apollo/client": "^4.0.10",
+    "@deck.gl/core": "^9.2.9",
+    "@deck.gl/layers": "^9.2.9",
+    "@deck.gl/mapbox": "^9.2.9",
     "@serwist/next": "^9.5.3",
     "@simplewebauthn/browser": "^13.2.2",
     "apollo3-cache-persist": "^0.15.0",
@@ -37,19 +40,22 @@
     "i18next": "^25.7.3",
     "idb": "^8.0.3",
     "jwt-decode": "^4.0.0",
+    "maplibre-gl": "^5.18.0",
     "next": "^16.1.5",
+    "pmtiles": "^4.4.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "^16.5.0",
-    "serwist": "^9.5.3"
+    "react-map-gl": "^8.1.0",
+    "serwist": "^9.5.3",
+    "supercluster": "^8.0.1"
   },
   "devDependencies": {
-    "@opennextjs/cloudflare": "^1.16.5",
-    "wrangler": "^4.59.2",
     "@axe-core/playwright": "^4.11.0",
     "@eslint/compat": "^2.0.0",
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.17.0",
+    "@opennextjs/cloudflare": "^1.16.5",
     "@playwright/test": "^1.57.0",
     "@serwist/build": "^9.5.3",
     "@tailwindcss/postcss": "^4.1.18",
@@ -62,6 +68,7 @@
     "@types/node": "^25.0.1",
     "@types/react": "^19.0.6",
     "@types/react-dom": "^19.0.2",
+    "@types/supercluster": "^7.1.3",
     "eslint": "^9.17.0",
     "eslint-config-next": "^16.1.5",
     "eslint-config-prettier": "^10.0.1",
@@ -76,7 +83,8 @@
     "prettier": "^3.4.2",
     "tailwindcss": "^4.1.18",
     "ts-jest": "^29.2.5",
-    "typescript": "^5.7.2"
+    "typescript": "^5.7.2",
+    "wrangler": "^4.59.2"
   },
   "overrides": {
     "eslint": "$eslint"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -65,9 +65,9 @@
   ],
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@types/jest": "^30.0.0",
+    "@types/jest": "^29.5.0",
     "@types/node": "^22.0.0",
-    "jest": "^30.0.0",
+    "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "typescript": "^5.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,15 @@ importers:
       '@apollo/client':
         specifier: ^4.0.10
         version: 4.0.10(graphql-ws@6.0.6(graphql@16.12.0)(ws@8.18.3(bufferutil@4.0.9)))(graphql@16.12.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rxjs@7.8.2)(subscriptions-transport-ws@0.11.0(bufferutil@4.0.9)(graphql@16.12.0))
+      '@deck.gl/core':
+        specifier: ^9.2.9
+        version: 9.2.9
+      '@deck.gl/layers':
+        specifier: ^9.2.9
+        version: 9.2.9(@deck.gl/core@9.2.9)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))
+      '@deck.gl/mapbox':
+        specifier: ^9.2.9
+        version: 9.2.9(@deck.gl/core@9.2.9)(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@math.gl/web-mercator@4.1.0)
       '@serwist/next':
         specifier: ^9.5.3
         version: 9.5.3(next@16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(webpack@5.103.0)
@@ -368,9 +377,15 @@ importers:
       jwt-decode:
         specifier: ^4.0.0
         version: 4.0.0
+      maplibre-gl:
+        specifier: ^5.18.0
+        version: 5.18.0
       next:
         specifier: ^16.1.5
         version: 16.1.6(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      pmtiles:
+        specifier: ^4.4.0
+        version: 4.4.0
       react:
         specifier: ^19.0.0
         version: 19.2.3
@@ -380,9 +395,15 @@ importers:
       react-i18next:
         specifier: ^16.5.0
         version: 16.5.0(i18next@25.7.3(typescript@5.9.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
+      react-map-gl:
+        specifier: ^8.1.0
+        version: 8.1.0(maplibre-gl@5.18.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       serwist:
         specifier: ^9.5.3
         version: 9.5.3(browserslist@4.28.1)(typescript@5.9.3)
+      supercluster:
+        specifier: ^8.0.1
+        version: 8.0.1
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.11.0
@@ -435,6 +456,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.0.2
         version: 19.2.3(@types/react@19.2.7)
+      '@types/supercluster':
+        specifier: ^7.1.3
+        version: 7.1.3
       eslint:
         specifier: ^9.17.0
         version: 9.39.2(jiti@2.6.1)
@@ -531,17 +555,17 @@ importers:
         version: 7.19.2
     devDependencies:
       '@types/jest':
-        specifier: ^30.0.0
-        version: 30.0.0
+        specifier: ^29.5.0
+        version: 29.5.14
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.3
       jest:
-        specifier: ^30.0.0
-        version: 30.2.0(@types/node@22.19.3)
+        specifier: ^29.7.0
+        version: 29.7.0(@types/node@22.19.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@30.2.0(@types/node@22.19.3))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@29.7.0(@types/node@22.19.3)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -2026,6 +2050,25 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@deck.gl/core@9.2.9':
+    resolution: {integrity: sha512-VBzYB5rh/YCnUZzlqYMLGBHglLvbUIiCeZHysYJPVVjPHRgrKo4wiTohCb1L1Z02pGp3HUN/8tEZhBPMIc+luw==}
+
+  '@deck.gl/layers@9.2.9':
+    resolution: {integrity: sha512-MGXSIIUDiFspDBLC0/KH2JHpCVW0TToPArCQEWTctUdAap0ClYu6tI3cbpEiesFV8jsoDHfjU3tKM8JFD2S0wQ==}
+    peerDependencies:
+      '@deck.gl/core': ~9.2.0
+      '@loaders.gl/core': ^4.3.4
+      '@luma.gl/core': ~9.2.6
+      '@luma.gl/engine': ~9.2.6
+
+  '@deck.gl/mapbox@9.2.9':
+    resolution: {integrity: sha512-KGsh47Rrei0mPf88g1gXi297IKoUj8tTNSGJUjd9oapkmfYAziSCSL1baP66436V37CkfJKyyzFZ2Q10KKG92w==}
+    peerDependencies:
+      '@deck.gl/core': ~9.2.0
+      '@luma.gl/constants': ~9.2.6
+      '@luma.gl/core': ~9.2.6
+      '@math.gl/web-mercator': ^4.1.0
 
   '@dotenvx/dotenvx@1.31.0':
     resolution: {integrity: sha512-GeDxvtjiRuoyWVU9nQneId879zIyNdL05bS7RKiqMkfBSKpHMWHLoRyRqjYWLaXmX/llKO1hTlqHDmatkQAjPA==}
@@ -3514,9 +3557,110 @@ packages:
   '@levischuck/tiny-cbor@0.2.11':
     resolution: {integrity: sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==}
 
+  '@loaders.gl/core@4.3.4':
+    resolution: {integrity: sha512-cG0C5fMZ1jyW6WCsf4LoHGvaIAJCEVA/ioqKoYRwoSfXkOf+17KupK1OUQyUCw5XoRn+oWA1FulJQOYlXnb9Gw==}
+
+  '@loaders.gl/images@4.3.4':
+    resolution: {integrity: sha512-qgc33BaNsqN9cWa/xvcGvQ50wGDONgQQdzHCKDDKhV2w/uptZoR5iofJfuG8UUV2vUMMd82Uk9zbopRx2rS4Ag==}
+    peerDependencies:
+      '@loaders.gl/core': ^4.3.0
+
+  '@loaders.gl/loader-utils@4.3.4':
+    resolution: {integrity: sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==}
+    peerDependencies:
+      '@loaders.gl/core': ^4.3.0
+
+  '@loaders.gl/schema@4.3.4':
+    resolution: {integrity: sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==}
+    peerDependencies:
+      '@loaders.gl/core': ^4.3.0
+
+  '@loaders.gl/worker-utils@4.3.4':
+    resolution: {integrity: sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==}
+    peerDependencies:
+      '@loaders.gl/core': ^4.3.0
+
   '@lukeed/csprng@1.1.0':
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
+
+  '@luma.gl/constants@9.2.6':
+    resolution: {integrity: sha512-rvFFrJuSm5JIWbDHFuR4Q2s4eudO3Ggsv0TsGKn9eqvO7bBiPm/ANugHredvh3KviEyYuMZZxtfJvBdr3kzldg==}
+
+  '@luma.gl/core@9.2.6':
+    resolution: {integrity: sha512-d8KcH8ZZcjDAodSN/G2nueA9YE2X8kMz7Q0OxDGpCww6to1MZXM3Ydate/Jqsb5DDKVgUF6yD6RL8P5jOki9Yw==}
+
+  '@luma.gl/engine@9.2.6':
+    resolution: {integrity: sha512-1AEDs2AUqOWh7Wl4onOhXmQF+Rz1zNdPXF+Kxm4aWl92RQ42Sh2CmTvRt2BJku83VQ91KFIEm/v3qd3Urzf+Uw==}
+    peerDependencies:
+      '@luma.gl/core': ~9.2.0
+      '@luma.gl/shadertools': ~9.2.0
+
+  '@luma.gl/shadertools@9.2.6':
+    resolution: {integrity: sha512-4+uUbynqPUra9d/z1nQChyHmhLgmKfSMjS7kOwLB6exSnhKnpHL3+Hu9fv55qyaX50nGH3oHawhGtJ6RRvu65w==}
+    peerDependencies:
+      '@luma.gl/core': ~9.2.0
+
+  '@luma.gl/webgl@9.2.6':
+    resolution: {integrity: sha512-NGBTdxJMk7j8Ygr1zuTyAvr1Tw+EpupMIQo7RelFjEsZXg6pujFqiDMM+rgxex8voCeuhWBJc7Rs+MoSqd46UQ==}
+    peerDependencies:
+      '@luma.gl/core': ~9.2.0
+
+  '@mapbox/geojson-rewind@0.5.2':
+    resolution: {integrity: sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==}
+    hasBin: true
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2':
+    resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
+    engines: {node: '>= 0.6'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.0.7':
+    resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/vector-tile@2.0.4':
+    resolution: {integrity: sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@5.0.4':
+    resolution: {integrity: sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==}
+
+  '@maplibre/maplibre-gl-style-spec@19.3.3':
+    resolution: {integrity: sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==}
+    hasBin: true
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
+    resolution: {integrity: sha512-UKhA4qv1h30XT768ccSv5NjNCX+dgfoq2qlLVmKejspPcSQTYD4SrVucgqegmYcKcmwf06wcNAa/kRd0NHWbUg==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.6':
+    resolution: {integrity: sha512-rgtY3x65lrrfXycLf6/T22ZnjTg5WgIOsptOIoCaMZy4O4UAKTyZlYY0h6v8le721pTptF94U65yMDQkug+URw==}
+
+  '@maplibre/vt-pbf@4.2.1':
+    resolution: {integrity: sha512-IxZBGq/+9cqf2qdWlFuQ+ZfoMhWpxDUGQZ/poPHOJBvwMUT1GuxLo6HgYTou+xxtsOsjfbcjI8PZaPCtmt97rA==}
+
+  '@math.gl/core@4.1.0':
+    resolution: {integrity: sha512-FrdHBCVG3QdrworwrUSzXIaK+/9OCRLscxI2OUy6sLOHyHgBMyfnEGs99/m3KNvs+95BsnQLWklVfpKfQzfwKA==}
+
+  '@math.gl/polygon@4.1.0':
+    resolution: {integrity: sha512-YA/9PzaCRHbIP5/0E9uTYrqe+jsYTQoqoDWhf6/b0Ixz8bPZBaGDEafLg3z7ffBomZLacUty9U3TlPjqMtzPjA==}
+
+  '@math.gl/sun@4.1.0':
+    resolution: {integrity: sha512-i3q6OCBLSZ5wgZVhXg+X7gsjY/TUtuFW/2KBiq/U1ypLso3S4sEykoU/MGjxUv1xiiGtr+v8TeMbO1OBIh/HmA==}
+
+  '@math.gl/types@4.1.0':
+    resolution: {integrity: sha512-clYZdHcmRvMzVK5fjeDkQlHUzXQSNdZ7s4xOqC3nJPgz4C/TZkUecTo9YS4PruZqtDda/ag4erndP0MIn40dGA==}
+
+  '@math.gl/web-mercator@4.1.0':
+    resolution: {integrity: sha512-HZo3vO5GCMkXJThxRJ5/QYUYRr3XumfT8CzNNCwoJfinxy5NtKUd7dusNTXn7yJ40UoB8FMIwkVwNlqaiRZZAw==}
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
@@ -4029,6 +4173,15 @@ packages:
 
   '@prisma/get-platform@5.22.0':
     resolution: {integrity: sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==}
+
+  '@probe.gl/env@4.1.1':
+    resolution: {integrity: sha512-+68seNDMVsEegRB47pFA/Ws1Fjy8agcFYXxzorKToyPcD6zd+gZ5uhwoLd7TzsSw6Ydns//2KEszWn+EnNHTbA==}
+
+  '@probe.gl/log@4.1.1':
+    resolution: {integrity: sha512-kcZs9BT44pL7hS1OkRGKYRXI/SN9KejUlPD+BY40DguRLzdC5tLG/28WGMyfKdn/51GT4a0p+0P8xvDn1Ez+Kg==}
+
+  '@probe.gl/stats@4.1.1':
+    resolution: {integrity: sha512-4VpAyMHOqydSvPlEyHwXaE+AkIdR03nX+Qhlxsk2D/IW4OVmDZgIsvJB1cDzyEEtcfKcnaEbfXeiPgejBceT6g==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -4629,6 +4782,9 @@ packages:
   '@types/express@5.0.6':
     resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -4698,6 +4854,9 @@ packages:
   '@types/node@25.0.1':
     resolution: {integrity: sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg==}
 
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
+
   '@types/passport-jwt@4.0.1':
     resolution: {integrity: sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==}
 
@@ -4744,6 +4903,9 @@ packages:
 
   '@types/superagent@8.1.9':
     resolution: {integrity: sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==}
+
+  '@types/supercluster@7.1.3':
+    resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
 
   '@types/supertest@6.0.3':
     resolution: {integrity: sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==}
@@ -4947,6 +5109,26 @@ packages:
   '@vercel/oidc@3.0.5':
     resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
     engines: {node: '>= 20'}
+
+  '@vis.gl/react-mapbox@8.1.0':
+    resolution: {integrity: sha512-FwvH822oxEjWYOr+pP2L8hpv+7cZB2UsQbHHHT0ryrkvvqzmTgt7qHDhamv0EobKw86e1I+B4ojENdJ5G5BkyQ==}
+    peerDependencies:
+      mapbox-gl: '>=3.5.0'
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
+    peerDependenciesMeta:
+      mapbox-gl:
+        optional: true
+
+  '@vis.gl/react-maplibre@8.1.0':
+    resolution: {integrity: sha512-PkAK/gp3mUfhCLhUuc+4gc3PN9zCtVGxTF2hB6R5R5yYUw+hdg84OZ770U5MU4tPMTCG6fbduExuIW6RRKN6qQ==}
+    peerDependencies:
+      maplibre-gl: '>=4.0.0'
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
+    peerDependenciesMeta:
+      maplibre-gl:
+        optional: true
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -5185,6 +5367,10 @@ packages:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
 
+  arr-union@3.1.0:
+    resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
+    engines: {node: '>=0.10.0'}
+
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
     engines: {node: '>= 0.4'}
@@ -5230,6 +5416,10 @@ packages:
   asn1js@3.0.7:
     resolution: {integrity: sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==}
     engines: {node: '>=12.0.0'}
+
+  assign-symbols@1.0.0:
+    resolution: {integrity: sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==}
+    engines: {node: '>=0.10.0'}
 
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -5484,6 +5674,12 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  bytewise-core@1.2.3:
+    resolution: {integrity: sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==}
+
+  bytewise@1.1.0:
+    resolution: {integrity: sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==}
 
   cacache@17.1.4:
     resolution: {integrity: sha512-/aJwG2l3ZMJ1xNAnqbMpA40of9dj/pIH3QfiuQSqjfPJF747VR0J/bHn+/KdNnHKc6XQcWt/AfRSBft82W1d2A==}
@@ -6071,6 +6267,12 @@ packages:
   duplexify@4.1.3:
     resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
+  earcut@2.2.4:
+    resolution: {integrity: sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==}
+
+  earcut@3.0.2:
+    resolution: {integrity: sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -6438,6 +6640,14 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  extend-shallow@3.0.2:
+    resolution: {integrity: sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==}
+    engines: {node: '>=0.10.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -6708,8 +6918,15 @@ packages:
     resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
     engines: {node: '>= 14'}
 
+  get-value@2.0.6:
+    resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
+    engines: {node: '>=0.10.0'}
+
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -7091,6 +7308,14 @@ packages:
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
+  is-extendable@1.0.1:
+    resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -7145,6 +7370,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -7222,6 +7451,10 @@ packages:
   isexe@3.1.5:
     resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
     engines: {node: '>=18'}
+
+  isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
 
   isomorphic-ws@4.0.1:
     resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
@@ -7639,6 +7872,12 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@3.0.0:
+    resolution: {integrity: sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==}
+
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
@@ -7679,6 +7918,9 @@ packages:
   jwt-decode@4.0.0:
     resolution: {integrity: sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==}
     engines: {node: '>=18'}
+
+  kdbush@4.0.2:
+    resolution: {integrity: sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -7986,6 +8228,10 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  maplibre-gl@5.18.0:
+    resolution: {integrity: sha512-UtWxPBpHuFvEkM+5FVfcFG9ZKEWZQI6+PZkvLErr8Zs5ux+O7/KQ3JjSUvAfOlMeMgd/77qlHpOw0yHL7JU5cw==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
@@ -8141,6 +8387,9 @@ packages:
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
+  mjolnir.js@3.0.0:
+    resolution: {integrity: sha512-siX3YCG7N2HnmN1xMH3cK4JkUZJhbkhRFJL+G5N1vH0mh1t5088rJknIoqDFWDIU6NPGvRRgLnYW3ZHjSMEBLA==}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
@@ -8173,6 +8422,9 @@ packages:
   multer@2.0.2:
     resolution: {integrity: sha512-u7f2xaZ/UG8oLXHvtF/oWTRvT44p9ecwBBqTwgJVq0+4BW1g8OW01TyMEGWBHbyMOYVHXslaut7qEQ1meATXgw==}
     engines: {node: '>= 10.16.0'}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   mustache@4.2.0:
     resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
@@ -8572,6 +8824,10 @@ packages:
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
+  pbf@4.0.1:
+    resolution: {integrity: sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==}
+    hasBin: true
+
   pdf-parse@2.4.5:
     resolution: {integrity: sha512-mHU89HGh7v+4u2ubfnevJ03lmPgQ5WU4CxAVmTSh/sxVTEDYd1er/dKS/A6vg77NX47KTEoihq8jZBLr8Cxuwg==}
     engines: {node: '>=20.16.0 <21 || >=22.3.0'}
@@ -8691,6 +8947,9 @@ packages:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
 
+  pmtiles@4.4.0:
+    resolution: {integrity: sha512-tCLI1C5134MR54i8izUWhse0QUtO/EC33n9yWp1N5dYLLvyc197U0fkF5gAJhq1TdWO9Tvl+9hgvFvM0fR27Zg==}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -8719,9 +8978,13 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -8791,6 +9054,9 @@ packages:
     resolution: {integrity: sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==}
     hasBin: true
 
+  protocol-buffers-schema@3.6.0:
+    resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -8842,6 +9108,9 @@ packages:
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -8886,6 +9155,19 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-map-gl@8.1.0:
+    resolution: {integrity: sha512-vDx/QXR3Tb+8/ap/z6gdMjJQ8ZEyaZf6+uMSPz7jhWF5VZeIsKsGfPvwHVPPwGF43Ryn+YR4bd09uEFNR5OPdg==}
+    peerDependencies:
+      mapbox-gl: '>=1.13.0'
+      maplibre-gl: '>=1.13.0'
+      react: '>=16.3.0'
+      react-dom: '>=16.3.0'
+    peerDependenciesMeta:
+      mapbox-gl:
+        optional: true
+      maplibre-gl:
+        optional: true
 
   react-promise-suspense@0.3.4:
     resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
@@ -8976,6 +9258,9 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
+
   resolve.exports@2.0.3:
     resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
     engines: {node: '>=10'}
@@ -9036,6 +9321,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
@@ -9134,6 +9422,10 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  set-value@2.0.1:
+    resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==}
+    engines: {node: '>=0.10.0'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -9236,6 +9528,18 @@ packages:
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
+  sort-asc@0.2.0:
+    resolution: {integrity: sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==}
+    engines: {node: '>=0.10.0'}
+
+  sort-desc@0.2.0:
+    resolution: {integrity: sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==}
+    engines: {node: '>=0.10.0'}
+
+  sort-object@3.0.3:
+    resolution: {integrity: sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==}
+    engines: {node: '>=0.10.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -9262,6 +9566,10 @@ packages:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
     deprecated: The work that was done in this beta branch won't be included in future versions
+
+  split-string@3.1.0:
+    resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==}
+    engines: {node: '>=0.10.0'}
 
   split2@3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
@@ -9436,6 +9744,9 @@ packages:
     resolution: {integrity: sha512-y/hkYGeXAj7wUMjxRbB21g/l6aAEituGXM9Rwl4o20+SX3e8YOSV6BxFXl+dL3Uk0mjSL3kCbNkwURm8/gEDig==}
     engines: {node: '>=14.18.0'}
 
+  supercluster@8.0.1:
+    resolution: {integrity: sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==}
+
   supertest@7.1.4:
     resolution: {integrity: sha512-tjLPs7dVyqgItVFirHYqe2T+MfWc2VOBQ8QFKKbWTA3PU7liZR8zoSpAi/C1k1ilm9RsXIKYf197oap9wXGVYg==}
     engines: {node: '>=14.18.0'}
@@ -9549,6 +9860,9 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -9830,6 +10144,12 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typewise-core@1.2.0:
+    resolution: {integrity: sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==}
+
+  typewise@1.0.3:
+    resolution: {integrity: sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==}
+
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
@@ -9865,6 +10185,10 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  union-value@1.0.1:
+    resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==}
+    engines: {node: '>=0.10.0'}
 
   unique-filename@3.0.0:
     resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
@@ -10010,6 +10334,9 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  wgsl_reflect@1.2.3:
+    resolution: {integrity: sha512-BQWBIsOn411M+ffBxmA6QRLvAOVbuz3Uk4NusxnqC1H7aeQcVLhdA3k2k/EFFFtqVjhz3z7JOOZF1a9hj2tv4Q==}
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
@@ -12164,6 +12491,48 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
+  '@deck.gl/core@9.2.9':
+    dependencies:
+      '@loaders.gl/core': 4.3.4
+      '@loaders.gl/images': 4.3.4(@loaders.gl/core@4.3.4)
+      '@luma.gl/constants': 9.2.6
+      '@luma.gl/core': 9.2.6
+      '@luma.gl/engine': 9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))
+      '@luma.gl/shadertools': 9.2.6(@luma.gl/core@9.2.6)
+      '@luma.gl/webgl': 9.2.6(@luma.gl/core@9.2.6)
+      '@math.gl/core': 4.1.0
+      '@math.gl/sun': 4.1.0
+      '@math.gl/types': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      '@probe.gl/env': 4.1.1
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+      '@types/offscreencanvas': 2019.7.3
+      gl-matrix: 3.4.4
+      mjolnir.js: 3.0.0
+
+  '@deck.gl/layers@9.2.9(@deck.gl/core@9.2.9)(@loaders.gl/core@4.3.4)(@luma.gl/core@9.2.6)(@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)))':
+    dependencies:
+      '@deck.gl/core': 9.2.9
+      '@loaders.gl/core': 4.3.4
+      '@loaders.gl/images': 4.3.4(@loaders.gl/core@4.3.4)
+      '@loaders.gl/schema': 4.3.4(@loaders.gl/core@4.3.4)
+      '@luma.gl/core': 9.2.6
+      '@luma.gl/engine': 9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))
+      '@luma.gl/shadertools': 9.2.6(@luma.gl/core@9.2.6)
+      '@mapbox/tiny-sdf': 2.0.7
+      '@math.gl/core': 4.1.0
+      '@math.gl/polygon': 4.1.0
+      '@math.gl/web-mercator': 4.1.0
+      earcut: 2.2.4
+
+  '@deck.gl/mapbox@9.2.9(@deck.gl/core@9.2.9)(@luma.gl/constants@9.2.6)(@luma.gl/core@9.2.6)(@math.gl/web-mercator@4.1.0)':
+    dependencies:
+      '@deck.gl/core': 9.2.9
+      '@luma.gl/constants': 9.2.6
+      '@luma.gl/core': 9.2.6
+      '@math.gl/web-mercator': 4.1.0
+
   '@dotenvx/dotenvx@1.31.0':
     dependencies:
       commander: 11.1.0
@@ -13409,7 +13778,141 @@ snapshots:
 
   '@levischuck/tiny-cbor@0.2.11': {}
 
+  '@loaders.gl/core@4.3.4':
+    dependencies:
+      '@loaders.gl/loader-utils': 4.3.4(@loaders.gl/core@4.3.4)
+      '@loaders.gl/schema': 4.3.4(@loaders.gl/core@4.3.4)
+      '@loaders.gl/worker-utils': 4.3.4(@loaders.gl/core@4.3.4)
+      '@probe.gl/log': 4.1.1
+
+  '@loaders.gl/images@4.3.4(@loaders.gl/core@4.3.4)':
+    dependencies:
+      '@loaders.gl/core': 4.3.4
+      '@loaders.gl/loader-utils': 4.3.4(@loaders.gl/core@4.3.4)
+
+  '@loaders.gl/loader-utils@4.3.4(@loaders.gl/core@4.3.4)':
+    dependencies:
+      '@loaders.gl/core': 4.3.4
+      '@loaders.gl/schema': 4.3.4(@loaders.gl/core@4.3.4)
+      '@loaders.gl/worker-utils': 4.3.4(@loaders.gl/core@4.3.4)
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+
+  '@loaders.gl/schema@4.3.4(@loaders.gl/core@4.3.4)':
+    dependencies:
+      '@loaders.gl/core': 4.3.4
+      '@types/geojson': 7946.0.16
+
+  '@loaders.gl/worker-utils@4.3.4(@loaders.gl/core@4.3.4)':
+    dependencies:
+      '@loaders.gl/core': 4.3.4
+
   '@lukeed/csprng@1.1.0': {}
+
+  '@luma.gl/constants@9.2.6': {}
+
+  '@luma.gl/core@9.2.6':
+    dependencies:
+      '@math.gl/types': 4.1.0
+      '@probe.gl/env': 4.1.1
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+      '@types/offscreencanvas': 2019.7.3
+
+  '@luma.gl/engine@9.2.6(@luma.gl/core@9.2.6)(@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6))':
+    dependencies:
+      '@luma.gl/core': 9.2.6
+      '@luma.gl/shadertools': 9.2.6(@luma.gl/core@9.2.6)
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+      '@probe.gl/log': 4.1.1
+      '@probe.gl/stats': 4.1.1
+
+  '@luma.gl/shadertools@9.2.6(@luma.gl/core@9.2.6)':
+    dependencies:
+      '@luma.gl/core': 9.2.6
+      '@math.gl/core': 4.1.0
+      '@math.gl/types': 4.1.0
+      wgsl_reflect: 1.2.3
+
+  '@luma.gl/webgl@9.2.6(@luma.gl/core@9.2.6)':
+    dependencies:
+      '@luma.gl/constants': 9.2.6
+      '@luma.gl/core': 9.2.6
+      '@math.gl/types': 4.1.0
+      '@probe.gl/env': 4.1.1
+
+  '@mapbox/geojson-rewind@0.5.2':
+    dependencies:
+      get-stream: 6.0.1
+      minimist: 1.2.8
+
+  '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.0.7': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/vector-tile@2.0.4':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.1
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@5.0.4': {}
+
+  '@maplibre/maplibre-gl-style-spec@19.3.3':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 3.0.0
+      minimist: 1.2.8
+      rw: 1.3.3
+      sort-object: 3.0.3
+
+  '@maplibre/maplibre-gl-style-spec@24.4.1':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/unitbezier': 0.0.1
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      rw: 1.3.3
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.6':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.2.1':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/vector-tile': 2.0.4
+      '@maplibre/geojson-vt': 5.0.4
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      pbf: 4.0.1
+      supercluster: 8.0.1
+
+  '@math.gl/core@4.1.0':
+    dependencies:
+      '@math.gl/types': 4.1.0
+
+  '@math.gl/polygon@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
+
+  '@math.gl/sun@4.1.0': {}
+
+  '@math.gl/types@4.1.0': {}
+
+  '@math.gl/web-mercator@4.1.0':
+    dependencies:
+      '@math.gl/core': 4.1.0
 
   '@microsoft/tsdoc@0.16.0': {}
 
@@ -13954,6 +14457,14 @@ snapshots:
   '@prisma/get-platform@5.22.0':
     dependencies:
       '@prisma/debug': 5.22.0
+
+  '@probe.gl/env@4.1.1': {}
+
+  '@probe.gl/log@4.1.1':
+    dependencies:
+      '@probe.gl/env': 4.1.1
+
+  '@probe.gl/stats@4.1.1': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -14731,6 +15242,8 @@ snapshots:
       '@types/express-serve-static-core': 5.1.0
       '@types/serve-static': 2.2.0
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 25.0.1
@@ -14810,6 +15323,8 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/offscreencanvas@2019.7.3': {}
+
   '@types/passport-jwt@4.0.1':
     dependencies:
       '@types/jsonwebtoken': 9.0.10
@@ -14870,6 +15385,10 @@ snapshots:
       '@types/methods': 1.1.4
       '@types/node': 25.0.1
       form-data: 4.0.5
+
+  '@types/supercluster@7.1.3':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/supertest@6.0.3':
     dependencies:
@@ -15070,6 +15589,19 @@ snapshots:
     optional: true
 
   '@vercel/oidc@3.0.5': {}
+
+  '@vis.gl/react-mapbox@8.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@vis.gl/react-maplibre@8.1.0(maplibre-gl@5.18.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@maplibre/maplibre-gl-style-spec': 19.3.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      maplibre-gl: 5.18.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -15325,6 +15857,8 @@ snapshots:
 
   aria-query@5.3.2: {}
 
+  arr-union@3.1.0: {}
+
   array-buffer-byte-length@1.0.2:
     dependencies:
       call-bound: 1.0.4
@@ -15403,6 +15937,8 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  assign-symbols@1.0.0: {}
 
   ast-types-flow@0.0.8: {}
 
@@ -15717,6 +16253,15 @@ snapshots:
       streamsearch: 1.1.0
 
   bytes@3.1.2: {}
+
+  bytewise-core@1.2.3:
+    dependencies:
+      typewise-core: 1.2.0
+
+  bytewise@1.1.0:
+    dependencies:
+      bytewise-core: 1.2.3
+      typewise: 1.0.3
 
   cacache@17.1.4:
     dependencies:
@@ -16320,6 +16865,10 @@ snapshots:
       readable-stream: 3.6.2
       stream-shift: 1.0.3
     optional: true
+
+  earcut@2.2.4: {}
+
+  earcut@3.0.2: {}
 
   eastasianwidth@0.2.0: {}
 
@@ -16942,6 +17491,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  extend-shallow@3.0.2:
+    dependencies:
+      assign-symbols: 1.0.0
+      is-extendable: 1.0.1
+
   extend@3.0.2: {}
 
   extract-zip@2.0.1:
@@ -17252,7 +17810,11 @@ snapshots:
       - supports-color
     optional: true
 
+  get-value@2.0.6: {}
+
   github-from-package@0.0.0: {}
+
+  gl-matrix@3.4.4: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -17672,6 +18234,12 @@ snapshots:
 
   is-electron@2.2.2: {}
 
+  is-extendable@0.1.1: {}
+
+  is-extendable@1.0.1:
+    dependencies:
+      is-plain-object: 2.0.4
+
   is-extglob@2.1.1: {}
 
   is-finalizationregistry@1.1.1:
@@ -17714,6 +18282,10 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-plain-object@2.0.4:
+    dependencies:
+      isobject: 3.0.1
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -17782,6 +18354,8 @@ snapshots:
   isexe@2.0.0: {}
 
   isexe@3.1.5: {}
+
+  isobject@3.0.1: {}
 
   isomorphic-ws@4.0.1(ws@8.18.3(bufferutil@4.0.9)):
     dependencies:
@@ -18783,6 +19357,10 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@3.0.0: {}
+
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@1.0.2:
     dependencies:
       minimist: 1.2.8
@@ -18842,6 +19420,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   jwt-decode@4.0.0: {}
+
+  kdbush@4.0.2: {}
 
   keyv@4.5.4:
     dependencies:
@@ -19142,6 +19722,31 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  maplibre-gl@5.18.0:
+    dependencies:
+      '@mapbox/geojson-rewind': 0.5.2
+      '@mapbox/jsonlint-lines-primitives': 2.0.2
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.0.7
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.4
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 5.0.4
+      '@maplibre/maplibre-gl-style-spec': 24.4.1
+      '@maplibre/mlt': 1.1.6
+      '@maplibre/vt-pbf': 4.2.1
+      '@types/geojson': 7946.0.16
+      '@types/supercluster': 7.1.3
+      earcut: 3.0.2
+      gl-matrix: 3.4.4
+      kdbush: 4.0.2
+      murmurhash-js: 1.0.0
+      pbf: 4.0.1
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      supercluster: 8.0.1
+      tinyqueue: 3.0.0
+
   marky@1.3.0:
     optional: true
 
@@ -19273,6 +19878,8 @@ snapshots:
   mitt@3.0.1:
     optional: true
 
+  mjolnir.js@3.0.0: {}
+
   mkdirp-classic@0.5.3: {}
 
   mkdirp@0.5.6:
@@ -19332,6 +19939,8 @@ snapshots:
       object-assign: 4.1.1
       type-is: 1.6.18
       xtend: 4.0.2
+
+  murmurhash-js@1.0.0: {}
 
   mustache@4.2.0: {}
 
@@ -19773,6 +20382,10 @@ snapshots:
 
   pause@0.0.1: {}
 
+  pbf@4.0.1:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   pdf-parse@2.4.5:
     dependencies:
       '@napi-rs/canvas': 0.1.80
@@ -19894,6 +20507,10 @@ snapshots:
 
   pluralize@8.0.0: {}
 
+  pmtiles@4.4.0:
+    dependencies:
+      fflate: 0.8.2
+
   possible-typed-array-names@1.1.0: {}
 
   postcss@8.4.31:
@@ -19917,6 +20534,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  potpack@2.1.0: {}
 
   prebuild-install@7.1.3:
     dependencies:
@@ -20014,6 +20633,8 @@ snapshots:
       '@types/node': 25.0.1
       long: 4.0.0
 
+  protocol-buffers-schema@3.6.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -20082,6 +20703,8 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  quickselect@3.0.0: {}
+
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -20123,6 +20746,15 @@ snapshots:
   react-is@17.0.2: {}
 
   react-is@18.3.1: {}
+
+  react-map-gl@8.1.0(maplibre-gl@5.18.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@vis.gl/react-mapbox': 8.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@vis.gl/react-maplibre': 8.1.0(maplibre-gl@5.18.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      maplibre-gl: 5.18.0
 
   react-promise-suspense@0.3.4:
     dependencies:
@@ -20224,6 +20856,10 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.0
+
   resolve.exports@2.0.3: {}
 
   resolve@1.22.11:
@@ -20284,6 +20920,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   rxjs@7.8.1:
     dependencies:
@@ -20414,6 +21052,13 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  set-value@2.0.1:
+    dependencies:
+      extend-shallow: 2.0.1
+      is-extendable: 0.1.1
+      is-plain-object: 2.0.4
+      split-string: 3.1.0
 
   setprototypeof@1.2.0: {}
 
@@ -20591,6 +21236,19 @@ snapshots:
     dependencies:
       atomic-sleep: 1.0.0
 
+  sort-asc@0.2.0: {}
+
+  sort-desc@0.2.0: {}
+
+  sort-object@3.0.3:
+    dependencies:
+      bytewise: 1.1.0
+      get-value: 2.0.6
+      is-extendable: 0.1.1
+      sort-asc: 0.2.0
+      sort-desc: 0.2.0
+      union-value: 1.0.1
+
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.13:
@@ -20612,6 +21270,10 @@ snapshots:
   source-map@0.8.0-beta.0:
     dependencies:
       whatwg-url: 7.1.0
+
+  split-string@3.1.0:
+    dependencies:
+      extend-shallow: 3.0.2
 
   split2@3.2.2:
     dependencies:
@@ -20815,6 +21477,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  supercluster@8.0.1:
+    dependencies:
+      kdbush: 4.0.2
+
   supertest@7.1.4:
     dependencies:
       methods: 1.1.2
@@ -20963,6 +21629,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyqueue@3.0.0: {}
 
   tldts-core@6.1.86: {}
 
@@ -21333,6 +22001,12 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typewise-core@1.2.0: {}
+
+  typewise@1.0.3:
+    dependencies:
+      typewise-core: 1.2.0
+
   uglify-js@3.19.3:
     optional: true
 
@@ -21366,6 +22040,13 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  union-value@1.0.1:
+    dependencies:
+      arr-union: 3.1.0
+      get-value: 2.0.6
+      is-extendable: 0.1.1
+      set-value: 2.0.1
 
   unique-filename@3.0.0:
     dependencies:
@@ -21522,6 +22203,8 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  wgsl_reflect@1.2.3: {}
 
   whatwg-encoding@3.1.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Full-stack petition map view at `/petition/map` with MapLibre GL dark basemap, Protomaps/PMTiles vector tiles, and Supercluster client-side clustering
- Backend: PostGIS bulk location queries (`petitionMapLocations`, `petitionMapStats`) with bounding box, date range, and document type filters
- Frontend: MapView, PetitionMarkers (pulsing teal/gold SVG markers), PetitionSidebar (detail panel + petition list + stats footer), MapLegend, MapFilters (type/date/Near me), and `useMapPetitions` data hook with 300ms debounced bounds updates
- 75 new tests (68 frontend across 6 suites, 7 backend) — all passing
- Fixes pre-existing `packages/common` jest@30 broken symlink (downgraded to jest@29.7.0)

## Test plan
- [x] Backend unit tests pass (1180/1180)
- [x] Frontend unit tests pass (947/947)
- [x] Frontend lint passes
- [x] Frontend build passes (`/petition/map` route included)
- [x] Backend build passes
- [x] Docker integration tests pass (215/215)
- [ ] Navigate to `/petition/map` — dark map renders with basemap tiles
- [ ] Petition markers appear as teal pulsing circles with counts
- [ ] Click marker — gold highlight + sidebar shows detail
- [ ] Sidebar petition list sorted with progress indicators
- [ ] Date/type filters update markers in real-time
- [ ] "Near me" button centers map on user location
- [ ] Zoom in/out — clusters expand/collapse

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)