### PR TITLE
refactor: create custom exception class hierarchy (#469)

### DIFF
--- a/apps/backend/src/api/src/app.module.ts
+++ b/apps/backend/src/api/src/app.module.ts
@@ -41,6 +41,7 @@ import { HmacSignerService } from 'src/common/services/hmac-signer.service';
 import { GracefulShutdownService } from 'src/common/services/graceful-shutdown.service';
 import { HmacRemoteGraphQLDataSource } from './hmac-data-source';
 import { GatewayServicesModule } from './gateway-services.module';
+import { WebSocketConnectionException } from 'src/common/exceptions/app.exceptions';
 
 /**
  * Extract authenticated user from request context for GraphQL operations.
@@ -179,7 +180,9 @@ const handleAuth = ({ req, res }: { req: Request; res: Response }) => {
                   }) => {
                     const { connectionParams, extra } = context;
                     if (!connectionParams) {
-                      throw new Error('Missing connection parameters');
+                      throw new WebSocketConnectionException(
+                        'Missing connection parameters',
+                      );
                     }
 
                     // SECURITY: Validate WebSocket origin against allowed origins
@@ -187,7 +190,7 @@ const handleAuth = ({ req, res }: { req: Request; res: Response }) => {
                     if (allowedOriginSet) {
                       const origin = extra?.request?.headers?.origin;
                       if (!origin || !allowedOriginSet.has(origin)) {
-                        throw new Error(
+                        throw new WebSocketConnectionException(
                           `WebSocket connection rejected: origin "${origin || 'none'}" is not allowed`,
                         );
                       }

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -17,6 +17,7 @@ import {
   type IPipelineService,
   type IRegionPlugin,
 } from '@opuspopuli/region-provider';
+import { ServiceInitializationException } from 'src/common/exceptions/app.exceptions';
 import {
   resolveConfigPlaceholders,
   type Proposition,
@@ -281,7 +282,9 @@ export class RegionDomainService implements OnModuleInit {
     // Set up the local region service for GraphQL resolvers (propositions, meetings, reps)
     const localPlugin = this.pluginRegistry.getLocal();
     if (!localPlugin) {
-      throw new Error('No local region plugin available after initialization');
+      throw new ServiceInitializationException(
+        'No local region plugin available after initialization',
+      );
     }
 
     this.regionService = new RegionProviderService(localPlugin);

--- a/apps/backend/src/common/auth/jwt.strategy.ts
+++ b/apps/backend/src/common/auth/jwt.strategy.ts
@@ -7,6 +7,7 @@ import { Request } from 'express';
 import { IAuthConfig } from 'src/config';
 
 import { ILogin } from 'src/interfaces/login.interface';
+import { ConfigurationException } from 'src/common/exceptions/app.exceptions';
 
 /**
  * Extract JWT from httpOnly cookie
@@ -35,7 +36,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       configService.get<IAuthConfig>('auth');
 
     if (!authConfig) {
-      throw new Error('Authentication config is missing');
+      throw new ConfigurationException('Authentication config is missing');
     }
 
     const region = configService.get<string>('region');

--- a/apps/backend/src/common/auth/websocket-auth.service.ts
+++ b/apps/backend/src/common/auth/websocket-auth.service.ts
@@ -3,6 +3,10 @@ import { ConfigService } from '@nestjs/config';
 import jwt, { JwtHeader, JwtPayload, SigningKeyCallback } from 'jsonwebtoken';
 import jwksRsa, { JwksClient } from 'jwks-rsa';
 import { ILogin } from 'src/interfaces/login.interface';
+import {
+  ConfigurationException,
+  AuthenticationException,
+} from 'src/common/exceptions/app.exceptions';
 
 interface ISupabaseConfig {
   url: string;
@@ -30,7 +34,7 @@ export class WebSocketAuthService {
   constructor(private readonly configService: ConfigService) {
     const supabaseConfig = this.configService.get<ISupabaseConfig>('supabase');
     if (!supabaseConfig?.url) {
-      throw new Error('Supabase configuration is missing');
+      throw new ConfigurationException('Supabase configuration is missing');
     }
 
     // Supabase Auth JWT issuer is the project URL with /auth/v1
@@ -141,7 +145,7 @@ export class WebSocketAuthService {
       this.logger.warn(
         'WebSocket connection rejected: Missing authentication token',
       );
-      throw new Error('Missing authentication token');
+      throw new AuthenticationException('Missing authentication token');
     }
 
     const user = await this.validateToken(token);
@@ -150,7 +154,7 @@ export class WebSocketAuthService {
       this.logger.warn(
         'WebSocket connection rejected: Invalid authentication token',
       );
-      throw new Error('Invalid authentication token');
+      throw new AuthenticationException('Invalid authentication token');
     }
 
     this.logger.log(`WebSocket connection authenticated for user: ${user.id}`);

--- a/apps/backend/src/common/exceptions/app.exceptions.spec.ts
+++ b/apps/backend/src/common/exceptions/app.exceptions.spec.ts
@@ -1,0 +1,69 @@
+import {
+  AppException,
+  ConfigurationException,
+  AuthenticationException,
+  WebSocketConnectionException,
+  ServiceInitializationException,
+} from './app.exceptions';
+
+describe('Custom Exception Hierarchy', () => {
+  describe('AppException', () => {
+    it('should extend Error', () => {
+      const error = new AppException('test message', 'TEST_CODE');
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(AppException);
+    });
+
+    it('should set message and code', () => {
+      const error = new AppException('test message', 'TEST_CODE');
+      expect(error.message).toBe('test message');
+      expect(error.code).toBe('TEST_CODE');
+    });
+
+    it('should set name to class name', () => {
+      const error = new AppException('test', 'TEST');
+      expect(error.name).toBe('AppException');
+    });
+  });
+
+  describe('ConfigurationException', () => {
+    it('should extend AppException with CONFIGURATION_ERROR code', () => {
+      const error = new ConfigurationException('missing config');
+      expect(error).toBeInstanceOf(AppException);
+      expect(error).toBeInstanceOf(Error);
+      expect(error.code).toBe('CONFIGURATION_ERROR');
+      expect(error.message).toBe('missing config');
+      expect(error.name).toBe('ConfigurationException');
+    });
+  });
+
+  describe('AuthenticationException', () => {
+    it('should extend AppException with AUTHENTICATION_ERROR code', () => {
+      const error = new AuthenticationException('invalid token');
+      expect(error).toBeInstanceOf(AppException);
+      expect(error.code).toBe('AUTHENTICATION_ERROR');
+      expect(error.message).toBe('invalid token');
+      expect(error.name).toBe('AuthenticationException');
+    });
+  });
+
+  describe('WebSocketConnectionException', () => {
+    it('should extend AppException with WEBSOCKET_CONNECTION_ERROR code', () => {
+      const error = new WebSocketConnectionException('origin rejected');
+      expect(error).toBeInstanceOf(AppException);
+      expect(error.code).toBe('WEBSOCKET_CONNECTION_ERROR');
+      expect(error.message).toBe('origin rejected');
+      expect(error.name).toBe('WebSocketConnectionException');
+    });
+  });
+
+  describe('ServiceInitializationException', () => {
+    it('should extend AppException with SERVICE_INITIALIZATION_ERROR code', () => {
+      const error = new ServiceInitializationException('plugin not available');
+      expect(error).toBeInstanceOf(AppException);
+      expect(error.code).toBe('SERVICE_INITIALIZATION_ERROR');
+      expect(error.message).toBe('plugin not available');
+      expect(error.name).toBe('ServiceInitializationException');
+    });
+  });
+});

--- a/apps/backend/src/common/exceptions/app.exceptions.ts
+++ b/apps/backend/src/common/exceptions/app.exceptions.ts
@@ -1,0 +1,60 @@
+/**
+ * Custom Exception Hierarchy
+ *
+ * Provides consistent error categorization across the codebase.
+ * All custom exceptions extend a common base class with error codes
+ * for structured logging and error handling.
+ *
+ * @see https://github.com/OpusPopuli/opuspopuli/issues/469
+ */
+
+/**
+ * Base exception for all application errors.
+ * Provides a consistent structure with error codes for logging and categorization.
+ */
+export class AppException extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+/**
+ * Thrown when required configuration is missing or invalid at startup.
+ * These are fatal errors that prevent the application from starting.
+ */
+export class ConfigurationException extends AppException {
+  constructor(message: string) {
+    super(message, 'CONFIGURATION_ERROR');
+  }
+}
+
+/**
+ * Thrown when authentication fails (missing/invalid tokens, missing credentials).
+ */
+export class AuthenticationException extends AppException {
+  constructor(message: string) {
+    super(message, 'AUTHENTICATION_ERROR');
+  }
+}
+
+/**
+ * Thrown when a WebSocket connection is rejected (origin validation, missing params).
+ */
+export class WebSocketConnectionException extends AppException {
+  constructor(message: string) {
+    super(message, 'WEBSOCKET_CONNECTION_ERROR');
+  }
+}
+
+/**
+ * Thrown when a service fails to initialize properly.
+ */
+export class ServiceInitializationException extends AppException {
+  constructor(message: string) {
+    super(message, 'SERVICE_INITIALIZATION_ERROR');
+  }
+}

--- a/apps/backend/src/config/cors.config.ts
+++ b/apps/backend/src/config/cors.config.ts
@@ -2,6 +2,7 @@ import { Logger } from '@nestjs/common';
 import { CorsOptions } from '@nestjs/common/interfaces/external/cors-options.interface';
 import { ConfigService } from '@nestjs/config';
 import { isProduction } from './environment.config';
+import { ConfigurationException } from 'src/common/exceptions/app.exceptions';
 
 /**
  * CORS Configuration
@@ -85,7 +86,7 @@ export function parseAllowedOrigins(
 
   // Production: ALLOWED_ORIGINS is required (defense in depth — env.validation.ts also enforces this)
   if (!allowedOrigins || allowedOrigins.trim() === '') {
-    throw new Error(
+    throw new ConfigurationException(
       'ALLOWED_ORIGINS must be set in production. Provide a comma-separated list of HTTPS origins.',
     );
   }
@@ -96,14 +97,14 @@ export function parseAllowedOrigins(
     .filter(Boolean);
 
   if (origins.length === 0) {
-    throw new Error(
+    throw new ConfigurationException(
       'ALLOWED_ORIGINS must contain at least one valid origin in production.',
     );
   }
 
   const invalidOrigins = origins.filter((o) => !isValidProductionOrigin(o));
   if (invalidOrigins.length > 0) {
-    throw new Error(
+    throw new ConfigurationException(
       `Invalid origins in ALLOWED_ORIGINS: ${invalidOrigins.join(', ')}. All production origins must use HTTPS.`,
     );
   }

--- a/apps/backend/src/config/index.ts
+++ b/apps/backend/src/config/index.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@nestjs/config';
 import { createLogger, LogLevel } from '@opuspopuli/logging-provider';
 import { DBConnection, DBType } from 'src/common/enums/db.enums';
+import { ConfigurationException } from 'src/common/exceptions/app.exceptions';
 
 /**
  * Config logger for use during application initialization
@@ -85,7 +86,7 @@ export default async (): Promise<Partial<IAppConfig>> => {
   const region = configService.get('REGION');
 
   if (!project || !application || !version || !description || !port) {
-    throw new Error(
+    throw new ConfigurationException(
       `Missing service configuration: PROJECT=${project} APPLICATION=${application} VERSION=${version} DESCRIPTION=${description} PORT=${port}`,
     );
   }


### PR DESCRIPTION
## Summary
- Create typed exception classes (`ConfigurationException`, `AuthenticationException`, `WebSocketConnectionException`, `ServiceInitializationException`) extending a common `AppException` base with error codes
- Replace all 11 `throw new Error(...)` instances across 6 backend files with the appropriate typed exception
- Add unit tests for the new exception hierarchy (100% coverage)

Closes #469

## Test plan
- [x] All 1302 backend unit tests pass
- [x] New exception spec validates inheritance, error codes, and class names
- [x] Existing tests (cors.config, jwt.strategy, websocket-auth) continue to pass — `toThrow()` matches on message content

🤖 Generated with [Claude Code](https://claude.com/claude-code)