### PR TITLE
fix: add Docker resource limits and HMAC signer tests

### DIFF
--- a/apps/backend/src/common/services/hmac-signer.service.spec.ts
+++ b/apps/backend/src/common/services/hmac-signer.service.spec.ts
@@ -1,0 +1,234 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import crypto from 'node:crypto';
+import { HmacSignerService } from './hmac-signer.service';
+
+// NOSONAR: Test constants are not real credentials
+
+describe('HmacSignerService', () => {
+  let service: HmacSignerService;
+
+  const TEST_SECRET = 'test-hmac-secret-key-for-signing';
+  const TEST_CLIENT_ID = 'test-gateway';
+
+  function createService(
+    secret: string | undefined = TEST_SECRET,
+    clientId: string | undefined = TEST_CLIENT_ID,
+  ): Promise<TestingModule> {
+    return Test.createTestingModule({
+      providers: [
+        HmacSignerService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'GATEWAY_HMAC_SECRET') return secret;
+              if (key === 'GATEWAY_CLIENT_ID') return clientId;
+              return undefined;
+            }),
+          },
+        },
+      ],
+    }).compile();
+  }
+
+  beforeEach(async () => {
+    const module = await createService();
+    service = module.get<HmacSignerService>(HmacSignerService);
+  });
+
+  describe('isEnabled', () => {
+    it('should return true when secret is configured', () => {
+      expect(service.isEnabled()).toBe(true);
+    });
+
+    it('should return false when secret is empty', async () => {
+      const module = await createService('');
+      const disabledService = module.get<HmacSignerService>(HmacSignerService);
+      expect(disabledService.isEnabled()).toBe(false);
+    });
+
+    it('should return false when secret is not configured', async () => {
+      const module = await Test.createTestingModule({
+        providers: [
+          HmacSignerService,
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn(() => undefined),
+            },
+          },
+        ],
+      }).compile();
+      const disabledService = module.get<HmacSignerService>(HmacSignerService);
+      expect(disabledService.isEnabled()).toBe(false);
+    });
+  });
+
+  describe('sign', () => {
+    it('should return a valid HMAC header string', () => {
+      const result = service.sign('POST', '/graphql');
+
+      expect(result).toMatch(/^HMAC \{.*\}$/);
+    });
+
+    it('should include correct credentials in the header', () => {
+      const result = service.sign('POST', '/graphql');
+      const jsonStr = result.replace('HMAC ', '');
+      const credentials = JSON.parse(jsonStr);
+
+      expect(credentials.username).toBe(TEST_CLIENT_ID);
+      expect(credentials.algorithm).toBe('hmac-sha256');
+      expect(credentials.headers).toBe('@request-target,content-type');
+      expect(credentials.signature).toBeDefined();
+      expect(typeof credentials.signature).toBe('string');
+    });
+
+    it('should produce a valid base64 HMAC-SHA256 signature', () => {
+      const result = service.sign('POST', '/graphql');
+      const credentials = JSON.parse(result.replace('HMAC ', ''));
+
+      // Manually compute expected signature
+      const signatureString = 'post /graphql\ncontent-type: application/json';
+      const expected = crypto
+        .createHmac('sha256', TEST_SECRET)
+        .update(signatureString)
+        .digest('base64');
+
+      expect(credentials.signature).toBe(expected);
+    });
+
+    it('should use custom content type when provided', () => {
+      const result = service.sign('POST', '/graphql', 'text/plain');
+      const credentials = JSON.parse(result.replace('HMAC ', ''));
+
+      const signatureString = 'post /graphql\ncontent-type: text/plain';
+      const expected = crypto
+        .createHmac('sha256', TEST_SECRET)
+        .update(signatureString)
+        .digest('base64');
+
+      expect(credentials.signature).toBe(expected);
+    });
+
+    it('should lowercase the HTTP method in the signature', () => {
+      const resultLower = service.sign('post', '/graphql');
+      const resultUpper = service.sign('POST', '/graphql');
+
+      const credLower = JSON.parse(resultLower.replace('HMAC ', ''));
+      const credUpper = JSON.parse(resultUpper.replace('HMAC ', ''));
+
+      expect(credLower.signature).toBe(credUpper.signature);
+    });
+
+    it('should produce different signatures for different paths', () => {
+      const result1 = service.sign('POST', '/graphql');
+      const result2 = service.sign('POST', '/api/v1');
+
+      const cred1 = JSON.parse(result1.replace('HMAC ', ''));
+      const cred2 = JSON.parse(result2.replace('HMAC ', ''));
+
+      expect(cred1.signature).not.toBe(cred2.signature);
+    });
+
+    it('should produce different signatures for different methods', () => {
+      const result1 = service.sign('POST', '/graphql');
+      const result2 = service.sign('GET', '/graphql');
+
+      const cred1 = JSON.parse(result1.replace('HMAC ', ''));
+      const cred2 = JSON.parse(result2.replace('HMAC ', ''));
+
+      expect(cred1.signature).not.toBe(cred2.signature);
+    });
+
+    it('should return empty string when signing is disabled', async () => {
+      const module = await createService('');
+      const disabledService = module.get<HmacSignerService>(HmacSignerService);
+
+      expect(disabledService.sign('POST', '/graphql')).toBe('');
+    });
+
+    it('should handle empty path', () => {
+      const result = service.sign('POST', '');
+      expect(result).toMatch(/^HMAC \{.*\}$/);
+    });
+
+    it('should handle special characters in path', () => {
+      const result = service.sign('POST', '/api/v1?query=test&foo=bar');
+      expect(result).toMatch(/^HMAC \{.*\}$/);
+    });
+  });
+
+  describe('signGraphQLRequest', () => {
+    it('should extract pathname and sign with POST method', () => {
+      const result = service.signGraphQLRequest('http://users:8080/graphql');
+      const credentials = JSON.parse(result.replace('HMAC ', ''));
+
+      const signatureString = 'post /graphql\ncontent-type: application/json';
+      const expected = crypto
+        .createHmac('sha256', TEST_SECRET)
+        .update(signatureString)
+        .digest('base64');
+
+      expect(credentials.signature).toBe(expected);
+    });
+
+    it('should handle URLs with different paths', () => {
+      const result = service.signGraphQLRequest(
+        'http://documents:8080/graphql',
+      );
+
+      expect(result).toMatch(/^HMAC \{.*\}$/);
+      const credentials = JSON.parse(result.replace('HMAC ', ''));
+      expect(credentials.username).toBe(TEST_CLIENT_ID);
+    });
+
+    it('should fall back to /graphql for invalid URLs', () => {
+      const result = service.signGraphQLRequest('not-a-valid-url');
+      const credentials = JSON.parse(result.replace('HMAC ', ''));
+
+      // Should use /graphql as fallback path
+      const signatureString = 'post /graphql\ncontent-type: application/json';
+      const expected = crypto
+        .createHmac('sha256', TEST_SECRET)
+        .update(signatureString)
+        .digest('base64');
+
+      expect(credentials.signature).toBe(expected);
+    });
+
+    it('should return empty string when signing is disabled', async () => {
+      const module = await createService('');
+      const disabledService = module.get<HmacSignerService>(HmacSignerService);
+
+      expect(
+        disabledService.signGraphQLRequest('http://users:8080/graphql'),
+      ).toBe('');
+    });
+  });
+
+  describe('constructor', () => {
+    it('should use default client ID when not configured', async () => {
+      const module = await Test.createTestingModule({
+        providers: [
+          HmacSignerService,
+          {
+            provide: ConfigService,
+            useValue: {
+              get: jest.fn((key: string) => {
+                if (key === 'GATEWAY_HMAC_SECRET') return TEST_SECRET;
+                return undefined;
+              }),
+            },
+          },
+        ],
+      }).compile();
+      const svc = module.get<HmacSignerService>(HmacSignerService);
+
+      const result = svc.sign('POST', '/graphql');
+      const credentials = JSON.parse(result.replace('HMAC ', ''));
+
+      expect(credentials.username).toBe('api-gateway');
+    });
+  });
+});

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -57,6 +57,14 @@ services:
     command: ["/usr/local/bin/db-migrate.sh"]
     networks:
       - opuspopuli-network
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   users:
     build:
