### PR TITLE
Merge develop to main (#431)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -135,6 +135,15 @@ AUDIT_RETENTION_DAYS=90
 # EXTRACTION_RETRY_MAX_DELAY_MS=30000  # Maximum retry delay
 
 # ============================================================
+# Prompt Service Configuration (optional)
+# ============================================================
+# When set, prompt-client delegates to the remote AI Prompt Service
+# instead of reading templates from the local database.
+# PROMPT_SERVICE_URL='http://localhost:3200'
+# PROMPT_SERVICE_API_KEY='dev-key-1'
+# PROMPT_SERVICE_NODE_ID=''              # Node UUID — enables HMAC signing when set
+
+# ============================================================
 # Region Configuration
 # ============================================================
 # Region provider selection (example, california, etc.)

--- a/apps/backend/src/apps/documents/src/domains/documents.module.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { DocumentsService } from './documents.service';
 import { DocumentsResolver } from './documents.resolver';
 import { StorageModule } from '@opuspopuli/storage-provider';
@@ -23,7 +24,16 @@ import { PromptClientModule } from '@opuspopuli/prompt-client';
     OcrModule,
     ExtractionModule,
     LLMModule,
-    PromptClientModule,
+    PromptClientModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        config: {
+          promptServiceUrl: config.get('PROMPT_SERVICE_URL'),
+          promptServiceApiKey: config.get('PROMPT_SERVICE_API_KEY'),
+          hmacNodeId: config.get('PROMPT_SERVICE_NODE_ID'),
+        },
+      }),
+    }),
   ],
   providers: [DocumentsService, DocumentsResolver],
   exports: [DocumentsService],

--- a/apps/backend/src/apps/knowledge/src/domains/knowledge.module.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/knowledge.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { KnowledgeService } from './knowledge.service';
 import { KnowledgeResolver } from './knowledge.resolver';
 import { EmbeddingsModule } from '@opuspopuli/embeddings-provider';
@@ -16,7 +17,21 @@ import { PromptClientModule } from '@opuspopuli/prompt-client';
  * All components are self-hosted OSS for full transparency and privacy.
  */
 @Module({
-  imports: [EmbeddingsModule, VectorDBModule, LLMModule, PromptClientModule],
+  imports: [
+    EmbeddingsModule,
+    VectorDBModule,
+    LLMModule,
+    PromptClientModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        config: {
+          promptServiceUrl: config.get('PROMPT_SERVICE_URL'),
+          promptServiceApiKey: config.get('PROMPT_SERVICE_API_KEY'),
+          hmacNodeId: config.get('PROMPT_SERVICE_NODE_ID'),
+        },
+      }),
+    }),
+  ],
   providers: [KnowledgeService, KnowledgeResolver],
   exports: [KnowledgeService],
 })

