### PR TITLE
Merge develop to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  packages-build:
+    name: Build Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build packages
+        run: pnpm -r --filter './packages/*' build
+
+      - name: Upload package build artifacts
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        with:
+          name: packages-dist
+          path: packages/*/dist/
+          retention-days: 1
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -44,6 +77,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: [packages-build]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -66,8 +100,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build packages
-        run: pnpm -r --filter './packages/*' build
+      - name: Download package build artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: packages-dist
+          path: packages/
+
+      - name: Generate Prisma client
+        run: pnpm --filter @opuspopuli/relationaldb-provider db:generate
 
       - name: Run tests with coverage
         run: pnpm test:ci
@@ -85,7 +125,7 @@ jobs:
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [packages-build, test]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -108,8 +148,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build packages
-        run: pnpm -r --filter './packages/*' build
+      - name: Download package build artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: packages-dist
+          path: packages/
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
@@ -126,7 +169,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [lint, packages-build]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -147,8 +190,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build packages
-        run: pnpm -r --filter './packages/*' build
+      - name: Download package build artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: packages-dist
+          path: packages/
+
+      - name: Generate Prisma client
+        run: pnpm --filter @opuspopuli/relationaldb-provider db:generate
 
       - name: Build backend
         run: pnpm --filter backend build
@@ -159,7 +208,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: [test]  # Changed from [build] - no need to wait for build since we rebuild frontend here
+    needs: [packages-build, test]
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -200,8 +249,14 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build packages
-        run: pnpm -r --filter './packages/*' build
+      - name: Download package build artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
+        with:
+          name: packages-dist
+          path: packages/
+
+      - name: Generate Prisma client
+        run: pnpm --filter @opuspopuli/relationaldb-provider db:generate
 
       - name: Run backend integration tests
         run: pnpm test:integration

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -22,7 +22,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "incremental": true,
-    "skipLibCheck": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
     "resolveJsonModule": true,

--- a/apps/frontend/tsconfig.sw.json
+++ b/apps/frontend/tsconfig.sw.json
@@ -6,7 +6,6 @@
     "moduleResolution": "bundler",
     "strict": true,
     "noEmit": true,
-    "skipLibCheck": true,
     "isolatedModules": true,
     "esModuleInterop": true
   },

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -60,7 +60,7 @@ The **Frontend** (Next.js) can be deployed to the edge proxy layer (e.g., Cloudf
 | **Edge Proxy** | Public ingress, TLS termination, DDoS protection, CDN | Routes HTTPS to the compute node | Cloudflare Tunnel (free) | Nginx + Let's Encrypt, Caddy, Tailscale Funnel, ngrok |
 | **User-Facing Database** | Users, auth, documents, knowledge base, file storage | Managed PostgreSQL + pgvector, auth service, object storage | Supabase Cloud | Self-hosted Supabase, any PostgreSQL + auth stack |
 | **AI/Scratch Database** | Structural manifests, pipeline state, prompt templates | PostgreSQL + pgvector, low-latency to LLM | Runs in Docker on the compute node (always local) | N/A (always colocated with compute) |
-| **LLM Endpoint** | Inference for structural analysis, RAG, content evaluation | Ollama-compatible API, GPU required for production inference (Mistral 7B, Llama 3.1) | Ollama native (macOS Metal, Linux CUDA) | Claude API, OpenAI API, vLLM, Ollama in Docker (CPU, development only) |
+| **LLM Endpoint** | Inference for structural analysis, RAG, content evaluation | Ollama-compatible API, GPU required for production inference (Mistral 7B, Llama 3.1) | Ollama native (macOS Metal, Linux CUDA) | Ollama in Docker (CPU, development only) |
 | **Frontend** | User-facing web application (Next.js) | Static hosting or edge runtime | Cloudflare Workers | Vercel, Netlify, Docker container (self-hosted) |
 
 ## Dual-Database Strategy

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -452,7 +452,7 @@ See [Authentication Security Guide](../guides/auth-security.md) for implementati
 ## Future Enhancements
 
 ### Planned Providers
-- **LLM**: vLLM, Text Generation Inference
+- **LLM**: Additional Ollama-compatible models, dedicated inference servers
 - **Embeddings**: Custom fine-tuned models
 
 ### Planned Features

--- a/docs/guides/docker-setup.md
+++ b/docs/guides/docker-setup.md
@@ -207,7 +207,7 @@ LLM_MODEL='mistral'
 
 3. Restart your backend application
 
-Available models: https://ollama.ai/library
+Available models: https://ollama.com/library
 
 ## GPU Support (Optional)
 

--- a/docs/guides/llm-configuration.md
+++ b/docs/guides/llm-configuration.md
@@ -470,4 +470,4 @@ LLM_MODEL=my-custom-model
 - [AI/ML Pipeline](../architecture/ai-ml-pipeline.md) - Architecture details
 - [RAG Implementation](rag-implementation.md) - Using the RAG system
 - [Docker Setup](docker-setup.md) - Infrastructure configuration
-- [Ollama Library](https://ollama.ai/library) - Browse all available models
+- [Ollama Library](https://ollama.com/library) - Browse all available models

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -11,7 +11,6 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },

--- a/packages/email-provider/tsconfig.json
+++ b/packages/email-provider/tsconfig.json
@@ -10,8 +10,8 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,
-    "esModuleInterop": true,
     "skipLibCheck": true,
+    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true

--- a/packages/llm-provider/tsconfig.json
+++ b/packages/llm-provider/tsconfig.json
@@ -11,7 +11,6 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "experimentalDecorators": true,

--- a/packages/logging-provider/tsconfig.json
+++ b/packages/logging-provider/tsconfig.json
@@ -10,7 +10,6 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",

--- a/packages/prompt-client/tsconfig.json
+++ b/packages/prompt-client/tsconfig.json
@@ -11,7 +11,6 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "experimentalDecorators": true,

--- a/packages/region-provider/tsconfig.json
+++ b/packages/region-provider/tsconfig.json
@@ -11,7 +11,6 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "experimentalDecorators": true,

--- a/packages/relationaldb-provider/src/db.service.ts
+++ b/packages/relationaldb-provider/src/db.service.ts
@@ -138,11 +138,15 @@ export class DbService
       const gauges = metrics.gauges;
 
       const open =
-        gauges.find((g) => g.key === "prisma_pool_connections_open")?.value ??
-        0;
+        gauges.find(
+          (g: { key: string; value: number }) =>
+            g.key === "prisma_pool_connections_open",
+        )?.value ?? 0;
       const idle =
-        gauges.find((g) => g.key === "prisma_pool_connections_idle")?.value ??
-        0;
+        gauges.find(
+          (g: { key: string; value: number }) =>
+            g.key === "prisma_pool_connections_idle",
+        )?.value ?? 0;
       const busy = open - idle;
 
       return { open, idle, busy };

--- a/packages/relationaldb-provider/tsconfig.json
+++ b/packages/relationaldb-provider/tsconfig.json
@@ -11,7 +11,6 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true

--- a/packages/scraping-pipeline/tsconfig.json
+++ b/packages/scraping-pipeline/tsconfig.json
@@ -11,7 +11,6 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true

--- a/packages/vectordb-provider/tsconfig.json
+++ b/packages/vectordb-provider/tsconfig.json
@@ -11,7 +11,6 @@
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "experimentalDecorators": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "incremental": true,
-    "skipLibCheck": true,
     "strictNullChecks": true,
     "noImplicitAny": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
## Summary
- **#467**: Eliminate duplicate CI builds — add `packages-build` job with artifact sharing
- **#472**: Remove `skipLibCheck: true` from 11 tsconfigs where unnecessary; retain in 8 that need it for third-party DOM-typed `.d.ts` files
- **#474**: Update stale vLLM/TGI doc references and fix outdated Ollama URLs
- **#468**: Standardize async/await patterns, remove `.then()/.catch()` chains
- **#460**: Enable `@typescript-eslint/no-explicit-any` as `warn`
- **#455, #457, #458**: Pagination validation, petition map stats, activity feed CTE fixes
- Docker hardening (env cleanup, non-root user, pinned images)
- Resource limits & HMAC signer tests
- Database indexes, migration split, DB-side matching

## Test plan
- [x] All 3,443 unit tests pass across all workspace packages
- [x] Docker service builds verified locally
- [x] CI pipeline passes on develop

🤖 Generated with [Claude Code](https://claude.com/claude-code)