### PR TITLE
Merge develop to main (#445)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ opuspopuli/
 │   ├── logging-provider/     # Audit logging
 │   ├── ocr-provider/         # OCR functionality
 │   ├── scraping-pipeline/   # AI-powered web scraping (schema-on-read)
-│   └── region-provider/      # Civic data integration (declarative plugins)
+│   ├── region-provider/      # Civic data integration (declarative plugins)
+│   └── prompt-client/        # AI prompt template client (circuit breaker, HMAC)
 ├── apps/
 │   ├── backend/              # NestJS microservices
 │   │   └── src/
@@ -147,6 +148,7 @@ The `packages/` directory contains reusable workspace packages that provide plug
 | `@opuspopuli/ocr-provider` | OCR functionality | - |
 | `@opuspopuli/scraping-pipeline` | AI-powered schema-on-read web scraping with structural manifests | - |
 | `@opuspopuli/region-provider` | Civic data integration (declarative plugins, propositions, meetings, representatives) | - |
+| `@opuspopuli/prompt-client` | AI prompt template client with circuit breaker, HMAC auth, and caching | - |
 
 ## Development
 
@@ -199,6 +201,9 @@ docker-compose logs -f   # View logs
 - ✅ **Internationalization** - English and Spanish with react-i18next
 - ✅ **Civic Data Integration** - Declarative region plugins for propositions, meetings, and representatives
 - ✅ **AI-Powered Scraping** - Schema-on-read pipeline with structural manifests and self-healing
+- ✅ **Petition Scanning** - Mobile-friendly petition capture with OCR, geolocation, and real-time activity feed
+- ✅ **Transparency Pages** - AI system card, commitments, and prompt charter
+- ✅ **Campaign Finance** - Committees, contributions, expenditures, and independent expenditures
 - ✅ **Accessibility** - WCAG 2.2 Level AA compliant
 - ✅ **100% Self-Hosted** - Complete data control and privacy
 

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -36,10 +36,10 @@ pnpm test
 | Service | Port | Purpose |
 |---------|------|---------|
 | API Gateway | 3000 | GraphQL Federation gateway |
-| Users | 3001 | User management, authentication (Passkeys, Magic Links, Password), profiles, consents |
-| Documents | 3002 | Document storage |
+| Users | 3001 | User management, authentication (Passkeys, Magic Links, Password), profiles, consents, activity logging |
+| Documents | 3002 | Document storage, petition scanning, OCR, document analysis, activity feed |
 | Knowledge | 3003 | RAG/semantic search |
-| Files | 3004 | File processing |
+| Region | 3004 | Civic data (propositions, meetings, representatives, campaign finance) |
 
 ## Health Endpoints
 
@@ -87,6 +87,36 @@ The Users service includes a comprehensive profile management API:
 - `bulkUpdateConsents` - Update multiple consents at once
 - `hasValidConsent` - Check if specific consent is valid
 - Full audit trail with IP, user agent, timestamps
+
+## Documents GraphQL API
+
+### Petition Scanning
+- `processScan` - Process a captured petition image (OCR + analysis)
+- `extractTextFromFile` / `extractTextFromBase64` - Text extraction from images
+- `analyzeDocument` - AI-powered document analysis
+- `setDocumentLocation` / `getDocumentLocation` - Geolocation for petition scans
+- `submitAbuseReport` - Report abuse on petition content
+
+### Petition Activity Feed
+- `petitionActivityFeed` - Real-time activity feed with hourly trends and location counts
+- `petitionMapLocations` - Map markers for petition scan locations
+- `petitionMapStats` - Aggregate statistics for the petition map
+
+### File Storage
+- `listFiles` / `getUploadUrl` / `getDownloadUrl` / `deleteFile` - Supabase Storage operations
+
+## Region GraphQL API
+
+### Civic Data
+- `propositions` / `proposition` - Ballot propositions with filtering and pagination
+- `meetings` / `meeting` - Government meetings
+- `representatives` / `representative` - Elected representatives
+
+### Campaign Finance (Transparency)
+- `committees` / `committee` - Campaign committees
+- `contributions` / `contribution` - Campaign contributions
+- `expenditures` / `expenditure` - Campaign expenditures
+- `independentExpenditures` / `independentExpenditure` - Independent expenditures
 
 ## Configuration
 

--- a/apps/backend/__tests__/integration/documents/documents.integration.spec.ts
+++ b/apps/backend/__tests__/integration/documents/documents.integration.spec.ts
@@ -17,6 +17,8 @@ import {
   DocumentType,
   Prisma,
 } from '@opuspopuli/relationaldb-provider';
+/** Privacy threshold — must match PRIVACY_THRESHOLD from activity-feed.dto.ts */
+const PRIVACY_THRESHOLD = 3;
 
 describe('Document Integration Tests', () => {
   beforeEach(async () => {
@@ -1274,6 +1276,166 @@ describe('Document Integration Tests', () => {
 
       expect(result[0].latitude).toBeCloseTo(0, 4);
       expect(result[0].longitude).toBeCloseTo(179.9, 4);
+    });
+  });
+
+  describe('Activity Feed Aggregation', () => {
+    it('should aggregate petition scans above privacy threshold', async () => {
+      const user = await createUser({ email: 'activity-feed@example.com' });
+      const contentHash = `feed-hash-${generateId()}`;
+      const db = await getDbService();
+
+      // Create PRIVACY_THRESHOLD documents with same content hash
+      for (let i = 0; i < PRIVACY_THRESHOLD; i++) {
+        const doc = await createDocument({
+          userId: user.id,
+          key: `feed-petition-${i}.png`,
+          contentHash,
+          type: DocumentType.petition,
+          analysis: { summary: 'Test petition for parks' },
+        });
+
+        // Set scan locations at slightly different city-level positions
+        await db.$executeRaw`
+          UPDATE documents
+          SET scan_location = ST_SetSRID(ST_MakePoint(${-122.4194 + i * 0.01}, ${37.7749 + i * 0.01}), 4326)::geography
+          WHERE id::text = ${doc.id}
+        `;
+      }
+
+      // Query the activity feed using the same SQL pattern as the service
+      const items = await db.$queryRaw<
+        Array<{
+          content_hash: string;
+          summary: string | null;
+          scan_count: bigint;
+          location_count: bigint;
+        }>
+      >`
+        SELECT
+          content_hash,
+          (MAX(analysis::json->>'summary'))::text as summary,
+          COUNT(*) as scan_count,
+          COUNT(DISTINCT CONCAT(
+            ROUND(ST_Y(scan_location::geometry)::numeric, 2),
+            ',',
+            ROUND(ST_X(scan_location::geometry)::numeric, 2)
+          )) FILTER (WHERE scan_location IS NOT NULL) as location_count
+        FROM documents
+        WHERE
+          content_hash IS NOT NULL
+          AND type = 'petition'
+          AND deleted_at IS NULL
+          AND created_at >= NOW() - INTERVAL '24 hours'
+        GROUP BY content_hash
+        HAVING COUNT(*) >= ${PRIVACY_THRESHOLD}
+        ORDER BY MAX(created_at) DESC
+      `;
+
+      expect(items.length).toBeGreaterThanOrEqual(1);
+      const item = items.find((i) => i.content_hash === contentHash);
+      expect(item).toBeDefined();
+      expect(Number(item!.scan_count)).toBe(PRIVACY_THRESHOLD);
+      expect(item!.summary).toBe('Test petition for parks');
+    });
+
+    it('should NOT include petitions below privacy threshold', async () => {
+      const user = await createUser({ email: 'below-threshold@example.com' });
+      const belowHash = `below-${generateId()}`;
+      const db = await getDbService();
+
+      // Create fewer than PRIVACY_THRESHOLD documents
+      for (let i = 0; i < PRIVACY_THRESHOLD - 1; i++) {
+        await createDocument({
+          userId: user.id,
+          key: `below-${i}.png`,
+          contentHash: belowHash,
+          type: DocumentType.petition,
+        });
+      }
+
+      const items = await db.$queryRaw<
+        Array<{ content_hash: string; scan_count: bigint }>
+      >`
+        SELECT content_hash, COUNT(*) as scan_count
+        FROM documents
+        WHERE
+          content_hash = ${belowHash}
+          AND type = 'petition'
+          AND deleted_at IS NULL
+          AND created_at >= NOW() - INTERVAL '24 hours'
+        GROUP BY content_hash
+        HAVING COUNT(*) >= ${PRIVACY_THRESHOLD}
+      `;
+
+      expect(items).toHaveLength(0);
+    });
+
+    it('should return hourly trend buckets', async () => {
+      const user = await createUser({ email: 'hourly-trend@example.com' });
+      const db = await getDbService();
+
+      await createDocument({
+        userId: user.id,
+        key: 'trend-1.png',
+        type: DocumentType.petition,
+      });
+
+      const trend = await db.$queryRaw<
+        Array<{ hour: Date; scan_count: bigint }>
+      >`
+        SELECT
+          date_trunc('hour', created_at) as hour,
+          COUNT(*) as scan_count
+        FROM documents
+        WHERE
+          type = 'petition'
+          AND deleted_at IS NULL
+          AND created_at >= NOW() - INTERVAL '24 hours'
+        GROUP BY date_trunc('hour', created_at)
+        ORDER BY hour ASC
+      `;
+
+      expect(trend.length).toBeGreaterThanOrEqual(1);
+      expect(Number(trend[0].scan_count)).toBeGreaterThanOrEqual(1);
+      expect(trend[0].hour).toBeInstanceOf(Date);
+    });
+
+    it('should aggregate city-level locations for privacy', async () => {
+      const user = await createUser({ email: 'privacy-locs@example.com' });
+      const hash = `priv-loc-${generateId()}`;
+      const db = await getDbService();
+
+      // Create 3 docs at same city-level location (within 0.005 degree, all ROUND to 37.77)
+      for (let i = 0; i < 3; i++) {
+        const doc = await createDocument({
+          userId: user.id,
+          key: `priv-${i}.png`,
+          contentHash: hash,
+          type: DocumentType.petition,
+        });
+
+        // All within same city-level grid cell (ROUND to 2 decimals)
+        await db.$executeRaw`
+          UPDATE documents
+          SET scan_location = ST_SetSRID(ST_MakePoint(-122.4194, ${37.771 + i * 0.001}), 4326)::geography
+          WHERE id::text = ${doc.id}
+        `;
+      }
+
+      const result = await db.$queryRaw<Array<{ location_count: bigint }>>`
+        SELECT
+          COUNT(DISTINCT CONCAT(
+            ROUND(ST_Y(scan_location::geometry)::numeric, 2),
+            ',',
+            ROUND(ST_X(scan_location::geometry)::numeric, 2)
+          )) FILTER (WHERE scan_location IS NOT NULL) as location_count
+        FROM documents
+        WHERE content_hash = ${hash} AND deleted_at IS NULL
+      `;
+
+      // All 3 are within 0.001 degrees, so ROUND(x, 2) groups them as 1 location
+      expect(Number(result[0].location_count)).toBe(1);
     });
   });
 });

--- a/apps/backend/src/apps/documents/src/domains/documents.resolver.spec.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.resolver.spec.ts
@@ -253,6 +253,25 @@ describe('DocumentsResolver', () => {
     });
   });
 