@@ -84,6 +92,14 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   documents:
     build:
@@ -111,6 +127,14 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   knowledge:
     build:
@@ -138,6 +162,14 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   region:
     build:
@@ -165,6 +197,14 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   # API Gateway - Port 4000 to avoid conflict with frontend on port 3000
   api:
@@ -200,3 +240,11 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -77,6 +77,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+        reservations:
+          cpus: '0.05'
+          memory: 64M
 
   # ---------------------------------------------------------------------------
   # Local PostgreSQL — AI scratch data
@@ -98,6 +106,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 1024M
+        reservations:
+          cpus: '0.5'
+          memory: 512M
 
   # ---------------------------------------------------------------------------
   # Redis
@@ -116,6 +132,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
 
   # ---------------------------------------------------------------------------
   # Database Migrations
@@ -135,6 +159,14 @@ services:
     command: ["/usr/local/bin/db-migrate.sh"]
     networks:
       - opuspopuli-prod
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   # ---------------------------------------------------------------------------
   # NestJS Microservices
@@ -158,6 +190,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   documents:
     build:
@@ -178,6 +218,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   knowledge:
     build:
@@ -201,6 +249,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   region:
     build:
@@ -224,6 +280,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   api:
     build:
@@ -253,6 +317,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
 
   # ---------------------------------------------------------------------------
   # Observability
