### PR TITLE
fix: async/await standardization and no-explicit-any warning

### DIFF
--- a/apps/backend/.eslintrc.cjs
+++ b/apps/backend/.eslintrc.cjs
@@ -15,11 +15,11 @@ module.exports = {
     node: true,
     jest: true,
   },
-  ignorePatterns: ['.eslintrc.js'],
+  ignorePatterns: ['.eslintrc.cjs'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'warn',
   },
 };

--- a/apps/backend/src/apps/documents/src/domains/documents.service.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.service.ts
@@ -587,13 +587,9 @@ export class DocumentsService {
         Array.isArray(parsed.relatedMeasures) &&
         (parsed.relatedMeasures as string[]).length > 0
       ) {
-        this.matchAndLinkPropositions(
+        this.matchAndLinkPropositionsSafely(
           documentId,
           parsed.relatedMeasures as string[],
-        ).catch((err) =>
-          this.logger.warn(
-            `Auto-match failed for ${documentId}: ${(err as Error).message}`,
-          ),
         );
       }
 
@@ -1356,6 +1352,19 @@ export class DocumentsService {
       `Auto-matched ${linkedIds.length}/${relatedMeasures.length} measures for document ${documentId}`,
     );
     return { matched: linkedIds.length, propositionIds: linkedIds };
+  }
+
+  private async matchAndLinkPropositionsSafely(
+    documentId: string,
+    relatedMeasures: string[],
+  ): Promise<void> {
+    try {
+      await this.matchAndLinkPropositions(documentId, relatedMeasures);
+    } catch (err) {
+      this.logger.warn(
+        `Auto-match failed for ${documentId}: ${(err as Error).message}`,
+      );
+    }
   }
 
   /**

--- a/apps/backend/src/apps/users/src/domains/auth/auth.service.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.service.spec.ts
@@ -556,6 +556,7 @@ describe('AuthService', () => {
       expect(emailService.sendWelcomeEmail).toHaveBeenCalledWith(
         'new-id',
         'new@example.com',
+        undefined,
       );
     });
 

--- a/apps/backend/src/apps/users/src/domains/auth/auth.service.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.service.ts
@@ -86,15 +86,9 @@ export class AuthService {
     await this.usersService.update(user.id, { id: userId });
     await this.usersService.updateAuthStrategy(userId, AuthStrategy.PASSWORD);
 
-    // Send welcome email (async, don't wait for it)
+    // Send welcome email (fire-and-forget)
     if (this.emailService) {
-      this.emailService
-        .sendWelcomeEmail(userId, email, username)
-        .catch((err) => {
-          this.logger.warn(
-            `Failed to send welcome email to ${email}: ${err.message}`,
-          );
-        });
+      this.sendWelcomeEmailSafely(userId, email, username);
     }
 
     return userId;
@@ -265,13 +259,9 @@ export class AuthService {
     // Create user in our database first (passwordless - no password required)
     const newUser = await this.usersService.createPasswordlessUser(email);
 
-    // Send welcome email (async, don't wait for it)
+    // Send welcome email (fire-and-forget)
     if (this.emailService && newUser) {
-      this.emailService.sendWelcomeEmail(newUser.id, email).catch((err) => {
-        this.logger.warn(
-          `Failed to send welcome email to ${email}: ${err.message}`,
-        );
-      });
+      this.sendWelcomeEmailSafely(newUser.id, email);
     }
 
     return this.authProvider.registerWithMagicLink(email, redirectTo);
@@ -292,5 +282,19 @@ export class AuthService {
       `Generating tokens for passkey-authenticated user: ${user.email}`,
     );
     return this.authProvider.createSessionForUser(user.email);
+  }
+
+  private async sendWelcomeEmailSafely(
+    userId: string,
+    email: string,
+    username?: string,
+  ): Promise<void> {
+    try {
+      await this.emailService!.sendWelcomeEmail(userId, email, username);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to send welcome email to ${email}: ${(err as Error).message}`,
+      );
+    }
   }
 }

--- a/apps/backend/src/apps/users/src/domains/user/users.service.ts
+++ b/apps/backend/src/apps/users/src/domains/user/users.service.ts
@@ -63,13 +63,13 @@ export class UsersService {
           `authService error registering (${JSON.stringify(createUserDto)}): ${error instanceof Error ? error.message : String(error)}`,
         );
 
-        this.db.user
-          .delete({ where: { id: dbUser.id } })
-          .catch((deleteError: Error) => {
-            this.logger.error(
-              `Error deleting user after authService error: ${deleteError.message}`,
-            );
-          });
+        try {
+          await this.db.user.delete({ where: { id: dbUser.id } });
+        } catch (deleteError) {
+          this.logger.error(
+            `Error deleting user after authService error: ${(deleteError as Error).message}`,
+          );
+        }
 
         throw error;
       }


### PR DESCRIPTION
## Summary
- **#468**: Convert all `.then()/.catch()` patterns to `async/await` with `try/catch` across `auth.service.ts`, `users.service.ts`, and `documents.service.ts`
- **#460**: Enable `@typescript-eslint/no-explicit-any` as `'warn'` to begin tracking `as any` usage reduction
- Rename `.eslintrc.js` → `.eslintrc.cjs` to prevent lint-staged from passing config file to ESLint as a lint target

## Changes
- **`auth.service.ts`**: Extract fire-and-forget welcome emails into `sendWelcomeEmailSafely()` async method
- **`users.service.ts`**: Await user cleanup delete before rethrowing (was fire-and-forget `.catch()`)
- **`documents.service.ts`**: Extract fire-and-forget proposition matching into `matchAndLinkPropositionsSafely()` async method
- **`.eslintrc.cjs`**: Renamed from `.js`, `no-explicit-any` set to `'warn'`

## Test plan
- [x] All 1295 backend tests pass
- [x] All 1110 frontend tests pass
- [x] `pnpm --filter backend lint` passes (0 errors)
- [ ] CI pipeline confirms no regressions

Closes #468, #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)