### PR TITLE
feat: add transparency pages (#419, #420, #421, #422)

### DIFF
--- a/apps/frontend/__tests__/components/Footer.test.tsx
+++ b/apps/frontend/__tests__/components/Footer.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { Footer } from "@/components/Footer";
+
+describe("Footer", () => {
+  beforeEach(() => {
+    render(<Footer />);
+  });
+
+  it("should render copyright text", () => {
+    const year = new Date().getFullYear();
+    expect(
+      screen.getByText(new RegExp(`${year} Opus Populi`)),
+    ).toBeInTheDocument();
+  });
+
+  it("should render Privacy Policy link", () => {
+    const link = screen.getByRole("link", { name: "Privacy Policy" });
+    expect(link).toHaveAttribute("href", "/privacy");
+  });
+
+  it("should render Terms of Service link", () => {
+    const link = screen.getByRole("link", { name: "Terms of Service" });
+    expect(link).toHaveAttribute("href", "/terms");
+  });
+
+  it("should render Transparency link", () => {
+    const link = screen.getByRole("link", { name: "Transparency" });
+    expect(link).toHaveAttribute("href", "/transparency");
+  });
+});

--- a/apps/frontend/__tests__/pages/transparency/ai-commitments.test.tsx
+++ b/apps/frontend/__tests__/pages/transparency/ai-commitments.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("@/components/Header", () => ({
+  Header: () => <header data-testid="mock-header">Mock Header</header>,
+}));
+
+jest.mock("@/components/Footer", () => ({
+  Footer: () => <footer data-testid="mock-footer">Mock Footer</footer>,
+}));
+
+import AICommitmentsPage from "@/app/transparency/ai-commitments/page";
+
+describe("AICommitmentsPage", () => {
+  beforeEach(() => {
+    render(<AICommitmentsPage />);
+  });
+
+  it("should render the page title", () => {
+    expect(screen.getByText("AI Commitments")).toBeInTheDocument();
+  });
+
+  it("should render the intro text", () => {
+    expect(screen.getByText(/binding commitments/)).toBeInTheDocument();
+  });
+
+  it("should render all 6 commitment headings", () => {
+    expect(
+      screen.getByText("Never Make Voting Recommendations"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Never Suppress or Promote Political Positions"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Never Store Prompt Templates in Client Code"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Never Train on User Documents"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Never Share Data Between Federated Nodes Without Consent",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Never Sell or Monetize User Data"),
+    ).toBeInTheDocument();
+  });
+
+  it("should render Technical Control for each commitment", () => {
+    const controls = screen.getAllByText("Technical Control:");
+    expect(controls).toHaveLength(6);
+  });
+
+  it("should render How to Verify for each commitment", () => {
+    const verifications = screen.getAllByText("How to Verify:");
+    expect(verifications).toHaveLength(6);
+  });
+
+  it("should link to AI System Card", () => {
+    const link = screen.getByRole("link", { name: /AI System Card/ });
+    expect(link).toHaveAttribute("href", "/transparency/system-card");
+  });
+
+  it("should link to Prompt Service Charter", () => {
+    const link = screen.getByRole("link", {
+      name: /Prompt Service Charter/,
+    });
+    expect(link).toHaveAttribute("href", "/transparency/prompt-charter");
+  });
+
+  it("should link back to transparency index", () => {
+    const link = screen.getByRole("link", {
+      name: /Back to Transparency/,
+    });
+    expect(link).toHaveAttribute("href", "/transparency");
+  });
+
+  it("should render header and footer", () => {
+    expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-footer")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/pages/transparency/index.test.tsx
+++ b/apps/frontend/__tests__/pages/transparency/index.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("@/components/Header", () => ({
+  Header: () => <header data-testid="mock-header">Mock Header</header>,
+}));
+
+jest.mock("@/components/Footer", () => ({
+  Footer: () => <footer data-testid="mock-footer">Mock Footer</footer>,
+}));
+
+import TransparencyPage from "@/app/transparency/page";
+
+describe("TransparencyPage", () => {
+  beforeEach(() => {
+    render(<TransparencyPage />);
+  });
+
+  it("should render the page title", () => {
+    expect(screen.getByText("Transparency")).toBeInTheDocument();
+  });
+
+  it("should render intro text", () => {
+    expect(
+      screen.getByText(/committed to AI transparency/),
+    ).toBeInTheDocument();
+  });
+
+  it("should render AI System Card link", () => {
+    const link = screen.getByRole("link", { name: /AI System Card/ });
+    expect(link).toHaveAttribute("href", "/transparency/system-card");
+  });
+
+  it("should render AI Commitments link", () => {
+    const link = screen.getByRole("link", { name: /AI Commitments/ });
+    expect(link).toHaveAttribute("href", "/transparency/ai-commitments");
+  });
+
+  it("should render Prompt Service Charter link", () => {
+    const link = screen.getByRole("link", {
+      name: /Prompt Service Charter/,
+    });
+    expect(link).toHaveAttribute("href", "/transparency/prompt-charter");
+  });
+
+  it("should render all three card descriptions", () => {
+    expect(
+      screen.getByText(/How our AI works, what data it processes/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/What this AI will never do/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/How our prompts are designed, managed/),
+    ).toBeInTheDocument();
+  });
+
+  it("should render header and footer", () => {
+    expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-footer")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/pages/transparency/prompt-charter.test.tsx
+++ b/apps/frontend/__tests__/pages/transparency/prompt-charter.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("@/components/Header", () => ({
+  Header: () => <header data-testid="mock-header">Mock Header</header>,
+}));
+
+jest.mock("@/components/Footer", () => ({
+  Footer: () => <footer data-testid="mock-footer">Mock Footer</footer>,
+}));
+
+import PromptCharterPage from "@/app/transparency/prompt-charter/page";
+
+describe("PromptCharterPage", () => {
+  beforeEach(() => {
+    render(<PromptCharterPage />);
+  });
+
+  it("should render the page title", () => {
+    expect(screen.getByText("Prompt Service Charter")).toBeInTheDocument();
+  });
+
+  it("should render the last updated date", () => {
+    expect(screen.getByText(/Last updated: March 2026/)).toBeInTheDocument();
+  });
+
+  it("should render all 5 sections", () => {
+    expect(screen.getByText("1. What Prompts Do")).toBeInTheDocument();
+    expect(screen.getByText("2. Design Principles")).toBeInTheDocument();
+    expect(screen.getByText("3. How Prompts Are Managed")).toBeInTheDocument();
+    expect(
+      screen.getByText("4. Verification and Auditability"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("5. What We Do Not Disclose")).toBeInTheDocument();
+  });
+
+  it("should render all 4 design principles", () => {
+    expect(screen.getByText("Neutrality")).toBeInTheDocument();
+    expect(screen.getByText("Completeness")).toBeInTheDocument();
+    expect(screen.getByText("Source Attribution")).toBeInTheDocument();
+    expect(screen.getByText("Transparency")).toBeInTheDocument();
+  });
+
+  it("should link to AI System Card", () => {
+    const links = screen.getAllByRole("link", { name: /System Card/ });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links[0]).toHaveAttribute("href", "/transparency/system-card");
+  });
+
+  it("should link to AI Commitments", () => {
+    const links = screen.getAllByRole("link", { name: /AI Commitments/ });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links[0]).toHaveAttribute("href", "/transparency/ai-commitments");
+  });
+
+  it("should link back to transparency index", () => {
+    const link = screen.getByRole("link", {
+      name: /Back to Transparency/,
+    });
+    expect(link).toHaveAttribute("href", "/transparency");
+  });
+
+  it("should render header and footer", () => {
+    expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-footer")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/pages/transparency/system-card.test.tsx
+++ b/apps/frontend/__tests__/pages/transparency/system-card.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+jest.mock("@/components/Header", () => ({
+  Header: () => <header data-testid="mock-header">Mock Header</header>,
+}));
+
+jest.mock("@/components/Footer", () => ({
+  Footer: () => <footer data-testid="mock-footer">Mock Footer</footer>,
+}));
+
+import SystemCardPage from "@/app/transparency/system-card/page";
+
+describe("SystemCardPage", () => {
+  beforeEach(() => {
+    render(<SystemCardPage />);
+  });
+
+  it("should render the page title", () => {
+    expect(screen.getByText("AI System Card")).toBeInTheDocument();
+  });
+
+  it("should render the last updated date", () => {
+    expect(screen.getByText(/Last updated: March 2026/)).toBeInTheDocument();
+  });
+
+  it("should render all 8 sections", () => {
+    expect(screen.getByText("1. What the AI Does")).toBeInTheDocument();
+    expect(screen.getByText("2. Data Processed")).toBeInTheDocument();
+    expect(screen.getByText("3. Training Data and Models")).toBeInTheDocument();
+    expect(screen.getByText("4. Prompt Architecture")).toBeInTheDocument();
+    expect(screen.getByText("5. Known Limitations")).toBeInTheDocument();
+    expect(screen.getByText("6. Failure Modes")).toBeInTheDocument();
+    expect(screen.getByText("7. Abuse Reporting")).toBeInTheDocument();
+    expect(screen.getByText("8. Changelog")).toBeInTheDocument();
+  });
+
+  it("should link to AI Commitments", () => {
+    const links = screen.getAllByRole("link", { name: /AI Commitments/ });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links[0]).toHaveAttribute("href", "/transparency/ai-commitments");
+  });
+
+  it("should link to Prompt Service Charter", () => {
+    const links = screen.getAllByRole("link", {
+      name: /Prompt Service Charter/,
+    });
+    expect(links.length).toBeGreaterThanOrEqual(1);
+    expect(links[0]).toHaveAttribute("href", "/transparency/prompt-charter");
+  });
+
+  it("should include abuse reporting contact email", () => {
+    const emailLink = screen.getByRole("link", {
+      name: "transparency@opuspopuli.org",
+    });
+    expect(emailLink).toHaveAttribute(
+      "href",
+      "mailto:transparency@opuspopuli.org",
+    );
+  });
+
+  it("should render the changelog table", () => {
+    expect(screen.getByText("v1.0")).toBeInTheDocument();
+    expect(
+      screen.getByText("Initial system card publication."),
+    ).toBeInTheDocument();
+  });
+
+  it("should link back to transparency index", () => {
+    const link = screen.getByRole("link", {
+      name: /Back to Transparency/,
+    });
+    expect(link).toHaveAttribute("href", "/transparency");
+  });
+
+  it("should render header and footer", () => {
+    expect(screen.getByTestId("mock-header")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-footer")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/app/sitemap.ts
+++ b/apps/frontend/app/sitemap.ts
@@ -28,5 +28,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: "monthly",
       priority: 0.4,
     },
+    {
+      url: `${baseUrl}/transparency`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/transparency/system-card`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/transparency/ai-commitments`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/transparency/prompt-charter`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
   ];
 }

--- a/apps/frontend/app/transparency/ai-commitments/page.tsx
+++ b/apps/frontend/app/transparency/ai-commitments/page.tsx
@@ -1,0 +1,137 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+
+export const metadata: Metadata = {
+  title: "AI Commitments | Opus Populi",
+  description:
+    "What Opus Populi's AI will never do \u2014 binding commitments with technical controls and verification methods.",
+};
+
+const commitments = [
+  {
+    title: "Never Make Voting Recommendations",
+    commitment:
+      "The AI will never suggest how to vote on any measure, candidate, or issue. It provides analysis to inform your own decision.",
+    control:
+      "Prompt templates are constrained to analytical output only. No recommendation, endorsement, or persuasive language is permitted in prompt instructions.",
+    verify:
+      "Review any analysis output \u2014 you will find summaries, key points, and impact assessments, but never a recommendation on how to vote.",
+  },
+  {
+    title: "Never Suppress or Promote Political Positions",
+    commitment:
+      "The AI presents all perspectives found in the source document without favoring or suppressing any political viewpoint.",
+    control:
+      "Prompts are tested against bias benchmarks. Instructions explicitly require the AI to include all provisions and viewpoints from the source text.",
+    verify:
+      "Compare any analysis against the original source document. All substantive provisions should be represented.",
+  },
+  {
+    title: "Never Store Prompt Templates in Client Code",
+    commitment:
+      "All AI prompts live in a private, centralized prompt service. The open-source codebase never contains prompt text.",
+    control:
+      "Prompts are served via authenticated API calls at analysis time. The prompt service is a separate, private repository.",
+    verify:
+      "Inspect the open-source codebase on GitHub \u2014 you will find prompt service API calls but no prompt template text.",
+  },
+  {
+    title: "Never Train on User Documents",
+    commitment:
+      "User-uploaded documents are never used to train or fine-tune AI models. We use only pre-trained, open-source models.",
+    control:
+      "No fine-tuning pipeline exists in our infrastructure. Models are downloaded pre-trained and used as-is for inference only.",
+    verify:
+      "Our architecture documentation and open-source code confirm there is no training pipeline. Model versions are disclosed per analysis.",
+  },
+  {
+    title: "Never Share Data Between Federated Nodes Without Consent",
+    commitment:
+      "In federated deployments, each node operates in isolation. No user data crosses node boundaries without explicit user action.",
+    control:
+      "Node-to-node communication is restricted to configuration sync. User data storage is local to each node with no cross-node replication.",
+    verify:
+      "Network architecture is documented in the open-source repository. Node isolation can be verified through configuration inspection.",
+  },
+  {
+    title: "Never Sell or Monetize User Data",
+    commitment:
+      "We will never sell, license, or otherwise monetize user data. We have no ad-tech integrations and no data broker relationships.",
+    control:
+      "No advertising SDKs, tracking pixels, or data export pipelines exist in our codebase. Third-party services are limited to infrastructure providers.",
+    verify:
+      "Review our third-party service list in the Privacy Policy and inspect the open-source codebase for the absence of ad-tech integrations.",
+  },
+];
+
+export default function AICommitmentsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
+      <Header />
+      <main className="flex-1 max-w-3xl mx-auto px-8 py-12">
+        <div className="mb-6">
+          <Link
+            href="/transparency"
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            &larr; Back to Transparency
+          </Link>
+        </div>
+
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          AI Commitments
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400 mb-8">
+          These are binding commitments &mdash; not aspirations. Each commitment
+          is backed by a technical control that you can verify.
+        </p>
+
+        <div className="space-y-6">
+          {commitments.map((item) => (
+            <div
+              key={item.title}
+              className="bg-white dark:bg-gray-800 rounded-lg shadow p-6"
+            >
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+                {item.title}
+              </h2>
+              <div className="space-y-2 text-sm text-gray-700 dark:text-gray-300">
+                <p>
+                  <strong>Commitment:</strong> {item.commitment}
+                </p>
+                <p>
+                  <strong>Technical Control:</strong> {item.control}
+                </p>
+                <p>
+                  <strong>How to Verify:</strong> {item.verify}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 pt-4 border-t border-gray-200 dark:border-gray-700">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            See also:{" "}
+            <Link
+              href="/transparency/system-card"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              AI System Card
+            </Link>
+            {" \u00B7 "}
+            <Link
+              href="/transparency/prompt-charter"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Prompt Service Charter
+            </Link>
+          </p>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/frontend/app/transparency/page.tsx
+++ b/apps/frontend/app/transparency/page.tsx
@@ -1,0 +1,67 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+
+export const metadata: Metadata = {
+  title: "Transparency | Opus Populi",
+  description:
+    "Learn how Opus Populi's AI works, what commitments we make, and how our prompts are designed and verified.",
+};
+
+const pages = [
+  {
+    href: "/transparency/system-card",
+    title: "AI System Card",
+    description:
+      "How our AI works, what data it processes, and its known limitations.",
+  },
+  {
+    href: "/transparency/ai-commitments",
+    title: "AI Commitments",
+    description:
+      "What this AI will never do \u2014 our binding commitments and their technical controls.",
+  },
+  {
+    href: "/transparency/prompt-charter",
+    title: "Prompt Service Charter",
+    description:
+      "How our prompts are designed, managed, and verified for neutrality.",
+  },
+];
+
+export default function TransparencyPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
+      <Header />
+      <main className="flex-1 max-w-4xl mx-auto px-8 py-12">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          Transparency
+        </h1>
+        <p className="text-gray-600 dark:text-gray-400 mb-8">
+          Opus Populi is committed to AI transparency. We believe you have the
+          right to understand how our AI analyzes documents, what commitments
+          govern its behavior, and how we verify its neutrality.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {pages.map((page) => (
+            <Link
+              key={page.href}
+              href={page.href}
+              className="group block p-6 bg-white dark:bg-gray-800 rounded-lg shadow hover:shadow-lg transition-shadow"
+            >
+              <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2 group-hover:text-blue-600 dark:group-hover:text-blue-400">
+                {page.title}
+              </h2>
+              <p className="text-gray-600 dark:text-gray-300 text-sm">
+                {page.description}
+              </p>
+            </Link>
+          ))}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/frontend/app/transparency/prompt-charter/page.tsx
+++ b/apps/frontend/app/transparency/prompt-charter/page.tsx
@@ -1,0 +1,236 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+
+export const metadata: Metadata = {
+  title: "Prompt Service Charter | Opus Populi",
+  description:
+    "How Opus Populi designs, manages, and verifies AI prompts for neutrality and completeness.",
+};
+
+export default function PromptCharterPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
+      <Header />
+      <main className="flex-1 max-w-3xl mx-auto px-8 py-12">
+        <div className="mb-6">
+          <Link
+            href="/transparency"
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            &larr; Back to Transparency
+          </Link>
+        </div>
+
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          Prompt Service Charter
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+          Last updated: March 2026
+        </p>
+
+        <div className="space-y-8 text-gray-700 dark:text-gray-300">
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              1. What Prompts Do
+            </h2>
+            <p className="mb-3">
+              Prompts are structured instructions given to AI models that shape
+              how they analyze documents. In Opus Populi, prompts define:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                What information to extract from a document (key provisions,
+                entities, fiscal impacts).
+              </li>
+              <li>
+                How to structure the output (summary, key points, impact
+                analysis).
+              </li>
+              <li>
+                What standards to apply (neutrality, completeness, source
+                fidelity).
+              </li>
+              <li>
+                What constraints to enforce (no recommendations, no partisan
+                language).
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              2. Design Principles
+            </h2>
+            <p className="mb-4">
+              Every prompt in the Opus Populi system is governed by four core
+              principles:
+            </p>
+
+            <div className="space-y-4">
+              <div className="pl-4 border-l-2 border-blue-500">
+                <h3 className="font-semibold text-gray-900 dark:text-white">
+                  Neutrality
+                </h3>
+                <p className="text-sm">
+                  Prompts never include partisan language, leading questions, or
+                  instructions that could steer the AI toward a particular
+                  conclusion. The AI is directed to present facts and
+                  implications, not opinions.
+                </p>
+              </div>
+
+              <div className="pl-4 border-l-2 border-blue-500">
+                <h3 className="font-semibold text-gray-900 dark:text-white">
+                  Completeness
+                </h3>
+                <p className="text-sm">
+                  Prompts require the AI to address all substantive provisions
+                  in a document, not cherry-pick favorable or unfavorable
+                  elements. Data completeness scores are provided so users can
+                  see when information is missing.
+                </p>
+              </div>
+
+              <div className="pl-4 border-l-2 border-blue-500">
+                <h3 className="font-semibold text-gray-900 dark:text-white">
+                  Source Attribution
+                </h3>
+                <p className="text-sm">
+                  Every claim in an analysis must be traceable to the source
+                  document or a disclosed data source. The AI must not introduce
+                  information that is not present in or directly derivable from
+                  the inputs.
+                </p>
+              </div>
+
+              <div className="pl-4 border-l-2 border-blue-500">
+                <h3 className="font-semibold text-gray-900 dark:text-white">
+                  Transparency
+                </h3>
+                <p className="text-sm">
+                  Prompt versions and cryptographic hashes are published with
+                  every analysis result. Users can detect when prompts change
+                  and verify consistency across analyses.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              3. How Prompts Are Managed
+            </h2>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Prompts are stored in a <strong>private repository</strong>,
+                separate from the open-source application code.
+              </li>
+              <li>
+                Every prompt change goes through code review before deployment.
+              </li>
+              <li>
+                Each prompt version is assigned a{" "}
+                <strong>semantic version number</strong> (e.g., v2.1.0).
+              </li>
+              <li>
+                A <strong>SHA-256 cryptographic hash</strong> is computed at
+                deployment time and embedded in every analysis result.
+              </li>
+              <li>
+                Prompts are served via a centralized prompt service with
+                authenticated API access &mdash; individual nodes in a federated
+                deployment cannot modify prompts.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              4. Verification and Auditability
+            </h2>
+            <p className="mb-3">We design for auditability at every level:</p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Every analysis result includes the <strong>prompt hash</strong>{" "}
+                used to generate it. Users can compare hashes across analyses to
+                detect prompt changes.
+              </li>
+              <li>
+                The{" "}
+                <Link
+                  href="/transparency/system-card"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  System Card
+                </Link>{" "}
+                changelog documents all prompt version updates.
+              </li>
+              <li>
+                Data sources contributing to each analysis are disclosed with
+                freshness indicators so users can assess data quality.
+              </li>
+              <li>
+                Users can report issues with any analysis through the in-app
+                reporting mechanism, triggering a review of the relevant prompt.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              5. What We Do Not Disclose
+            </h2>
+            <p className="mb-3">
+              The exact text of our prompts is proprietary. We do not publish
+              prompt templates because:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Publishing exact prompts would allow bad actors to craft
+                documents specifically designed to manipulate or evade the
+                analysis pipeline.
+              </li>
+              <li>
+                Prompt engineering is a key part of our value proposition and
+                intellectual property.
+              </li>
+              <li>
+                The principles, constraints, and verification mechanisms
+                described above provide meaningful transparency without
+                compromising system integrity.
+              </li>
+            </ul>
+            <p className="mt-3">
+              We believe this approach balances transparency with security
+              &mdash; you can verify <em>what</em> the AI is constrained to do
+              and <em>how</em> those constraints are enforced, without exposing
+              implementation details that could be exploited.
+            </p>
+          </section>
+
+          <section className="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              See also:{" "}
+              <Link
+                href="/transparency/system-card"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                AI System Card
+              </Link>
+              {" \u00B7 "}
+              <Link
+                href="/transparency/ai-commitments"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                AI Commitments
+              </Link>
+            </p>
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/frontend/app/transparency/system-card/page.tsx
+++ b/apps/frontend/app/transparency/system-card/page.tsx
@@ -1,0 +1,303 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+
+export const metadata: Metadata = {
+  title: "AI System Card | Opus Populi",
+  description:
+    "How Opus Populi's AI system works, what data it processes, its limitations, and how to report issues.",
+};
+
+export default function SystemCardPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
+      <Header />
+      <main className="flex-1 max-w-3xl mx-auto px-8 py-12">
+        <div className="mb-6">
+          <Link
+            href="/transparency"
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+          >
+            &larr; Back to Transparency
+          </Link>
+        </div>
+
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-white mb-2">
+          AI System Card
+        </h1>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mb-8">
+          Last updated: March 2026
+        </p>
+
+        <div className="space-y-8 text-gray-700 dark:text-gray-300">
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              1. What the AI Does
+            </h2>
+            <p className="mb-3">
+              Opus Populi uses AI to help citizens understand civic documents
+              such as petitions, ballot measures, and legislative proposals. The
+              AI performs:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                <strong>Text extraction:</strong> Reads scanned documents using
+                optical character recognition (OCR).
+              </li>
+              <li>
+                <strong>Summarization:</strong> Produces plain-language
+                summaries of complex legal and legislative text.
+              </li>
+              <li>
+                <strong>Impact analysis:</strong> Identifies who benefits, who
+                may be affected, and potential concerns.
+              </li>
+              <li>
+                <strong>Entity extraction:</strong> Identifies organizations,
+                agencies, and officials mentioned in the document.
+              </li>
+            </ul>
+            <p className="mt-3 font-medium">
+              The AI performs analysis only. It never makes voting
+              recommendations or endorses political positions.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              2. Data Processed
+            </h2>
+            <p className="mb-3">
+              The AI processes only documents that users explicitly upload or
+              scan:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Petition images captured through the in-app camera scanner.
+              </li>
+              <li>Uploaded PDF or text documents submitted for analysis.</li>
+            </ul>
+            <p className="mt-3">
+              Document content is stored only for the purpose of providing
+              analysis results. We do not use uploaded documents to train or
+              fine-tune AI models. See our{" "}
+              <Link
+                href="/transparency/ai-commitments"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                AI Commitments
+              </Link>{" "}
+              for binding guarantees.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              3. Training Data and Models
+            </h2>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                We use pre-trained, open-source large language models served
+                through Ollama (e.g., Llama, Mistral).
+              </li>
+              <li>
+                <strong>No fine-tuning</strong> is performed on user data or
+                Opus Populi content.
+              </li>
+              <li>
+                Model provider and version are disclosed with every analysis
+                result (e.g., &quot;Analyzed by Ollama (llama3.2)&quot;).
+              </li>
+              <li>
+                Models are selected for their ability to follow structured
+                extraction instructions reliably.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              4. Prompt Architecture
+            </h2>
+            <p className="mb-3">
+              Prompts are the instructions given to the AI that shape how it
+              analyzes documents. Our prompt system is designed for
+              auditability:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Every prompt is <strong>versioned</strong> with a semantic
+                version number.
+              </li>
+              <li>
+                Every prompt is <strong>cryptographically hashed</strong>{" "}
+                (SHA-256) at deployment time.
+              </li>
+              <li>
+                Each analysis result includes the prompt hash so users can
+                detect when prompts change.
+              </li>
+              <li>
+                Prompts are served from a centralized, private prompt service
+                &mdash; they cannot be modified by individual nodes in a
+                federated deployment.
+              </li>
+            </ul>
+            <p className="mt-3">
+              For more detail on our prompt methodology, see the{" "}
+              <Link
+                href="/transparency/prompt-charter"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Prompt Service Charter
+              </Link>
+              .
+            </p>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              5. Known Limitations
+            </h2>
+            <p className="mb-3">
+              Like all AI systems, ours has limitations. Users should be aware
+              that the AI:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                May miss nuance in complex legal language, particularly in
+                lengthy or highly technical documents.
+              </li>
+              <li>
+                May not catch all fiscal or budgetary implications if they are
+                not explicitly stated in the document.
+              </li>
+              <li>
+                Depends on the quality of the source text &mdash; poor scans or
+                OCR errors reduce analysis accuracy.
+              </li>
+              <li>
+                Cannot evaluate political feasibility or predict real-world
+                outcomes of proposed measures.
+              </li>
+              <li>
+                May produce different results for the same document if the
+                prompt version or model changes.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              6. Failure Modes
+            </h2>
+            <p className="mb-3">
+              When the AI cannot produce a confident analysis, it communicates
+              this transparently:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                <strong>Confidence scores</strong> are displayed with every OCR
+                extraction so users can judge text quality.
+              </li>
+              <li>
+                <strong>Data completeness indicators</strong> show what
+                percentage of ideal data sources were available for the
+                analysis.
+              </li>
+              <li>
+                The AI will surface missing data points rather than silently
+                omitting them.
+              </li>
+              <li>
+                Users are always encouraged to read the original source document
+                alongside any AI analysis.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              7. Abuse Reporting
+            </h2>
+            <p className="mb-3">
+              If you encounter an AI analysis that is incorrect, misleading,
+              offensive, or otherwise problematic:
+            </p>
+            <ul className="list-disc pl-6 space-y-2">
+              <li>
+                Use the <strong>&quot;Report Issue&quot;</strong> button on any
+                analysis results page to submit a report directly.
+              </li>
+              <li>
+                Reports are reviewed by our team and used to improve prompt
+                quality and identify failure patterns.
+              </li>
+              <li>
+                You can also contact us at{" "}
+                <a
+                  href="mailto:transparency@opuspopuli.org"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  transparency@opuspopuli.org
+                </a>
+                .
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-3">
+              8. Changelog
+            </h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-gray-200 dark:border-gray-700">
+                    <th className="text-left py-2 pr-4 font-semibold text-gray-900 dark:text-white">
+                      Version
+                    </th>
+                    <th className="text-left py-2 pr-4 font-semibold text-gray-900 dark:text-white">
+                      Date
+                    </th>
+                    <th className="text-left py-2 font-semibold text-gray-900 dark:text-white">
+                      Changes
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-gray-100 dark:border-gray-800">
+                    <td className="py-2 pr-4">v1.0</td>
+                    <td className="py-2 pr-4">March 2026</td>
+                    <td className="py-2">Initial system card publication.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="pt-4 border-t border-gray-200 dark:border-gray-700">
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              See also:{" "}
+              <Link
+                href="/transparency/ai-commitments"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                AI Commitments
+              </Link>
+              {" \u00B7 "}
+              <Link
+                href="/transparency/prompt-charter"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Prompt Service Charter
+              </Link>
+            </p>
+          </section>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/apps/frontend/components/Footer.tsx
+++ b/apps/frontend/components/Footer.tsx
@@ -20,6 +20,12 @@ export function Footer() {
           >
             Terms of Service
           </Link>
+          <Link
+            href="/transparency"
+            className="text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
+          >
+            Transparency
+          </Link>
         </nav>
       </div>
     </footer>

--- a/apps/frontend/locales/en/common.json
+++ b/apps/frontend/locales/en/common.json
@@ -42,6 +42,11 @@
   "toast": {
     "closeNotification": "Close notification"
   },
+  "footer": {
+    "privacyPolicy": "Privacy Policy",
+    "termsOfService": "Terms of Service",
+    "transparency": "Transparency"
+  },
   "states": {
     "AL": "Alabama",
     "AK": "Alaska",

--- a/apps/frontend/locales/es/common.json
+++ b/apps/frontend/locales/es/common.json
@@ -42,6 +42,11 @@
   "toast": {
     "closeNotification": "Cerrar notificacion"
   },
+  "footer": {
+    "privacyPolicy": "Pol\u00edtica de Privacidad",
+    "termsOfService": "T\u00e9rminos de Servicio",
+    "transparency": "Transparencia"
+  },
   "states": {
     "AL": "Alabama",
     "AK": "Alaska",


### PR DESCRIPTION
## Summary

Adds a complete transparency section to Opus Populi with four new pages and navigation infrastructure:

- **System Card** (`/transparency/system-card`) — 8 sections covering what the AI does, data processed, training data, prompt architecture, known limitations, failure modes, abuse reporting, and changelog (#419)
- **AI Commitments** (`/transparency/ai-commitments`) — 6 binding commitment cards, each with technical control and verification method (e.g., never make voting recommendations, never train on user documents) (#420)
- **Prompt Service Charter** (`/transparency/prompt-charter`) — 5 sections on prompt design principles (neutrality, completeness, source attribution, transparency), management, and auditability (#421)
- **Transparency index** (`/transparency`) — Card-based navigation to all sub-pages, footer link added site-wide, sitemap updated (#422)

All pages follow the existing server component pattern (no `"use client"`) matching `privacy/page.tsx`. Each sub-page includes cross-links to the other transparency pages and a back link to the index.

Resolves the broken `/transparency/prompt-charter` link added in #424.

## Test plan

- [x] 37 new tests across 5 test files — all passing (1020 total frontend tests)
- [x] Footer test verifies Privacy, Terms, and new Transparency links
- [x] Each page test verifies title, all sections/headings, cross-links, and header/footer rendering
- [ ] Manual: Visit `/transparency` — 3 cards with correct links
- [ ] Manual: Each sub-page renders content, cross-links work
- [ ] Manual: Footer shows "Transparency" link on all pages
- [ ] Manual: Dark mode renders correctly on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>