### PR TITLE
Merge develop to main: usage tracking metrics (#308)

### DIFF
--- a/apps/backend/src/common/metrics/metrics.module.ts
+++ b/apps/backend/src/common/metrics/metrics.module.ts
@@ -145,6 +145,51 @@ export class MetricsModule {
         help: 'Number of busy database connections',
         labelNames: ['service'],
       }),
+      // === Business Metrics: Document Processing Pipeline ===
+      // @see https://github.com/OpusPopuli/opuspopuli/issues/308
+      makeCounterProvider({
+        name: 'document_scans_total',
+        help: 'Total number of document scans processed',
+        labelNames: ['service', 'document_type', 'status'],
+      }),
+      makeHistogramProvider({
+        name: 'document_scan_duration_seconds',
+        help: 'Duration of scan processing (upload + OCR) in seconds',
+        labelNames: ['service', 'document_type'],
+        buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+      }),
+      makeCounterProvider({
+        name: 'ocr_extractions_total',
+        help: 'Total OCR extraction attempts',
+        labelNames: ['service', 'provider', 'status'],
+      }),
+      makeHistogramProvider({
+        name: 'ocr_confidence',
+        help: 'Distribution of OCR confidence scores (0-100)',
+        labelNames: ['service', 'provider'],
+        buckets: [10, 20, 30, 40, 50, 60, 70, 80, 90, 95, 100],
+      }),
+      makeCounterProvider({
+        name: 'document_analyses_total',
+        help: 'Total document analysis attempts',
+        labelNames: ['service', 'document_type', 'status'],
+      }),
+      makeHistogramProvider({
+        name: 'document_analysis_duration_seconds',
+        help: 'Duration of AI document analysis in seconds',
+        labelNames: ['service', 'document_type'],
+        buckets: [0.5, 1, 2.5, 5, 10, 30, 60],
+      }),
+      makeCounterProvider({
+        name: 'document_analysis_cache_hits_total',
+        help: 'Total analysis cache hits',
+        labelNames: ['service'],
+      }),
+      makeCounterProvider({
+        name: 'document_analysis_cache_misses_total',
+        help: 'Total analysis cache misses',
+        labelNames: ['service'],
+      }),
     ];
 
     return {

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -262,6 +262,7 @@ services:
     container_name: opuspopuli-prod-prometheus
     volumes:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./observability/prometheus-alerts.yml:/etc/prometheus/alerts/prometheus-alerts.yml:ro
       - prometheus-data:/prometheus
     networks:
       - opuspopuli-prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -468,6 +468,7 @@ services:
       - '--web.enable-lifecycle'
     volumes:
       - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./observability/prometheus-alerts.yml:/etc/prometheus/alerts/prometheus-alerts.yml:ro
       - prometheus-data:/prometheus
     networks:
       - opuspopuli-network

--- a/observability/grafana/provisioning/dashboards/opuspopuli-analytics.json
+++ b/observability/grafana/provisioning/dashboards/opuspopuli-analytics.json
@@ -1,0 +1,304 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Business-level usage analytics for the OPUSPOPULI document processing pipeline",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "title": "Scans per Hour",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "sum(increase(document_scans_total[1h])) by (document_type)",
+          "legendFormat": "{{document_type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 20, "lineWidth": 2 },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["sum"]
+        },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "title": "OCR Success Rate",
+      "type": "gauge",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "sum(rate(ocr_extractions_total{status=\"success\"}[1h])) / sum(rate(ocr_extractions_total[1h]))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.85 },
+              { "color": "green", "value": 0.95 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "title": "Analysis Cache Hit Rate",
+      "type": "gauge",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "sum(rate(document_analysis_cache_hits_total[1h])) / (sum(rate(document_analysis_cache_hits_total[1h])) + sum(rate(document_analysis_cache_misses_total[1h])))",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "yellow", "value": 0.25 },
+              { "color": "green", "value": 0.5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "title": "Scan Processing Latency",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(document_scan_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(document_scan_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["mean", "max"]
+        },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "title": "Analysis Latency",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(document_analysis_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(document_analysis_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "fillOpacity": 10, "lineWidth": 2 },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": ["mean", "max"]
+        },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "title": "Document Type Distribution (24h)",
+      "type": "piechart",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "sum(increase(document_scans_total{status=\"success\"}[24h])) by (document_type)",
+          "legendFormat": "{{document_type}}",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": ["value", "percent"]
+        },
+        "pieType": "donut",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "title": "Conversion Funnel (24h)",
+      "type": "bargauge",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "sum(increase(document_scans_total[24h]))",
+          "legendFormat": "Scans",
+          "refId": "A"
+        },
+        {
+          "expr": "sum(increase(ocr_extractions_total{status=\"success\"}[24h]))",
+          "legendFormat": "OCR Extracted",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(increase(document_analyses_total{status=\"success\"}[24h]))",
+          "legendFormat": "Analyzed",
+          "refId": "C"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "blue", "value": null }]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "orientation": "horizontal",
+        "displayMode": "gradient",
+        "reduceOptions": { "calcs": ["lastNotNull"] }
+      }
+    },
+    {
+      "title": "Active Errors (1h)",
+      "type": "table",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "sum(increase(document_scans_total{status=\"failure\"}[1h])) by (service, document_type)",
+          "legendFormat": "Scan: {{document_type}}",
+          "refId": "A",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "expr": "sum(increase(document_analyses_total{status=\"failure\"}[1h])) by (service, document_type)",
+          "legendFormat": "Analysis: {{document_type}}",
+          "refId": "B",
+          "format": "table",
+          "instant": true
+        },
+        {
+          "expr": "sum(increase(ocr_extractions_total{status=\"failure\"}[1h])) by (service, provider)",
+          "legendFormat": "OCR: {{provider}}",
+          "refId": "C",
+          "format": "table",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "showHeader": true,
+        "sortBy": [{ "displayName": "Value", "desc": true }]
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["opuspopuli", "analytics", "business-metrics"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "OPUSPOPULI Analytics",
+  "uid": "opuspopuli-analytics",
+  "version": 1
+}

--- a/observability/prometheus-alerts.yml
+++ b/observability/prometheus-alerts.yml
@@ -1,0 +1,90 @@
+# Prometheus Alerting Rules for OPUSPOPULI
+# @see https://github.com/OpusPopuli/opuspopuli/issues/308
+
+groups:
+  - name: opuspopuli-service-health
+    rules:
+      # Alert when a scrape target is unreachable for 2 minutes
+      - alert: ServiceDown
+        expr: up == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Service {{ $labels.job }} is down"
+          description: "{{ $labels.job }} has been unreachable for more than 2 minutes."
+
+      # Alert when HTTP error rate exceeds 5% over 5 minutes
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum(rate(http_requests_total{status_code=~"5.."}[5m])) by (service)
+            /
+            sum(rate(http_requests_total[5m])) by (service)
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High error rate on {{ $labels.service }}"
+          description: "{{ $labels.service }} has >5% HTTP 5xx error rate (current: {{ $value | humanizePercentage }})."
+
+  - name: opuspopuli-document-pipeline
+    rules:
+      # Alert when OCR failure rate spikes (>10% over 10 minutes)
+      - alert: OcrFailureSpike
+        expr: |
+          (
+            sum(rate(ocr_extractions_total{status="failure"}[10m])) by (service)
+            /
+            sum(rate(ocr_extractions_total[10m])) by (service)
+          ) > 0.10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "OCR failure rate spiking on {{ $labels.service }}"
+          description: "OCR failure rate >10% for 5 minutes (current: {{ $value | humanizePercentage }})."
+
+      # Alert when scan failure rate exceeds 5%
+      - alert: HighScanFailureRate
+        expr: |
+          (
+            sum(rate(document_scans_total{status="failure"}[10m])) by (service)
+            /
+            sum(rate(document_scans_total[10m])) by (service)
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High scan failure rate on {{ $labels.service }}"
+          description: "Scan failure rate >5% for 5 minutes (current: {{ $value | humanizePercentage }})."
+
+      # Alert when scan processing p95 latency exceeds 5 seconds
+      - alert: HighScanLatency
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(document_scan_duration_seconds_bucket[5m])) by (service, le)
+          ) > 5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High scan latency on {{ $labels.service }}"
+          description: "p95 scan processing latency >5s (current: {{ $value | humanizeDuration }})."
+
+      # Alert when analysis failure rate exceeds 10%
+      - alert: HighAnalysisFailureRate
+        expr: |
+          (
+            sum(rate(document_analyses_total{status="failure"}[10m])) by (service)
+            /
+            sum(rate(document_analyses_total[10m])) by (service)
+          ) > 0.10
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High AI analysis failure rate on {{ $labels.service }}"
+          description: "AI analysis failure rate >10% for 5 minutes (current: {{ $value | humanizePercentage }})."

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -7,6 +7,9 @@ global:
   scrape_interval: 15s
   evaluation_interval: 15s
 
+rule_files:
+  - /etc/prometheus/alerts/*.yml
+
 scrape_configs:
   # Prometheus self-monitoring
   - job_name: 'prometheus'


### PR DESCRIPTION
## Summary

Merges develop into main with the following changes since last release:

- **Usage tracking metrics, alerts, and analytics dashboard (#308)**: 8 new Prometheus business metrics for the document processing pipeline (scan volume/latency, OCR success rate/confidence, analysis cache hits), 6 alerting rules, and a Grafana analytics dashboard with 8 panels

## Changes

- 8 new Prometheus metric providers (counters + histograms) in `MetricsModule`
- 5 recording methods in `MetricsService` for scan, OCR, and analysis instrumentation
- `DocumentsService` instrumented at all success/failure exit points
- Prometheus alerting rules: ServiceDown, HighErrorRate, OcrFailureSpike, HighScanFailureRate, HighScanLatency, HighAnalysisFailureRate
- Grafana analytics dashboard with scans/hour, OCR success gauge, cache hit gauge, latency charts, document type distribution, conversion funnel, and error table
- Full test coverage for all new metrics

## Test plan

- [x] All 1188 backend tests pass
- [x] Lint clean
- [x] CI passed on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)