### PR TITLE
feat: add abuse reporting mechanism (#300)

### DIFF
--- a/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
@@ -39,6 +39,10 @@ import {
   MapFiltersInput,
 } from './dto/location.dto';
 import { ProcessScanInput, ProcessScanResult } from './dto/scan.dto';
+import {
+  SubmitAbuseReportInput,
+  SubmitAbuseReportResult,
+} from './dto/abuse-report.dto';
 
 /**
  * Documents Resolver
@@ -243,5 +247,24 @@ export class DocumentsResolver {
   @Permissions({ action: Action.Read, subject: 'File' })
   async petitionMapStats(): Promise<PetitionMapStats> {
     return this.documentsService.getPetitionMapStats();
+  }
+
+  /**
+   * Submit an abuse report for incorrect or problematic scan results
+   */
+  @Mutation(() => SubmitAbuseReportResult)
+  @UseGuards(AuthGuard)
+  @Permissions({ action: Action.Create, subject: 'File' })
+  async submitAbuseReport(
+    @Args('input') input: SubmitAbuseReportInput,
+    @Context() context: GqlContext,
+  ): Promise<SubmitAbuseReportResult> {
+    const user = getUserFromContext(context);
+    return this.documentsService.submitAbuseReport(
+      user.id,
+      input.documentId,
+      input.reason,
+      input.description,
+    );
   }
 }

--- a/apps/backend/src/apps/documents/src/domains/dto/abuse-report.dto.ts
+++ b/apps/backend/src/apps/documents/src/domains/dto/abuse-report.dto.ts
@@ -1,0 +1,52 @@
+import {
+  Field,
+  InputType,
+  ObjectType,
+  registerEnumType,
+} from '@nestjs/graphql';
+import {
+  IsUUID,
+  IsEnum,
+  IsOptional,
+  IsString,
+  MaxLength,
+} from 'class-validator';
+import { AbuseReportReason } from '@opuspopuli/relationaldb-provider';
+
+// Register enum for GraphQL schema
+registerEnumType(AbuseReportReason, {
+  name: 'AbuseReportReason',
+  description: 'Reason for reporting a document analysis',
+});
+
+/**
+ * Input for submitting an abuse report on a document analysis
+ */
+@InputType()
+export class SubmitAbuseReportInput {
+  @Field()
+  @IsUUID()
+  documentId!: string;
+
+  @Field(() => AbuseReportReason)
+  @IsEnum(AbuseReportReason)
+  reason!: AbuseReportReason;
+
+  @Field({ nullable: true })
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  description?: string;
+}
+
+/**
+ * Result of submitting an abuse report
+ */
+@ObjectType()
+export class SubmitAbuseReportResult {
+  @Field()
+  success!: boolean;
+
+  @Field()
+  reportId!: string;
+}