@@ -267,6 +339,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 256M
 
   loki:
     image: grafana/loki:2.9.5
@@ -277,6 +357,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 256M
 
   promtail:
     image: grafana/promtail:2.9.5
@@ -289,6 +377,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+        reservations:
+          cpus: '0.05'
+          memory: 64M
 
   grafana:
     image: grafana/grafana:10.4.1
@@ -305,6 +401,14 @@ services:
     networks:
       - opuspopuli-prod
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
 networks:
   opuspopuli-prod:

--- a/docker-compose-uat.yml
+++ b/docker-compose-uat.yml
@@ -62,6 +62,14 @@ services:
     command: ["/usr/local/bin/db-migrate.sh"]
     networks:
       - opuspopuli-network
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   users:
     build:
@@ -89,6 +97,14 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   documents:
     build:
@@ -116,6 +132,14 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   knowledge:
     build:
@@ -146,6 +170,14 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   region:
     build:
@@ -178,6 +210,14 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
 
   api:
     build:
@@ -212,3 +252,11 @@ services:
     networks:
       - opuspopuli-network
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 128M


### PR DESCRIPTION
## Summary
- Add `deploy.resources.limits` and `reservations` to all services in `docker-compose-prod.yml`, `docker-compose-e2e.yml`, and `docker-compose-uat.yml`
- Production: 1 CPU/512M for microservices, 2 CPU/1G for PostgreSQL, lighter limits for infra services
- Test environments: 0.5 CPU/256M across the board
- Add comprehensive unit tests for `HmacSignerService` (18 tests, 100% coverage)

Closes #453
Closes #454

Also created #481 to track Ollama native setup docs for production deployment.

## Test plan
- [x] All three compose configs validate (`docker compose config --quiet`)
- [x] Docker integration tests pass with resource limits applied (215 tests)
- [x] Lint passes (0 errors)
- [x] Backend unit tests pass (1295 tests, +18 new)
- [x] Frontend unit tests pass (1110 tests)
- [x] Frontend build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)