--- a/docs/architecture/ai-ml-pipeline.md
+++ b/docs/architecture/ai-ml-pipeline.md
@@ -409,22 +409,39 @@ async answerQuery(userId: string, query: string): Promise<string> {
 
 ---
 
-## Prompt Engineering
+## Prompt Management
 
-### RAG Prompt Template
+### @opuspopuli/prompt-client
+
+All AI prompt construction is managed by `@opuspopuli/prompt-client`, which provides:
+
+- **Database-backed templates** — prompt templates stored in PostgreSQL, editable without code changes
+- **Remote delegation** — optionally delegates to a federated [AI Prompt Service](https://github.com/OpusPopuli/prompt-service)
+- **3-tier fallback** — remote service → database → hardcoded defaults
+- **Resilience** — circuit breaker, retry with backoff, TTL-based caching, HMAC authentication
 
 ```typescript
-private buildRAGPrompt(context: string, query: string): string {
-  return `You are a helpful assistant. Answer the question based on the context provided below.
+// Knowledge Service uses prompt-client for RAG prompts
+const { promptText, promptHash, promptVersion } =
+  await this.promptClient.getRAGPrompt({
+    context: contextChunks.join('\n\n'),
+    query: userQuery,
+  });
 
-Context:
-${context}
-
-Question: ${query}
-
-Answer:`;
-}
+const result = await this.llm.generate(promptText, options);
 ```
+
+### Template Types
+
+| Method | Templates | Use Case |
+|--------|-----------|----------|
+| `getStructuralAnalysisPrompt()` | `structural-analysis`, `structural-schema-*` | Web scraping schema extraction |
+| `getDocumentAnalysisPrompt()` | `document-analysis-*`, `document-analysis-base-instructions` | Document AI analysis |
+| `getRAGPrompt()` | `rag` | Retrieval-augmented generation |
+
+Each template uses `{{VARIABLE}}` placeholders that are interpolated at runtime.
+
+**See**: [prompt-client README](../../packages/prompt-client/README.md) for full configuration and resilience details.
 
 ### Best Practices
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -109,6 +109,7 @@ All external dependencies use the **Strategy Pattern + Dependency Injection** fo
 | `@opuspopuli/ocr-provider` | OCR functionality | `OCR_PROVIDER` |
 | `@opuspopuli/scraping-pipeline` | AI-powered schema-on-read web scraping | `SCRAPING_PIPELINE` |
 | `@opuspopuli/region-provider` | Civic data integration (declarative plugins) | `REGION_PROVIDER` |
+| `@opuspopuli/prompt-client` | AI prompt templates with remote delegation, HMAC, circuit breaker | `PROMPT_CLIENT_CONFIG` |
 
 ### Relational Database Provider
 **Package**: `@opuspopuli/relationaldb-provider`

--- a/docs/guides/auth-security.md
+++ b/docs/guides/auth-security.md
@@ -216,6 +216,57 @@ export class HMACMiddleware implements NestMiddleware {
 }
 ```
 
+## Prompt Service HMAC Authentication
+
+The `@opuspopuli/prompt-client` package supports HMAC request signing for authenticating with a remote [AI Prompt Service](https://github.com/OpusPopuli/prompt-service). This is a **separate protocol** from the gateway HMAC above.
+
+### Protocol Differences
+
+| | Gateway HMAC | Prompt Service HMAC |
+|---|---|---|
+| **Header** | `X-HMAC-Auth` (JSON payload) | `X-HMAC-Signature` + `X-HMAC-Timestamp` + `X-HMAC-Key-Id` |
+| **Signature input** | `${timestamp}:${url}` | `${timestamp}\n${method}\n${path}\n${bodyHash}` |
+| **Body included** | No | Yes (SHA-256 hash) |
+| **Use case** | Gateway → microservices | Nodes → prompt-service |
+
+### How It Works
+
+When `PROMPT_SERVICE_NODE_ID` is configured, the prompt-client signs every request:
+
+```typescript
+// packages/prompt-client/src/hmac-signer.ts
+const timestamp = Math.floor(Date.now() / 1000).toString();
+const bodyHash = createHash('sha256').update(body).digest('hex');
+const signatureString = `${timestamp}\n${method}\n${path}\n${bodyHash}`;
+const signature = createHmac('sha256', apiKey)
+  .update(signatureString)
+  .digest('base64');
+
+// Headers sent:
+// X-HMAC-Signature: <base64 signature>
+// X-HMAC-Timestamp: <unix seconds>
+// X-HMAC-Key-Id: <node UUID>
+```
+
+The prompt-service validates the signature, checks the timestamp window (5 minutes), and verifies the node's API key from its database.
+
+### Configuration
+
+```bash
+PROMPT_SERVICE_URL='http://localhost:3200'
+PROMPT_SERVICE_API_KEY='your-node-api-key'
+PROMPT_SERVICE_NODE_ID='your-node-uuid'    # Enables HMAC (omit for Bearer auth)
+```
+
+### Resilience
+
+The prompt-client wraps remote calls with:
+- **Circuit breaker** — opens after 3 consecutive failures, half-open after 15s
+- **Retry with backoff** — retries on network/5xx errors, skips retry on circuit open
+- **Fallback chain** — remote → database → hardcoded defaults
+
+See the [prompt-client README](../../packages/prompt-client/README.md) for full details.
+
 ## Cookie Propagation in Federated GraphQL
 
 In Apollo Federation, subgraphs respond to the gateway, not directly to the browser. This means cookies set by subgraphs (like the Users service during login) need to be propagated through the gateway.
@@ -301,6 +352,7 @@ GATEWAY_CLIENT_ID='api-gateway'
 - [ ] GraphQL depth limiting enabled (default: 10)
 - [ ] GraphQL complexity limiting enabled (default: 1000)
 - [ ] `NODE_ENV=production` (not 'prod' or 'dev')
+- [ ] Prompt service nodes use HMAC auth (`PROMPT_SERVICE_NODE_ID` set)
 
 ## Environment Configuration
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -56,6 +56,24 @@ open http://localhost:3101
 | `circuit_breaker_state` | Gauge | service, circuit_name | 0=closed, 0.5=half-open, 1=open |
 | `circuit_breaker_failures_total` | Counter | service, circuit_name | Failure count |
 
+#### Prompt Client Metrics
+
+The `@opuspopuli/prompt-client` exposes built-in metrics via `promptClient.getMetrics()`:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `totalRequests` | Counter | Total prompt requests across all sources |
+| `cacheHits` | Counter | Requests served from template cache |
+| `remoteCalls` | Counter | Requests sent to remote prompt service |
+| `dbFallbacks` | Counter | Requests that fell back to database after remote failure |
+| `hardcodedFallbacks` | Counter | Requests that used hardcoded fallback templates |
+| `avgRemoteLatencyMs` | Gauge | Average latency for remote prompt service calls |
+| `circuitBreakerState` | String | Current circuit breaker state (closed/open/half_open) |
+| `cacheHitRate` | Gauge | Cache hit rate (0-1) |
+| `fallbackRate` | Gauge | Fallback rate (0-1), includes DB + hardcoded fallbacks |
+
+Circuit breaker health is also available via `promptClient.getCircuitBreakerHealth()`.
+
 #### Database Metrics
 
 | Metric | Type | Labels | Description |

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -66,7 +66,7 @@ npm install @opuspopuli/common --registry https://npm.pkg.github.com
 | **Rate Limiting** | `RateLimiter`, `IRateLimiter`, `RateLimitOptions` | Token bucket rate limiter |
 | **Retry** | `withRetry()`, `RetryPredicates`, `calculateDelay()`, `RetryConfig` | Exponential backoff with jitter |
 | **Caching** | `MemoryCache<T>`, `ICache<T>`, `CacheOptions` | In-memory cache with TTL and LRU eviction |
-| **Resilience** | `CircuitBreakerManager`, `createCircuitBreaker()`, `CircuitBreakerConfig` | Circuit breaker pattern |
+| **Resilience** | `CircuitBreakerManager`, `createCircuitBreaker()`, `CircuitBreakerConfig`, `DEFAULT_CIRCUIT_CONFIGS` | Circuit breaker pattern (Ollama, Supabase, Extraction, PromptService) |
 | **HTTP** | `HttpPoolManager`, `getSharedHttpPool()`, `createPooledFetch()` | HTTP connection pooling via undici |
 
 ## Usage

--- a/packages/common/src/providers/resilience/types.ts
+++ b/packages/common/src/providers/resilience/types.ts
@@ -83,4 +83,10 @@ export const DEFAULT_CIRCUIT_CONFIGS: Record<string, CircuitBreakerConfig> = {
     halfOpenAfterMs: 60000, // 60 seconds
     serviceName: "Extraction",
   },
+  /** Prompt Service - fast recovery (internal infrastructure) */
+  promptService: {
+    failureThreshold: 3,
+    halfOpenAfterMs: 15000, // 15 seconds
+    serviceName: "PromptService",
+  },
 };

--- a/packages/prompt-client/README.md
+++ b/packages/prompt-client/README.md
@@ -1,0 +1,229 @@
+# @opuspopuli/prompt-client
+
+Database-backed prompt template client for AI-powered features. Reads prompt templates from PostgreSQL, composes them with variables, and optionally delegates to a remote [AI Prompt Service](https://github.com/OpusPopuli/prompt-service) with HMAC authentication, circuit breaker protection, and retry logic.
+
+## Features
+
+- **Database templates** — reads prompt templates from PostgreSQL via Prisma
+- **Remote delegation** — optionally delegates to a remote AI Prompt Service
+- **HMAC authentication** — signs requests using HMAC-SHA256 for federated node auth
+- **Circuit breaker** — prevents cascading failures when prompt-service is down
+- **Retry with backoff** — handles transient network/server errors
+- **TTL-based caching** — pluggable `ICache<T>` interface (MemoryCache default, Redis optional)
+- **3-tier fallback** — remote service → database → hardcoded defaults
+- **Metrics** — cache hit rate, fallback rate, remote latency, circuit breaker state
+
+## Installation
+
+```bash
+pnpm add @opuspopuli/prompt-client
+```
+
+## Quick Start
+
+### Local mode (database templates)
+
+```typescript
+import { Module } from '@nestjs/common';
+import { PromptClientModule } from '@opuspopuli/prompt-client';
+
+@Module({
+  imports: [PromptClientModule],
+})
+export class AppModule {}
+```
+
+### Remote mode (with AI Prompt Service)
+
+```typescript
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { PromptClientModule } from '@opuspopuli/prompt-client';
+
+@Module({
+  imports: [
+    PromptClientModule.forRootAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        config: {
+          promptServiceUrl: config.get('PROMPT_SERVICE_URL'),
+          promptServiceApiKey: config.get('PROMPT_SERVICE_API_KEY'),
+          hmacNodeId: config.get('PROMPT_SERVICE_NODE_ID'),
+        },
+      }),
+    }),
+  ],
+})
+export class AppModule {}
+```
+
+## Usage
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { PromptClientService } from '@opuspopuli/prompt-client';
+
+@Injectable()
+export class MyService {
+  constructor(private readonly promptClient: PromptClientService) {}
+
+  async analyzeDocument(text: string) {
+    const { promptText, promptHash, promptVersion } =
+      await this.promptClient.getDocumentAnalysisPrompt({
+        documentType: 'petition',
+        text,
+      });
+    // Use promptText with your LLM provider
+  }
+
+  async answerQuestion(context: string, query: string) {
+    const { promptText } = await this.promptClient.getRAGPrompt({
+      context,
+      query,
+    });
+    // Use promptText with your LLM provider
+  }
+
+  async extractStructure(html: string) {
+    const { promptText } = await this.promptClient.getStructuralAnalysisPrompt({
+      dataType: 'propositions',
+      contentGoal: 'Extract ballot measures',
+      html,
+    });
+    // Use promptText with your LLM provider
+  }
+}
+```
+
+## Configuration
+
+All configuration fields are optional with sensible defaults:
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `promptServiceUrl` | `undefined` | Remote prompt service URL (undefined = local DB mode) |
+| `promptServiceApiKey` | `undefined` | API key for Bearer auth or HMAC signing |
+| `hmacNodeId` | `undefined` | Node UUID — enables HMAC auth when set (instead of Bearer) |
+| `timeoutMs` | `10000` | Request timeout for remote calls |
+| `retryMaxAttempts` | `3` | Max retry attempts for transient errors |
+| `retryBaseDelayMs` | `1000` | Base delay for exponential backoff |
+| `retryMaxDelayMs` | `10000` | Maximum delay between retries |
+| `circuitBreakerFailureThreshold` | `3` | Failures before opening circuit |
+| `circuitBreakerHalfOpenMs` | `15000` | Time before testing half-open |
+| `cache` | `MemoryCache` | Custom `ICache<PromptTemplate>` (e.g., Redis-backed) |
+| `cacheTtlMs` | `300000` | Cache TTL in ms (5 minutes) |
+| `cacheMaxSize` | `50` | Max entries in built-in MemoryCache |
+
+### Environment Variables
+
+```bash
+# Remote AI Prompt Service (all optional)
+PROMPT_SERVICE_URL='http://localhost:3200'
+PROMPT_SERVICE_API_KEY='your-api-key'
+PROMPT_SERVICE_NODE_ID='node-uuid'      # Enables HMAC auth when set
+```
+
+## Authentication Modes
+
+### Bearer Token (default when URL + API key set)
+
+Standard `Authorization: Bearer <key>` header. Simple, suitable for trusted internal networks.
+
+### HMAC Signing (when `hmacNodeId` is also set)
+
+Cryptographic request signing for federated node authentication:
+
+```
+X-HMAC-Signature: HMAC-SHA256(apiKey, "${timestamp}\n${method}\n${path}\n${bodyHash}")
+X-HMAC-Timestamp: <unix-seconds>
+X-HMAC-Key-Id: <nodeId>
+```
+
+This protocol matches the [prompt-service HMAC validation](https://github.com/OpusPopuli/prompt-service) and provides:
+- **Replay protection** via timestamp validation (5-minute window)
+- **Tamper detection** via body hash in signature
+- **Key rotation** via the key ID header
+
+## Resilience Architecture
+
+```
+Request
+  │
+  ├─ Cache hit? ──────────────────────────── Return cached template
+  │
+  ├─ Remote URL configured?
+  │   │
+  │   └─ withRetry() ──► CircuitBreaker ──► fetch(HMAC/Bearer)
+  │       │                   │
+  │       │ retry on 5xx/     │ open after N failures
+  │       │ network errors    │ fail fast with CircuitOpenError
+  │       │                   │
+  │       └── on failure ─────┴──► composeFromDb()
+  │                                    │
+  │                                    ├─ DB template found? ── Return
+  │                                    └─ Hardcoded fallback ── Return (v0)
+  │
+  └─ Local mode (no URL)
+      │
+      └─ composeFromDb() ──► DB or hardcoded fallback
+```
+
+### Circuit Breaker States
+
+| State | Behavior |
+|-------|----------|
+| **Closed** | Requests pass through normally |
+| **Open** | Requests fail fast, fall back to DB immediately |
+| **Half-Open** | One test request allowed; success resets, failure re-opens |
+
+## Monitoring
+
+### Metrics
+
+```typescript
+const metrics = promptClient.getMetrics();
+// {
+//   totalRequests: 150,
+//   cacheHits: 80,
+//   remoteCalls: 50,
+//   dbFallbacks: 15,
+//   hardcodedFallbacks: 5,
+//   avgRemoteLatencyMs: 45,
+//   circuitBreakerState: 'closed',
+//   cacheHitRate: 0.53,
+//   fallbackRate: 0.13,
+// }
+```
+
+### Circuit Breaker Health
+
+```typescript
+const health = promptClient.getCircuitBreakerHealth();
+// {
+//   serviceName: 'PromptService',
+//   state: 'closed',
+//   isHealthy: true,
+//   failureCount: 0,
+//   lastFailureTime: null,
+// }
+```
+
+## Prompt Types
+
+| Method | Template(s) | Use Case |
+|--------|-------------|----------|
+| `getStructuralAnalysisPrompt()` | `structural-analysis`, `structural-schema-*` | Web scraping schema extraction |
+| `getDocumentAnalysisPrompt()` | `document-analysis-*`, `document-analysis-base-instructions` | Document AI analysis |
+| `getRAGPrompt()` | `rag` | Retrieval-augmented generation |
+
+## Testing
+
+```bash
+pnpm test           # Run all tests
+pnpm test --coverage # With coverage report
+```
+
+## License
+
+AGPL-3.0

--- a/packages/prompt-client/__tests__/hmac-signer.spec.ts
+++ b/packages/prompt-client/__tests__/hmac-signer.spec.ts
@@ -1,0 +1,122 @@
+import { createHash, createHmac } from "node:crypto";
+import { signRequest, type HmacSigningConfig } from "../src/hmac-signer.js";
+
+describe("signRequest", () => {
+  const config: HmacSigningConfig = {
+    apiKey: "test-secret-key-abc123",
+    nodeId: "node-uuid-1234",
+  };
+
+  it("should return all three HMAC headers", () => {
+    const headers = signRequest(
+      config,
+      "POST",
+      "/prompts/rag",
+      '{"query":"test"}',
+    );
+
+    expect(headers).toHaveProperty("X-HMAC-Signature");
+    expect(headers).toHaveProperty("X-HMAC-Timestamp");
+    expect(headers).toHaveProperty("X-HMAC-Key-Id");
+  });
+
+  it("should set X-HMAC-Key-Id to the node ID", () => {
+    const headers = signRequest(config, "POST", "/prompts/rag", "{}");
+
+    expect(headers["X-HMAC-Key-Id"]).toBe("node-uuid-1234");
+  });
+
+  it("should produce a valid Base64 signature", () => {
+    const headers = signRequest(config, "POST", "/prompts/rag", "{}");
+    const decoded = Buffer.from(headers["X-HMAC-Signature"], "base64");
+
+    // HMAC-SHA256 produces 32 bytes
+    expect(decoded.length).toBe(32);
+  });
+
+  it("should set timestamp to current unix seconds", () => {
+    const before = Math.floor(Date.now() / 1000);
+    const headers = signRequest(config, "POST", "/prompts/rag", "{}");
+    const after = Math.floor(Date.now() / 1000);
+
+    const timestamp = parseInt(headers["X-HMAC-Timestamp"], 10);
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it("should uppercase the method in the signature string", () => {
+    const body = '{"test":"data"}';
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+
+    // Manually compute what the signature should be with uppercase POST
+    const bodyHash = createHash("sha256").update(body).digest("hex");
+    const signatureString = `${timestamp}\nPOST\n/prompts/rag\n${bodyHash}`;
+    const expected = createHmac("sha256", config.apiKey)
+      .update(signatureString)
+      .digest("base64");
+
+    // Mock Date.now to control timestamp
+    const dateSpy = jest
+      .spyOn(Date, "now")
+      .mockReturnValue(parseInt(timestamp) * 1000);
+    const headers = signRequest(config, "post", "/prompts/rag", body);
+    dateSpy.mockRestore();
+
+    expect(headers["X-HMAC-Signature"]).toBe(expected);
+  });
+
+  it("should produce different signatures for different bodies", () => {
+    const dateSpy = jest.spyOn(Date, "now").mockReturnValue(1700000000000);
+
+    const headers1 = signRequest(
+      config,
+      "POST",
+      "/prompts/rag",
+      '{"query":"one"}',
+    );
+    const headers2 = signRequest(
+      config,
+      "POST",
+      "/prompts/rag",
+      '{"query":"two"}',
+    );
+
+    dateSpy.mockRestore();
+
+    expect(headers1["X-HMAC-Signature"]).not.toBe(headers2["X-HMAC-Signature"]);
+  });
+
+  it("should produce different signatures for different paths", () => {
+    const dateSpy = jest.spyOn(Date, "now").mockReturnValue(1700000000000);
+
+    const headers1 = signRequest(config, "POST", "/prompts/rag", "{}");
+    const headers2 = signRequest(
+      config,
+      "POST",
+      "/prompts/document-analysis",
+      "{}",
+    );
+
+    dateSpy.mockRestore();
+
+    expect(headers1["X-HMAC-Signature"]).not.toBe(headers2["X-HMAC-Signature"]);
+  });
+
+  it("should produce different signatures for different API keys", () => {
+    const dateSpy = jest.spyOn(Date, "now").mockReturnValue(1700000000000);
+    const body = "{}";
+    const path = "/prompts/rag";
+
+    const headers1 = signRequest(config, "POST", path, body);
+    const headers2 = signRequest(
+      { apiKey: "different-key", nodeId: "node-uuid-1234" },
+      "POST",
+      path,
+      body,
+    );
+
+    dateSpy.mockRestore();
+
+    expect(headers1["X-HMAC-Signature"]).not.toBe(headers2["X-HMAC-Signature"]);
+  });
+});

--- a/packages/prompt-client/__tests__/metrics.spec.ts
+++ b/packages/prompt-client/__tests__/metrics.spec.ts
@@ -1,0 +1,88 @@
+import { MetricsCollector } from "../src/metrics.js";
+
+describe("MetricsCollector", () => {
+  let collector: MetricsCollector;
+
+  beforeEach(() => {
+    collector = new MetricsCollector();
+  });
+
+  it("should start with zero counts", () => {
+    const metrics = collector.getMetrics("closed");
+    expect(metrics.totalRequests).toBe(0);
+    expect(metrics.cacheHits).toBe(0);
+    expect(metrics.remoteCalls).toBe(0);
+    expect(metrics.dbFallbacks).toBe(0);
+    expect(metrics.hardcodedFallbacks).toBe(0);
+    expect(metrics.avgRemoteLatencyMs).toBe(0);
+    expect(metrics.cacheHitRate).toBe(0);
+    expect(metrics.fallbackRate).toBe(0);
+  });
+
+  it("should record cache hits", () => {
+    collector.recordCacheHit();
+    collector.recordCacheHit();
+    const metrics = collector.getMetrics("closed");
+    expect(metrics.cacheHits).toBe(2);
+    expect(metrics.totalRequests).toBe(2);
+    expect(metrics.cacheHitRate).toBe(1);
+  });
+
+  it("should record remote calls with latency", () => {
+    collector.recordRemoteCall(100);
+    collector.recordRemoteCall(200);
+    const metrics = collector.getMetrics("closed");
+    expect(metrics.remoteCalls).toBe(2);
+    expect(metrics.avgRemoteLatencyMs).toBe(150);
+  });
+
+  it("should record DB fallbacks", () => {
+    collector.recordDbFallback();
+    collector.recordDbFallback();
+    collector.recordDbFallback();
+    const metrics = collector.getMetrics("closed");
+    expect(metrics.dbFallbacks).toBe(3);
+    expect(metrics.totalRequests).toBe(3);
+    expect(metrics.fallbackRate).toBe(1);
+  });
+
+  it("should record hardcoded fallbacks", () => {
+    collector.recordHardcodedFallback();
+    const metrics = collector.getMetrics("closed");
+    expect(metrics.hardcodedFallbacks).toBe(1);
+    expect(metrics.fallbackRate).toBe(1);
+  });
+
+  it("should calculate combined fallback rate", () => {
+    collector.recordRemoteCall(50);
+    collector.recordDbFallback();
+    collector.recordHardcodedFallback();
+    const metrics = collector.getMetrics("closed");
+    expect(metrics.totalRequests).toBe(3);
+    expect(metrics.fallbackRate).toBeCloseTo(2 / 3);
+  });
+
+  it("should pass through circuit breaker state", () => {
+    const metrics = collector.getMetrics("open");
+    expect(metrics.circuitBreakerState).toBe("open");
+  });
+
+  it("should reset all counters to zero", () => {
+    collector.recordCacheHit();
+    collector.recordRemoteCall(100);
+    collector.recordDbFallback();
+    collector.recordHardcodedFallback();
+
+    collector.reset();
+
+    const metrics = collector.getMetrics("closed");
+    expect(metrics.totalRequests).toBe(0);
+    expect(metrics.cacheHits).toBe(0);
+    expect(metrics.remoteCalls).toBe(0);
+    expect(metrics.dbFallbacks).toBe(0);
+    expect(metrics.hardcodedFallbacks).toBe(0);
+    expect(metrics.avgRemoteLatencyMs).toBe(0);
+    expect(metrics.cacheHitRate).toBe(0);
+    expect(metrics.fallbackRate).toBe(0);
+  });
+});

--- a/packages/prompt-client/__tests__/prompt-client.integration.spec.ts
+++ b/packages/prompt-client/__tests__/prompt-client.integration.spec.ts
@@ -1,0 +1,510 @@
+/**
+ * Integration tests for PromptClientService
+ *
+ * Tests the full service lifecycle including:
+ * - NestJS module initialization (onModuleInit / onModuleDestroy)
+ * - 3-tier fallback chain: remote → database → hardcoded
+ * - Cache behavior with ICache interface
+ * - HMAC vs Bearer auth selection
+ * - Circuit breaker recovery flow
+ * - Metrics accumulation across multiple operations
+ */
+
+import { Test, TestingModule } from "@nestjs/testing";
+import { PromptClientService } from "../src/prompt-client.service.js";
+import { DbService } from "@opuspopuli/relationaldb-provider";
+import { PROMPT_CLIENT_CONFIG } from "../src/types.js";
+
+describe("PromptClientService Integration", () => {
+  const mockTemplate = (name: string, templateText: string, version = 1) => ({
+    id: `id-${name}`,
+    name,
+    category: "rag" as const,
+    description: "test",
+    templateText,
+    variables: [],
+    version,
+    isActive: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+
+  // -------------------------------------------------------------------------
+  // Full fallback chain: remote → DB → hardcoded
+  // -------------------------------------------------------------------------
+
+  describe("3-tier fallback chain", () => {
+    let service: PromptClientService;
+    let mockDb: any;
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(async () => {
+      mockDb = {
+        promptTemplate: {
+          findFirst: jest.fn(),
+        },
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: {
+              promptServiceUrl: "http://prompt-service:3005",
+              promptServiceApiKey: "test-key",
+              retryMaxAttempts: 1,
+              circuitBreakerFailureThreshold: 1,
+              circuitBreakerHalfOpenMs: 60000,
+            },
+          },
+        ],
+      }).compile();
+
+      service = module.get(PromptClientService);
+    });
+
+    afterEach(async () => {
+      globalThis.fetch = originalFetch;
+      await service.onModuleDestroy();
+    });
+
+    it("should use remote when available (tier 1)", async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "from remote",
+            promptHash: "abc",
+            promptVersion: "v5",
+          }),
+      });
+
+      const result = await service.getRAGPrompt({
+        context: "ctx",
+        query: "q",
+      });
+
+      expect(result.promptText).toBe("from remote");
+      expect(result.promptVersion).toBe("v5");
+
+      const metrics = service.getMetrics();
+      expect(metrics.remoteCalls).toBe(1);
+      expect(metrics.dbFallbacks).toBe(0);
+      expect(metrics.hardcodedFallbacks).toBe(0);
+    });
+
+    it("should fall back to DB when remote fails (tier 2)", async () => {
+      globalThis.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("connection refused"));
+
+      mockDb.promptTemplate.findFirst.mockResolvedValue(
+        mockTemplate("rag", "DB template: {{CONTEXT}} - {{QUERY}}", 3),
+      );
+
+      const result = await service.getRAGPrompt({
+        context: "test ctx",
+        query: "test q",
+      });
+
+      expect(result.promptText).toContain("DB template: test ctx - test q");
+      expect(result.promptVersion).toBe("v3");
+
+      const metrics = service.getMetrics();
+      expect(metrics.dbFallbacks).toBe(1);
+      expect(metrics.hardcodedFallbacks).toBe(0);
+    });
+
+    it("should fall back to hardcoded when remote and DB both fail (tier 3)", async () => {
+      globalThis.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("connection refused"));
+
+      // DB returns nothing
+      mockDb.promptTemplate.findFirst.mockResolvedValue(null);
+
+      const result = await service.getRAGPrompt({
+        context: "fallback ctx",
+        query: "fallback q",
+      });
+
+      expect(result.promptText).toContain("fallback ctx");
+      expect(result.promptText).toContain("fallback q");
+      expect(result.promptVersion).toBe("v0");
+
+      const metrics = service.getMetrics();
+      expect(metrics.dbFallbacks).toBe(1);
+      expect(metrics.hardcodedFallbacks).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Custom ICache integration
+  // -------------------------------------------------------------------------
+
+  describe("custom ICache integration", () => {
+    let service: PromptClientService;
+    let mockDb: any;
+    let customCache: any;
+
+    beforeEach(async () => {
+      mockDb = {
+        promptTemplate: {
+          findFirst: jest.fn(),
+        },
+      };
+
+      customCache = {
+        get: jest.fn().mockResolvedValue(undefined),
+        set: jest.fn().mockResolvedValue(undefined),
+        has: jest.fn().mockResolvedValue(false),
+        delete: jest.fn().mockResolvedValue(true),
+        clear: jest.fn().mockResolvedValue(undefined),
+        size: 0,
+        keys: jest.fn().mockResolvedValue([]),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      } as any;
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: { cache: customCache },
+          },
+        ],
+      }).compile();
+
+      service = module.get(PromptClientService);
+    });
+
+    afterEach(async () => {
+      await service.onModuleDestroy();
+    });
+
+    it("should use custom cache for template storage", async () => {
+      mockDb.promptTemplate.findFirst.mockResolvedValue(
+        mockTemplate("rag", "{{CONTEXT}} {{QUERY}}"),
+      );
+
+      await service.getRAGPrompt({ context: "a", query: "b" });
+
+      // Cache get was called (miss), then set was called (storing template)
+      expect(customCache.get).toHaveBeenCalledWith("rag");
+      expect(customCache.set).toHaveBeenCalledWith(
+        "rag",
+        expect.objectContaining({ name: "rag" }),
+      );
+    });
+
+    it("should serve from custom cache on second request", async () => {
+      const template = mockTemplate("rag", "cached: {{CONTEXT}} {{QUERY}}");
+
+      // First call: cache miss → DB
+      customCache.get.mockResolvedValueOnce(undefined);
+      mockDb.promptTemplate.findFirst.mockResolvedValueOnce(template);
+
+      await service.getRAGPrompt({ context: "a", query: "b" });
+
+      // Second call: cache hit
+      customCache.get.mockResolvedValueOnce(template);
+
+      const result = await service.getRAGPrompt({ context: "c", query: "d" });
+
+      expect(result.promptText).toBe("cached: c d");
+      // DB only called once (first request)
+      expect(mockDb.promptTemplate.findFirst).toHaveBeenCalledTimes(1);
+    });
+
+    it("should delegate clearCache to custom cache", async () => {
+      await service.clearCache();
+
+      expect(customCache.clear).toHaveBeenCalled();
+    });
+
+    it("should delegate destroy to custom cache on module destroy", async () => {
+      await service.onModuleDestroy();
+
+      expect(customCache.destroy).toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Metrics accumulation across operations
+  // -------------------------------------------------------------------------
+
+  describe("metrics accumulation", () => {
+    let service: PromptClientService;
+    let mockDb: any;
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(async () => {
+      mockDb = {
+        promptTemplate: {
+          findFirst: jest.fn(),
+        },
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: {
+              promptServiceUrl: "http://prompt-service:3005",
+              promptServiceApiKey: "test-key",
+              retryMaxAttempts: 1,
+              circuitBreakerFailureThreshold: 5, // High threshold to prevent circuit opening
+            },
+          },
+        ],
+      }).compile();
+
+      service = module.get(PromptClientService);
+    });
+
+    afterEach(async () => {
+      globalThis.fetch = originalFetch;
+      await service.onModuleDestroy();
+    });
+
+    it("should accumulate metrics across multiple operations", async () => {
+      // 2 successful remote calls
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "remote",
+            promptHash: "abc",
+            promptVersion: "v1",
+          }),
+      });
+
+      await service.getRAGPrompt({ context: "a", query: "b" });
+      await service.getRAGPrompt({ context: "c", query: "d" });
+
+      // 1 failed remote call → DB fallback
+      globalThis.fetch = jest.fn().mockRejectedValue(new Error("timeout"));
+      mockDb.promptTemplate.findFirst.mockResolvedValue(
+        mockTemplate("rag", "fb: {{CONTEXT}} {{QUERY}}"),
+      );
+
+      await service.getRAGPrompt({ context: "e", query: "f" });
+
+      const metrics = service.getMetrics();
+      expect(metrics.remoteCalls).toBe(2);
+      expect(metrics.dbFallbacks).toBe(1);
+      expect(metrics.totalRequests).toBeGreaterThanOrEqual(3);
+      expect(metrics.avgRemoteLatencyMs).toBeGreaterThanOrEqual(0);
+      expect(metrics.fallbackRate).toBeGreaterThan(0);
+      expect(metrics.circuitBreakerState).toBe("closed");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Module lifecycle
+  // -------------------------------------------------------------------------
+
+  describe("module lifecycle", () => {
+    it("should complete full init-use-destroy lifecycle in local mode", async () => {
+      const mockDb = {
+        promptTemplate: {
+          findFirst: jest.fn().mockResolvedValue(null),
+        },
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+        ],
+      }).compile();
+
+      const service = module.get(PromptClientService);
+
+      // Init (validates templates)
+      await service.onModuleInit();
+
+      // Use (with hardcoded fallbacks since DB returns null)
+      const result = await service.getRAGPrompt({
+        context: "lifecycle test",
+        query: "question",
+      });
+      expect(result.promptText).toContain("lifecycle test");
+
+      // Metrics reflect usage
+      const metrics = service.getMetrics();
+      expect(metrics.hardcodedFallbacks).toBeGreaterThan(0);
+
+      // Destroy (cleans up cache)
+      await service.onModuleDestroy();
+    });
+
+    it("should complete full init-use-destroy lifecycle in remote mode", async () => {
+      const originalFetch = globalThis.fetch;
+      const mockDb = {
+        promptTemplate: {
+          findFirst: jest.fn(),
+        },
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: {
+              promptServiceUrl: "http://prompt-service:3005",
+              promptServiceApiKey: "test-key",
+              hmacNodeId: "node-123",
+              retryMaxAttempts: 1,
+            },
+          },
+        ],
+      }).compile();
+
+      const service = module.get(PromptClientService);
+
+      // Init (skips validation in remote mode)
+      await service.onModuleInit();
+      expect(mockDb.promptTemplate.findFirst).not.toHaveBeenCalled();
+
+      // Use with HMAC auth
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "hmac response",
+            promptHash: "hash",
+            promptVersion: "v2",
+          }),
+      });
+
+      const result = await service.getRAGPrompt({
+        context: "hmac test",
+        query: "question",
+      });
+      expect(result.promptText).toBe("hmac response");
+
+      // Verify HMAC headers were sent
+      const fetchCall = (globalThis.fetch as jest.Mock).mock.calls[0];
+      expect(fetchCall[1].headers["X-HMAC-Signature"]).toBeDefined();
+      expect(fetchCall[1].headers["X-HMAC-Key-Id"]).toBe("node-123");
+      expect(fetchCall[1].headers["Authorization"]).toBeUndefined();
+
+      // Circuit breaker is healthy
+      const health = service.getCircuitBreakerHealth();
+      expect(health).not.toBeNull();
+      expect(health!.isHealthy).toBe(true);
+
+      // Destroy
+      await service.onModuleDestroy();
+      globalThis.fetch = originalFetch;
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // All three prompt types end-to-end
+  // -------------------------------------------------------------------------
+
+  describe("all prompt types end-to-end", () => {
+    let service: PromptClientService;
+    let mockDb: any;
+
+    beforeEach(async () => {
+      mockDb = {
+        promptTemplate: {
+          findFirst: jest.fn(),
+        },
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+        ],
+      }).compile();
+
+      service = module.get(PromptClientService);
+    });
+
+    afterEach(async () => {
+      await service.onModuleDestroy();
+    });
+
+    it("should compose structural analysis with all variables", async () => {
+      mockDb.promptTemplate.findFirst
+        .mockResolvedValueOnce(
+          mockTemplate(
+            "structural-analysis",
+            "Type: {{DATA_TYPE}}\nGoal: {{CONTENT_GOAL}}\nCat: {{CATEGORY}}\n{{HINTS_SECTION}}Schema: {{SCHEMA_DESCRIPTION}}\n{{HTML}}",
+            2,
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockTemplate("structural-schema-propositions", "proposition fields"),
+        );
+
+      const result = await service.getStructuralAnalysisPrompt({
+        dataType: "propositions" as any,
+        contentGoal: "Extract ballot measures",
+        category: "elections",
+        hints: ["Check tables", "Look for links"],
+        html: "<table>data</table>",
+      });
+
+      expect(result.promptText).toContain("Type: propositions");
+      expect(result.promptText).toContain("Goal: Extract ballot measures");
+      expect(result.promptText).toContain("Cat: elections");
+      expect(result.promptText).toContain("- Check tables");
+      expect(result.promptText).toContain("- Look for links");
+      expect(result.promptText).toContain("proposition fields");
+      expect(result.promptText).toContain("<table>data</table>");
+      expect(result.promptVersion).toBe("v2");
+      expect(result.promptHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    it("should compose document analysis with type-specific template", async () => {
+      mockDb.promptTemplate.findFirst
+        .mockResolvedValueOnce(
+          mockTemplate("document-analysis-petition", "PETITION:\n{{TEXT}}", 4),
+        )
+        .mockResolvedValueOnce(
+          mockTemplate(
+            "document-analysis-base-instructions",
+            "Respond JSON only.",
+          ),
+        );
+
+      const result = await service.getDocumentAnalysisPrompt({
+        documentType: "petition",
+        text: "We the undersigned...",
+      });
+
+      expect(result.promptText).toContain("PETITION:");
+      expect(result.promptText).toContain("We the undersigned...");
+      expect(result.promptText).toContain("Respond JSON only.");
+      expect(result.promptVersion).toBe("v4");
+    });
+
+    it("should compose RAG prompt with context and query", async () => {
+      mockDb.promptTemplate.findFirst.mockResolvedValueOnce(
+        mockTemplate("rag", "Context:\n{{CONTEXT}}\n\nQ: {{QUERY}}\n\nA:", 7),
+      );
+
+      const result = await service.getRAGPrompt({
+        context: "The capital of France is Paris.",
+        query: "What is the capital of France?",
+      });
+
+      expect(result.promptText).toContain("The capital of France is Paris.");
+      expect(result.promptText).toContain("What is the capital of France?");
+      expect(result.promptVersion).toBe("v7");
+    });
+  });
+});