--- a/apps/frontend/__tests__/components/ReportIssueButton.test.tsx
+++ b/apps/frontend/__tests__/components/ReportIssueButton.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { ReportIssueButton } from "@/components/ReportIssueButton";
+
+// Mock react-i18next
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// Mock toast
+const mockShowToast = jest.fn();
+jest.mock("@/lib/toast", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+// Mock Apollo Client
+const mockSubmitReport = jest.fn();
+let mockLoading = false;
+
+jest.mock("@apollo/client/react", () => ({
+  ...jest.requireActual("@apollo/client/react"),
+  useMutation: () => [mockSubmitReport, { loading: mockLoading }],
+}));
+
+describe("ReportIssueButton", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLoading = false;
+    mockSubmitReport.mockResolvedValue({
+      data: { submitAbuseReport: { success: true, reportId: "report-1" } },
+    });
+  });
+
+  it("should render the report button", () => {
+    render(<ReportIssueButton documentId="doc-123" />);
+
+    expect(screen.getByText("report.button")).toBeInTheDocument();
+  });
+
+  it("should open the report panel when clicked", async () => {
+    const user = userEvent.setup();
+    render(<ReportIssueButton documentId="doc-123" />);
+
+    await user.click(screen.getByText("report.button"));
+
+    expect(screen.getByText("report.title")).toBeInTheDocument();
+    expect(
+      screen.getByText("report.reasons.incorrectAnalysis"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("report.reasons.offensiveContent"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("report.reasons.wrongDocumentType"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("report.reasons.privacyConcern"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("report.reasons.other")).toBeInTheDocument();
+  });
+
+  it("should have submit button disabled until a reason is selected", async () => {
+    const user = userEvent.setup();
+    render(<ReportIssueButton documentId="doc-123" />);
+
+    await user.click(screen.getByText("report.button"));
+
+    const submitButton = screen.getByText("report.submit");
+    expect(submitButton).toBeDisabled();
+
+    // Select a reason
+    await user.click(screen.getByText("report.reasons.incorrectAnalysis"));
+
+    expect(submitButton).not.toBeDisabled();
+  });
+
+  it("should submit report with selected reason", async () => {
+    const user = userEvent.setup();
+    render(<ReportIssueButton documentId="doc-123" />);
+
+    await user.click(screen.getByText("report.button"));
+    await user.click(screen.getByText("report.reasons.incorrectAnalysis"));
+    await user.click(screen.getByText("report.submit"));
+
+    await waitFor(() => {
+      expect(mockSubmitReport).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            documentId: "doc-123",
+            reason: "incorrect_analysis",
+          },
+        },
+      });
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith("report.success", "success");
+  });
+
+  it("should submit report with reason and description", async () => {
+    const user = userEvent.setup();
+    render(<ReportIssueButton documentId="doc-123" />);
+
+    await user.click(screen.getByText("report.button"));
+    await user.click(screen.getByText("report.reasons.other"));
+
+    const textarea = screen.getByPlaceholderText(
+      "report.descriptionPlaceholder",
+    );
+    await user.type(textarea, "The summary is inaccurate");
+
+    await user.click(screen.getByText("report.submit"));
+
+    await waitFor(() => {
+      expect(mockSubmitReport).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            documentId: "doc-123",
+            reason: "other",
+            description: "The summary is inaccurate",
+          },
+        },
+      });
+    });
+  });
+
+  it("should show 'Reported' state after successful submission", async () => {
+    const user = userEvent.setup();
+    render(<ReportIssueButton documentId="doc-123" />);
+
+    await user.click(screen.getByText("report.button"));
+    await user.click(screen.getByText("report.reasons.incorrectAnalysis"));
+    await user.click(screen.getByText("report.submit"));
+
+    await waitFor(() => {
+      expect(screen.getByText("report.submitted")).toBeInTheDocument();
+    });
+
+    // Button should no longer be visible
+    expect(screen.queryByText("report.button")).not.toBeInTheDocument();
+  });
+
+  it("should show warning toast for duplicate report", async () => {
+    mockSubmitReport.mockRejectedValue(
+      new Error("You have already reported this document."),
+    );
+
+    const user = userEvent.setup();
+    render(<ReportIssueButton documentId="doc-123" />);
+
+    await user.click(screen.getByText("report.button"));
+    await user.click(screen.getByText("report.reasons.incorrectAnalysis"));
+    await user.click(screen.getByText("report.submit"));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        "report.alreadyReported",
+        "warning",
+      );
+    });
+
+    // Should still show reported state
+    expect(screen.getByText("report.submitted")).toBeInTheDocument();
+  });
+
+  it("should show error toast on general failure", async () => {
+    mockSubmitReport.mockRejectedValue(new Error("Server error"));
+
+    const user = userEvent.setup();
+    render(<ReportIssueButton documentId="doc-123" />);
+
+    await user.click(screen.getByText("report.button"));
+    await user.click(screen.getByText("report.reasons.incorrectAnalysis"));
+    await user.click(screen.getByText("report.submit"));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith("report.error", "error");
+    });
+
+    // Should still show the report button (not reported state)
+    expect(screen.getByText("report.title")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/pages/petition/results.test.tsx
+++ b/apps/frontend/__tests__/pages/petition/results.test.tsx
@@ -26,6 +26,11 @@ jest.mock("react-i18next", () => ({
   }),
 }));
 