+  describe('petitionActivityFeed', () => {
+    it('should call service and return feed', async () => {
+      const mockFeed = {
+        items: [],
+        hourlyTrend: [],
+        totalScansLast24h: 10,
+        activePetitionsLast24h: 3,
+      };
+      documentsService.getPetitionActivityFeed = jest
+        .fn()
+        .mockResolvedValue(mockFeed);
+
+      const result = await documentsResolver.petitionActivityFeed();
+
+      expect(result).toEqual(mockFeed);
+      expect(documentsService.getPetitionActivityFeed).toHaveBeenCalled();
+    });
+  });
+
   describe('submitAbuseReport', () => {
     it('should call service with correct arguments', async () => {
       const mockResult = { success: true, reportId: 'report-1' };

--- a/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
@@ -19,6 +19,7 @@ import {
   GqlContext,
   getUserFromContext,
 } from 'src/common/utils/graphql-context';
+import { PetitionActivityFeed } from './dto/activity-feed.dto';
 import { FilenameInput } from './dto/documents.dto';
 import {
   ExtractTextFromFileInput,
@@ -247,6 +248,17 @@ export class DocumentsResolver {
   @Permissions({ action: Action.Read, subject: 'File' })
   async petitionMapStats(): Promise<PetitionMapStats> {
     return this.documentsService.getPetitionMapStats();
+  }
+
+  /**
+   * Get real-time petition activity feed (aggregated, privacy-preserving)
+   */
+  @Query(() => PetitionActivityFeed)
+  @UseGuards(AuthGuard)
+  @Permissions({ action: Action.Read, subject: 'File' })
+  @Extensions({ complexity: 30 })
+  async petitionActivityFeed(): Promise<PetitionActivityFeed> {
+    return this.documentsService.getPetitionActivityFeed();
   }
 
   /**

--- a/apps/backend/src/apps/documents/src/domains/documents.service.spec.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.service.spec.ts
@@ -1694,6 +1694,167 @@ describe('DocumentsService', () => {
     });
   });
 
+  describe('getPetitionActivityFeed', () => {
+    it('should return aggregated items above privacy threshold', async () => {
+      mockDb.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            content_hash: 'hash-1',
+            summary: 'A petition about parks',
+            document_type: 'petition',
+            scan_count: BigInt(5),
+            location_count: BigInt(3),
+            latest_scan_at: new Date('2024-06-01T12:00:00Z'),
+            earliest_scan_at: new Date('2024-06-01T08:00:00Z'),
+          },
+        ])
+        .mockResolvedValueOnce([
+          { hour: new Date('2024-06-01T08:00:00Z'), scan_count: BigInt(2) },
+          { hour: new Date('2024-06-01T09:00:00Z'), scan_count: BigInt(3) },
+        ])
+        .mockResolvedValueOnce([
+          { total_scans: BigInt(5), active_petitions: BigInt(1) },
+        ]);
+
+      const feed = await documentsService.getPetitionActivityFeed();
+
+      expect(feed.items).toHaveLength(1);
+      expect(feed.items[0]).toEqual({
+        contentHash: 'hash-1',
+        summary: 'A petition about parks',
+        documentType: 'petition',
+        scanCount: 5,
+        locationCount: 3,
+        latestScanAt: new Date('2024-06-01T12:00:00Z'),
+        earliestScanAt: new Date('2024-06-01T08:00:00Z'),
+      });
+      expect(feed.hourlyTrend).toHaveLength(2);
+      expect(feed.hourlyTrend[0].scanCount).toBe(2);
+      expect(feed.totalScansLast24h).toBe(5);
+      expect(feed.activePetitionsLast24h).toBe(1);
+    });
+
+    it('should return empty feed when no scans above threshold', async () => {
+      mockDb.$queryRaw
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { total_scans: BigInt(0), active_petitions: BigInt(0) },
+        ]);
+
+      const feed = await documentsService.getPetitionActivityFeed();
+
+      expect(feed.items).toEqual([]);
+      expect(feed.hourlyTrend).toEqual([]);
+      expect(feed.totalScansLast24h).toBe(0);
+      expect(feed.activePetitionsLast24h).toBe(0);
+    });
+
+    it('should convert bigint values to numbers', async () => {
+      mockDb.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            content_hash: 'hash-2',
+            summary: 'Test',
+            document_type: null,
+            scan_count: BigInt(10),
+            location_count: BigInt(7),
+            latest_scan_at: new Date(),
+            earliest_scan_at: new Date(),
+          },
+        ])
+        .mockResolvedValueOnce([{ hour: new Date(), scan_count: BigInt(10) }])
+        .mockResolvedValueOnce([
+          { total_scans: BigInt(10), active_petitions: BigInt(1) },
+        ]);
+
+      const feed = await documentsService.getPetitionActivityFeed();
+
+      expect(typeof feed.items[0].scanCount).toBe('number');
+      expect(typeof feed.items[0].locationCount).toBe('number');
+      expect(typeof feed.hourlyTrend[0].scanCount).toBe('number');
+      expect(typeof feed.totalScansLast24h).toBe('number');
+    });
+
+    it('should handle null summary gracefully', async () => {
+      mockDb.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            content_hash: 'hash-3',
+            summary: null,
+            document_type: 'petition',
+            scan_count: BigInt(4),
+            location_count: BigInt(1),
+            latest_scan_at: new Date(),
+            earliest_scan_at: new Date(),
+          },
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { total_scans: BigInt(4), active_petitions: BigInt(1) },
+        ]);
+
+      const feed = await documentsService.getPetitionActivityFeed();
+
+      expect(feed.items[0].summary).toBe('Petition scan recorded');
+    });
+
+    it('should handle empty summaryStats array', async () => {
+      mockDb.$queryRaw
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+
+      const feed = await documentsService.getPetitionActivityFeed();
+
+      expect(feed.totalScansLast24h).toBe(0);
+      expect(feed.activePetitionsLast24h).toBe(0);
+    });
+
+    it('should handle null document_type', async () => {
+      mockDb.$queryRaw
+        .mockResolvedValueOnce([
+          {
+            content_hash: 'hash-4',
+            summary: 'Test petition',
+            document_type: null,
+            scan_count: BigInt(3),
+            location_count: BigInt(1),
+            latest_scan_at: new Date(),
+            earliest_scan_at: new Date(),
+          },
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          { total_scans: BigInt(3), active_petitions: BigInt(1) },
+        ]);
+
+      const feed = await documentsService.getPetitionActivityFeed();
+
+      expect(feed.items[0].documentType).toBeUndefined();
+    });
+
+    it('should return multiple hourly trend buckets in order', async () => {
+      const buckets = Array.from({ length: 24 }, (_, i) => ({
+        hour: new Date(`2024-06-01T${String(i).padStart(2, '0')}:00:00Z`),
+        scan_count: BigInt(i + 1),
+      }));
+
+      mockDb.$queryRaw
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(buckets)
+        .mockResolvedValueOnce([
+          { total_scans: BigInt(300), active_petitions: BigInt(5) },
+        ]);
+
+      const feed = await documentsService.getPetitionActivityFeed();
+
+      expect(feed.hourlyTrend).toHaveLength(24);
+      expect(feed.hourlyTrend[0].scanCount).toBe(1);
+      expect(feed.hourlyTrend[23].scanCount).toBe(24);
+    });
+  });
+
   describe('submitAbuseReport', () => {
     it('should create abuse report successfully', async () => {
       mockDb.document.findUnique.mockResolvedValue({

--- a/apps/backend/src/apps/documents/src/domains/documents.service.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.service.ts
@@ -25,6 +25,10 @@ import { File } from './models/file.model';
 import { ExtractTextResult } from './dto/ocr.dto';
 import { ProcessScanResult } from './dto/scan.dto';
 import { SubmitAbuseReportResult } from './dto/abuse-report.dto';
+import {
+  PetitionActivityFeed,
+  PRIVACY_THRESHOLD,
+} from './dto/activity-feed.dto';
 import { DocumentAnalysis, AnalyzeDocumentResult } from './dto/analysis.dto';
 import {
   GeoLocation,
@@ -1014,6 +1018,103 @@ export class DocumentsService {
     return {
       success: true,
       reportId: report.id,
+    };
+  }
+
+  /**
+   * Get aggregated petition activity feed for the last 24 hours.
+   *
+   * Privacy: Only petitions with >= PRIVACY_THRESHOLD scans are included.
+   * Location counts use city-level precision (rounded to 0.01 degrees).
+   * No individual user information is returned.
+   */
+  async getPetitionActivityFeed(): Promise<PetitionActivityFeed> {
+    const items = await this.db.$queryRaw<
+      Array<{
+        content_hash: string;
+        summary: string | null;
+        document_type: string | null;
+        scan_count: bigint;
+        location_count: bigint;
+        latest_scan_at: Date;
+        earliest_scan_at: Date;
+      }>
+    >`
+      SELECT
+        content_hash,
+        (MAX(analysis::json->>'summary'))::text as summary,
+        MAX(type::text) as document_type,
+        COUNT(*) as scan_count,
+        COUNT(DISTINCT CONCAT(
+          ROUND(ST_Y(scan_location::geometry)::numeric, 2),
+          ',',
+          ROUND(ST_X(scan_location::geometry)::numeric, 2)
+        )) FILTER (WHERE scan_location IS NOT NULL) as location_count,
+        MAX(created_at) as latest_scan_at,
+        MIN(created_at) as earliest_scan_at
+      FROM documents
+      WHERE
+        content_hash IS NOT NULL
+        AND type = 'petition'
+        AND deleted_at IS NULL
+        AND created_at >= NOW() - INTERVAL '24 hours'
+      GROUP BY content_hash
+      HAVING COUNT(*) >= ${PRIVACY_THRESHOLD}
+      ORDER BY MAX(created_at) DESC
+      LIMIT 50
+    `;
+
+    const hourlyTrend = await this.db.$queryRaw<
+      Array<{
+        hour: Date;
+        scan_count: bigint;
+      }>
+    >`
+      SELECT
+        date_trunc('hour', created_at) as hour,
+        COUNT(*) as scan_count
+      FROM documents
+      WHERE
+        type = 'petition'
+        AND deleted_at IS NULL
+        AND created_at >= NOW() - INTERVAL '24 hours'
+      GROUP BY date_trunc('hour', created_at)
+      ORDER BY hour ASC
+    `;
+
+    const summaryStats = await this.db.$queryRaw<
+      Array<{
+        total_scans: bigint;
+        active_petitions: bigint;
+      }>
+    >`
+      SELECT
+        COUNT(*) as total_scans,
+        COUNT(DISTINCT content_hash) as active_petitions
+      FROM documents
+      WHERE
+        type = 'petition'
+        AND content_hash IS NOT NULL
+        AND deleted_at IS NULL
+        AND created_at >= NOW() - INTERVAL '24 hours'
+    `;
+
+    return {
+      items: items.map((item) => ({
+        contentHash: item.content_hash,
+        summary: item.summary || 'Petition scan recorded',
+        documentType: item.document_type ?? undefined,
+        scanCount: Number(item.scan_count),
+        locationCount: Number(item.location_count),
+        latestScanAt: item.latest_scan_at,
+        earliestScanAt: item.earliest_scan_at,
+      })),
+      hourlyTrend: hourlyTrend.map((bucket) => ({
+        hour: bucket.hour,
+        scanCount: Number(bucket.scan_count),
+      })),
+      totalScansLast24h: Number(summaryStats[0]?.total_scans ?? 0),
+      activePetitionsLast24h: Number(summaryStats[0]?.active_petitions ?? 0),
     };
   }
 }

--- a/apps/backend/src/apps/documents/src/domains/dto/activity-feed.dto.ts
+++ b/apps/backend/src/apps/documents/src/domains/dto/activity-feed.dto.ts
@@ -1,0 +1,56 @@
+import { Field, Int, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Privacy threshold: minimum number of scans for a petition
+ * to appear in the public activity feed.
+ * Prevents identifying individual scan activity.
+ */
+export const PRIVACY_THRESHOLD = 3;
+
+@ObjectType()
+export class PetitionActivityItem {
+  @Field()
+  contentHash!: string;
+
+  @Field()
+  summary!: string;
+
+  @Field({ nullable: true })
+  documentType?: string;
+
+  @Field(() => Int)
+  scanCount!: number;
+
+  @Field(() => Int)
+  locationCount!: number;
+
+  @Field()
+  latestScanAt!: Date;
+
+  @Field()
+  earliestScanAt!: Date;
+}
+
+@ObjectType()
+export class ActivityHourBucket {
+  @Field()
+  hour!: Date;
+
+  @Field(() => Int)
+  scanCount!: number;
+}
+
+@ObjectType()
+export class PetitionActivityFeed {
+  @Field(() => [PetitionActivityItem])
+  items!: PetitionActivityItem[];
+
+  @Field(() => [ActivityHourBucket])
+  hourlyTrend!: ActivityHourBucket[];
+
+  @Field(() => Int)
+  totalScansLast24h!: number;
+
+  @Field(() => Int)
+  activePetitionsLast24h!: number;
+}

--- a/apps/frontend/README.md
+++ b/apps/frontend/README.md
@@ -28,7 +28,7 @@ pnpm test
 
 ## Development
 
-The app runs on http://localhost:3000 with hot module replacement (HMR).
+The app runs on http://localhost:3200 with hot module replacement (HMR).
 
 ## Authentication
 
@@ -64,6 +64,8 @@ const { sendMagicLink, verifyMagicLink, emailSent } = useMagicLink();
 | `/register`             | Email-first passwordless registration            |
 | `/register/add-passkey` | Post-registration passkey setup                  |
 | `/auth/callback`        | Magic link verification                          |
+| `/forgot-password`      | Request password reset email                     |
+| `/reset-password`       | Set new password from reset link                 |
 
 ## User Settings
 
@@ -76,6 +78,7 @@ The settings pages provide comprehensive user profile and preference management:
 | `/settings/notifications` | Email, push, and civic notification preferences |
 | `/settings/privacy`       | GDPR/CCPA consent management                    |
 | `/settings/security`      | Passkeys, sessions, and 2FA settings            |
+| `/settings/activity`      | Activity log and session management             |
 
 ### Settings Features
 
@@ -84,6 +87,7 @@ The settings pages provide comprehensive user profile and preference management:
 - **Notifications**: Toggle email, push, SMS, and civic notifications with frequency controls
 - **Privacy**: Manage consent for marketing, analytics, and data sharing with GDPR/CCPA compliance
 - **Security**: Passkey management (placeholder), active session viewing, 2FA setup
+- **Activity**: Activity log with filtering, audit trail visualization, and session management
 
 All settings pages use Apollo Client for GraphQL operations with optimistic UI updates.
 
@@ -126,6 +130,37 @@ The frontend is designed to meet WCAG 2.2 Level AA accessibility standards:
 - **Keyboard Navigation**: All interactive elements are keyboard accessible
 
 See [Frontend Architecture](../../docs/architecture/frontend-architecture.md) for detailed accessibility patterns.
+
+## Petition Scanning
+
+Mobile-friendly petition capture with camera integration:
+
+- **Camera Capture**: Real-time camera with lighting analysis for optimal scan quality
+- **OCR Processing**: Automatic text extraction from captured petition images
+- **Geolocation**: Location tagging for petition scans
+- **Activity Feed**: Real-time petition scanning activity with hourly trends and location counts
+- **Map View**: Interactive map showing petition scan locations with clustering
+
+### Petition Hooks
+
+```typescript
+import { useCamera } from "@/lib/hooks/useCamera";
+import { useLightingAnalysis } from "@/lib/hooks/useLightingAnalysis";
+import { useGeolocation } from "@/lib/hooks/useGeolocation";
+import { useActivityFeed } from "@/lib/hooks/useActivityFeed";
+import { useMapPetitions } from "@/lib/hooks/useMapPetitions";
+```
+
+## Transparency Pages
+
+Public-facing transparency documentation:
+
+| Route                          | Purpose                       |
+| ------------------------------ | ----------------------------- |
+| `/transparency`                | Transparency hub overview     |
+| `/transparency/system-card`    | AI system card                |
+| `/transparency/ai-commitments` | AI commitments and principles |
+| `/transparency/prompt-charter` | Prompt service charter        |
 
 ## GraphQL API
 

--- a/apps/frontend/__tests__/components/petition/ActivityFeed.test.tsx
+++ b/apps/frontend/__tests__/components/petition/ActivityFeed.test.tsx
@@ -1,0 +1,303 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {
+  ActivityFeed,
+  formatRelativeTime,
+  truncate,
+} from "@/components/petition/ActivityFeed";
+
+const mockUseActivityFeed = jest.fn();
+jest.mock("@/lib/hooks", () => ({
+  useActivityFeed: () => mockUseActivityFeed(),
+}));
+
+const mockFeed = {
+  items: [
+    {
+      contentHash: "hash-1",
+      summary: "A petition about improving local parks and recreation areas",
+      documentType: "petition",
+      scanCount: 5,
+      locationCount: 3,
+      latestScanAt: new Date("2024-06-01T12:00:00Z"),
+      earliestScanAt: new Date("2024-06-01T08:00:00Z"),
+    },
+    {
+      contentHash: "hash-2",
+      summary: "Petition for traffic safety improvements",
+      documentType: "petition",
+      scanCount: 8,
+      locationCount: 2,
+      latestScanAt: new Date("2024-06-01T11:00:00Z"),
+      earliestScanAt: new Date("2024-06-01T07:00:00Z"),
+    },
+  ],
+  hourlyTrend: [
+    { hour: new Date("2024-06-01T08:00:00Z"), scanCount: 2 },
+    { hour: new Date("2024-06-01T09:00:00Z"), scanCount: 5 },
+    { hour: new Date("2024-06-01T10:00:00Z"), scanCount: 3 },
+  ],
+  totalScansLast24h: 13,
+  activePetitionsLast24h: 2,
+};
+
+describe("formatRelativeTime", () => {
+  it("returns 'just now' for times less than 1 minute ago", () => {
+    const now = new Date();
+    expect(formatRelativeTime(now)).toBe("just now");
+    expect(formatRelativeTime(new Date(Date.now() - 30_000))).toBe("just now");
+  });
+
+  it("returns minutes for times 1-59 minutes ago", () => {
+    expect(formatRelativeTime(new Date(Date.now() - 60_000))).toBe("1m ago");
+    expect(formatRelativeTime(new Date(Date.now() - 5 * 60_000))).toBe(
+      "5m ago",
+    );
+    expect(formatRelativeTime(new Date(Date.now() - 59 * 60_000))).toBe(
+      "59m ago",
+    );
+  });
+
+  it("returns hours for times 1-23 hours ago", () => {
+    expect(formatRelativeTime(new Date(Date.now() - 60 * 60_000))).toBe(
+      "1h ago",
+    );
+    expect(formatRelativeTime(new Date(Date.now() - 12 * 60 * 60_000))).toBe(
+      "12h ago",
+    );
+    expect(formatRelativeTime(new Date(Date.now() - 23 * 60 * 60_000))).toBe(
+      "23h ago",
+    );
+  });
+
+  it("returns days for times 24+ hours ago", () => {
+    expect(formatRelativeTime(new Date(Date.now() - 24 * 60 * 60_000))).toBe(
+      "1d ago",
+    );
+    expect(formatRelativeTime(new Date(Date.now() - 72 * 60 * 60_000))).toBe(
+      "3d ago",
+    );
+  });
+});
+
+describe("truncate", () => {
+  it("returns text unchanged when shorter than max", () => {
+    expect(truncate("short text", 120)).toBe("short text");
+  });
+
+  it("returns text unchanged when exactly at max length", () => {
+    const text = "a".repeat(120);
+    expect(truncate(text, 120)).toBe(text);
+  });
+
+  it("truncates and adds ellipsis when text exceeds max", () => {
+    const text = "a".repeat(130);
+    const result = truncate(text, 120);
+    expect(result).toHaveLength(121); // 120 chars + ellipsis
+    expect(result.endsWith("\u2026")).toBe(true);
+  });
+
+  it("trims trailing whitespace before ellipsis", () => {
+    const text = "word ".repeat(25); // 125 chars
+    const result = truncate(text, 120);
+    expect(result.endsWith(" \u2026")).toBe(false);
+    expect(result.endsWith("\u2026")).toBe(true);
+  });
+
+  it("handles empty string", () => {
+    expect(truncate("", 120)).toBe("");
+  });
+});
+
+describe("ActivityFeed", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders loading skeleton on initial load", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: null,
+      loading: true,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(screen.getByTestId("activity-feed-loading")).toBeInTheDocument();
+  });
+
+  it("renders null on error (graceful degradation)", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: null,
+      loading: false,
+      error: new Error("Failed"),
+    });
+
+    const { container } = render(<ActivityFeed />);
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows empty state when no activity", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: {
+        items: [],
+        hourlyTrend: [],
+        totalScansLast24h: 0,
+        activePetitionsLast24h: 0,
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(
+      screen.getByText(/No petition activity in the last 24 hours/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders activity items with counts", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: mockFeed,
+      loading: false,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(screen.getByTestId("activity-feed")).toBeInTheDocument();
+    expect(screen.getByText(/improving local parks/)).toBeInTheDocument();
+    expect(screen.getByText(/traffic safety/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Scanned 5 times in 3 locations/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Scanned 8 times in 2 locations/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders stats banner with scan counts", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: mockFeed,
+      loading: false,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(screen.getByText("13")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText(/scans in the last 24 hours/)).toBeInTheDocument();
+  });
+
+  it("renders sparkline bars", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: mockFeed,
+      loading: false,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(screen.getByLabelText("Hourly scan trend")).toBeInTheDocument();
+    expect(screen.getByText("Last 24 hours")).toBeInTheDocument();
+  });
+
+  it("shows live indicator", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: mockFeed,
+      loading: false,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(screen.getByText("Live")).toBeInTheDocument();
+  });
+
+  it("does not show skeleton when loading with cached data", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: mockFeed,
+      loading: true,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(
+      screen.queryByTestId("activity-feed-loading"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("activity-feed")).toBeInTheDocument();
+  });
+
+  it("uses singular forms for 1 scan and 1 location", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: {
+        items: [
+          {
+            contentHash: "hash-s",
+            summary: "Single scan petition",
+            scanCount: 1,
+            locationCount: 1,
+            latestScanAt: new Date(),
+            earliestScanAt: new Date(),
+          },
+        ],
+        hourlyTrend: [],
+        totalScansLast24h: 1,
+        activePetitionsLast24h: 1,
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(
+      screen.getByText(/Scanned 1 time in 1 location/),
+    ).toBeInTheDocument();
+    // Verify singular forms: "scan" not "scans", "petition" not "petitions"
+    const statsEl = screen
+      .getByTestId("activity-feed")
+      .querySelector("p.text-sm.text-gray-300");
+    expect(statsEl?.textContent).toMatch(/\bscan\b/);
+    expect(statsEl?.textContent).not.toMatch(/\bscans\b/);
+    expect(statsEl?.textContent).toMatch(/\bpetition\b/);
+    expect(statsEl?.textContent).not.toMatch(/\bpetitions\b/);
+  });
+
+  it("hides sparkline when hourlyTrend is empty", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: {
+        items: mockFeed.items,
+        hourlyTrend: [],
+        totalScansLast24h: 13,
+        activePetitionsLast24h: 2,
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(
+      screen.queryByLabelText("Hourly scan trend"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText("Last 24 hours")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when feed is null", () => {
+    mockUseActivityFeed.mockReturnValue({
+      feed: null,
+      loading: false,
+      error: null,
+    });
+
+    render(<ActivityFeed />);
+
+    expect(
+      screen.getByText(/No petition activity in the last 24 hours/),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/hooks/useActivityFeed.test.ts
+++ b/apps/frontend/__tests__/hooks/useActivityFeed.test.ts
@@ -1,0 +1,95 @@
+import { renderHook } from "@testing-library/react";
+import { useActivityFeed } from "@/lib/hooks/useActivityFeed";
+
+const mockUseQuery = jest.fn();
+jest.mock("@apollo/client/react", () => ({
+  useQuery: (...args: unknown[]) => mockUseQuery(...args),
+}));
+
+const mockFeed = {
+  items: [
+    {
+      contentHash: "hash-1",
+      summary: "A petition about parks",
+      documentType: "petition",
+      scanCount: 5,
+      locationCount: 3,
+      latestScanAt: "2024-06-01T12:00:00Z",
+      earliestScanAt: "2024-06-01T08:00:00Z",
+    },
+  ],
+  hourlyTrend: [
+    { hour: "2024-06-01T08:00:00Z", scanCount: 2 },
+    { hour: "2024-06-01T09:00:00Z", scanCount: 3 },
+  ],
+  totalScansLast24h: 5,
+  activePetitionsLast24h: 1,
+};
+
+describe("useActivityFeed", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null feed when loading", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useActivityFeed());
+
+    expect(result.current.feed).toBeNull();
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns feed data on completion", () => {
+    mockUseQuery.mockReturnValue({
+      data: { petitionActivityFeed: mockFeed },
+      loading: false,
+      error: undefined,
+    });
+
+    const { result } = renderHook(() => useActivityFeed());
+
+    expect(result.current.feed).toEqual(mockFeed);
+    expect(result.current.feed?.items).toHaveLength(1);
+    expect(result.current.feed?.totalScansLast24h).toBe(5);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("returns error when query fails", () => {
+    const error = new Error("Network error");
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: false,
+      error,
+    });
+
+    const { result } = renderHook(() => useActivityFeed());
+
+    expect(result.current.error).toBe(error);
+    expect(result.current.feed).toBeNull();
+  });
+
+  it("uses 30s poll interval", () => {
+    mockUseQuery.mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: undefined,
+    });
+
+    renderHook(() => useActivityFeed());
+
+    expect(mockUseQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        pollInterval: 30_000,
+        fetchPolicy: "cache-and-network",
+      }),
+    );
+  });
+});

--- a/apps/frontend/app/petition/page.tsx
+++ b/apps/frontend/app/petition/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { ActivityFeed } from "@/components/petition/ActivityFeed";
 
 export default function PetitionPage() {
   return (
@@ -36,6 +37,7 @@ export default function PetitionPage() {
       >
         View Map
       </Link>
+      <ActivityFeed />
       <Link
         href="/"
         className="mt-4 text-sm text-gray-400 hover:text-gray-300 transition-colors"

--- a/apps/frontend/components/petition/ActivityFeed.tsx
+++ b/apps/frontend/components/petition/ActivityFeed.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useActivityFeed } from "@/lib/hooks";
+import { PetitionActivityItem } from "@/lib/graphql/documents";
+
+export function formatRelativeTime(date: Date | string): string {
+  const now = Date.now();
+  const diffMs = now - new Date(date).getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return `${Math.floor(diffHr / 24)}d ago`;
+}
+
+export function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max).trimEnd() + "\u2026";
+}
+
+function Sparkline({
+  hourlyTrend,
+}: {
+  hourlyTrend: { hour: Date | string; scanCount: number }[];
+}) {
+  const maxCount = Math.max(...hourlyTrend.map((b) => b.scanCount), 1);
+  return (
+    <div className="flex items-end gap-px h-10" aria-label="Hourly scan trend">
+      {hourlyTrend.map((bucket, i) => {
+        const heightPct = (bucket.scanCount / maxCount) * 100;
+        return (
+          <div
+            key={i}
+            className="flex-1 bg-blue-500 rounded-t-sm min-w-[2px] transition-all"
+            style={{ height: `${Math.max(heightPct, 4)}%` }}
+            title={`${bucket.scanCount} scans`}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function ActivityItem({ item }: { item: PetitionActivityItem }) {
+  return (
+    <div className="px-4 py-3 bg-gray-800 rounded-lg">
+      <p className="text-sm text-gray-200 mb-1">
+        {truncate(item.summary || "Petition document", 120)}
+      </p>
+      <div className="flex items-center gap-3 text-xs text-gray-400">
+        <span>
+          Scanned {item.scanCount} {item.scanCount === 1 ? "time" : "times"} in{" "}
+          {item.locationCount}{" "}
+          {item.locationCount === 1 ? "location" : "locations"}
+        </span>
+        <span>{formatRelativeTime(item.latestScanAt)}</span>
+      </div>
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div
+      className="space-y-3 animate-pulse"
+      data-testid="activity-feed-loading"
+    >
+      <div className="h-4 bg-gray-700 rounded w-3/4" />
+      <div className="h-10 bg-gray-800 rounded" />
+      <div className="h-16 bg-gray-800 rounded" />
+      <div className="h-16 bg-gray-800 rounded" />
+    </div>
+  );
+}
+
+export function ActivityFeed() {
+  const { feed, loading, error } = useActivityFeed();
+
+  if (error) return null;
+
+  if (loading && !feed) {
+    return (
+      <section className="w-full max-w-sm mt-8">
+        <LoadingSkeleton />
+      </section>
+    );
+  }
+
+  if (!feed || (feed.totalScansLast24h === 0 && feed.items.length === 0)) {
+    return (
+      <section className="w-full max-w-sm mt-8 text-center">
+        <p className="text-sm text-gray-500">
+          No petition activity in the last 24 hours. Be the first to scan!
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="w-full max-w-sm mt-8" data-testid="activity-feed">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="relative flex h-2 w-2">
+          <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+          <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+        </span>
+        <span className="text-xs font-medium text-green-400">Live</span>
+      </div>
+
+      <p className="text-sm text-gray-300 mb-3">
+        <span className="text-white font-semibold">
+          {feed.totalScansLast24h}
+        </span>{" "}
+        {feed.totalScansLast24h === 1 ? "scan" : "scans"} in the last 24 hours
+        across{" "}
+        <span className="text-white font-semibold">
+          {feed.activePetitionsLast24h}
+        </span>{" "}
+        {feed.activePetitionsLast24h === 1 ? "petition" : "petitions"}
+      </p>
+
+      {feed.hourlyTrend.length > 0 && (
+        <div className="mb-4">
+          <Sparkline hourlyTrend={feed.hourlyTrend} />
+          <p className="text-xs text-gray-400 mt-1">Last 24 hours</p>
+        </div>
+      )}
+
+      {feed.items.length > 0 && (
+        <div className="space-y-2">
+          {feed.items.map((item) => (
+            <ActivityItem key={item.contentHash} item={item} />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/e2e/petition-capture.spec.ts
+++ b/apps/frontend/e2e/petition-capture.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 import {
   setupAuthSession,
+  mockGraphQL,
+  mockGraphQLError,
   checkAccessibility,
   viewports,
 } from "./utils/test-helpers";
@@ -296,6 +298,108 @@ test.describe("Petition Capture", () => {
       // covered by unit tests in LocationPrompt.test.tsx
       const container = page.locator(".fixed.inset-0.bg-black");
       await expect(container).toBeVisible();
+    });
+  });
+
+  test.describe("Activity Feed", () => {
+    test("should show activity feed with data", async ({ page }) => {
+      await setupAuthSession(page);
+      await mockGraphQL(page, {
+        petitionActivityFeed: {
+          petitionActivityFeed: {
+            items: [
+              {
+                contentHash: "hash-1",
+                summary: "A petition about improving local parks",
+                documentType: "petition",
+                scanCount: 5,
+                locationCount: 3,
+                latestScanAt: new Date().toISOString(),
+                earliestScanAt: new Date().toISOString(),
+              },
+            ],
+            hourlyTrend: [{ hour: new Date().toISOString(), scanCount: 5 }],
+            totalScansLast24h: 5,
+            activePetitionsLast24h: 1,
+          },
+        },
+      });
+
+      await page.goto("/petition");
+
+      await expect(page.getByTestId("activity-feed")).toBeVisible();
+      await expect(page.getByText("Live")).toBeVisible();
+      await expect(page.getByText(/scans in the last 24 hours/)).toBeVisible();
+      await expect(page.getByText(/improving local parks/)).toBeVisible();
+    });
+
+    test("should show empty state when no activity", async ({ page }) => {
+      await setupAuthSession(page);
+      await mockGraphQL(page, {
+        petitionActivityFeed: {
+          petitionActivityFeed: {
+            items: [],
+            hourlyTrend: [],
+            totalScansLast24h: 0,
+            activePetitionsLast24h: 0,
+          },
+        },
+      });
+
+      await page.goto("/petition");
+
+      await expect(
+        page.getByText(/No petition activity in the last 24 hours/),
+      ).toBeVisible();
+    });
+
+    test("should hide feed gracefully on error", async ({ page }) => {
+      await setupAuthSession(page);
+      await mockGraphQLError(
+        page,
+        "petitionActivityFeed",
+        "Internal server error",
+      );
+
+      await page.goto("/petition");
+
+      // Page should still work — feed just hides
+      await expect(page.getByText("Scan a Petition")).toBeVisible();
+      await expect(page.getByTestId("activity-feed")).not.toBeVisible();
+    });
+
+    test("activity feed should have no critical accessibility violations", async ({
+      page,
+    }) => {
+      await setupAuthSession(page);
+      await mockGraphQL(page, {
+        petitionActivityFeed: {
+          petitionActivityFeed: {
+            items: [
+              {
+                contentHash: "hash-a11y",
+                summary: "Accessibility test petition",
+                documentType: "petition",
+                scanCount: 4,
+                locationCount: 2,
+                latestScanAt: new Date().toISOString(),
+                earliestScanAt: new Date().toISOString(),
+              },
+            ],
+            hourlyTrend: [{ hour: new Date().toISOString(), scanCount: 4 }],
+            totalScansLast24h: 4,
+            activePetitionsLast24h: 1,
+          },
+        },
+      });
+
+      await page.goto("/petition");
+      await expect(page.getByTestId("activity-feed")).toBeVisible();
+
+      const violations = await checkAccessibility(page, {
+        includedImpacts: ["critical", "serious"],
+      });
+      expect(violations).toEqual([]);
     });
   });
 

--- a/apps/frontend/lib/graphql/documents.ts
+++ b/apps/frontend/lib/graphql/documents.ts
@@ -233,6 +233,54 @@ export const GET_PETITION_MAP_STATS = gql`
 `;
 
 // ============================================
+// Activity Feed Types
+// ============================================
+
+export interface PetitionActivityItem {
+  contentHash: string;
+  summary: string;
+  documentType?: string;
+  scanCount: number;
+  locationCount: number;
+  latestScanAt: string;
+  earliestScanAt: string;
+}
+
+export interface ActivityHourBucket {
+  hour: string;
+  scanCount: number;
+}
+
+export interface PetitionActivityFeed {
+  items: PetitionActivityItem[];
+  hourlyTrend: ActivityHourBucket[];
+  totalScansLast24h: number;
+  activePetitionsLast24h: number;
+}
+
+export const GET_PETITION_ACTIVITY_FEED = gql`
+  query PetitionActivityFeed {
+    petitionActivityFeed {
+      items {
+        contentHash
+        summary
+        documentType
+        scanCount
+        locationCount
+        latestScanAt
+        earliestScanAt
+      }
+      hourlyTrend {
+        hour
+        scanCount
+      }
+      totalScansLast24h
+      activePetitionsLast24h
+    }
+  }
+`;
+
+// ============================================
 // Response Types
 // ============================================
 
@@ -258,4 +306,8 @@ export interface PetitionMapStatsData {
 
 export interface SubmitAbuseReportData {
   submitAbuseReport: SubmitAbuseReportResult;
+}
+
+export interface PetitionActivityFeedData {
+  petitionActivityFeed: PetitionActivityFeed;
 }

--- a/apps/frontend/lib/hooks/index.ts
+++ b/apps/frontend/lib/hooks/index.ts
@@ -4,3 +4,4 @@ export { useCamera } from "./useCamera";
 export { useLightingAnalysis } from "./useLightingAnalysis";
 export { useGeolocation } from "./useGeolocation";
 export { useMapPetitions } from "./useMapPetitions";
+export { useActivityFeed } from "./useActivityFeed";

--- a/apps/frontend/lib/hooks/useActivityFeed.ts
+++ b/apps/frontend/lib/hooks/useActivityFeed.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_PETITION_ACTIVITY_FEED,
+  PetitionActivityFeedData,
+  PetitionActivityFeed,
+} from "../graphql/documents";
+
+const POLL_INTERVAL_MS = 30_000;
+
+export interface UseActivityFeedReturn {
+  feed: PetitionActivityFeed | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useActivityFeed(): UseActivityFeedReturn {
+  const { data, loading, error } = useQuery<PetitionActivityFeedData>(
+    GET_PETITION_ACTIVITY_FEED,
+    {
+      fetchPolicy: "cache-and-network",
+      pollInterval: POLL_INTERVAL_MS,
+    },
+  );
+
+  return {
+    feed: data?.petitionActivityFeed ?? null,
+    loading,
+    error: error ?? null,
+  };
+}

--- a/apps/frontend/locales/en/petition.json
+++ b/apps/frontend/locales/en/petition.json
@@ -103,6 +103,16 @@
     "tryAgain": "Scan Again",
     "copiedToClipboard": "Analysis copied to clipboard"
   },
+  "activityFeed": {
+    "live": "Live",
+    "scansLast24h": "{{count}} scans in the last 24 hours",
+    "activePetitions": "across {{count}} petitions",
+    "scannedTimes": "Scanned {{count}} times in {{locations}} locations",
+    "lastScanned": "Last scanned {{time}}",
+    "noActivity": "No petition activity in the last 24 hours. Be the first to scan!",
+    "hourlyTrend": "Last 24 hours",
+    "loading": "Loading activity..."
+  },
   "report": {
     "button": "Report Issue",
     "buttonLabel": "Report an issue with this analysis",

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,10 @@ Practical guides for common tasks and workflows.
 - [**Region Setup and Validation**](guides/region-setup-and-validation-guide.md) - Step-by-step guide for standing up and validating a new region
 - [**Deployment**](guides/deployment.md) - Deploy a region node (on-premise + Cloudflare reference implementation)
 - [**Observability**](guides/observability.md) - Prometheus metrics and Loki logging
+- [**Auth Security**](guides/auth-security.md) - Authentication security patterns and best practices
+- [**Secrets Management**](guides/secrets-management.md) - Secrets management with Supabase Vault
+- [**Container Resources**](guides/container-resources.md) - Container CPU/memory resource requirements
+- [**Docker Health Checks**](guides/docker-healthchecks.md) - Health check configuration for services
 
 ## Quick Links
 
@@ -55,7 +59,11 @@ Practical guides for common tasks and workflows.
 - [Data Layer Architecture](architecture/data-layer.md)
 - [Database Migration](guides/database-migration.md)
 - [Audit Logging](guides/audit-logging.md)
+- [Auth Security](guides/auth-security.md) - Authentication security patterns
+- [Secrets Management](guides/secrets-management.md) - Secrets management with Supabase Vault
 - [Observability](guides/observability.md) - Prometheus, Loki, Grafana
+- [Container Resources](guides/container-resources.md) - Container resource requirements
+- [Docker Health Checks](guides/docker-healthchecks.md) - Health check configuration
 - [Region Setup and Validation](guides/region-setup-and-validation-guide.md) - Full region standup and UAT
 
 ### For AI/ML Engineers
@@ -112,6 +120,7 @@ The `packages/` directory contains workspace packages (`@opuspopuli/*`) that imp
 | `@opuspopuli/ocr-provider` | Image text extraction (Tesseract.js) |
 | `@opuspopuli/scraping-pipeline` | AI-powered schema-on-read web scraping with structural manifests |
 | `@opuspopuli/region-provider` | Civic data integration (declarative plugins, propositions, meetings, representatives) |
+| `@opuspopuli/prompt-client` | AI prompt template client with circuit breaker, HMAC auth, and caching |
 
 See [Provider Pattern](architecture/provider-pattern.md) and [Region Provider Guide](guides/region-provider.md) for implementation details.
 

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -63,10 +63,17 @@ Opus Populi is built on a modular, provider-based architecture with three core p
 ### Documents Service
 - **Technology**: NestJS + Apollo Federation
 - **Port**: 3002
-- **Purpose**: Document storage, metadata management, and file processing
+- **Purpose**: Document storage, petition scanning, OCR, document analysis, and activity feed
 - **Location**: `apps/backend/src/apps/documents`
 - **Database**: Relational (Document metadata)
 - **Storage**: Supabase Storage
+- **Features**:
+  - Petition image capture and OCR processing
+  - AI-powered document analysis
+  - Geolocation tagging for petition scans
+  - Real-time petition activity feed with hourly trends
+  - Map-based petition location visualization
+  - Abuse reporting
 
 ### Knowledge Service
 - **Technology**: NestJS + Apollo Federation
@@ -76,16 +83,17 @@ Opus Populi is built on a modular, provider-based architecture with three core p
 - **Components**:
   - Embeddings generation (Xenova/Ollama)
   - Vector search (pgvector on PostgreSQL)
-  - LLM inference (Ollama with Falcon 7B)
+  - LLM inference (Ollama with Mistral, Llama 3.1)
 
 ### Region Service
 - **Technology**: NestJS + Apollo Federation
 - **Port**: 3004
-- **Purpose**: Civic data integration (propositions, meetings, representatives)
+- **Purpose**: Civic data integration (propositions, meetings, representatives, campaign finance)
 - **Location**: `apps/backend/src/apps/region`
 - **Components**:
   - Declarative region plugin loading via `@opuspopuli/region-provider`
   - Propositions, meetings, and representatives data
+  - Campaign finance data (committees, contributions, expenditures, independent expenditures)
   - Plugin lifecycle management (initialize, health check, destroy)
 
 ## Provider Architecture


### PR DESCRIPTION
## Summary
- **Real-time Petition Activity Feed** (#298): Backend query + service for 24-hour petition activity with hourly trends and location counts; frontend ActivityFeed component with 30-second polling, sparkline chart, and live indicator; custom `useActivityFeed` hook; full test coverage (unit, integration, E2E)
- **Documentation updates**: Added prompt-client package to all package listings, fixed frontend dev port (3000→3200), fixed backend service table (Files→Region), added missing guides to docs index, updated system overview with current LLM models and expanded service descriptions

## Test plan
- [x] Unit tests pass (documents resolver, documents service, ActivityFeed component, useActivityFeed hook)
- [x] Integration tests pass (petition activity feed)
- [x] E2E tests pass (petition capture with activity feed)
- [x] CI pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)