### PR TITLE
Release: develop → main

### DIFF
--- a/apps/backend/src/apps/users/src/domains/profile/models/data-export-result.model.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/models/data-export-result.model.ts
@@ -1,0 +1,11 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import GraphQLJSON from 'graphql-type-json';
+
+@ObjectType()
+export class DataExportResult {
+  @Field()
+  exportedAt!: string;
+
+  @Field(() => GraphQLJSON)
+  data!: Record<string, unknown>;
+}

--- a/apps/backend/src/apps/users/src/domains/profile/profile.resolver.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.resolver.spec.ts
@@ -11,6 +11,7 @@ import { UserProfileModel } from './models/user-profile.model';
 import { UserAddressModel } from './models/user-address.model';
 import { NotificationPreferenceModel } from './models/notification-preference.model';
 import { UserConsentModel } from './models/user-consent.model';
+import { DataExportResult } from './models/data-export-result.model';
 
 describe('ProfileResolver', () => {
   let resolver: ProfileResolver;
@@ -430,6 +431,43 @@ describe('ProfileResolver', () => {
           userAgent: 'test-agent',
         }),
       );
+    });
+  });
+
+  // ============================================
+  // Data Export Tests
+  // ============================================
+
+  describe('exportMyData', () => {
+    const mockExportResult: DataExportResult = {
+      exportedAt: '2026-02-16T00:00:00.000Z',
+      data: {
+        account: { id: mockUserId, email: mockUserEmail },
+        profile: { firstName: 'John' },
+        addresses: [],
+        consents: [],
+        sessions: [],
+        notificationPreferences: null,
+        emailCorrespondence: [],
+        passkeyCredentials: [],
+      },
+    };
+
+    it('should return exported data for authenticated user', async () => {
+      profileService.exportUserData = jest
+        .fn()
+        .mockResolvedValue(mockExportResult);
+
+      const result = await resolver.exportMyData(mockContext as any);
+
+      expect(result).toEqual(mockExportResult);
+      expect(profileService.exportUserData).toHaveBeenCalledWith(mockUserId);
+    });
+
+    it('should throw UserInputError if user not authenticated', async () => {
+      await expect(
+        resolver.exportMyData(mockContextNoUser as any),
+      ).rejects.toThrow(UserInputError);
     });
   });
 

--- a/apps/backend/src/apps/users/src/domains/profile/profile.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.resolver.ts
@@ -17,6 +17,7 @@ import {
   WithdrawConsentDto,
 } from './dto/consent.dto';
 import { ProfileCompletionResult } from './models/profile-completion.model';
+import { DataExportResult } from './models/data-export-result.model';
 import { UserProfileModel } from './models/user-profile.model';
 import { UserAddressModel } from './models/user-address.model';
 import { NotificationPreferenceModel } from './models/notification-preference.model';
@@ -264,6 +265,18 @@ export class ProfileResolver {
       metadata,
     );
     return consent as unknown as UserConsentModel;
+  }
+
+  // ============================================
+  // Data Export Mutations
+  // ============================================
+
+  @Mutation(() => DataExportResult)
+  async exportMyData(
+    @Context() context: GqlContext,
+  ): Promise<DataExportResult> {
+    const user = getUserFromContext(context);
+    return this.profileService.exportUserData(user.id);
   }
 
   @Query(() => Boolean)

--- a/apps/frontend/__tests__/Home.test.tsx
+++ b/apps/frontend/__tests__/Home.test.tsx
@@ -6,11 +6,21 @@ jest.mock("@/components/Header", () => ({
   Header: () => <header data-testid="mock-header">Mock Header</header>,
 }));
 