+// Mock toast
+jest.mock("@/lib/toast", () => ({
+  useToast: () => ({ showToast: jest.fn() }),
+}));
+
 // Mock Apollo Client mutations
 const mockProcessScan = jest.fn();
 const mockAnalyzeDocument = jest.fn();
@@ -286,6 +291,16 @@ describe("PetitionResultsPage", () => {
     await user.click(backButton);
 
     expect(mockPush).toHaveBeenCalledWith("/petition");
+  });
+
+  it("should show Report Issue button when analysis is complete", async () => {
+    sessionStorage.setItem("petition-scan-data", "dGVzdA==");
+
+    render(<PetitionResultsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("report.button")).toBeInTheDocument();
+    });
   });
 
   it("should navigate to /petition/capture when try again is clicked", async () => {

--- a/apps/frontend/app/petition/results/page.tsx
+++ b/apps/frontend/app/petition/results/page.tsx
@@ -14,6 +14,7 @@ import {
   type SetDocumentLocationData,
   type DocumentAnalysis,
 } from "@/lib/graphql/documents";
+import { ReportIssueButton } from "@/components/ReportIssueButton";
 
 type ProcessingStep = "extracting" | "analyzing" | "complete" | "error";
 
@@ -34,6 +35,7 @@ export default function PetitionResultsPage() {
   const [analysis, setAnalysis] = useState<DocumentAnalysis | null>(null);
   const [fromCache, setFromCache] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [documentId, setDocumentId] = useState<string | null>(null);
 
   const [processScan] = useMutation<ProcessScanData>(PROCESS_SCAN);
   const [analyzeDocument] = useMutation<AnalyzeDocumentData>(ANALYZE_DOCUMENT);
@@ -64,6 +66,7 @@ export default function PetitionResultsPage() {
 
         setOcrText(scan.text);
         setOcrConfidence(scan.confidence);
+        setDocumentId(scan.documentId);
 
         // Step 2: Set location (fire-and-forget)
         if (location) {
@@ -386,6 +389,13 @@ export default function PetitionResultsPage() {
           >
             {t("results.saveToTrack")}
           </button>
+        </div>
+      )}
+
+      {/* Report Issue */}
+      {step === "complete" && documentId && (
+        <div className="px-4 pb-6 flex justify-end">
+          <ReportIssueButton documentId={documentId} />
         </div>
       )}
 

--- a/apps/frontend/components/ReportIssueButton.tsx
+++ b/apps/frontend/components/ReportIssueButton.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { useMutation } from "@apollo/client/react";
+import { useTranslation } from "react-i18next";
+import { useToast } from "@/lib/toast";
+import {
+  SUBMIT_ABUSE_REPORT,
+  type AbuseReportReason,
+  type SubmitAbuseReportData,
+} from "@/lib/graphql/documents";
+
+const REPORT_REASONS: AbuseReportReason[] = [
+  "incorrect_analysis",
+  "offensive_content",
+  "wrong_document_type",
+  "privacy_concern",
+  "other",
+];
+
+const REASON_I18N_KEYS: Record<AbuseReportReason, string> = {
+  incorrect_analysis: "report.reasons.incorrectAnalysis",
+  offensive_content: "report.reasons.offensiveContent",
+  wrong_document_type: "report.reasons.wrongDocumentType",
+  privacy_concern: "report.reasons.privacyConcern",
+  other: "report.reasons.other",
+};
+
+interface ReportIssueButtonProps {
+  documentId: string;
+}
+
+export function ReportIssueButton({ documentId }: ReportIssueButtonProps) {
+  const { t } = useTranslation("petition");
+  const { showToast } = useToast();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [reported, setReported] = useState(false);
+  const [reason, setReason] = useState<AbuseReportReason | null>(null);
+  const [description, setDescription] = useState("");
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const [submitReport, { loading }] =
+    useMutation<SubmitAbuseReportData>(SUBMIT_ABUSE_REPORT);
+
+  // Close panel on click outside
+  useEffect(() => {
+    if (!isOpen) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  const handleSubmit = async () => {
+    if (!reason) return;
+
+    try {
+      await submitReport({
+        variables: {
+          input: {
+            documentId,
+            reason,
+            ...(description.trim() && { description: description.trim() }),
+          },
+        },
+      });
+
+      showToast(t("report.success"), "success");
+      setReported(true);
+      setIsOpen(false);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : t("report.error");
+
+      if (message.includes("already reported")) {
+        showToast(t("report.alreadyReported"), "warning");
+        setReported(true);
+        setIsOpen(false);
+      } else {
+        showToast(t("report.error"), "error");
+      }
+    }
+  };
+
+  // After successful report, show static "Reported" state
+  if (reported) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-sm text-gray-500">
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M5 13l4 4L19 7"
+          />
+        </svg>
+        {t("report.submitted")}
+      </span>
+    );
+  }
+
+  return (
+    <div className="relative" ref={panelRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-red-400 transition-colors"
+        aria-label={t("report.buttonLabel")}
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2z"
+          />
+        </svg>
+        {t("report.button")}
+      </button>
+
+      {isOpen && (
+        <div className="absolute bottom-full right-0 mb-2 w-72 bg-gray-800 border border-gray-700 rounded-lg shadow-xl p-4 z-20">
+          <h3 className="text-sm font-semibold text-white mb-3">
+            {t("report.title")}
+          </h3>
+
+          <div className="space-y-2 mb-3">
+            {REPORT_REASONS.map((r) => (
+              <label
+                key={r}
+                className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer hover:text-white"
+              >
+                <input
+                  type="radio"
+                  name="report-reason"
+                  value={r}
+                  checked={reason === r}
+                  onChange={() => setReason(r)}
+                  className="accent-blue-500"
+                />
+                {t(REASON_I18N_KEYS[r])}
+              </label>
+            ))}
+          </div>
+
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder={t("report.descriptionPlaceholder")}
+            maxLength={1000}
+            rows={2}
+            className="w-full bg-gray-900 text-gray-200 rounded p-2 text-sm border border-gray-700 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 outline-none resize-none mb-3"
+          />
+
+          <button
+            onClick={handleSubmit}
+            disabled={!reason || loading}
+            className="w-full py-2 text-sm font-medium rounded bg-red-600 text-white hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? t("report.submitting") : t("report.submit")}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/lib/graphql/documents.ts
+++ b/apps/frontend/lib/graphql/documents.ts
@@ -95,6 +95,18 @@ export interface MapFiltersInput {
   endDate?: string;
 }
 
+export type AbuseReportReason =
+  | "incorrect_analysis"
+  | "offensive_content"
+  | "wrong_document_type"
+  | "privacy_concern"
+  | "other";
+
+export interface SubmitAbuseReportResult {
+  success: boolean;
+  reportId: string;
+}
+
 // ============================================
 // Mutations
 // ============================================
@@ -148,6 +160,15 @@ export const ANALYZE_DOCUMENT = gql`
   }
 `;
 
+export const SUBMIT_ABUSE_REPORT = gql`
+  mutation SubmitAbuseReport($input: SubmitAbuseReportInput!) {
+    submitAbuseReport(input: $input) {
+      success
+      reportId
+    }
+  }
+`;
+
 // ============================================
 // Queries
 // ============================================
@@ -196,4 +217,8 @@ export interface PetitionMapLocationsData {
 
 export interface PetitionMapStatsData {
   petitionMapStats: PetitionMapStats;
+}
+
+export interface SubmitAbuseReportData {
+  submitAbuseReport: SubmitAbuseReportResult;
 }

--- a/apps/frontend/locales/en/petition.json
+++ b/apps/frontend/locales/en/petition.json
@@ -90,5 +90,24 @@
     "backToHome": "Back to Home",
     "tryAgain": "Scan Again",
     "copiedToClipboard": "Analysis copied to clipboard"
+  },
+  "report": {
+    "button": "Report Issue",
+    "buttonLabel": "Report an issue with this analysis",
+    "title": "What's wrong with this analysis?",
+    "reasons": {
+      "incorrectAnalysis": "Analysis is incorrect or misleading",
+      "offensiveContent": "Contains offensive content",
+      "wrongDocumentType": "Wrong document type detected",
+      "privacyConcern": "Contains private information",
+      "other": "Other issue"
+    },
+    "descriptionPlaceholder": "Additional details (optional)",
+    "submit": "Submit Report",
+    "submitting": "Submitting...",
+    "success": "Report submitted. Thank you for your feedback.",
+    "error": "Failed to submit report. Please try again.",
+    "alreadyReported": "You have already reported this document.",
+    "submitted": "Reported"
   }
 }

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -176,6 +176,7 @@ model User {
   passkeyCredentials     PasskeyCredential[]
   emailCorrespondence    EmailCorrespondence[]
   notificationPreference NotificationPreference?
+  abuseReports           AbuseReport[]
 
   @@map("users")
 }
@@ -507,13 +508,52 @@ model Document {
   updatedAt DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt DateTime? @map("deleted_at") @db.Timestamptz
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user         User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+  abuseReports AbuseReport[]
 
   @@index([userId])
   @@index([checksum])
   @@index([type])
   @@index([contentHash])
   @@map("documents")
+}
+
+// ============================================
+// ABUSE REPORTING
+// ============================================
+
+enum AbuseReportReason {
+  incorrect_analysis  @map("incorrect_analysis")
+  offensive_content   @map("offensive_content")
+  wrong_document_type @map("wrong_document_type")
+  privacy_concern     @map("privacy_concern")
+  other               @map("other")
+}
+
+enum AbuseReportStatus {
+  pending   @map("pending")
+  reviewed  @map("reviewed")
+  resolved  @map("resolved")
+  dismissed @map("dismissed")
+}
+
+model AbuseReport {
+  id          String            @id @default(uuid())
+  documentId  String            @map("document_id")
+  reporterId  String            @map("reporter_id")
+  reason      AbuseReportReason
+  description String?           @db.Text
+  status      AbuseReportStatus @default(pending)
+  createdAt   DateTime          @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime          @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  document Document @relation(fields: [documentId], references: [id], onDelete: Cascade)
+  reporter User     @relation(fields: [reporterId], references: [id], onDelete: Cascade)
+
+  @@index([documentId])
+  @@index([reporterId])
+  @@index([status])
+  @@map("abuse_reports")
 }
 
 // ============================================

--- a/packages/relationaldb-provider/src/index.ts
+++ b/packages/relationaldb-provider/src/index.ts
@@ -69,6 +69,7 @@ export type {
   Expenditure,
   IndependentExpenditure,
   PromptTemplate,
+  AbuseReport,
 } from "@prisma/client";
 
 // Re-export database enums
@@ -88,6 +89,8 @@ export {
   DocumentStatus,
   DocumentType,
   PromptCategory,
+  AbuseReportReason,
+  AbuseReportStatus,
 } from "@prisma/client";
 
 // Test utilities are available from "@opuspopuli/relationaldb-provider/testing"


### PR DESCRIPTION
## Summary
- Adds full-stack abuse reporting so users can flag incorrect or problematic petition analysis results
- New `AbuseReport` Prisma model with enums, relations, and indexes for efficient querying
- Backend `submitAbuseReport` mutation with document validation, duplicate detection, and auth guard
- Frontend `ReportIssueButton` component with popover form (5 reasons, optional description, toast feedback)
- Integrated into petition results page below action buttons; shows "Reported" checkmark after submission

## Test plan
- [x] Backend service tests: 5 tests (create, not-found, duplicate, no-description, any-user)
- [x] Backend resolver tests: 2 tests (correct args, unauthenticated)
- [x] Frontend ReportIssueButton tests: 8 tests (render, open, disabled, submit, description, reported state, duplicate warning, error toast)
- [x] Frontend results page test: Report Issue button appears when analysis is complete
- [x] All 1,202 backend tests pass
- [x] All 967 frontend tests pass
- [x] Frontend lint and build clean

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)