### PR TITLE
Merge develop to main (#464)

### DIFF
--- a/apps/backend/src/apps/users/src/domains/auth/admin.resolver.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/admin.resolver.spec.ts
@@ -1,0 +1,171 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Test, TestingModule } from '@nestjs/testing';
+import { Response } from 'express';
+import { createMock } from '@golevelup/ts-jest';
+
+import { AdminResolver } from './admin.resolver';
+import { AuthService } from './auth.service';
+import { Role } from 'src/common/enums/role.enum';
+import { GqlContext } from 'src/common/utils/graphql-context';
+
+// Mock context for admin tests
+const createMockContext = (): GqlContext => ({
+  req: {
+    user: undefined,
+    headers: {},
+    ip: '127.0.0.1',
+  },
+  res: {
+    cookie: jest.fn(),
+    clearCookie: jest.fn(),
+  } as unknown as Response,
+});
+
+describe('AdminResolver', () => {
+  let resolver: AdminResolver;
+  let authService: AuthService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminResolver,
+        { provide: AuthService, useValue: createMock<AuthService>() },
+      ],
+    }).compile();
+
+    resolver = module.get<AdminResolver>(AdminResolver);
+    authService = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolver should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  it('should confirm a user', async () => {
+    authService.confirmUser = jest.fn().mockImplementation((id: string) => {
+      return Promise.resolve(true);
+    });
+
+    const mockContext = createMockContext();
+    expect(await resolver.confirmUser('1', mockContext)).toBe(true);
+    expect(authService.confirmUser).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail to confirm an unknown user', async () => {
+    authService.confirmUser = jest.fn().mockImplementation((id: string) => {
+      return Promise.resolve(false);
+    });
+
+    const mockContext = createMockContext();
+    try {
+      await resolver.confirmUser('1', mockContext);
+    } catch (error) {
+      expect(error.message).toEqual('User not confirmed!');
+      expect(authService.confirmUser).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('should fail to confirm a user due to error', async () => {
+    authService.confirmUser = jest.fn().mockImplementation((id: string) => {
+      return Promise.reject(new Error('Failed confirm user!'));
+    });
+
+    const mockContext = createMockContext();
+    try {
+      await resolver.confirmUser('1', mockContext);
+    } catch (error) {
+      expect(error.message).toEqual('Failed confirm user!');
+      expect(authService.confirmUser).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('should add admin permissions', async () => {
+    authService.addPermission = jest
+      .fn()
+      .mockImplementation((id: string, role: Role) => {
+        return Promise.resolve(true);
+      });
+
+    const mockContext = createMockContext();
+    expect(await resolver.addAdminPermission('1', mockContext)).toBe(true);
+    expect(authService.addPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail to add admin permission to an unknown user', async () => {
+    authService.addPermission = jest
+      .fn()
+      .mockImplementation((id: string, role: Role) => {
+        return Promise.resolve(false);
+      });
+
+    const mockContext = createMockContext();
+    try {
+      await resolver.addAdminPermission('1', mockContext);
+    } catch (error) {
+      expect(error.message).toEqual('Admin Permissions were not granted!');
+      expect(authService.addPermission).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('should fail to add admin permission due to error', async () => {
+    authService.addPermission = jest.fn().mockImplementation((id: string) => {
+      return Promise.reject(new Error('Failed to add admin permissions!'));
+    });
+
+    const mockContext = createMockContext();
+    try {
+      await resolver.addAdminPermission('1', mockContext);
+    } catch (error) {
+      expect(error.message).toEqual('Failed to add admin permissions!');
+      expect(authService.addPermission).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('should remove admin permissions', async () => {
+    authService.removePermission = jest
+      .fn()
+      .mockImplementation((id: string, role: Role) => {
+        return Promise.resolve(true);
+      });
+
+    const mockContext = createMockContext();
+    expect(await resolver.removeAdminPermission('1', mockContext)).toBe(true);
+    expect(authService.removePermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail to remove admin permission from an unknown user', async () => {
+    authService.removePermission = jest
+      .fn()
+      .mockImplementation((id: string, role: Role) => {
+        return Promise.resolve(false);
+      });
+
+    const mockContext = createMockContext();
+    try {
+      await resolver.removeAdminPermission('1', mockContext);
+    } catch (error) {
+      expect(error.message).toEqual('Admin Permissions were not revoked!');
+      expect(authService.removePermission).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('should fail to remove admin permission due to error', async () => {
+    authService.removePermission = jest
+      .fn()
+      .mockImplementation((id: string) => {
+        return Promise.reject(new Error('Failed to revoke admin permissions!'));
+      });
+
+    const mockContext = createMockContext();
+    try {
+      await resolver.removeAdminPermission('1', mockContext);
+    } catch (error) {
+      expect(error.message).toEqual('Failed to revoke admin permissions!');
+      expect(authService.removePermission).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/apps/backend/src/apps/users/src/domains/auth/admin.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/admin.resolver.ts
@@ -1,0 +1,115 @@
+import { Args, ID, Mutation, Resolver, Context } from '@nestjs/graphql';
+import { Optional } from '@nestjs/common';
+
+import { UserInputError } from '@nestjs/apollo';
+
+import { AuthService } from './auth.service';
+
+import { Role } from 'src/common/enums/role.enum';
+import { Roles } from 'src/common/decorators/roles.decorator';
+import { AuditAction } from 'src/common/enums/audit-action.enum';
+import {
+  GqlContext,
+  createAuditContext,
+} from 'src/common/utils/graphql-context';
+import { AuditLogService } from 'src/common/services/audit-log.service';
+
+/**
+ * Admin Resolver
+ *
+ * Handles admin-only user management operations:
+ * - User confirmation
+ * - Permission management (grant/revoke admin role)
+ *
+ * All operations require @Roles(Role.Admin).
+ *
+ * @see https://github.com/OpusPopuli/opuspopuli/issues/464
+ */
+@Resolver(() => Boolean)
+export class AdminResolver {
+  private readonly serviceName = 'users-service';
+
+  constructor(
+    private readonly authService: AuthService,
+    @Optional() private readonly auditLogService?: AuditLogService,
+  ) {}
+
+  @Mutation(() => Boolean)
+  @Roles(Role.Admin)
+  async confirmUser(
+    @Args({ name: 'id', type: () => ID }) id: string,
+    @Context() context: GqlContext,
+  ): Promise<boolean> {
+    const auditContext = createAuditContext(context, this.serviceName);
+
+    const result = await this.authService.confirmUser(id);
+
+    // Audit: User confirmation
+    this.auditLogService?.log({
+      ...auditContext,
+      action: AuditAction.USER_CONFIRMED,
+      success: result,
+      entityType: 'User',
+      entityId: id,
+      resolverName: 'confirmUser',
+      operationType: 'mutation',
+    });
+
+    if (!result) throw new UserInputError('User not confirmed!');
+    return result;
+  }
+
+  @Mutation(() => Boolean)
+  @Roles(Role.Admin)
+  async addAdminPermission(
+    @Args({ name: 'id', type: () => ID }) id: string,
+    @Context() context: GqlContext,
+  ): Promise<boolean> {
+    const auditContext = createAuditContext(context, this.serviceName);
+
+    const result = await this.authService.addPermission(id, Role.Admin);
+
+    // Audit: Admin permission granted
+    this.auditLogService?.log({
+      ...auditContext,
+      action: AuditAction.PERMISSION_GRANTED,
+      success: result,
+      entityType: 'User',
+      entityId: id,
+      resolverName: 'addAdminPermission',
+      operationType: 'mutation',
+      newValues: { role: Role.Admin },
+    });
+
+    if (!result)
+      throw new UserInputError('Admin Permissions were not granted!');
+    return result;
+  }
+
+  @Mutation(() => Boolean)
+  @Roles(Role.Admin)
+  async removeAdminPermission(
+    @Args({ name: 'id', type: () => ID }) id: string,
+    @Context() context: GqlContext,
+  ): Promise<boolean> {
+    const auditContext = createAuditContext(context, this.serviceName);
+
+    const result = await this.authService.removePermission(id, Role.Admin);
+
+    // Audit: Admin permission revoked
+    this.auditLogService?.log({
+      ...auditContext,
+      action: AuditAction.PERMISSION_REVOKED,
+      success: result,
+      entityType: 'User',
+      entityId: id,
+      resolverName: 'removeAdminPermission',
+      operationType: 'mutation',
+      previousValues: { role: Role.Admin },
+    });
+
+    if (!result)
+      throw new UserInputError('Admin Permissions were not revoked!');
+    return result;
+  }
+}

--- a/apps/backend/src/apps/users/src/domains/auth/auth.module.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.module.ts
@@ -2,6 +2,8 @@ import { Module, forwardRef } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 
 import { AuthResolver } from './auth.resolver';
+import { SessionResolver } from './session.resolver';
+import { AdminResolver } from './admin.resolver';
 import { AuthService } from './auth.service';
 import { PasskeyService } from './services/passkey.service';
 import { AccountLockoutService } from './services/account-lockout.service';
@@ -21,6 +23,8 @@ import { AuthModule as AuthProviderModule } from '@opuspopuli/auth-provider';
   ],
   providers: [
     AuthResolver,
+    SessionResolver,
+    AdminResolver,
     AuthService,
     PasskeyService,
     AccountLockoutService,

--- a/apps/backend/src/apps/users/src/domains/auth/auth.resolver.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.resolver.spec.ts
@@ -15,16 +15,13 @@ import { AccountLockoutService } from './services/account-lockout.service';
 import { UsersService } from '../user/users.service';
 
 import {
-  changePasswordDto,
   confirmForgotPasswordDto,
   loginUserDto,
   registerUserDto,
 } from '../../../../data.spec';
 import { RegisterUserDto } from './dto/register-user.dto';
 import { LoginUserDto } from './dto/login-user.dto';
-import { ChangePasswordDto } from './dto/change-password.dto';
 import { ConfirmForgotPasswordDto } from './dto/confirm-forgot-password.dto';
-import { Role } from 'src/common/enums/role.enum';
 import { GqlContext } from 'src/common/utils/graphql-context';
 
 // Mock context for tests that set cookies
@@ -149,36 +146,6 @@ describe('AuthResolver', () => {
     }
   });
 
-  it('should change a user password', async () => {
-    authService.changePassword = jest
-      .fn()
-      .mockImplementation((id: string, changePassword: ChangePasswordDto) => {
-        return Promise.resolve(true);
-      });
-
-    const mockContext = createMockContext();
-    expect(await resolver.changePassword(changePasswordDto, mockContext)).toBe(
-      true,
-    );
-    expect(authService.changePassword).toHaveBeenCalledTimes(1);
-  });
-
-  it('should fail to change a user password', async () => {
-    authService.changePassword = jest
-      .fn()
-      .mockImplementation((id: string, changePassword: ChangePasswordDto) => {
-        return Promise.reject(new Error('Failed user password change!'));
-      });
-
-    const mockContext = createMockContext();
-    try {
-      await resolver.changePassword(changePasswordDto, mockContext);
-    } catch (error) {
-      expect(error.message).toEqual('Failed user password change!');
-      expect(authService.changePassword).toHaveBeenCalledTimes(1);
-    }
-  });
-
   it('should send a forgot user password', async () => {
     authService.forgotPassword = jest
       .fn()
@@ -224,132 +191,6 @@ describe('AuthResolver', () => {
     } catch (error) {
       expect(error.message).toEqual('Failed forgot user password change!');
       expect(authService.confirmForgotPassword).toHaveBeenCalledTimes(1);
-    }
-  });
-
-  it('should confirm a user', async () => {
-    authService.confirmUser = jest.fn().mockImplementation((id: string) => {
-      return Promise.resolve(true);
-    });
-
-    const mockContext = createMockContext();
-    expect(await resolver.confirmUser('1', mockContext)).toBe(true);
-    expect(authService.confirmUser).toHaveBeenCalledTimes(1);
-  });
-
-  it('should fail to confirm an unknown user', async () => {
-    authService.confirmUser = jest.fn().mockImplementation((id: string) => {
-      return Promise.resolve(false);
-    });
-
-    const mockContext = createMockContext();
-    try {
-      await resolver.confirmUser('1', mockContext);
-    } catch (error) {
-      expect(error.message).toEqual('User not confirmed!');
-      expect(authService.confirmUser).toHaveBeenCalledTimes(1);
-    }
-  });
-
-  it('should fail to confirm a user due to error', async () => {
-    authService.confirmForgotPassword = jest
-      .fn()
-      .mockImplementation((id: string) => {
-        return Promise.reject(new Error('Failed confirm user!'));
-      });
-
-    const mockContext = createMockContext();
-    try {
-      await resolver.confirmUser('1', mockContext);
-    } catch (error) {
-      expect(error.message).toEqual('Failed confirm user!');
-      expect(authService.confirmUser).toHaveBeenCalledTimes(1);
-    }
-  });
-
-  it('should add admin permissions', async () => {
-    authService.addPermission = jest
-      .fn()
-      .mockImplementation((id: string, role: Role) => {
-        return Promise.resolve(true);
-      });
-
-    const mockContext = createMockContext();
-    expect(await resolver.addAdminPermission('1', mockContext)).toBe(true);
-    expect(authService.addPermission).toHaveBeenCalledTimes(1);
-  });
-
-  it('should fail to add admin permission to an unknown user', async () => {
-    authService.addPermission = jest
-      .fn()
-      .mockImplementation((id: string, role: Role) => {
-        return Promise.resolve(false);
-      });
-
-    const mockContext = createMockContext();
-    try {
-      await resolver.addAdminPermission('1', mockContext);
-    } catch (error) {
-      expect(error.message).toEqual('Admin Permissions were not granted!');
-      expect(authService.addPermission).toHaveBeenCalledTimes(1);
-    }
-  });
-
-  it('should fail to add admin permission due to error', async () => {
-    authService.addPermission = jest.fn().mockImplementation((id: string) => {
-      return Promise.reject(new Error('Failed to add admin permissions!'));
-    });
-
-    const mockContext = createMockContext();
-    try {
-      await resolver.addAdminPermission('1', mockContext);
-    } catch (error) {
-      expect(error.message).toEqual('Failed to add admin permissions!');
-      expect(authService.addPermission).toHaveBeenCalledTimes(1);
-    }
-  });
-
-  it('should remove admin permissions', async () => {
-    authService.removePermission = jest
-      .fn()
-      .mockImplementation((id: string, role: Role) => {
-        return Promise.resolve(true);
-      });
-
-    const mockContext = createMockContext();
-    expect(await resolver.removeAdminPermission('1', mockContext)).toBe(true);
-    expect(authService.removePermission).toHaveBeenCalledTimes(1);
-  });
-
-  it('should fail to remove admin permission from an unknown user', async () => {
-    authService.removePermission = jest
-      .fn()
-      .mockImplementation((id: string, role: Role) => {
-        return Promise.resolve(false);
-      });
-
-    const mockContext = createMockContext();
-    try {
-      await resolver.removeAdminPermission('1', mockContext);
-    } catch (error) {
-      expect(error.message).toEqual('Admin Permissions were not revoked!');
-      expect(authService.removePermission).toHaveBeenCalledTimes(1);
-    }
-  });
-
-  it('should fail to add admin permission due to error', async () => {
-    authService.removePermission = jest
-      .fn()
-      .mockImplementation((id: string) => {
-        return Promise.reject(new Error('Failed to revoke admin permissions!'));
-      });
-
-    const mockContext = createMockContext();
-    try {
-      await resolver.removeAdminPermission('1', mockContext);
-    } catch (error) {
-      expect(error.message).toEqual('Failed to revoke admin permissions!');
-      expect(authService.removePermission).toHaveBeenCalledTimes(1);
     }
   });
 
@@ -646,119 +487,6 @@ describe('AuthResolver', () => {
     });
   });
 
-  describe('myPasskeys', () => {
-    let passkeyService: PasskeyService;
-
-    beforeEach(async () => {
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          AuthResolver,
-          { provide: AuthService, useValue: createMock<AuthService>() },
-          { provide: PasskeyService, useValue: createMock<PasskeyService>() },
-          { provide: UsersService, useValue: createMock<UsersService>() },
-          { provide: ConfigService, useValue: createMock<ConfigService>() },
-          {
-            provide: AccountLockoutService,
-            useValue: createMockLockoutService(),
-          },
-        ],
-      }).compile();
-
-      resolver = module.get<AuthResolver>(AuthResolver);
-      passkeyService = module.get<PasskeyService>(PasskeyService);
-    });
-
-    // SECURITY: Tests now use request.user (set by passport) instead of headers.user (spoofable)
-    // @see https://github.com/OpusPopuli/opuspopuli/issues/183
-    it('should return user passkeys', async () => {
-      const mockCredentials = [{ id: 'cred-1', friendlyName: 'Device 1' }];
-      passkeyService.getUserCredentials = jest
-        .fn()
-        .mockResolvedValue(mockCredentials);
-
-      const context: GqlContext = {
-        req: {
-          user: {
-            id: 'user-1',
-            email: 'test@example.com',
-            roles: ['User'],
-            department: 'Engineering',
-            clearance: 'Secret',
-          },
-          headers: {},
-        },
-      };
-      const result = await resolver.myPasskeys(context);
-
-      expect(result).toEqual(mockCredentials);
-    });
-
-    it('should throw error when user not authenticated', async () => {
-      const context: GqlContext = { req: { user: undefined, headers: {} } };
-
-      await expect(resolver.myPasskeys(context)).rejects.toThrow(
-        'User not authenticated',
-      );
-    });
-  });
-
-  describe('deletePasskey', () => {
-    let passkeyService: PasskeyService;
-
-    beforeEach(async () => {
-      const module: TestingModule = await Test.createTestingModule({
-        providers: [
-          AuthResolver,
-          { provide: AuthService, useValue: createMock<AuthService>() },
-          { provide: PasskeyService, useValue: createMock<PasskeyService>() },
-          { provide: UsersService, useValue: createMock<UsersService>() },
-          { provide: ConfigService, useValue: createMock<ConfigService>() },
-          {
-            provide: AccountLockoutService,
-            useValue: createMockLockoutService(),
-          },
-        ],
-      }).compile();
-
-      resolver = module.get<AuthResolver>(AuthResolver);
-      passkeyService = module.get<PasskeyService>(PasskeyService);
-    });
-
-    // SECURITY: Tests now use request.user (set by passport) instead of headers.user (spoofable)
-    // @see https://github.com/OpusPopuli/opuspopuli/issues/183
-    it('should delete passkey successfully', async () => {
-      passkeyService.deleteCredential = jest.fn().mockResolvedValue(true);
-
-      const context: GqlContext = {
-        req: {
-          user: {
-            id: 'user-1',
-            email: 'test@example.com',
-            roles: ['User'],
-            department: 'Engineering',
-            clearance: 'Secret',
-          },
-          headers: {},
-        },
-      };
-      const result = await resolver.deletePasskey('cred-1', context);
-
-      expect(result).toBe(true);
-      expect(passkeyService.deleteCredential).toHaveBeenCalledWith(
-        'cred-1',
-        'user-1',
-      );
-    });
-
-    it('should throw error when user not authenticated', async () => {
-      const context: GqlContext = { req: { user: undefined, headers: {} } };
-
-      await expect(resolver.deletePasskey('cred-1', context)).rejects.toThrow(
-        'User not authenticated',
-      );
-    });
-  });
-
   // ============================================
   // Magic Link Tests
   // ============================================
@@ -857,30 +585,6 @@ describe('AuthResolver', () => {
           mockContext,
         ),
       ).rejects.toThrow('Register failed');
-    });
-  });
-
-  // ============================================
-  // Logout Tests
-  // ============================================
-
-  describe('logout', () => {
-    it('should clear cookies on logout', async () => {
-      const mockContext = createMockContext();
-      const result = await resolver.logout(mockContext);
-
-      expect(result).toBe(true);
-      // Verify cookies were cleared
-      expect(mockContext.res?.clearCookie).toHaveBeenCalled();
-    });
-
-    it('should return true even without res object', async () => {
-      const contextWithoutRes = {
-        req: { user: undefined, headers: {} },
-      } as GqlContext;
-      const result = await resolver.logout(contextWithoutRes);
-
-      expect(result).toBe(true);
     });
   });
 });

--- a/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
@@ -1,38 +1,28 @@
-import { Args, ID, Mutation, Query, Resolver, Context } from '@nestjs/graphql';
+import { Args, Mutation, Resolver, Context } from '@nestjs/graphql';
 import { ConfigService } from '@nestjs/config';
 import { ForbiddenException, Optional } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
-import { randomUUID } from 'node:crypto';
 import { AuthService } from './auth.service';
 import { LoginUserDto } from './dto/login-user.dto';
 import { RegisterUserDto } from './dto/register-user.dto';
-import { ChangePasswordDto } from './dto/change-password.dto';
 
 import { UserInputError } from '@nestjs/apollo';
 
 import { Auth } from './models/auth.model';
-import { Permissions } from 'src/common/decorators/permissions.decorator';
 import { Public } from 'src/common/decorators/public.decorator';
-import { Role } from 'src/common/enums/role.enum';
 import { AuthStrategy } from 'src/common/enums/auth-strategy.enum';
-import { Roles } from 'src/common/decorators/roles.decorator';
-import { Action } from 'src/common/enums/action.enum';
 import { AuditAction } from 'src/common/enums/audit-action.enum';
 import { ConfirmForgotPasswordDto } from './dto/confirm-forgot-password.dto';
 import { UsersService } from '../user/users.service';
 import {
   GqlContext,
-  getUserFromContext,
+  createAuditContext,
 } from 'src/common/utils/graphql-context';
-import {
-  setAuthCookies,
-  clearAuthCookies,
-} from 'src/common/utils/cookie.utils';
+import { setAuthCookies } from 'src/common/utils/cookie.utils';
 import { AUTH_THROTTLE } from 'src/config/auth-throttle.config';
 import { AccountLockoutService } from './services/account-lockout.service';
 import { AuditLogService } from 'src/common/services/audit-log.service';
 import { SecureLogger } from 'src/common/services/secure-logger.service';
-import { IAuditContext } from 'src/common/interfaces/audit.interface';
 
 // Passkey DTOs
 import {
@@ -42,7 +32,6 @@ import {
   VerifyPasskeyAuthenticationDto,
   PasskeyRegistrationOptions,
   PasskeyAuthenticationOptions,
-  PasskeyCredential,
 } from './dto/passkey.dto';
 import { PasskeyService } from './services/passkey.service';
 
@@ -53,6 +42,19 @@ import {
   RegisterWithMagicLinkDto,
 } from './dto/magic-link.dto';
 
+/**
+ * Auth Resolver
+ *
+ * Handles public authentication operations:
+ * - Registration (standard + magic link)
+ * - Login (password, passkey, magic link)
+ * - Password reset (forgot/confirm)
+ * - Passkey registration and authentication
+ *
+ * All operations are @Public() and rate-limited.
+ *
+ * @see https://github.com/OpusPopuli/opuspopuli/issues/464
+ */
 @Resolver(() => Boolean)
 export class AuthResolver {
   // Use SecureLogger to automatically redact PII (emails, IPs) from log messages
@@ -70,27 +72,6 @@ export class AuthResolver {
   ) {}
 
   /**
-   * Create audit context from GraphQL context
-   * @see https://github.com/OpusPopuli/opuspopuli/issues/191
-   */
-  private createAuditContext(
-    context: GqlContext,
-    userEmail?: string,
-  ): IAuditContext {
-    const user = context.req?.user;
-    return {
-      requestId: randomUUID(),
-      userId: user?.id,
-      userEmail: userEmail || user?.email,
-      ipAddress:
-        context.req?.ip ||
-        (context.req?.headers as Record<string, string>)?.['x-forwarded-for'],
-      userAgent: context.req?.headers?.['user-agent'],
-      serviceName: this.serviceName,
-    };
-  }
-
-  /**
    * Register a new user account
    * Rate limited: 3 attempts per minute
    * @see https://github.com/OpusPopuli/opuspopuli/issues/187
@@ -102,8 +83,9 @@ export class AuthResolver {
     @Args('registerUserDto') registerUserDto: RegisterUserDto,
     @Context() context: GqlContext,
   ): Promise<boolean> {
-    const auditContext = this.createAuditContext(
+    const auditContext = createAuditContext(
       context,
+      this.serviceName,
       registerUserDto.email,
     );
 
@@ -152,7 +134,7 @@ export class AuthResolver {
     @Context() context: GqlContext,
   ): Promise<Auth> {
     const { email } = loginUserDto;
-    const auditContext = this.createAuditContext(context, email);
+    const auditContext = createAuditContext(context, this.serviceName, email);
     const clientIp = auditContext.ipAddress;
 
     // Check if account is locked
@@ -241,46 +223,6 @@ export class AuthResolver {
     return auth;
   }
 
-  @Mutation(() => Boolean)
-  @Permissions({
-    action: Action.Update,
-    subject: 'User',
-    conditions: { id: '{{ id }}' },
-  })
-  async changePassword(
-    @Args('changePasswordDto') changePasswordDto: ChangePasswordDto,
-    @Context() context: GqlContext,
-  ): Promise<boolean> {
-    const auditContext = this.createAuditContext(context);
-
-    let passwordUpdated: boolean;
-    try {
-      passwordUpdated =
-        await this.authService.changePassword(changePasswordDto);
-
-      // Audit: Password change success
-      this.auditLogService?.log({
-        ...auditContext,
-        action: AuditAction.PASSWORD_CHANGE,
-        success: true,
-        resolverName: 'changePassword',
-        operationType: 'mutation',
-      });
-    } catch (error) {
-      // Audit: Password change failure
-      this.auditLogService?.logSync({
-        ...auditContext,
-        action: AuditAction.PASSWORD_CHANGE_FAILED,
-        success: false,
-        resolverName: 'changePassword',
-        operationType: 'mutation',
-        errorMessage: error.message,
-      });
-      throw new UserInputError(error.message);
-    }
-    return passwordUpdated;
-  }
-
   /**
    * Request password reset email
    * Rate limited: 3 attempts per hour (prevents email bombing)
@@ -293,7 +235,7 @@ export class AuthResolver {
     @Args('email') email: string,
     @Context() context: GqlContext,
   ): Promise<boolean> {
-    const auditContext = this.createAuditContext(context, email);
+    const auditContext = createAuditContext(context, this.serviceName, email);
 
     // Audit: Password reset request (always log, regardless of user existence)
     this.auditLogService?.log({
@@ -314,8 +256,9 @@ export class AuthResolver {
     confirmForgotPasswordDto: ConfirmForgotPasswordDto,
     @Context() context: GqlContext,
   ): Promise<boolean> {
-    const auditContext = this.createAuditContext(
+    const auditContext = createAuditContext(
       context,
+      this.serviceName,
       confirmForgotPasswordDto.email,
     );
 
@@ -346,86 +289,6 @@ export class AuthResolver {
       throw new UserInputError(error.message);
     }
     return passwordUpdated;
-  }
-
-  /** Administration */
-  @Mutation(() => Boolean)
-  @Roles(Role.Admin)
-  async confirmUser(
-    @Args({ name: 'id', type: () => ID }) id: string,
-    @Context() context: GqlContext,
-  ): Promise<boolean> {
-    const auditContext = this.createAuditContext(context);
-
-    const result = await this.authService.confirmUser(id);
-
-    // Audit: User confirmation
-    this.auditLogService?.log({
-      ...auditContext,
-      action: AuditAction.USER_CONFIRMED,
-      success: result,
-      entityType: 'User',
-      entityId: id,
-      resolverName: 'confirmUser',
-      operationType: 'mutation',
-    });
-
-    if (!result) throw new UserInputError('User not confirmed!');
-    return result;
-  }
-
-  @Mutation(() => Boolean)
-  @Roles(Role.Admin)
-  async addAdminPermission(
-    @Args({ name: 'id', type: () => ID }) id: string,
-    @Context() context: GqlContext,
-  ): Promise<boolean> {
-    const auditContext = this.createAuditContext(context);
-
-    const result = await this.authService.addPermission(id, Role.Admin);
-
-    // Audit: Admin permission granted
-    this.auditLogService?.log({
-      ...auditContext,
-      action: AuditAction.PERMISSION_GRANTED,
-      success: result,
-      entityType: 'User',
-      entityId: id,
-      resolverName: 'addAdminPermission',
-      operationType: 'mutation',
-      newValues: { role: Role.Admin },
-    });
-
-    if (!result)
-      throw new UserInputError('Admin Permissions were not granted!');
-    return result;
-  }
-
-  @Mutation(() => Boolean)
-  @Roles(Role.Admin)
-  async removeAdminPermission(
-    @Args({ name: 'id', type: () => ID }) id: string,
-    @Context() context: GqlContext,
-  ): Promise<boolean> {
-    const auditContext = this.createAuditContext(context);
-
-    const result = await this.authService.removePermission(id, Role.Admin);
-
-    // Audit: Admin permission revoked
-    this.auditLogService?.log({
-      ...auditContext,
-      action: AuditAction.PERMISSION_REVOKED,
-      success: result,
-      entityType: 'User',
-      entityId: id,
-      resolverName: 'removeAdminPermission',
-      operationType: 'mutation',
-      previousValues: { role: Role.Admin },
-    });
-
-    if (!result)
-      throw new UserInputError('Admin Permissions were not revoked!');
-    return result;
   }
 
   // ============================================
@@ -465,7 +328,11 @@ export class AuthResolver {
     @Args('input') input: VerifyPasskeyRegistrationDto,
     @Context() context: GqlContext,
   ): Promise<boolean> {
-    const auditContext = this.createAuditContext(context, input.email);
+    const auditContext = createAuditContext(
+      context,
+      this.serviceName,
+      input.email,
+    );
 
     try {
       const user = await this.authService.getUserByEmail(input.email);
@@ -553,7 +420,7 @@ export class AuthResolver {
     @Args('input') input: VerifyPasskeyAuthenticationDto,
     @Context() context: GqlContext,
   ): Promise<Auth> {
-    const auditContext = this.createAuditContext(context);
+    const auditContext = createAuditContext(context, this.serviceName);
 
     try {
       const { verification, user } =
@@ -614,49 +481,6 @@ export class AuthResolver {
     }
   }
 
-  @Query(() => [PasskeyCredential])
-  async myPasskeys(
-    @Context() context: GqlContext,
-  ): Promise<PasskeyCredential[]> {
-    const user = getUserFromContext(context);
-    const credentials = await this.passkeyService.getUserCredentials(user.id);
-    // Map database types (null) to GraphQL types (undefined)
-    return credentials.map((cred) => ({
-      id: cred.id,
-      friendlyName: cred.friendlyName ?? undefined,
-      deviceType: cred.deviceType ?? undefined,
-      createdAt: cred.createdAt,
-      lastUsedAt: cred.lastUsedAt,
-    }));
-  }
-
-  @Mutation(() => Boolean)
-  async deletePasskey(
-    @Args('credentialId') credentialId: string,
-    @Context() context: GqlContext,
-  ): Promise<boolean> {
-    const user = getUserFromContext(context);
-    const auditContext = this.createAuditContext(context, user.email);
-
-    const result = await this.passkeyService.deleteCredential(
-      credentialId,
-      user.id,
-    );
-
-    // Audit: Passkey deletion
-    this.auditLogService?.log({
-      ...auditContext,
-      action: AuditAction.PASSKEY_DELETED,
-      success: result,
-      entityType: 'PasskeyCredential',
-      entityId: credentialId,
-      resolverName: 'deletePasskey',
-      operationType: 'mutation',
-    });
-
-    return result;
-  }
-
   // ============================================
   // Magic Link Mutations
   // Rate limited: 3 attempts per minute
@@ -670,7 +494,11 @@ export class AuthResolver {
     @Args('input') input: SendMagicLinkDto,
     @Context() context: GqlContext,
   ): Promise<boolean> {
-    const auditContext = this.createAuditContext(context, input.email);
+    const auditContext = createAuditContext(
+      context,
+      this.serviceName,
+      input.email,
+    );
 
     try {
       const result = await this.authService.sendMagicLink(
@@ -700,7 +528,11 @@ export class AuthResolver {
     @Args('input') input: VerifyMagicLinkDto,
     @Context() context: GqlContext,
   ): Promise<Auth> {
-    const auditContext = this.createAuditContext(context, input.email);
+    const auditContext = createAuditContext(
+      context,
+      this.serviceName,
+      input.email,
+    );
 
     try {
       const auth = await this.authService.verifyMagicLink(
@@ -749,7 +581,11 @@ export class AuthResolver {
     @Args('input') input: RegisterWithMagicLinkDto,
     @Context() context: GqlContext,
   ): Promise<boolean> {
-    const auditContext = this.createAuditContext(context, input.email);
+    const auditContext = createAuditContext(
+      context,
+      this.serviceName,
+      input.email,
+    );
 
     try {
       const result = await this.authService.registerWithMagicLink(
@@ -770,30 +606,5 @@ export class AuthResolver {
     } catch (error) {
       throw new UserInputError(error.message);
     }
-  }
-
-  // ============================================
-  // Logout
-  // ============================================
-
-  @Mutation(() => Boolean)
-  async logout(@Context() context: GqlContext): Promise<boolean> {
-    const auditContext = this.createAuditContext(context);
-
-    // Clear httpOnly auth cookies
-    if (context.res) {
-      clearAuthCookies(context.res, this.configService);
-    }
-
-    // Audit: Logout
-    this.auditLogService?.log({
-      ...auditContext,
-      action: AuditAction.LOGOUT,
-      success: true,
-      resolverName: 'logout',
-      operationType: 'mutation',
-    });
-
-    return true;
   }
 }

--- a/apps/backend/src/apps/users/src/domains/auth/session.resolver.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/session.resolver.spec.ts
@@ -1,0 +1,176 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Test, TestingModule } from '@nestjs/testing';
+import { Response } from 'express';
+import { ConfigService } from '@nestjs/config';
+import { createMock } from '@golevelup/ts-jest';
+
+import { SessionResolver } from './session.resolver';
+import { AuthService } from './auth.service';
+import { PasskeyService } from './services/passkey.service';
+
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { changePasswordDto } from '../../../../data.spec';
+import { GqlContext } from 'src/common/utils/graphql-context';
+
+// Mock context for tests that set cookies
+const createMockContext = (): GqlContext => ({
+  req: {
+    user: undefined,
+    headers: {},
+    ip: '127.0.0.1',
+  },
+  res: {
+    cookie: jest.fn(),
+    clearCookie: jest.fn(),
+  } as unknown as Response,
+});
+
+describe('SessionResolver', () => {
+  let resolver: SessionResolver;
+  let authService: AuthService;
+  let passkeyService: PasskeyService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SessionResolver,
+        { provide: AuthService, useValue: createMock<AuthService>() },
+        { provide: PasskeyService, useValue: createMock<PasskeyService>() },
+        { provide: ConfigService, useValue: createMock<ConfigService>() },
+      ],
+    }).compile();
+
+    resolver = module.get<SessionResolver>(SessionResolver);
+    authService = module.get<AuthService>(AuthService);
+    passkeyService = module.get<PasskeyService>(PasskeyService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolver should be defined', () => {
+    expect(resolver).toBeDefined();
+  });
+
+  it('should change a user password', async () => {
+    authService.changePassword = jest
+      .fn()
+      .mockImplementation((id: string, changePassword: ChangePasswordDto) => {
+        return Promise.resolve(true);
+      });
+
+    const mockContext = createMockContext();
+    expect(await resolver.changePassword(changePasswordDto, mockContext)).toBe(
+      true,
+    );
+    expect(authService.changePassword).toHaveBeenCalledTimes(1);
+  });
+
+  it('should fail to change a user password', async () => {
+    authService.changePassword = jest
+      .fn()
+      .mockImplementation((id: string, changePassword: ChangePasswordDto) => {
+        return Promise.reject(new Error('Failed user password change!'));
+      });
+
+    const mockContext = createMockContext();
+    try {
+      await resolver.changePassword(changePasswordDto, mockContext);
+    } catch (error) {
+      expect(error.message).toEqual('Failed user password change!');
+      expect(authService.changePassword).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  describe('myPasskeys', () => {
+    // SECURITY: Tests now use request.user (set by passport) instead of headers.user (spoofable)
+    // @see https://github.com/OpusPopuli/opuspopuli/issues/183
+    it('should return user passkeys', async () => {
+      const mockCredentials = [{ id: 'cred-1', friendlyName: 'Device 1' }];
+      passkeyService.getUserCredentials = jest
+        .fn()
+        .mockResolvedValue(mockCredentials);
+
+      const context: GqlContext = {
+        req: {
+          user: {
+            id: 'user-1',
+            email: 'test@example.com',
+            roles: ['User'],
+            department: 'Engineering',
+            clearance: 'Secret',
+          },
+          headers: {},
+        },
+      };
+      const result = await resolver.myPasskeys(context);
+
+      expect(result).toEqual(mockCredentials);
+    });
+
+    it('should throw error when user not authenticated', async () => {
+      const context: GqlContext = { req: { user: undefined, headers: {} } };
+
+      await expect(resolver.myPasskeys(context)).rejects.toThrow(
+        'User not authenticated',
+      );
+    });
+  });
+
+  describe('deletePasskey', () => {
+    // SECURITY: Tests now use request.user (set by passport) instead of headers.user (spoofable)
+    // @see https://github.com/OpusPopuli/opuspopuli/issues/183
+    it('should delete passkey successfully', async () => {
+      passkeyService.deleteCredential = jest.fn().mockResolvedValue(true);
+
+      const context: GqlContext = {
+        req: {
+          user: {
+            id: 'user-1',
+            email: 'test@example.com',
+            roles: ['User'],
+            department: 'Engineering',
+            clearance: 'Secret',
+          },
+          headers: {},
+        },
+      };
+      const result = await resolver.deletePasskey('cred-1', context);
+
+      expect(result).toBe(true);
+      expect(passkeyService.deleteCredential).toHaveBeenCalledWith(
+        'cred-1',
+        'user-1',
+      );
+    });
+
+    it('should throw error when user not authenticated', async () => {
+      const context: GqlContext = { req: { user: undefined, headers: {} } };
+
+      await expect(resolver.deletePasskey('cred-1', context)).rejects.toThrow(
+        'User not authenticated',
+      );
+    });
+  });
+
+  describe('logout', () => {
+    it('should clear cookies on logout', async () => {
+      const mockContext = createMockContext();
+      const result = await resolver.logout(mockContext);
+
+      expect(result).toBe(true);
+      // Verify cookies were cleared
+      expect(mockContext.res?.clearCookie).toHaveBeenCalled();
+    });
+
+    it('should return true even without res object', async () => {
+      const contextWithoutRes = {
+        req: { user: undefined, headers: {} },
+      } as GqlContext;
+      const result = await resolver.logout(contextWithoutRes);
+
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/apps/backend/src/apps/users/src/domains/auth/session.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/session.resolver.ts
@@ -1,0 +1,151 @@
+import { Args, Mutation, Query, Resolver, Context } from '@nestjs/graphql';
+import { ConfigService } from '@nestjs/config';
+import { Optional } from '@nestjs/common';
+
+import { UserInputError } from '@nestjs/apollo';
+
+import { AuthService } from './auth.service';
+import { ChangePasswordDto } from './dto/change-password.dto';
+import { PasskeyCredential } from './dto/passkey.dto';
+import { PasskeyService } from './services/passkey.service';
+
+import { Permissions } from 'src/common/decorators/permissions.decorator';
+import { Action } from 'src/common/enums/action.enum';
+import { AuditAction } from 'src/common/enums/audit-action.enum';
+import {
+  GqlContext,
+  getUserFromContext,
+  createAuditContext,
+} from 'src/common/utils/graphql-context';
+import { clearAuthCookies } from 'src/common/utils/cookie.utils';
+import { AuditLogService } from 'src/common/services/audit-log.service';
+
+/**
+ * Session Resolver
+ *
+ * Handles authenticated user session operations:
+ * - Logout (cookie clearing)
+ * - Password changes
+ * - Passkey credential management (list, delete)
+ *
+ * @see https://github.com/OpusPopuli/opuspopuli/issues/464
+ */
+@Resolver(() => Boolean)
+export class SessionResolver {
+  private readonly serviceName = 'users-service';
+
+  constructor(
+    private readonly authService: AuthService,
+    private readonly passkeyService: PasskeyService,
+    private readonly configService: ConfigService,
+    @Optional() private readonly auditLogService?: AuditLogService,
+  ) {}
+
+  @Mutation(() => Boolean)
+  @Permissions({
+    action: Action.Update,
+    subject: 'User',
+    conditions: { id: '{{ id }}' },
+  })
+  async changePassword(
+    @Args('changePasswordDto') changePasswordDto: ChangePasswordDto,
+    @Context() context: GqlContext,
+  ): Promise<boolean> {
+    const auditContext = createAuditContext(context, this.serviceName);
+
+    let passwordUpdated: boolean;
+    try {
+      passwordUpdated =
+        await this.authService.changePassword(changePasswordDto);
+
+      // Audit: Password change success
+      this.auditLogService?.log({
+        ...auditContext,
+        action: AuditAction.PASSWORD_CHANGE,
+        success: true,
+        resolverName: 'changePassword',
+        operationType: 'mutation',
+      });
+    } catch (error) {
+      // Audit: Password change failure
+      this.auditLogService?.logSync({
+        ...auditContext,
+        action: AuditAction.PASSWORD_CHANGE_FAILED,
+        success: false,
+        resolverName: 'changePassword',
+        operationType: 'mutation',
+        errorMessage: error.message,
+      });
+      throw new UserInputError(error.message);
+    }
+    return passwordUpdated;
+  }
+
+  @Query(() => [PasskeyCredential])
+  async myPasskeys(
+    @Context() context: GqlContext,
+  ): Promise<PasskeyCredential[]> {
+    const user = getUserFromContext(context);
+    const credentials = await this.passkeyService.getUserCredentials(user.id);
+    // Map database types (null) to GraphQL types (undefined)
+    return credentials.map((cred) => ({
+      id: cred.id,
+      friendlyName: cred.friendlyName ?? undefined,
+      deviceType: cred.deviceType ?? undefined,
+      createdAt: cred.createdAt,
+      lastUsedAt: cred.lastUsedAt,
+    }));
+  }
+
+  @Mutation(() => Boolean)
+  async deletePasskey(
+    @Args('credentialId') credentialId: string,
+    @Context() context: GqlContext,
+  ): Promise<boolean> {
+    const user = getUserFromContext(context);
+    const auditContext = createAuditContext(
+      context,
+      this.serviceName,
+      user.email,
+    );
+
+    const result = await this.passkeyService.deleteCredential(
+      credentialId,
+      user.id,
+    );
+
+    // Audit: Passkey deletion
+    this.auditLogService?.log({
+      ...auditContext,
+      action: AuditAction.PASSKEY_DELETED,
+      success: result,
+      entityType: 'PasskeyCredential',
+      entityId: credentialId,
+      resolverName: 'deletePasskey',
+      operationType: 'mutation',
+    });
+
+    return result;
+  }
+
+  @Mutation(() => Boolean)
+  async logout(@Context() context: GqlContext): Promise<boolean> {
+    const auditContext = createAuditContext(context, this.serviceName);
+
+    // Clear httpOnly auth cookies
+    if (context.res) {
+      clearAuthCookies(context.res, this.configService);
+    }
+
+    // Audit: Logout
+    this.auditLogService?.log({
+      ...auditContext,
+      action: AuditAction.LOGOUT,
+      success: true,
+      resolverName: 'logout',
+      operationType: 'mutation',
+    });
+
+    return true;
+  }
+}

--- a/apps/backend/src/common/utils/graphql-context.spec.ts
+++ b/apps/backend/src/common/utils/graphql-context.spec.ts
@@ -2,6 +2,7 @@ import { UserInputError } from '@nestjs/apollo';
 import {
   getUserFromContext,
   getSessionTokenFromContext,
+  createAuditContext,
   GqlContext,
 } from './graphql-context';
 import { ILogin } from 'src/interfaces/login.interface';
@@ -131,5 +132,83 @@ describe('getSessionTokenFromContext', () => {
     const result = getSessionTokenFromContext(context);
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe('createAuditContext', () => {
+  const mockUser: ILogin = {
+    id: 'user-123',
+    email: 'test@example.com',
+    roles: ['User'],
+    department: 'Engineering',
+    clearance: 'Secret',
+  };
+
+  it('should create audit context from authenticated request', () => {
+    const context: GqlContext = {
+      req: {
+        ip: '192.168.1.1',
+        user: mockUser,
+        headers: {
+          'user-agent': 'TestAgent/1.0',
+        },
+      },
+    };
+
+    const result = createAuditContext(context, 'users-service');
+
+    expect(result.requestId).toBeDefined();
+    expect(result.userId).toBe('user-123');
+    expect(result.userEmail).toBe('test@example.com');
+    expect(result.ipAddress).toBe('192.168.1.1');
+    expect(result.userAgent).toBe('TestAgent/1.0');
+    expect(result.serviceName).toBe('users-service');
+  });
+
+  it('should use provided userEmail over context user email', () => {
+    const context: GqlContext = {
+      req: {
+        user: mockUser,
+        headers: {},
+      },
+    };
+
+    const result = createAuditContext(
+      context,
+      'users-service',
+      'override@example.com',
+    );
+
+    expect(result.userEmail).toBe('override@example.com');
+  });
+
+  it('should fall back to x-forwarded-for when ip is not available', () => {
+    const context = {
+      req: {
+        user: mockUser,
+        headers: {
+          'x-forwarded-for': '10.0.0.1',
+        },
+      },
+    } as unknown as GqlContext;
+
+    const result = createAuditContext(context, 'users-service');
+
+    expect(result.ipAddress).toBe('10.0.0.1');
+  });
+
+  it('should handle unauthenticated context gracefully', () => {
+    const context: GqlContext = {
+      req: {
+        headers: {},
+      },
+    };
+
+    const result = createAuditContext(context, 'users-service');
+
+    expect(result.requestId).toBeDefined();
+    expect(result.userId).toBeUndefined();
+    expect(result.userEmail).toBeUndefined();
+    expect(result.serviceName).toBe('users-service');
   });
 });

--- a/apps/backend/src/common/utils/graphql-context.ts
+++ b/apps/backend/src/common/utils/graphql-context.ts
@@ -1,6 +1,8 @@
 import { UserInputError } from '@nestjs/apollo';
 import { Response } from 'express';
+import { randomUUID } from 'node:crypto';
 import { ILogin } from 'src/interfaces/login.interface';
+import { IAuditContext } from '../interfaces/audit.interface';
 
 /**
  * User information extracted from the authenticated context
@@ -75,4 +77,32 @@ export function getSessionTokenFromContext(
   }
   // Extract token from "Bearer <token>"
   return auth.replace(/^Bearer\s+/i, '');
+}
+
+/**
+ * Creates an audit context from the GraphQL request context.
+ *
+ * @param context - The GraphQL context containing the request
+ * @param serviceName - The name of the service creating the audit entry
+ * @param userEmail - Optional email override (for unauthenticated flows like registration/login)
+ * @returns An IAuditContext with request metadata for audit logging
+ *
+ * @see https://github.com/OpusPopuli/opuspopuli/issues/191
+ */
+export function createAuditContext(
+  context: GqlContext,
+  serviceName: string,
+  userEmail?: string,
+): IAuditContext {
+  const user = context.req?.user;
+  return {
+    requestId: randomUUID(),
+    userId: user?.id,
+    userEmail: userEmail || user?.email,
+    ipAddress:
+      context.req?.ip ||
+      (context.req?.headers as Record<string, string>)?.['x-forwarded-for'],
+    userAgent: context.req?.headers?.['user-agent'],
+    serviceName,
+  };
 }


### PR DESCRIPTION
## Summary
- Split monolithic `auth.resolver.ts` into domain-focused resolvers (`AdminResolver`, `SessionResolver`, `AuthResolver`) for better separation of concerns
- Extracted duplicate `createAuditContext` method into shared utility function in `graphql-context.ts` to eliminate Sonar-flagged code duplication
- Added comprehensive test coverage for new resolvers and shared utility

## Test plan
- [x] All 1309 backend tests pass
- [x] Lint and format checks pass
- [x] No Sonar duplicate code issues remaining

🤖 Generated with [Claude Code](https://claude.com/claude-code)