### PR TITLE
perf: implement spatial pagination for map queries (#465)

### DIFF
--- a/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
+++ b/apps/backend/src/apps/documents/src/domains/documents.resolver.ts
@@ -34,7 +34,7 @@ import {
   GeoLocation,
   SetDocumentLocationInput,
   SetDocumentLocationResult,
-  PetitionMapMarker,
+  PetitionMapResult,
   PetitionMapStats,
   MapFiltersInput,
 } from './dto/location.dto';
@@ -265,13 +265,13 @@ export class DocumentsResolver {
    * Get petition locations for map display
    * Returns fuzzed coordinates for all documents with scan locations
    */
-  @Query(() => [PetitionMapMarker])
+  @Query(() => PetitionMapResult)
   @UseGuards(AuthGuard)
   @Permissions({ action: Action.Read, subject: 'File' })
   @Extensions({ complexity: 25 })
   async petitionMapLocations(
     @Args('filters', { nullable: true }) filters?: MapFiltersInput,
-  ): Promise<PetitionMapMarker[]> {
+  ): Promise<PetitionMapResult> {
     return this.locationService.getPetitionMapLocations(filters);
   }
 

--- a/apps/backend/src/apps/documents/src/domains/dto/location.dto.ts
+++ b/apps/backend/src/apps/documents/src/domains/dto/location.dto.ts
@@ -126,6 +126,28 @@ export class MapFiltersInput {
   @Field({ nullable: true })
   @IsOptional()
   endDate?: Date;
+
+  @Field(() => Int, {
+    nullable: true,
+    description: 'Max results to return (1-1000, default 1000)',
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(1000)
+  limit?: number;
+}
+
+@ObjectType()
+export class PetitionMapResult {
+  @Field(() => [PetitionMapMarker])
+  markers!: PetitionMapMarker[];
+
+  @Field(() => Int)
+  totalCount!: number;
+
+  @Field()
+  truncated!: boolean;
 }
 
 /**

--- a/apps/backend/src/apps/documents/src/domains/services/file.service.ts
+++ b/apps/backend/src/apps/documents/src/domains/services/file.service.ts
@@ -15,12 +15,12 @@ import { File } from '../models/file.model';
 @Injectable()
 export class FileService {
   private readonly logger = new Logger(FileService.name, { timestamp: true });
-  private fileConfig: IFileConfig;
+  private readonly fileConfig: IFileConfig;
 
   constructor(
     private readonly db: DbService,
-    @Inject('STORAGE_PROVIDER') private storage: IStorageProvider,
-    private configService: ConfigService,
+    @Inject('STORAGE_PROVIDER') private readonly storage: IStorageProvider,
+    private readonly configService: ConfigService,
   ) {
     const fileConfig: IFileConfig | undefined =
       configService.get<IFileConfig>('file');

--- a/apps/backend/src/apps/documents/src/domains/services/location.service.spec.ts
+++ b/apps/backend/src/apps/documents/src/domains/services/location.service.spec.ts
@@ -116,35 +116,80 @@ describe('LocationService', () => {
   });
 
   describe('getPetitionMapLocations', () => {
-    it('should return map markers', async () => {
-      db.$queryRawUnsafe.mockResolvedValue([
-        {
-          id: 'doc-1',
-          latitude: 37.775,
-          longitude: -122.419,
-          document_type: 'petition',
-          created_at: new Date('2024-01-01'),
-        },
-      ]);
+    it('should return map result with markers, totalCount, and truncated', async () => {
+      db.$queryRawUnsafe
+        .mockResolvedValueOnce([{ count: BigInt(1) }]) // count query
+        .mockResolvedValueOnce([
+          {
+            id: 'doc-1',
+            latitude: 37.775,
+            longitude: -122.419,
+            document_type: 'petition',
+            created_at: new Date('2024-01-01'),
+          },
+        ]); // data query
 
       const result = await service.getPetitionMapLocations();
 
-      expect(result).toHaveLength(1);
-      expect(result[0].id).toBe('doc-1');
-      expect(result[0].latitude).toBe(37.775);
-      expect(result[0].documentType).toBe('petition');
+      expect(result.markers).toHaveLength(1);
+      expect(result.markers[0].id).toBe('doc-1');
+      expect(result.markers[0].latitude).toBe(37.775);
+      expect(result.markers[0].documentType).toBe('petition');
+      expect(result.totalCount).toBe(1);
+      expect(result.truncated).toBe(false);
     });
 
-    it('should return empty array when no locations', async () => {
-      db.$queryRawUnsafe.mockResolvedValue([]);
+    it('should return empty markers when no locations', async () => {
+      db.$queryRawUnsafe
+        .mockResolvedValueOnce([{ count: BigInt(0) }])
+        .mockResolvedValueOnce([]);
 
       const result = await service.getPetitionMapLocations();
 
-      expect(result).toEqual([]);
+      expect(result.markers).toEqual([]);
+      expect(result.totalCount).toBe(0);
+      expect(result.truncated).toBe(false);
+    });
+
+    it('should set truncated=true when totalCount exceeds limit', async () => {
+      db.$queryRawUnsafe
+        .mockResolvedValueOnce([{ count: BigInt(1500) }])
+        .mockResolvedValueOnce([]);
+
+      const result = await service.getPetitionMapLocations();
+
+      expect(result.totalCount).toBe(1500);
+      expect(result.truncated).toBe(true);
+    });
+
+    it('should respect custom limit from filters', async () => {
+      db.$queryRawUnsafe
+        .mockResolvedValueOnce([{ count: BigInt(50) }])
+        .mockResolvedValueOnce([]);
+
+      const result = await service.getPetitionMapLocations({ limit: 10 });
+
+      expect(result.totalCount).toBe(50);
+      expect(result.truncated).toBe(true);
+      const dataQuery = db.$queryRawUnsafe.mock.calls[1][0] as string;
+      expect(dataQuery).toContain('LIMIT 10');
+    });
+
+    it('should cap limit at 1000', async () => {
+      db.$queryRawUnsafe
+        .mockResolvedValueOnce([{ count: BigInt(0) }])
+        .mockResolvedValueOnce([]);
+
+      await service.getPetitionMapLocations({ limit: 5000 });
+
+      const dataQuery = db.$queryRawUnsafe.mock.calls[1][0] as string;
+      expect(dataQuery).toContain('LIMIT 1000');
     });
 
     it('should apply filters when provided', async () => {
-      db.$queryRawUnsafe.mockResolvedValue([]);
+      db.$queryRawUnsafe
+        .mockResolvedValueOnce([{ count: BigInt(0) }])
+        .mockResolvedValueOnce([]);
 
       await service.getPetitionMapLocations({
         documentType: 'petition',
@@ -152,9 +197,36 @@ describe('LocationService', () => {
       });
 
       expect(db.$queryRawUnsafe).toHaveBeenCalled();
-      const query = db.$queryRawUnsafe.mock.calls[0][0] as string;
-      expect(query).toContain('type = $');
-      expect(query).toContain('created_at >= $');
+      const countQuery = db.$queryRawUnsafe.mock.calls[0][0] as string;
+      expect(countQuery).toContain('type = $');
+      expect(countQuery).toContain('created_at >= $');
+    });
+
+    it('should apply bounds and endDate filters', async () => {
+      db.$queryRawUnsafe
+        .mockResolvedValueOnce([{ count: BigInt(5) }])
+        .mockResolvedValueOnce([
+          {
+            id: 'doc-1',
+            latitude: 37.0,
+            longitude: -122.0,
+            document_type: 'petition',
+            created_at: new Date('2024-06-01'),
+          },
+        ]);
+
+      const result = await service.getPetitionMapLocations({
+        bounds: { swLat: 34, swLng: -119, neLat: 38, neLng: -117 },
+        endDate: new Date('2024-12-31'),
+      });
+
+      const countQuery = db.$queryRawUnsafe.mock.calls[0][0] as string;
+      expect(countQuery).toContain('ST_Within');
+      expect(countQuery).toContain('ST_MakeEnvelope');
+      expect(countQuery).toContain('created_at <= $');
+      expect(result.markers).toHaveLength(1);
+      expect(result.totalCount).toBe(5);
+      expect(result.truncated).toBe(false);
     });
   });
 

--- a/apps/backend/src/apps/documents/src/domains/services/location.service.ts
+++ b/apps/backend/src/apps/documents/src/domains/services/location.service.ts
@@ -4,7 +4,7 @@ import { DbService } from '@opuspopuli/relationaldb-provider';
 import {
   GeoLocation,
   SetDocumentLocationResult,
-  PetitionMapMarker,
+  PetitionMapResult,
   PetitionMapStats,
   MapFiltersInput,
   fuzzLocation,
@@ -106,14 +106,17 @@ export class LocationService {
     };
   }
 
+  private static readonly MAX_MAP_LIMIT = 1000;
+  private static readonly DEFAULT_MAP_LIMIT = 1000;
+
   /**
-   * Get petition locations for map display
+   * Get petition locations for map display with spatial pagination (#465)
    * Returns documents with scan locations, optionally filtered by bounds/type/date
    * Coordinates are already fuzzed at write time, safe to return directly
    */
   async getPetitionMapLocations(
     filters?: MapFiltersInput,
-  ): Promise<PetitionMapMarker[]> {
+  ): Promise<PetitionMapResult> {
     const conditions: string[] = ['scan_location IS NOT NULL'];
     const params: unknown[] = [];
 
@@ -146,36 +149,53 @@ export class LocationService {
     }
 
     const whereClause = conditions.join(' AND ');
-
-    const results = await this.db.$queryRawUnsafe<
-      Array<{
-        id: string;
-        latitude: number;
-        longitude: number;
-        document_type: string | null;
-        created_at: Date;
-      }>
-    >(
-      `SELECT
-        id::text as id,
-        ST_Y(scan_location::geometry) as latitude,
-        ST_X(scan_location::geometry) as longitude,
-        type as document_type,
-        created_at
-      FROM documents
-      WHERE ${whereClause}
-      ORDER BY created_at DESC
-      LIMIT 5000`,
-      ...params,
+    const limit = Math.min(
+      filters?.limit ?? LocationService.DEFAULT_MAP_LIMIT,
+      LocationService.MAX_MAP_LIMIT,
     );
 
-    return results.map((r) => ({
-      id: r.id,
-      latitude: r.latitude,
-      longitude: r.longitude,
-      documentType: r.document_type ?? undefined,
-      createdAt: r.created_at,
-    }));
+    // Run count and data queries in parallel
+    const [countResult, results] = await Promise.all([
+      this.db.$queryRawUnsafe<Array<{ count: bigint }>>(
+        `SELECT COUNT(*) as count FROM documents WHERE ${whereClause}`,
+        ...params,
+      ),
+      this.db.$queryRawUnsafe<
+        Array<{
+          id: string;
+          latitude: number;
+          longitude: number;
+          document_type: string | null;
+          created_at: Date;
+        }>
+      >(
+        `SELECT
+          id::text as id,
+          ST_Y(scan_location::geometry) as latitude,
+          ST_X(scan_location::geometry) as longitude,
+          type as document_type,
+          created_at
+        FROM documents
+        WHERE ${whereClause}
+        ORDER BY created_at DESC
+        LIMIT ${limit}`,
+        ...params,
+      ),
+    ]);
+
+    const totalCount = Number(countResult[0]?.count ?? 0);
+
+    return {
+      markers: results.map((r) => ({
+        id: r.id,
+        latitude: r.latitude,
+        longitude: r.longitude,
+        documentType: r.document_type ?? undefined,
+        createdAt: r.created_at,
+      })),
+      totalCount,
+      truncated: totalCount > limit,
+    };
   }
 
   /**

--- a/apps/backend/src/apps/documents/src/domains/services/scan.service.ts
+++ b/apps/backend/src/apps/documents/src/domains/services/scan.service.ts
@@ -27,12 +27,12 @@ import { FileService } from './file.service';
 @Injectable()
 export class ScanService {
   private readonly logger = new Logger(ScanService.name, { timestamp: true });
-  private fileConfig: IFileConfig;
+  private readonly fileConfig: IFileConfig;
 
   constructor(
     private readonly db: DbService,
-    @Inject('STORAGE_PROVIDER') private storage: IStorageProvider,
-    private configService: ConfigService,
+    @Inject('STORAGE_PROVIDER') private readonly storage: IStorageProvider,
+    private readonly configService: ConfigService,
     private readonly ocrService: OcrService,
     private readonly extractionProvider: ExtractionProvider,
     private readonly metricsService: MetricsService,

--- a/apps/frontend/__tests__/hooks/useMapPetitions.test.ts
+++ b/apps/frontend/__tests__/hooks/useMapPetitions.test.ts
@@ -49,6 +49,8 @@ describe("useMapPetitions", () => {
     const { result } = renderHook(() => useMapPetitions());
 
     expect(result.current.markers).toEqual([]);
+    expect(result.current.totalCount).toBe(0);
+    expect(result.current.truncated).toBe(false);
     expect(result.current.stats).toBeNull();
     expect(result.current.loading).toBe(true);
     expect(result.current.error).toBeNull();
@@ -57,7 +59,13 @@ describe("useMapPetitions", () => {
   it("returns markers from locations query", () => {
     mockUseQuery
       .mockReturnValueOnce({
-        data: { petitionMapLocations: mockMarkers },
+        data: {
+          petitionMapLocations: {
+            markers: mockMarkers,
+            totalCount: 2,
+            truncated: false,
+          },
+        },
         loading: false,
         error: undefined,
       })
@@ -77,7 +85,13 @@ describe("useMapPetitions", () => {
   it("returns stats from stats query", () => {
     mockUseQuery
       .mockReturnValueOnce({
-        data: { petitionMapLocations: mockMarkers },
+        data: {
+          petitionMapLocations: {
+            markers: mockMarkers,
+            totalCount: 2,
+            truncated: false,
+          },
+        },
         loading: false,
         error: undefined,
       })
@@ -146,7 +160,13 @@ describe("useMapPetitions", () => {
     const statsError = new Error("Stats failed");
     mockUseQuery
       .mockReturnValueOnce({
-        data: { petitionMapLocations: [] },
+        data: {
+          petitionMapLocations: {
+            markers: [],
+            totalCount: 0,
+            truncated: false,
+          },
+        },
         loading: false,
         error: undefined,
       })

--- a/apps/frontend/__tests__/pages/petition/map.test.tsx
+++ b/apps/frontend/__tests__/pages/petition/map.test.tsx
@@ -76,6 +76,8 @@ const mockUpdateFilters = jest.fn();
 jest.mock("@/lib/hooks/useMapPetitions", () => ({
   useMapPetitions: () => ({
     markers: [],
+    totalCount: 0,
+    truncated: false,
     stats: null,
     loading: false,
     error: null,

--- a/apps/frontend/lib/graphql/documents.ts
+++ b/apps/frontend/lib/graphql/documents.ts
@@ -115,6 +115,13 @@ export interface MapFiltersInput {
   documentType?: string;
   startDate?: string;
   endDate?: string;
+  limit?: number;
+}
+
+export interface PetitionMapResult {
+  markers: PetitionMapMarker[];
+  totalCount: number;
+  truncated: boolean;
 }
 
 export type AbuseReportReason =
@@ -213,11 +220,15 @@ export const SUBMIT_ABUSE_REPORT = gql`
 export const GET_PETITION_MAP_LOCATIONS = gql`
   query PetitionMapLocations($filters: MapFiltersInput) {
     petitionMapLocations(filters: $filters) {
-      id
-      latitude
-      longitude
-      documentType
-      createdAt
+      markers {
+        id
+        latitude
+        longitude
+        documentType
+        createdAt
+      }
+      totalCount
+      truncated
     }
   }
 `;
@@ -297,7 +308,7 @@ export interface AnalyzeDocumentData {
 }
 
 export interface PetitionMapLocationsData {
-  petitionMapLocations: PetitionMapMarker[];
+  petitionMapLocations: PetitionMapResult;
 }
 
 export interface PetitionMapStatsData {

--- a/apps/frontend/lib/hooks/useMapPetitions.ts
+++ b/apps/frontend/lib/hooks/useMapPetitions.ts
@@ -15,6 +15,8 @@ import {
 
 export interface UseMapPetitionsReturn {
   markers: PetitionMapMarker[];
+  totalCount: number;
+  truncated: boolean;
   stats: PetitionMapStats | null;
   loading: boolean;
   error: Error | null;
@@ -73,8 +75,12 @@ export function useMapPetitions(
     };
   }, []);
 
+  const mapResult = locationsData?.petitionMapLocations;
+
   return {
-    markers: locationsData?.petitionMapLocations ?? [],
+    markers: mapResult?.markers ?? [],
+    totalCount: mapResult?.totalCount ?? 0,
+    truncated: mapResult?.truncated ?? false,
     stats: statsData?.petitionMapStats ?? null,
     loading: locationsLoading || statsLoading,
     error: locationsError ?? statsError ?? null,


### PR DESCRIPTION
## Summary
- Reduce map query limit from hardcoded 5000 to configurable max of 1000 to prevent memory spikes
- Add `limit` field to `MapFiltersInput` (1-1000, validated, default 1000)
- Return `PetitionMapResult` wrapper with `markers`, `totalCount`, and `truncated` flag
- Run count and data queries in parallel for minimal latency impact
- Update frontend hook to expose `totalCount`/`truncated` for future UI indicators
- Add `readonly` modifiers to `file.service.ts` and `scan.service.ts` (SonarQube)

## Test plan
- [x] Backend location service: 17 tests pass (100% statement/line/function coverage)
- [x] Frontend useMapPetitions hook: 13 tests pass (100% coverage)
- [x] Frontend map page: 10 tests pass
- [x] Full backend suite: 1266 tests pass
- [x] Full frontend suite: 1110 tests pass
- [x] TypeScript compilation clean (only pre-existing errors in unrelated packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)