+jest.mock("@/components/Footer", () => ({
+  Footer: () => <footer data-testid="mock-footer">Mock Footer</footer>,
+}));
+
 import Home from "../app/page";
 
 describe("Home Page", () => {
   beforeEach(() => {
     render(<Home />);
+  });
+
+  describe("Layout", () => {
+    it("should render the footer", () => {
+      expect(screen.getByTestId("mock-footer")).toBeInTheDocument();
+    });
   });
 
   describe("Header section", () => {

--- a/apps/frontend/__tests__/pages/privacy.test.tsx
+++ b/apps/frontend/__tests__/pages/privacy.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// Mock the Header and Footer components
+jest.mock("@/components/Header", () => ({
+  Header: () => <header data-testid="mock-header">Mock Header</header>,
+}));
+
+jest.mock("@/components/Footer", () => ({
+  Footer: () => <footer data-testid="mock-footer">Mock Footer</footer>,
+}));
+
+import PrivacyPolicyPage from "@/app/privacy/page";
+
+describe("PrivacyPolicyPage", () => {
+  beforeEach(() => {
+    render(<PrivacyPolicyPage />);
+  });
+
+  it("should render the page title", () => {
+    expect(screen.getByText("Privacy Policy")).toBeInTheDocument();
+  });
+
+  it("should render the last updated date", () => {
+    expect(screen.getByText(/Last updated: February 2026/)).toBeInTheDocument();
+  });
+
+  it("should render all 9 sections", () => {
+    expect(screen.getByText("1. Information We Collect")).toBeInTheDocument();
+    expect(
+      screen.getByText("2. How We Use Your Information"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("3. Data Retention")).toBeInTheDocument();
+    expect(screen.getByText("4. Your Rights")).toBeInTheDocument();
+    expect(screen.getByText("5. Security Measures")).toBeInTheDocument();
+    expect(screen.getByText("6. Third-Party Services")).toBeInTheDocument();
+    expect(screen.getByText("7. Children's Privacy")).toBeInTheDocument();
+    expect(screen.getByText("8. Changes to This Policy")).toBeInTheDocument();
+    expect(screen.getByText("9. Contact Information")).toBeInTheDocument();
+  });
+
+  it("should include a link to data export settings", () => {
+    const exportLink = screen.getByRole("link", { name: "data export" });
+    expect(exportLink).toHaveAttribute("href", "/settings/privacy");
+  });
+
+  it("should include a link to privacy settings", () => {
+    const settingsLink = screen.getByRole("link", {
+      name: "privacy settings",
+    });
+    expect(settingsLink).toHaveAttribute("href", "/settings/privacy");
+  });
+
+  it("should include contact email", () => {
+    const emailLink = screen.getByRole("link", {
+      name: "privacy@opuspopuli.org",
+    });
+    expect(emailLink).toHaveAttribute("href", "mailto:privacy@opuspopuli.org");
+  });
+
+  it("should state data is not sold", () => {
+    expect(
+      screen.getByText("We do not sell your personal data to third parties."),
+    ).toBeInTheDocument();
+  });
+
+  it("should render header and footer", () => {
+    expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-footer")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/app/(auth)/layout.tsx
+++ b/apps/frontend/app/(auth)/layout.tsx
@@ -33,7 +33,7 @@ export default function AuthLayout({
       </main>
 
       {/* Footer */}
-      <footer className="p-6 text-center">
+      <footer className="p-6 text-center space-y-2">
         <p className="text-sm text-[#555555]">
           Powered by{" "}
           <a
@@ -44,6 +44,15 @@ export default function AuthLayout({
           >
             Opus Populi
           </a>
+        </p>
+        <p className="text-xs text-[#666666]">
+          <Link href="/privacy" className="hover:underline">
+            Privacy Policy
+          </Link>
+          {" · "}
+          <Link href="/terms" className="hover:underline">
+            Terms of Service
+          </Link>
         </p>
       </footer>
     </div>

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
 
 export const metadata: Metadata = {
   title: {
@@ -10,9 +11,9 @@ export const metadata: Metadata = {
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
       <Header />
-      <main className="max-w-4xl mx-auto px-8 py-16">
+      <main className="flex-1 max-w-4xl mx-auto px-8 py-16">
         <div className="text-center mb-16">
           <h1 className="text-5xl font-bold text-gray-900 dark:text-white mb-4">
             Opus Populi
@@ -70,6 +71,7 @@ export default function Home() {
           </div>
         </div>
       </main>
+      <Footer />
     </div>
   );
 }

--- a/apps/frontend/app/privacy/page.tsx
+++ b/apps/frontend/app/privacy/page.tsx
@@ -1,0 +1,291 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Opus Populi",
+  description:
+    "Learn how Opus Populi collects, uses, and protects your personal information.",
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
+      <Header />
+      <main className="flex-1 max-w-3xl mx-auto px-8 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          Privacy Policy
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+          Last updated: February 2026
+        </p>
+
+        <div className="space-y-8 text-gray-700 dark:text-gray-300">
+          {/* Introduction */}
+          <section>
+            <p>
+              Opus Populi (&quot;we,&quot; &quot;our,&quot; or &quot;us&quot;)
+              is an open-source civic engagement platform. We are committed to
+              protecting your privacy and being transparent about how we handle
+              your data. This policy explains what information we collect, how
+              we use it, and your rights regarding your data.
+            </p>
+          </section>
+
+          {/* 1. Information We Collect */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              1. Information We Collect
+            </h2>
+            <p className="mb-3">
+              We collect information that you provide directly and information
+              generated through your use of the platform:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                <strong>Account information:</strong> Email address, name, and
+                authentication credentials (passkey or password).
+              </li>
+              <li>
+                <strong>Profile information:</strong> Optional details such as
+                display name, photo, timezone, political affiliation, voting
+                frequency, and policy priorities.
+              </li>
+              <li>
+                <strong>Address information:</strong> Residential or mailing
+                addresses used to determine your electoral districts and
+                representatives.
+              </li>
+              <li>
+                <strong>Civic engagement data:</strong> Your interactions with
+                ballot measures, representatives, and legislative content.
+              </li>
+              <li>
+                <strong>Usage data:</strong> Session information (device type,
+                browser), consent records, and notification preferences.
+              </li>
+            </ul>
+          </section>
+
+          {/* 2. How We Use Your Information */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              2. How We Use Your Information
+            </h2>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Provide personalized civic information based on your location
+                and interests.
+              </li>
+              <li>
+                Match you with your elected representatives and relevant ballot
+                measures.
+              </li>
+              <li>
+                Send notifications about elections, voter deadlines, and
+                legislative updates (with your consent).
+              </li>
+              <li>
+                Improve the platform through anonymized, aggregated usage
+                analytics.
+              </li>
+              <li>Ensure account security and prevent abuse.</li>
+            </ul>
+          </section>
+
+          {/* 3. Data Retention */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              3. Data Retention
+            </h2>
+            <p className="mb-3">
+              We retain your data for as long as your account is active. When
+              you delete your account:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Personal data (profile, addresses, preferences) is deleted
+                within 30 days.
+              </li>
+              <li>
+                Consent records and audit logs are retained for up to 3 years
+                for legal compliance.
+              </li>
+              <li>
+                Anonymized, aggregated data may be retained indefinitely for
+                platform improvement.
+              </li>
+            </ul>
+          </section>
+
+          {/* 4. Your Rights */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              4. Your Rights
+            </h2>
+            <p className="mb-3">
+              You have the following rights regarding your personal data:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                <strong>Access:</strong> Request a copy of all data we hold
+                about you. Use the{" "}
+                <Link
+                  href="/settings/privacy"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  data export
+                </Link>{" "}
+                feature in your settings.
+              </li>
+              <li>
+                <strong>Deletion:</strong> Request deletion of your account and
+                associated data.
+              </li>
+              <li>
+                <strong>Correction:</strong> Update or correct your personal
+                information at any time through your profile settings.
+              </li>
+              <li>
+                <strong>Opt-out:</strong> Withdraw consent for optional data
+                processing (marketing, analytics, personalization) through your{" "}
+                <Link
+                  href="/settings/privacy"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  privacy settings
+                </Link>
+                .
+              </li>
+              <li>
+                <strong>Portability:</strong> Export your data in a
+                machine-readable JSON format.
+              </li>
+            </ul>
+            <p className="mt-3">
+              These rights apply under the California Consumer Privacy Act
+              (CCPA) and similar state privacy laws. We do not discriminate
+              against users who exercise their privacy rights.
+            </p>
+          </section>
+
+          {/* 5. Security */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              5. Security Measures
+            </h2>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                All connections are encrypted via TLS (HTTPS) through
+                Cloudflare&apos;s edge network.
+              </li>
+              <li>
+                Passwords are hashed using industry-standard algorithms;
+                passkeys use WebAuthn for phishing-resistant authentication.
+              </li>
+              <li>
+                Database access is restricted and monitored with audit logging.
+              </li>
+              <li>
+                We follow the principle of least privilege for all system
+                access.
+              </li>
+            </ul>
+          </section>
+
+          {/* 6. Third-Party Services */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              6. Third-Party Services
+            </h2>
+            <p className="mb-3">
+              We use the following third-party services to operate the platform:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                <strong>Cloudflare:</strong> CDN, DNS, and edge networking.
+                Subject to{" "}
+                <a
+                  href="https://www.cloudflare.com/privacypolicy/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Cloudflare&apos;s Privacy Policy
+                </a>
+                {"."}
+              </li>
+              <li>
+                <strong>Supabase:</strong> Database and authentication
+                infrastructure. Subject to{" "}
+                <a
+                  href="https://supabase.com/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  Supabase&apos;s Privacy Policy
+                </a>
+                {"."}
+              </li>
+              <li>
+                <strong>AI/LLM Processing:</strong> We use locally-hosted AI
+                models for content analysis. Your data is not sent to external
+                AI providers.
+              </li>
+            </ul>
+            <p className="mt-3 font-medium">
+              We do not sell your personal data to third parties.
+            </p>
+          </section>
+
+          {/* 7. Children's Privacy */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              7. Children&apos;s Privacy
+            </h2>
+            <p>
+              Opus Populi is intended for users aged 13 and older. We do not
+              knowingly collect personal information from children under 13. If
+              you believe a child has provided us with personal data, please
+              contact us and we will promptly delete it.
+            </p>
+          </section>
+
+          {/* 8. Changes to This Policy */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              8. Changes to This Policy
+            </h2>
+            <p>
+              We may update this privacy policy from time to time. Material
+              changes will be communicated through the platform or via email.
+              The &quot;Last updated&quot; date at the top of this page reflects
+              the most recent revision.
+            </p>
+          </section>
+
+          {/* 9. Contact */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              9. Contact Information
+            </h2>
+            <p>
+              If you have questions about this privacy policy or wish to
+              exercise your data rights, please contact us at{" "}
+              <a
+                href="mailto:privacy@opuspopuli.org"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                privacy@opuspopuli.org
+              </a>
+              {"."}
+            </p>
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/frontend/app/settings/privacy/page.tsx
+++ b/apps/frontend/app/settings/privacy/page.tsx
@@ -6,9 +6,11 @@ import {
   GET_MY_CONSENTS,
   UPDATE_CONSENT,
   WITHDRAW_CONSENT,
+  EXPORT_MY_DATA,
   MyConsentsData,
   UpdateConsentData,
   WithdrawConsentData,
+  ExportMyDataData,
   UserConsent,
   ConsentType,
   ConsentStatus,
@@ -177,6 +179,8 @@ export default function PrivacyPage() {
     useMutation<UpdateConsentData>(UPDATE_CONSENT);
   const [withdrawConsent, { loading: withdrawing }] =
     useMutation<WithdrawConsentData>(WITHDRAW_CONSENT);
+  const [exportMyData, { loading: exporting }] =
+    useMutation<ExportMyDataData>(EXPORT_MY_DATA);
 
   const consents = data?.myConsents || [];
   const getConsent = (type: ConsentType) =>
@@ -197,6 +201,25 @@ export default function PrivacyPage() {
         });
       }
       refetch();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : t("common:errors.generic"));
+    }
+  };
+
+  const handleExportData = async () => {
+    try {
+      const { data: exportData } = await exportMyData();
+      if (exportData?.exportMyData) {
+        const json = JSON.stringify(exportData.exportMyData.data, null, 2);
+        const blob = new Blob([json], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        const date = new Date().toISOString().split("T")[0];
+        a.href = url;
+        a.download = `opuspopuli-data-export-${date}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+      }
     } catch (err) {
       alert(err instanceof Error ? err.message : t("common:errors.generic"));
     }
@@ -310,8 +333,12 @@ export default function PrivacyPage() {
                 {t("privacy.dataManagement.exportDesc")}
               </p>
             </div>
-            <button className="px-4 py-2 text-sm font-medium border border-gray-200 text-[#222222] rounded-lg hover:bg-gray-50 transition-colors">
-              {t("privacy.dataManagement.exportButton")}
+            <button
+              onClick={handleExportData}
+              disabled={exporting}
+              className="px-4 py-2 text-sm font-medium border border-gray-200 text-[#222222] rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+            >
+              {exporting ? "..." : t("privacy.dataManagement.exportButton")}
             </button>
           </div>
 

--- a/apps/frontend/app/sitemap.ts
+++ b/apps/frontend/app/sitemap.ts
@@ -22,5 +22,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.3,
     },
+    {
+      url: `${baseUrl}/privacy`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.4,
+    },
   ];
 }

--- a/apps/frontend/components/Footer.tsx
+++ b/apps/frontend/components/Footer.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+
+export function Footer() {
+  return (
+    <footer className="border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+      <div className="max-w-4xl mx-auto px-8 py-6 flex flex-col sm:flex-row items-center justify-between gap-4">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          &copy; {new Date().getFullYear()} Opus Populi. All rights reserved.
+        </p>
+        <nav className="flex items-center gap-6">
+          <Link
+            href="/privacy"
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+          >
+            Privacy Policy
+          </Link>
+          <Link
+            href="/terms"
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+          >
+            Terms of Service
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/apps/frontend/lib/graphql/profile.ts
+++ b/apps/frontend/lib/graphql/profile.ts
@@ -608,6 +608,19 @@ export const HAS_VALID_CONSENT = gql`
 `;
 
 // ============================================
+// Data Export Mutations
+// ============================================
+
+export const EXPORT_MY_DATA = gql`
+  mutation ExportMyData {
+    exportMyData {
+      exportedAt
+      data
+    }
+  }
+`;
+
+// ============================================
 // Response Types
 // ============================================
 
@@ -665,6 +678,13 @@ export interface WithdrawConsentData {
 
 export interface HasValidConsentData {
   hasValidConsent: boolean;
+}
+
+export interface ExportMyDataData {
+  exportMyData: {
+    exportedAt: string;
+    data: Record<string, unknown>;
+  };
 }
 
 export interface MyProfileCompletionData {


### PR DESCRIPTION
## Summary

- **Privacy & data export** (#299): Public `/privacy` page, `exportMyData` GraphQL mutation with sensitive-field redaction, site-wide Footer, WCAG 2.2 AA contrast fix
- **SEO & discoverability** (#307): Meta tags, Open Graph/Twitter cards, sitemap.xml, robots.txt, JSON-LD structured data
- **Usage tracking & analytics** (#308): Prometheus metrics, Grafana dashboard, alert rules for usage monitoring
- **Terraform docs** (#312): Cloudflare Terraform README and plugin version compatibility
- **Petition map** (#297): Interactive map view with marker clustering, filters, and sidebar
- **Petition scan results** (#301): OCR and analysis pipeline results page
- **Security hardening**: CORS hardening (#381), CASL PoliciesGuard on all resolvers (#376), GraphQL introspection disabled in production (#378), env validation at startup (#379)
- **Infrastructure**: Cloudflare R2 storage provider (#391), Prisma connection pooling & pool metrics (#380), npm audit fixes
- **Cleanup**: Remove AWS secrets provider, remove dead AWS references

## Test plan

- [ ] All unit tests pass (backend + frontend + packages)
- [ ] E2E tests pass (accessibility, auth, PWA)
- [ ] SonarQube quality gate passes
- [ ] `/privacy` page renders publicly without auth
- [ ] Data export triggers JSON download from settings
- [ ] Sitemap and robots.txt accessible
- [ ] Petition map loads with clustering and filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)