--- a/packages/prompt-client/__tests__/prompt-client.service.spec.ts
+++ b/packages/prompt-client/__tests__/prompt-client.service.spec.ts
@@ -37,8 +37,9 @@ describe("PromptClientService", () => {
     service = module.get(PromptClientService);
   });
 
-  afterEach(() => {
-    service.clearCache();
+  afterEach(async () => {
+    await service.clearCache();
+    await service.onModuleDestroy();
   });
 
   describe("getStructuralAnalysisPrompt", () => {
@@ -201,10 +202,22 @@ describe("PromptClientService", () => {
       );
 
       await service.getRAGPrompt({ context: "a", query: "b" });
-      service.clearCache();
+      await service.clearCache();
       await service.getRAGPrompt({ context: "c", query: "d" });
 
       expect(mockDb.promptTemplate.findFirst).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("getPromptHash", () => {
+    it("should return sha256 hash of template text", async () => {
+      mockDb.promptTemplate.findFirst.mockResolvedValueOnce(
+        mockTemplate("rag", "Template text for hashing"),
+      );
+
+      const hash = await service.getPromptHash("rag");
+
+      expect(hash).toMatch(/^[a-f0-9]{64}$/);
     });
   });
 
@@ -212,8 +225,6 @@ describe("PromptClientService", () => {
     it("should throw when non-core template not found", async () => {
       mockDb.promptTemplate.findFirst.mockResolvedValue(null);
 
-      // getPromptHash calls getTemplate with no fallbackName,
-      // and "nonexistent-template" has no hardcoded fallback
       await expect(
         service.getPromptHash("nonexistent-template"),
       ).rejects.toThrow(
@@ -324,6 +335,7 @@ describe("PromptClientService", () => {
 
       // DB should not have been called for validation
       expect(mockDb.promptTemplate.findFirst).not.toHaveBeenCalled();
+      await remoteService.onModuleDestroy();
     });
 
     it("should complete without throwing when templates are missing", async () => {
@@ -334,8 +346,37 @@ describe("PromptClientService", () => {
     });
   });
 
+  describe("metrics", () => {
+    it("should return initial metrics with zero counts", () => {
+      const metrics = service.getMetrics();
+
+      expect(metrics.totalRequests).toBe(0);
+      expect(metrics.cacheHits).toBe(0);
+      expect(metrics.remoteCalls).toBe(0);
+      expect(metrics.dbFallbacks).toBe(0);
+      expect(metrics.hardcodedFallbacks).toBe(0);
+      expect(metrics.cacheHitRate).toBe(0);
+      expect(metrics.fallbackRate).toBe(0);
+      expect(metrics.circuitBreakerState).toBe("closed");
+    });
+
+    it("should track hardcoded fallback usage", async () => {
+      mockDb.promptTemplate.findFirst.mockResolvedValue(null);
+
+      await service.getRAGPrompt({ context: "a", query: "b" });
+      const metrics = service.getMetrics();
+
+      expect(metrics.hardcodedFallbacks).toBeGreaterThan(0);
+    });
+
+    it("should return null circuit breaker health when not in remote mode", () => {
+      expect(service.getCircuitBreakerHealth()).toBeNull();
+    });
+  });
+
   describe("remote mode", () => {
     let remoteService: PromptClientService;
+    const originalFetch = globalThis.fetch;
 
     beforeEach(async () => {
       const module: TestingModule = await Test.createTestingModule({
@@ -347,12 +388,18 @@ describe("PromptClientService", () => {
             useValue: {
               promptServiceUrl: "http://prompt-service:3005",
               promptServiceApiKey: "test-api-key",
+              retryMaxAttempts: 1, // Disable retries in tests for speed
             },
           },
         ],
       }).compile();
 
       remoteService = module.get(PromptClientService);
+    });
+
+    afterEach(async () => {
+      globalThis.fetch = originalFetch;
+      await remoteService.onModuleDestroy();
     });
 
     it("should throw if API key is missing when URL is set", async () => {
@@ -375,9 +422,10 @@ describe("PromptClientService", () => {
       await expect(
         noKeyService.getRAGPrompt({ context: "a", query: "b" }),
       ).rejects.toThrow("API key is required");
+      await noKeyService.onModuleDestroy();
     });
 
-    it("should call remote service when URL is configured", async () => {
+    it("should call remote service with Bearer auth when URL is configured", async () => {
       const mockFetch = jest.fn().mockResolvedValue({
         ok: true,
         json: () =>
@@ -387,7 +435,7 @@ describe("PromptClientService", () => {
             promptVersion: "v2",
           }),
       });
-      global.fetch = mockFetch;
+      globalThis.fetch = mockFetch;
 
       const result = await remoteService.getRAGPrompt({
         context: "test",
@@ -404,6 +452,582 @@ describe("PromptClientService", () => {
           }),
         }),
       );
+    });
+
+    it("should track remote call metrics on success", async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "remote",
+            promptHash: "abc",
+            promptVersion: "v1",
+          }),
+      });
+
+      await remoteService.getRAGPrompt({ context: "a", query: "b" });
+      const metrics = remoteService.getMetrics();
+
+      expect(metrics.remoteCalls).toBe(1);
+      expect(metrics.avgRemoteLatencyMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it("should fall back to DB when remote fails", async () => {
+      globalThis.fetch = jest.fn().mockRejectedValue(new Error("fetch failed"));
+
+      // Set up DB fallback
+      mockDb.promptTemplate.findFirst.mockResolvedValue(
+        mockTemplate("rag", "DB fallback: {{CONTEXT}} {{QUERY}}"),
+      );
+
+      const result = await remoteService.getRAGPrompt({
+        context: "test",
+        query: "test",
+      });
+
+      expect(result.promptText).toContain("DB fallback:");
+      const metrics = remoteService.getMetrics();
+      expect(metrics.dbFallbacks).toBe(1);
+    });
+
+    it("should return circuit breaker health in remote mode", () => {
+      const health = remoteService.getCircuitBreakerHealth();
+
+      expect(health).not.toBeNull();
+      expect(health!.serviceName).toBe("PromptService");
+      expect(health!.state).toBe("closed");
+      expect(health!.isHealthy).toBe(true);
+    });
+  });
+
+  describe("remote mode with HMAC", () => {
+    let hmacService: PromptClientService;
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: {
+              promptServiceUrl: "http://prompt-service:3005",
+              promptServiceApiKey: "hmac-secret-key",
+              hmacNodeId: "node-uuid-1234",
+              retryMaxAttempts: 1,
+            },
+          },
+        ],
+      }).compile();
+
+      hmacService = module.get(PromptClientService);
+    });
+
+    afterEach(async () => {
+      globalThis.fetch = originalFetch;
+      await hmacService.onModuleDestroy();
+    });
+
+    it("should use HMAC headers instead of Bearer when hmacNodeId is set", async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "hmac prompt",
+            promptHash: "def456",
+            promptVersion: "v1",
+          }),
+      });
+      globalThis.fetch = mockFetch;
+
+      await hmacService.getRAGPrompt({ context: "test", query: "test" });
+
+      const call = mockFetch.mock.calls[0];
+      const headers = call[1].headers;
+
+      // Should have HMAC headers
+      expect(headers["X-HMAC-Signature"]).toBeDefined();
+      expect(headers["X-HMAC-Timestamp"]).toBeDefined();
+      expect(headers["X-HMAC-Key-Id"]).toBe("node-uuid-1234");
+
+      // Should NOT have Bearer auth
+      expect(headers["Authorization"]).toBeUndefined();
+    });
+
+    it("should produce valid HMAC signature format", async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "test",
+            promptHash: "abc",
+            promptVersion: "v1",
+          }),
+      });
+      globalThis.fetch = mockFetch;
+
+      await hmacService.getRAGPrompt({ context: "ctx", query: "q" });
+
+      const headers = mockFetch.mock.calls[0][1].headers;
+
+      // Signature should be valid base64
+      const decoded = Buffer.from(headers["X-HMAC-Signature"], "base64");
+      expect(decoded.length).toBe(32); // SHA-256 = 32 bytes
+
+      // Timestamp should be a valid number
+      const ts = Number.parseInt(headers["X-HMAC-Timestamp"], 10);
+      expect(ts).toBeGreaterThan(0);
+    });
+  });
+
+  describe("circuit breaker behavior", () => {
+    let cbService: PromptClientService;
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: {
+              promptServiceUrl: "http://prompt-service:3005",
+              promptServiceApiKey: "test-key",
+              retryMaxAttempts: 1,
+              circuitBreakerFailureThreshold: 2,
+              circuitBreakerHalfOpenMs: 60000,
+            },
+          },
+        ],
+      }).compile();
+
+      cbService = module.get(PromptClientService);
+
+      // Set up DB fallback for all calls
+      mockDb.promptTemplate.findFirst.mockResolvedValue(
+        mockTemplate("rag", "fallback: {{CONTEXT}} {{QUERY}}"),
+      );
+    });
+
+    afterEach(async () => {
+      globalThis.fetch = originalFetch;
+      await cbService.onModuleDestroy();
+    });
+
+    it("should open circuit after consecutive failures", async () => {
+      globalThis.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("500 Internal Server Error"));
+
+      // Trigger failures to open the circuit (threshold = 2)
+      await cbService.getRAGPrompt({ context: "a", query: "b" });
+      await cbService.getRAGPrompt({ context: "c", query: "d" });
+
+      const health = cbService.getCircuitBreakerHealth();
+      expect(health!.state).toBe("open");
+      expect(health!.isHealthy).toBe(false);
+    });
+
+    it("should fall back to DB when circuit is open", async () => {
+      globalThis.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("500 Internal Server Error"));
+
+      // Open the circuit
+      await cbService.getRAGPrompt({ context: "a", query: "b" });
+      await cbService.getRAGPrompt({ context: "c", query: "d" });
+
+      // Next call should fail fast (circuit open) and fall back to DB
+      const result = await cbService.getRAGPrompt({
+        context: "fallback test",
+        query: "question",
+      });
+
+      expect(result.promptText).toContain("fallback:");
+    });
+
+    it("should recover after circuit breaker resets", async () => {
+      // Use a very short half-open timeout for testing
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: {
+              promptServiceUrl: "http://prompt-service:3005",
+              promptServiceApiKey: "test-key",
+              retryMaxAttempts: 1,
+              circuitBreakerFailureThreshold: 1,
+              circuitBreakerHalfOpenMs: 100,
+            },
+          },
+        ],
+      }).compile();
+
+      const resetService = module.get(PromptClientService);
+
+      // Break the circuit
+      globalThis.fetch = jest.fn().mockRejectedValue(new Error("fail"));
+      await resetService.getRAGPrompt({ context: "a", query: "b" });
+      expect(resetService.getCircuitBreakerHealth()!.state).toBe("open");
+
+      // Wait for half-open
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      // Successful request should reset the circuit
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "recovered",
+            promptHash: "abc",
+            promptVersion: "v1",
+          }),
+      });
+
+      const result = await resetService.getRAGPrompt({
+        context: "c",
+        query: "d",
+      });
+
+      expect(result.promptText).toBe("recovered");
+      expect(resetService.getCircuitBreakerHealth()!.state).toBe("closed");
+      await resetService.onModuleDestroy();
+    });
+  });
+
+  describe("remote mode - all endpoints", () => {
+    let remoteService: PromptClientService;
+    const originalFetch = globalThis.fetch;
+
+    beforeEach(async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: {
+              promptServiceUrl: "http://prompt-service:3005",
+              promptServiceApiKey: "test-api-key",
+              retryMaxAttempts: 1,
+            },
+          },
+        ],
+      }).compile();
+
+      remoteService = module.get(PromptClientService);
+    });
+
+    afterEach(async () => {
+      globalThis.fetch = originalFetch;
+      await remoteService.onModuleDestroy();
+    });
+
+    it("should call remote for getStructuralAnalysisPrompt", async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "remote structural",
+            promptHash: "hash1",
+            promptVersion: "v3",
+          }),
+      });
+      globalThis.fetch = mockFetch;
+
+      const result = await remoteService.getStructuralAnalysisPrompt({
+        dataType: "propositions" as any,
+        contentGoal: "test",
+        html: "<div/>",
+      });
+
+      expect(result.promptText).toBe("remote structural");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://prompt-service:3005/prompts/structural-analysis",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("should call remote for getDocumentAnalysisPrompt", async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "remote document",
+            promptHash: "hash2",
+            promptVersion: "v2",
+          }),
+      });
+      globalThis.fetch = mockFetch;
+
+      const result = await remoteService.getDocumentAnalysisPrompt({
+        documentType: "petition",
+        text: "doc text",
+      });
+
+      expect(result.promptText).toBe("remote document");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://prompt-service:3005/prompts/document-analysis",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    it("should fall back to DB for structural-analysis when remote fails", async () => {
+      globalThis.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("network error"));
+
+      mockDb.promptTemplate.findFirst
+        .mockResolvedValueOnce(
+          mockTemplate(
+            "structural-analysis",
+            "Analyze {{DATA_TYPE}}.\n{{HINTS_SECTION}}Schema: {{SCHEMA_DESCRIPTION}}\n{{HTML}}",
+          ),
+        )
+        .mockResolvedValueOnce(
+          mockTemplate("structural-schema-default", "default schema"),
+        );
+
+      const result = await remoteService.getStructuralAnalysisPrompt({
+        dataType: "propositions" as any,
+        contentGoal: "test",
+        html: "<div/>",
+      });
+
+      expect(result.promptText).toContain("Analyze propositions");
+      const metrics = remoteService.getMetrics();
+      expect(metrics.dbFallbacks).toBe(1);
+    });
+
+    it("should fall back to DB for document-analysis when remote fails", async () => {
+      globalThis.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error("network error"));
+
+      mockDb.promptTemplate.findFirst
+        .mockResolvedValueOnce(
+          mockTemplate("document-analysis-petition", "Analyze: {{TEXT}}"),
+        )
+        .mockResolvedValueOnce(
+          mockTemplate("document-analysis-base-instructions", "JSON only."),
+        );
+
+      const result = await remoteService.getDocumentAnalysisPrompt({
+        documentType: "petition",
+        text: "doc text",
+      });
+
+      expect(result.promptText).toContain("Analyze: doc text");
+      const metrics = remoteService.getMetrics();
+      expect(metrics.dbFallbacks).toBe(1);
+    });
+
+    it("should treat HTTP error responses as failures and fall back", async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      });
+
+      mockDb.promptTemplate.findFirst.mockResolvedValue(
+        mockTemplate("rag", "DB: {{CONTEXT}} {{QUERY}}"),
+      );
+
+      const result = await remoteService.getRAGPrompt({
+        context: "ctx",
+        query: "q",
+      });
+
+      expect(result.promptText).toContain("DB: ctx q");
+    });
+
+    it("should treat 4xx HTTP errors as non-retryable", async () => {
+      const mockFetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 400,
+        statusText: "Bad Request",
+      });
+      globalThis.fetch = mockFetch;
+
+      mockDb.promptTemplate.findFirst.mockResolvedValue(
+        mockTemplate("rag", "fallback: {{CONTEXT}} {{QUERY}}"),
+      );
+
+      // With retryMaxAttempts: 1, the 400 should not be retried
+      await remoteService.getRAGPrompt({ context: "a", query: "b" });
+
+      // fetch called only once (no retries for 4xx)
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("retry behavior", () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it("should retry on server errors and invoke onRetry callback", async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: {
+              promptServiceUrl: "http://prompt-service:3005",
+              promptServiceApiKey: "test-key",
+              retryMaxAttempts: 3,
+              retryBaseDelayMs: 10,
+              retryMaxDelayMs: 50,
+            },
+          },
+        ],
+      }).compile();
+
+      const retryService = module.get(PromptClientService);
+
+      // Fail twice, then succeed
+      const mockFetch = jest
+        .fn()
+        .mockRejectedValueOnce(new Error("500 Internal Server Error"))
+        .mockRejectedValueOnce(new Error("503 Service Unavailable"))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              promptText: "success after retries",
+              promptHash: "abc",
+              promptVersion: "v1",
+            }),
+        });
+      globalThis.fetch = mockFetch;
+
+      const result = await retryService.getRAGPrompt({
+        context: "a",
+        query: "b",
+      });
+
+      expect(result.promptText).toBe("success after retries");
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+
+      await retryService.onModuleDestroy();
+    });
+  });
+
+  describe("CircuitOpenError skips retry", () => {
+    const originalFetch = globalThis.fetch;
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it("should not retry when circuit is open", async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: {
+              promptServiceUrl: "http://prompt-service:3005",
+              promptServiceApiKey: "test-key",
+              retryMaxAttempts: 3,
+              retryBaseDelayMs: 10,
+              circuitBreakerFailureThreshold: 1,
+              circuitBreakerHalfOpenMs: 60000,
+            },
+          },
+        ],
+      }).compile();
+
+      const svc = module.get(PromptClientService);
+
+      // Break the circuit with one failure
+      const mockFetch = jest.fn().mockRejectedValue(new Error("server down"));
+      globalThis.fetch = mockFetch;
+
+      mockDb.promptTemplate.findFirst.mockResolvedValue(
+        mockTemplate("rag", "fallback: {{CONTEXT}} {{QUERY}}"),
+      );
+
+      await svc.getRAGPrompt({ context: "a", query: "b" });
+      expect(svc.getCircuitBreakerHealth()!.state).toBe("open");
+
+      // Reset fetch mock to track next call
+      mockFetch.mockClear();
+
+      // This call should hit CircuitOpenError and NOT retry (fail fast)
+      const result = await svc.getRAGPrompt({
+        context: "fast fallback",
+        query: "q",
+      });
+
+      expect(result.promptText).toContain("fallback:");
+      // fetch should NOT have been called (circuit open prevents it)
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      await svc.onModuleDestroy();
+    });
+  });
+
+  describe("composeFromDb unknown endpoint", () => {
+    it("should throw for unknown endpoint", async () => {
+      // Access the private method via prototype to test defensive default branch
+      const composeFromDb = (service as any).composeFromDb.bind(service);
+      await expect(composeFromDb("unknown-endpoint", {})).rejects.toThrow(
+        "Unknown prompt endpoint: unknown-endpoint",
+      );
+    });
+  });
+
+  describe("onModuleInit", () => {
+    it("should log success when all templates are found", async () => {
+      // All DB lookups return a valid template
+      mockDb.promptTemplate.findFirst.mockResolvedValue({ id: "exists" });
+
+      await service.onModuleInit();
+
+      // No error thrown, and validation ran (5 core templates queried)
+      expect(mockDb.promptTemplate.findFirst).toHaveBeenCalledTimes(5);
+    });
+  });
+
+  describe("onModuleDestroy", () => {
+    it("should call destroy on the template cache", async () => {
+      // onModuleDestroy is called in afterEach; verify it doesn't throw
+      await expect(service.onModuleDestroy()).resolves.toBeUndefined();
+    });
+
+    it("should call destroy on custom cache implementation", async () => {
+      const customCache = {
+        get: jest.fn().mockResolvedValue(undefined),
+        set: jest.fn().mockResolvedValue(undefined),
+        delete: jest.fn().mockResolvedValue(true),
+        clear: jest.fn().mockResolvedValue(undefined),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          PromptClientService,
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: PROMPT_CLIENT_CONFIG,
+            useValue: { cache: customCache },
+          },
+        ],
+      }).compile();
+
+      const customService = module.get(PromptClientService);
+      await customService.onModuleDestroy();
+
+      expect(customCache.destroy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/prompt-client/src/hmac-signer.ts
+++ b/packages/prompt-client/src/hmac-signer.ts
@@ -1,0 +1,53 @@
+/**
+ * HMAC Request Signer for Prompt Service
+ *
+ * Signs outbound requests using the prompt-service HMAC protocol.
+ * The API key never leaves the node — each request is signed with a
+ * timestamp and body hash for replay protection and tamper detection.
+ *
+ * NOTE: This is different from the gateway HmacSignerService which uses
+ * X-HMAC-Auth with JSON credentials. The prompt-service protocol uses
+ * separate X-HMAC-Signature/Timestamp/Key-Id headers with body hash.
+ */
+
+import { createHash, createHmac } from "node:crypto";
+
+export interface HmacSigningConfig {
+  /** The shared secret (node API key) */
+  apiKey: string;
+  /** Node UUID — sent as X-HMAC-Key-Id */
+  nodeId: string;
+}
+
+export interface HmacHeaders {
+  "X-HMAC-Signature": string;
+  "X-HMAC-Timestamp": string;
+  "X-HMAC-Key-Id": string;
+}
+
+/**
+ * Sign a request using the prompt-service HMAC protocol.
+ *
+ * Signature string: `${timestamp}\n${method}\n${path}\n${bodyHash}`
+ * Body hash: SHA-256 hex digest of the raw request body
+ * Signature: Base64-encoded HMAC-SHA256 of the signature string
+ */
+export function signRequest(
+  config: HmacSigningConfig,
+  method: string,
+  path: string,
+  body: string,
+): HmacHeaders {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const bodyHash = createHash("sha256").update(body).digest("hex");
+  const signatureString = `${timestamp}\n${method.toUpperCase()}\n${path}\n${bodyHash}`;
+  const signature = createHmac("sha256", config.apiKey)
+    .update(signatureString)
+    .digest("base64");
+
+  return {
+    "X-HMAC-Signature": signature,
+    "X-HMAC-Timestamp": timestamp,
+    "X-HMAC-Key-Id": config.nodeId,
+  };
+}

--- a/packages/prompt-client/src/index.ts
+++ b/packages/prompt-client/src/index.ts
@@ -41,3 +41,6 @@ export type {
   PromptServiceResponse,
 } from "./types.js";
 export { PROMPT_CLIENT_CONFIG } from "./types.js";
+export { signRequest } from "./hmac-signer.js";
+export type { HmacSigningConfig, HmacHeaders } from "./hmac-signer.js";
+export type { PromptClientMetrics } from "./metrics.js";

--- a/packages/prompt-client/src/metrics.ts
+++ b/packages/prompt-client/src/metrics.ts
@@ -1,0 +1,93 @@
+/**
+ * Prompt Client Metrics
+ *
+ * Simple counter-based metrics for monitoring prompt client health.
+ * Tracks cache hits, remote calls, fallbacks, and latency.
+ */
+
+/**
+ * Snapshot of prompt client metrics.
+ */
+export interface PromptClientMetrics {
+  /** Total requests made (all sources) */
+  totalRequests: number;
+  /** Requests served from cache */
+  cacheHits: number;
+  /** Requests sent to remote prompt service */
+  remoteCalls: number;
+  /** Requests that fell back to DB after remote failure */
+  dbFallbacks: number;
+  /** Requests that used hardcoded fallback templates */
+  hardcodedFallbacks: number;
+  /** Average remote call latency in ms (0 if no remote calls) */
+  avgRemoteLatencyMs: number;
+  /** Current circuit breaker state */
+  circuitBreakerState: string;
+  /** Cache hit rate (0–1) */
+  cacheHitRate: number;
+  /** Fallback rate (0–1) */
+  fallbackRate: number;
+}
+
+/**
+ * Accumulates prompt client metrics.
+ */
+export class MetricsCollector {
+  private totalRequests = 0;
+  private cacheHits = 0;
+  private remoteCalls = 0;
+  private dbFallbacks = 0;
+  private hardcodedFallbacks = 0;
+  private totalRemoteLatencyMs = 0;
+
+  recordCacheHit(): void {
+    this.totalRequests++;
+    this.cacheHits++;
+  }
+
+  recordRemoteCall(latencyMs: number): void {
+    this.totalRequests++;
+    this.remoteCalls++;
+    this.totalRemoteLatencyMs += latencyMs;
+  }
+
+  recordDbFallback(): void {
+    this.totalRequests++;
+    this.dbFallbacks++;
+  }
+
+  recordHardcodedFallback(): void {
+    this.totalRequests++;
+    this.hardcodedFallbacks++;
+  }
+
+  getMetrics(circuitBreakerState: string): PromptClientMetrics {
+    return {
+      totalRequests: this.totalRequests,
+      cacheHits: this.cacheHits,
+      remoteCalls: this.remoteCalls,
+      dbFallbacks: this.dbFallbacks,
+      hardcodedFallbacks: this.hardcodedFallbacks,
+      avgRemoteLatencyMs:
+        this.remoteCalls > 0
+          ? Math.round(this.totalRemoteLatencyMs / this.remoteCalls)
+          : 0,
+      circuitBreakerState,
+      cacheHitRate:
+        this.totalRequests > 0 ? this.cacheHits / this.totalRequests : 0,
+      fallbackRate:
+        this.totalRequests > 0
+          ? (this.dbFallbacks + this.hardcodedFallbacks) / this.totalRequests
+          : 0,
+    };
+  }
+
+  reset(): void {
+    this.totalRequests = 0;
+    this.cacheHits = 0;
+    this.remoteCalls = 0;
+    this.dbFallbacks = 0;
+    this.hardcodedFallbacks = 0;
+    this.totalRemoteLatencyMs = 0;
+  }
+}

--- a/packages/prompt-client/src/prompt-client.service.ts
+++ b/packages/prompt-client/src/prompt-client.service.ts
@@ -2,7 +2,10 @@
  * Prompt Client Service
  *
  * Reads AI prompt templates from the database and composes them with variables.
- * In the future, can switch to a remote AI Prompt Service by setting the URL.
+ * When configured with a remote AI Prompt Service URL, delegates to the service
+ * with HMAC request signing, circuit breaker protection, and retry logic.
+ *
+ * Fallback chain: remote → database → hardcoded defaults
  */
 
 import {
@@ -10,12 +13,27 @@ import {
   Injectable,
   Logger,
   OnModuleInit,
+  OnModuleDestroy,
   Optional,
 } from "@nestjs/common";
 import { createHash } from "node:crypto";
 import { DbService } from "@opuspopuli/relationaldb-provider";
 import type { PromptTemplate } from "@opuspopuli/relationaldb-provider";
-import type { PromptServiceResponse } from "@opuspopuli/common";
+import {
+  CircuitBreakerManager,
+  CircuitOpenError,
+  CircuitState,
+  createCircuitBreaker,
+  DEFAULT_CIRCUIT_CONFIGS,
+  MemoryCache,
+  withRetry,
+  RetryPredicates,
+  type CircuitBreakerHealth,
+  type ICache,
+  type PromptServiceResponse,
+} from "@opuspopuli/common";
+import { signRequest, type HmacSigningConfig } from "./hmac-signer.js";
+import { MetricsCollector, type PromptClientMetrics } from "./metrics.js";
 import type {
   PromptClientConfig,
   StructuralAnalysisParams,
@@ -113,9 +131,17 @@ Answer:`,
 ]);
 
 @Injectable()
-export class PromptClientService implements OnModuleInit {
+export class PromptClientService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(PromptClientService.name);
-  private readonly cache = new Map<string, PromptTemplate>();
+  private readonly templateCache: ICache<PromptTemplate>;
+  private readonly circuitBreaker?: CircuitBreakerManager;
+  private readonly hmacConfig?: HmacSigningConfig;
+  private readonly metrics = new MetricsCollector();
+  private readonly retryConfig: {
+    maxAttempts: number;
+    baseDelayMs: number;
+    maxDelayMs: number;
+  };
 
   constructor(
     private readonly db: DbService,
@@ -123,13 +149,61 @@ export class PromptClientService implements OnModuleInit {
     @Inject(PROMPT_CLIENT_CONFIG)
     private readonly config?: PromptClientConfig,
   ) {
-    if (this.config?.promptServiceUrl) {
+    // Initialize template cache
+    this.templateCache =
+      config?.cache ??
+      new MemoryCache<PromptTemplate>({
+        ttlMs: config?.cacheTtlMs ?? 300000,
+        maxSize: config?.cacheMaxSize ?? 50,
+      });
+
+    // Initialize circuit breaker (only when remote URL is configured)
+    if (config?.promptServiceUrl) {
+      const defaultCb = DEFAULT_CIRCUIT_CONFIGS.promptService;
+      this.circuitBreaker = createCircuitBreaker({
+        failureThreshold:
+          config.circuitBreakerFailureThreshold ?? defaultCb.failureThreshold,
+        halfOpenAfterMs:
+          config.circuitBreakerHalfOpenMs ?? defaultCb.halfOpenAfterMs,
+        serviceName: defaultCb.serviceName,
+      });
+
+      this.circuitBreaker.addListener((event) => {
+        switch (event) {
+          case "break":
+            this.logger.warn("Circuit breaker OPENED for PromptService");
+            break;
+          case "reset":
+            this.logger.log("Circuit breaker RESET for PromptService");
+            break;
+          case "half_open":
+            this.logger.log("Circuit breaker HALF-OPEN for PromptService");
+            break;
+        }
+      });
+
       this.logger.log(
-        `Prompt client configured for remote service: ${this.config.promptServiceUrl}`,
+        `Prompt client configured for remote service: ${config.promptServiceUrl}` +
+          (config.hmacNodeId ? " (HMAC auth)" : " (Bearer auth)"),
       );
     } else {
       this.logger.log("Prompt client using database templates");
     }
+
+    // Initialize HMAC config
+    if (config?.hmacNodeId && config?.promptServiceApiKey) {
+      this.hmacConfig = {
+        apiKey: config.promptServiceApiKey,
+        nodeId: config.hmacNodeId,
+      };
+    }
+
+    // Initialize retry config
+    this.retryConfig = {
+      maxAttempts: config?.retryMaxAttempts ?? 3,
+      baseDelayMs: config?.retryBaseDelayMs ?? 1000,
+      maxDelayMs: config?.retryMaxDelayMs ?? 10000,
+    };
   }
 
   async onModuleInit(): Promise<void> {
@@ -146,6 +220,10 @@ export class PromptClientService implements OnModuleInit {
           "Hardcoded fallbacks will be used. Run db:seed-prompts to populate.",
       );
     }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.templateCache.destroy();
   }
 
   /**
@@ -175,11 +253,178 @@ export class PromptClientService implements OnModuleInit {
     if (this.config?.promptServiceUrl) {
       return this.fetchRemotePrompt("structural-analysis", params);
     }
+    return this.composeStructuralAnalysis(params);
+  }
 
-    // Read base template
+  /**
+   * Get a document analysis prompt.
+   */
+  async getDocumentAnalysisPrompt(
+    params: DocumentAnalysisParams,
+  ): Promise<PromptServiceResponse> {
+    if (this.config?.promptServiceUrl) {
+      return this.fetchRemotePrompt("document-analysis", params);
+    }
+    return this.composeDocumentAnalysis(params);
+  }
+
+  /**
+   * Get a RAG prompt.
+   */
+  async getRAGPrompt(params: RAGParams): Promise<PromptServiceResponse> {
+    if (this.config?.promptServiceUrl) {
+      return this.fetchRemotePrompt("rag", params);
+    }
+    return this.composeRag(params);
+  }
+
+  /**
+   * Get the current prompt hash for cache invalidation.
+   */
+  async getPromptHash(templateName: string): Promise<string> {
+    const template = await this.getTemplate(templateName);
+    return this.hash(template.templateText);
+  }
+
+  /**
+   * Get current metrics snapshot.
+   */
+  getMetrics(): PromptClientMetrics {
+    const state = this.circuitBreaker?.getState() ?? CircuitState.CLOSED;
+    return this.metrics.getMetrics(state);
+  }
+
+  /**
+   * Get circuit breaker health (null if remote mode is not configured).
+   */
+  getCircuitBreakerHealth(): CircuitBreakerHealth | null {
+    return this.circuitBreaker?.getHealth() ?? null;
+  }
+
+  /**
+   * Clear the template cache.
+   */
+  async clearCache(): Promise<void> {
+    await this.templateCache.clear();
+    this.logger.log("Template cache cleared");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: Remote fetch with resilience
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Fetch prompt from the remote AI Prompt Service with retry and circuit breaker.
+   * Falls back to DB-based composition on failure.
+   */
+  private async fetchRemotePrompt(
+    endpoint: string,
+    params: StructuralAnalysisParams | DocumentAnalysisParams | RAGParams,
+  ): Promise<PromptServiceResponse> {
+    const url = this.config!.promptServiceUrl!;
+    const timeout = this.config?.timeoutMs ?? 10000;
+    const body = JSON.stringify(params);
+    const path = `/prompts/${endpoint}`;
+
+    // Build headers: HMAC or Bearer
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+
+    if (this.hmacConfig) {
+      Object.assign(headers, signRequest(this.hmacConfig, "POST", path, body));
+    } else {
+      const apiKey = this.config!.promptServiceApiKey;
+      if (!apiKey) {
+        throw new Error(
+          "API key is required when prompt service URL is configured",
+        );
+      }
+      headers["Authorization"] = `Bearer ${apiKey}`;
+    }
+
+    const startMs = Date.now();
+
+    try {
+      const result = await withRetry(
+        () =>
+          this.circuitBreaker!.execute(async () => {
+            const response = await fetch(`${url}${path}`, {
+              method: "POST",
+              headers,
+              body,
+              signal: AbortSignal.timeout(timeout),
+            });
+
+            if (!response.ok) {
+              throw new Error(
+                `Prompt service returned ${response.status}: ${response.statusText}`,
+              );
+            }
+
+            return (await response.json()) as PromptServiceResponse;
+          }),
+        {
+          maxAttempts: this.retryConfig.maxAttempts,
+          baseDelayMs: this.retryConfig.baseDelayMs,
+          maxDelayMs: this.retryConfig.maxDelayMs,
+          isRetryable: (error) => {
+            // Never retry when circuit is open — fail fast to DB fallback
+            if (error instanceof CircuitOpenError) return false;
+            // Only retry transient errors (network failures, 5xx)
+            return (
+              RetryPredicates.isNetworkError(error) ||
+              RetryPredicates.isServerError(error)
+            );
+          },
+          onRetry: (error, attempt, delayMs) => {
+            this.logger.warn(
+              `Retry attempt ${attempt} for ${endpoint} after ${delayMs}ms: ${error.message}`,
+            );
+          },
+        },
+      );
+
+      this.metrics.recordRemoteCall(Date.now() - startMs);
+      return result;
+    } catch (error) {
+      this.logger.warn(
+        `Remote prompt service failed for ${endpoint}, falling back to DB: ${(error as Error).message}`,
+      );
+      return this.composeFromDb(endpoint, params);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: DB-based composition (fallback path)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Route to the correct DB composition method based on endpoint.
+   */
+  private async composeFromDb(
+    endpoint: string,
+    params: StructuralAnalysisParams | DocumentAnalysisParams | RAGParams,
+  ): Promise<PromptServiceResponse> {
+    this.metrics.recordDbFallback();
+    switch (endpoint) {
+      case "structural-analysis":
+        return this.composeStructuralAnalysis(
+          params as StructuralAnalysisParams,
+        );
+      case "document-analysis":
+        return this.composeDocumentAnalysis(params as DocumentAnalysisParams);
+      case "rag":
+        return this.composeRag(params as RAGParams);
+      default:
+        throw new Error(`Unknown prompt endpoint: ${endpoint}`);
+    }
+  }
+
+  private async composeStructuralAnalysis(
+    params: StructuralAnalysisParams,
+  ): Promise<PromptServiceResponse> {
     const template = await this.getTemplate("structural-analysis");
-
-    // Read schema description for this data type
     const schemaTemplate = await this.getTemplate(
       `structural-schema-${params.dataType}`,
       `structural-schema-default`,
@@ -207,16 +452,9 @@ export class PromptClientService implements OnModuleInit {
     };
   }
 
-  /**
-   * Get a document analysis prompt.
-   */
-  async getDocumentAnalysisPrompt(
+  private async composeDocumentAnalysis(
     params: DocumentAnalysisParams,
   ): Promise<PromptServiceResponse> {
-    if (this.config?.promptServiceUrl) {
-      return this.fetchRemotePrompt("document-analysis", params);
-    }
-
     const template = await this.getTemplate(
       `document-analysis-${params.documentType}`,
       "document-analysis-generic",
@@ -237,14 +475,7 @@ export class PromptClientService implements OnModuleInit {
     };
   }
 
-  /**
-   * Get a RAG prompt.
-   */
-  async getRAGPrompt(params: RAGParams): Promise<PromptServiceResponse> {
-    if (this.config?.promptServiceUrl) {
-      return this.fetchRemotePrompt("rag", params);
-    }
-
+  private async composeRag(params: RAGParams): Promise<PromptServiceResponse> {
     const template = await this.getTemplate("rag");
 
     const promptText = this.interpolate(template.templateText, {
@@ -259,32 +490,19 @@ export class PromptClientService implements OnModuleInit {
     };
   }
 
-  /**
-   * Get the current prompt hash for cache invalidation.
-   */
-  async getPromptHash(templateName: string): Promise<string> {
-    const template = await this.getTemplate(templateName);
-    return this.hash(template.templateText);
-  }
+  // ---------------------------------------------------------------------------
+  // Private: Template loading with caching
+  // ---------------------------------------------------------------------------
 
   /**
-   * Clear the in-memory template cache.
-   */
-  clearCache(): void {
-    this.cache.clear();
-    this.logger.log("Template cache cleared");
-  }
-
-  /**
-   * Fetch a template from the database with in-memory caching.
-   * Falls back to a default template name if the primary is not found.
+   * Fetch a template from the database with caching and fallbacks.
    */
   private async getTemplate(
     name: string,
     fallbackName?: string,
   ): Promise<PromptTemplate> {
     // Check cache
-    const cached = this.cache.get(name);
+    const cached = await this.templateCache.get(name);
     if (cached) return cached;
 
     // Query database
@@ -307,20 +525,22 @@ export class PromptClientService implements OnModuleInit {
         this.logger.warn(
           `Using hardcoded fallback for "${name}" — run db:seed-prompts`,
         );
-        this.cache.set(name, fallback);
+        this.metrics.recordHardcodedFallback();
+        await this.templateCache.set(name, fallback);
         return fallback;
       }
       throw new Error(`Prompt template "${name}" not found in database`);
     }
 
     // Cache for future reads
-    this.cache.set(name, template);
+    await this.templateCache.set(name, template);
     return template;
   }
 
-  /**
-   * Interpolate {{VARIABLE}} placeholders in a template.
-   */
+  // ---------------------------------------------------------------------------
+  // Private: Utilities
+  // ---------------------------------------------------------------------------
+
   private interpolate(
     template: string,
     variables: Record<string, string>,
@@ -332,46 +552,7 @@ export class PromptClientService implements OnModuleInit {
     return result;
   }
 
-  /**
-   * Hash a template string for cache invalidation tracking.
-   */
   private hash(text: string): string {
     return createHash("sha256").update(text).digest("hex");
-  }
-
-  /**
-   * Fetch prompt from a remote AI Prompt Service.
-   */
-  private async fetchRemotePrompt(
-    endpoint: string,
-    params: StructuralAnalysisParams | DocumentAnalysisParams | RAGParams,
-  ): Promise<PromptServiceResponse> {
-    const url = this.config!.promptServiceUrl!;
-    const apiKey = this.config!.promptServiceApiKey;
-    const timeout = this.config?.timeoutMs ?? 10000;
-
-    if (!apiKey) {
-      throw new Error(
-        "API key is required when prompt service URL is configured",
-      );
-    }
-
-    const response = await fetch(`${url}/prompts/${endpoint}`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify(params),
-      signal: AbortSignal.timeout(timeout),
-    });
-
-    if (!response.ok) {
-      throw new Error(
-        `Prompt service returned ${response.status}: ${response.statusText}`,
-      );
-    }
-
-    return (await response.json()) as PromptServiceResponse;
   }
 }

--- a/packages/prompt-client/src/types.ts
+++ b/packages/prompt-client/src/types.ts
@@ -2,18 +2,45 @@
  * Prompt Client Types
  */
 
-import type { DataType, PromptServiceResponse } from "@opuspopuli/common";
+import type {
+  DataType,
+  PromptServiceResponse,
+  ICache,
+} from "@opuspopuli/common";
+import type { PromptTemplate } from "@opuspopuli/relationaldb-provider";
 
 /**
  * Configuration for the prompt client.
  */
 export interface PromptClientConfig {
-  /** URL of future remote AI Prompt Service (undefined = read from DB) */
+  /** URL of remote AI Prompt Service (undefined = read from DB) */
   promptServiceUrl?: string;
-  /** API key — always required when url is set */
+  /** API key — required when url is set (used for Bearer or HMAC signing) */
   promptServiceApiKey?: string;
   /** Request timeout in ms (default: 10000) */
   timeoutMs?: number;
+
+  /** Node UUID for HMAC signing. When set (along with apiKey), uses HMAC auth instead of Bearer. */
+  hmacNodeId?: string;
+
+  /** Max retry attempts for remote calls (default: 3) */
+  retryMaxAttempts?: number;
+  /** Base delay in ms for exponential backoff (default: 1000) */
+  retryBaseDelayMs?: number;
+  /** Max delay in ms between retries (default: 10000) */
+  retryMaxDelayMs?: number;
+
+  /** Failure threshold before opening circuit (default: 3) */
+  circuitBreakerFailureThreshold?: number;
+  /** Time in ms before testing half-open (default: 15000) */
+  circuitBreakerHalfOpenMs?: number;
+
+  /** External cache instance (e.g., Redis-backed). When undefined, uses MemoryCache. */
+  cache?: ICache<PromptTemplate>;
+  /** Cache TTL in ms for template entries (default: 300000 = 5 min) */
+  cacheTtlMs?: number;
+  /** Maximum in-memory cache entries (default: 50, only used for built-in MemoryCache) */
+  cacheMaxSize?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Enhance prompt-client with circuit breaker, HMAC auth, and caching** (#431) — Production-ready resilience for the `@opuspopuli/prompt-client` package
  - HMAC request signing for prompt-service authentication (separate protocol from gateway HMAC)
  - Circuit breaker with configurable failure threshold and half-open recovery
  - Retry with exponential backoff (skips retry on CircuitOpenError)
  - Pluggable `ICache<T>` support (inject Redis or use built-in MemoryCache with TTL)
  - Metrics collector (cache hits, remote calls, DB/hardcoded fallbacks, latency, circuit state)
  - 3-tier fallback chain: remote → database → hardcoded defaults
  - 100% test coverage (71 unit tests + 13 integration tests)
- Updated documentation: auth-security guide, observability guide, AI pipeline docs, system overview
- New prompt-client README with full usage guide

## Test plan

- [x] All 71 prompt-client unit tests pass
- [x] All 13 integration tests pass
- [x] 100% coverage across statements, branches, functions, lines
- [x] Full workspace build passes (1,202 tests)
- [x] SonarCloud lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)