### PR TITLE
Release: Redis caching and batch transactions (#459, #476)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -4,12 +4,18 @@ import {
   ScrapingPipelineModule,
   ScrapingPipelineService,
 } from '@opuspopuli/scraping-pipeline';
-import { ExtractionModule } from '@opuspopuli/extraction-provider';
+import {
+  ExtractionModule,
+  CacheFactory,
+  FallbackCache,
+} from '@opuspopuli/extraction-provider';
+import { MemoryCache } from '@opuspopuli/common';
 import { LLMModule } from '@opuspopuli/llm-provider';
 import { RegionDomainService } from './region.service';
 import { RegionResolver } from './region.resolver';
 import { RegionScheduler } from './region.scheduler';
 import { PrismaManifestRepository } from '../infrastructure/prisma-manifest-repository';
+import { REGION_CACHE } from './region.tokens';
 
 // RelationalDbModule is global, no need to import
 
@@ -46,6 +52,27 @@ import { PrismaManifestRepository } from '../infrastructure/prisma-manifest-repo
     {
       provide: 'SCRAPING_PIPELINE',
       useExisting: ScrapingPipelineService,
+    },
+    // Redis-backed cache with in-memory fallback for region reference data (#459)
+    // Disabled in test to prevent stale cached data between E2E test cases
+    {
+      provide: REGION_CACHE,
+      useFactory: () => {
+        const isTest = process.env.NODE_ENV === 'test';
+        const ttlMs = isTest ? 0 : 4 * 60 * 60 * 1000; // disabled in test, 4h in prod
+
+        const config = CacheFactory.createConfigFromEnv();
+        const primary = CacheFactory.createCache<string>({
+          ...config,
+          keyPrefix: 'region:',
+          cacheOptions: { ttlMs },
+        });
+        const fallback = new MemoryCache<string>({
+          ttlMs,
+          maxSize: 200,
+        });
+        return new FallbackCache<string>(primary, fallback);
+      },
     },
   ],
   exports: [RegionDomainService],

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { RegionDomainService } from './region.service';
+import { REGION_CACHE } from './region.tokens';
 import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
 import {
   createMockDbService,
@@ -116,15 +117,30 @@ function createMockPlugin(): jest.Mocked<IRegionPlugin> {
   };
 }
 
+function createMockCache() {
+  return {
+    get: jest.fn().mockResolvedValue(undefined),
+    set: jest.fn().mockResolvedValue(undefined),
+    has: jest.fn().mockResolvedValue(false),
+    delete: jest.fn().mockResolvedValue(true),
+    clear: jest.fn().mockResolvedValue(undefined),
+    keys: jest.fn().mockResolvedValue([]),
+    size: 0,
+    destroy: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe('RegionDomainService', () => {
   let service: RegionDomainService;
   let mockDb: MockDbClient;
   let mockPlugin: jest.Mocked<IRegionPlugin>;
   let mockRegistry: MockPluginRegistry;
+  let mockCache: ReturnType<typeof createMockCache>;
 
   beforeEach(async () => {
     mockDb = createMockDbService();
     mockPlugin = createMockPlugin();
+    mockCache = createMockCache();
 
     // The local registered plugin entry returned by getAll()
     const localRegistered: RegisteredPlugin = {
@@ -204,6 +220,7 @@ describe('RegionDomainService', () => {
         { provide: PluginLoaderService, useValue: mockLoader },
         { provide: PluginRegistryService, useValue: mockRegistry },
         { provide: DbService, useValue: mockDb },
+        { provide: REGION_CACHE, useValue: mockCache },
       ],
     }).compile();
 
@@ -372,9 +389,10 @@ describe('RegionDomainService', () => {
       expect(result.itemsProcessed).toBe(1000);
       expect(result.itemsCreated).toBe(1000);
 
-      // Verify only 2 database calls (not 2000)
+      // Verify efficient batching (not 2000 individual calls)
       expect(mockDb.proposition.findMany).toHaveBeenCalledTimes(1);
-      expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+      // 1000 items / 500 chunk size = 2 batched transactions (#476)
+      expect(mockDb.$transaction).toHaveBeenCalledTimes(2);
     });
 
     it('should correctly identify creates vs updates in mixed batch', async () => {
@@ -998,6 +1016,7 @@ describe('RegionDomainService — federal placeholder resolution', () => {
         { provide: PluginLoaderService, useValue: mockLoader },
         { provide: PluginRegistryService, useValue: mockRegistry },
         { provide: DbService, useValue: mockDb },
+        { provide: REGION_CACHE, useValue: createMockCache() },
       ],
     }).compile();
 
@@ -1081,6 +1100,7 @@ describe('RegionDomainService — federal placeholder resolution', () => {
         { provide: PluginLoaderService, useValue: mockLoader },
         { provide: PluginRegistryService, useValue: mockRegistry },
         { provide: DbService, useValue: mockDb },
+        { provide: REGION_CACHE, useValue: createMockCache() },
       ],
     }).compile();
 
@@ -1226,6 +1246,7 @@ describe('RegionDomainService — campaign finance sync', () => {
         { provide: PluginLoaderService, useValue: mockLoader },
         { provide: PluginRegistryService, useValue: mockRegistry },
         { provide: DbService, useValue: mockDb },
+        { provide: REGION_CACHE, useValue: createMockCache() },
       ],
     }).compile();
 
@@ -1289,5 +1310,234 @@ describe('RegionDomainService — campaign finance sync', () => {
     expect(cfResult).toBeDefined();
     expect(cfResult!.itemsProcessed).toBe(0);
     expect(cfResult!.itemsCreated).toBe(0);
+  });
+});
+
+/**
+ * Tests for Redis caching (#459) and batch transactions (#476).
+ * Uses the main test setup with mockCache injected.
+ */
+describe('RegionDomainService — caching and batch transactions', () => {
+  let service: RegionDomainService;
+  let mockDb: MockDbClient;
+  let mockPlugin: jest.Mocked<IRegionPlugin>;
+  let mockCache: ReturnType<typeof createMockCache>;
+
+  beforeEach(async () => {
+    mockDb = createMockDbService();
+    mockPlugin = createMockPlugin();
+    mockCache = createMockCache();
+
+    const localRegistered: RegisteredPlugin = {
+      name: 'test-provider',
+      instance: mockPlugin,
+      status: 'active',
+      loadedAt: new Date(),
+    };
+
+    const mockRegistry: MockPluginRegistry = {
+      register: jest.fn().mockResolvedValue(undefined),
+      unregister: jest.fn().mockResolvedValue(undefined),
+      getActive: jest.fn().mockReturnValue(mockPlugin),
+      registerLocal: jest.fn().mockResolvedValue(undefined),
+      registerFederal: jest.fn().mockResolvedValue(undefined),
+      getLocal: jest.fn().mockReturnValue(mockPlugin),
+      getFederal: jest.fn().mockReturnValue(undefined),
+      getAll: jest.fn().mockReturnValue([localRegistered]),
+      getActiveName: jest.fn().mockReturnValue('test-provider'),
+      hasActive: jest.fn().mockReturnValue(true),
+      getHealth: jest.fn(),
+      getStatus: jest.fn(),
+      onModuleDestroy: jest.fn(),
+    };
+
+    const mockLoader: MockPluginLoader = {
+      loadPlugin: jest.fn().mockResolvedValue(mockPlugin),
+      loadFederalPlugin: jest.fn().mockResolvedValue(mockPlugin),
+      unloadPlugin: jest.fn().mockResolvedValue(undefined),
+    };
+
+    mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+    mockDb.regionPlugin.findUnique.mockResolvedValue(null);
+    mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
+
+    mockDb.proposition.findMany.mockResolvedValue([]);
+    mockDb.proposition.count.mockResolvedValue(0);
+    mockDb.meeting.findMany.mockResolvedValue([]);
+    mockDb.meeting.count.mockResolvedValue(0);
+    mockDb.representative.findMany.mockResolvedValue([]);
+    mockDb.representative.count.mockResolvedValue(0);
+
+    (mockDb.$transaction as jest.Mock).mockImplementation(
+      async (operations: Promise<unknown>[]) => {
+        return Promise.all(operations);
+      },
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegionDomainService,
+        { provide: PluginLoaderService, useValue: mockLoader },
+        { provide: PluginRegistryService, useValue: mockRegistry },
+        { provide: DbService, useValue: mockDb },
+        { provide: REGION_CACHE, useValue: mockCache },
+      ],
+    }).compile();
+
+    service = module.get<RegionDomainService>(RegionDomainService);
+    await service.onModuleInit();
+  });
+
+  // ==========================================
+  // CACHING TESTS (#459)
+  // ==========================================
+
+  describe('caching', () => {
+    it('should return cached propositions on cache hit', async () => {
+      const cachedData = {
+        items: [{ id: 'cached-1', title: 'Cached Prop' }],
+        total: 1,
+        hasMore: false,
+      };
+      mockCache.get.mockResolvedValueOnce(JSON.stringify(cachedData));
+
+      const result = await service.getPropositions(0, 10);
+
+      expect(result).toEqual(cachedData);
+      expect(mockDb.proposition.findMany).not.toHaveBeenCalled();
+      expect(mockDb.proposition.count).not.toHaveBeenCalled();
+    });
+
+    it('should cache propositions on cache miss', async () => {
+      mockDb.proposition.findMany.mockResolvedValueOnce([
+        {
+          id: 'prop-1',
+          externalId: 'ext-1',
+          title: 'Prop 1',
+          summary: 'Sum',
+          fullText: null,
+          status: 'pending',
+          electionDate: null,
+          sourceUrl: null,
+          deletedAt: null,
+          createdAt: new Date('2024-01-01'),
+          updatedAt: new Date('2024-01-01'),
+        },
+      ]);
+      mockDb.proposition.count.mockResolvedValueOnce(1);
+
+      await service.getPropositions(0, 10);
+
+      expect(mockCache.set).toHaveBeenCalledWith(
+        'propositions:0:10',
+        expect.any(String),
+      );
+    });
+
+    it('should return cached meetings on cache hit', async () => {
+      const cachedData = {
+        items: [{ id: 'cached-m1', title: 'Cached Meeting' }],
+        total: 1,
+        hasMore: false,
+      };
+      mockCache.get.mockResolvedValueOnce(JSON.stringify(cachedData));
+
+      const result = await service.getMeetings(0, 10);
+
+      expect(result).toEqual(cachedData);
+      expect(mockDb.meeting.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should return cached representatives on cache hit', async () => {
+      const cachedData = {
+        items: [{ id: 'cached-r1', name: 'Cached Rep' }],
+        total: 1,
+        hasMore: false,
+      };
+      mockCache.get.mockResolvedValueOnce(JSON.stringify(cachedData));
+
+      const result = await service.getRepresentatives(0, 10);
+
+      expect(result).toEqual(cachedData);
+      expect(mockDb.representative.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should include chamber in representatives cache key', async () => {
+      mockCache.get.mockResolvedValueOnce(undefined);
+      mockDb.representative.findMany.mockResolvedValueOnce([]);
+      mockDb.representative.count.mockResolvedValueOnce(0);
+
+      await service.getRepresentatives(0, 10, 'Senate');
+
+      expect(mockCache.set).toHaveBeenCalledWith(
+        'representatives:0:10:Senate',
+        expect.any(String),
+      );
+    });
+  });
+
+  // ==========================================
+  // CACHE INVALIDATION TESTS (#459)
+  // ==========================================
+
+  describe('cache invalidation', () => {
+    it('should invalidate proposition cache after syncPropositions', async () => {
+      mockCache.keys.mockResolvedValueOnce([
+        'propositions:0:10',
+        'propositions:10:10',
+      ]);
+
+      await service.syncDataType(DataType.PROPOSITIONS);
+
+      expect(mockCache.keys).toHaveBeenCalled();
+      expect(mockCache.delete).toHaveBeenCalledWith('propositions:0:10');
+      expect(mockCache.delete).toHaveBeenCalledWith('propositions:10:10');
+    });
+
+    it('should invalidate meeting cache after syncMeetings', async () => {
+      mockCache.keys.mockResolvedValueOnce(['meetings:0:10']);
+
+      await service.syncDataType(DataType.MEETINGS);
+
+      expect(mockCache.delete).toHaveBeenCalledWith('meetings:0:10');
+    });
+
+    it('should invalidate representative cache after syncRepresentatives', async () => {
+      mockCache.keys.mockResolvedValueOnce(['representatives:0:10:all']);
+
+      await service.syncDataType(DataType.REPRESENTATIVES);
+
+      expect(mockCache.delete).toHaveBeenCalledWith('representatives:0:10:all');
+    });
+  });
+
+  // ==========================================
+  // BATCH TRANSACTION TESTS (#476)
+  // ==========================================
+
+  describe('batch transactions', () => {
+    it('should chunk large datasets into multiple transactions', async () => {
+      const manyPropositions = Array.from({ length: 1200 }, (_, i) => ({
+        externalId: `prop-${i}`,
+        title: `Proposition ${i}`,
+        summary: `Summary ${i}`,
+        fullText: undefined,
+        status: PropositionStatus.PENDING,
+        electionDate: undefined,
+        sourceUrl: undefined,
+      }));
+      mockPlugin.fetchPropositions.mockResolvedValueOnce(manyPropositions);
+
+      await service.syncDataType(DataType.PROPOSITIONS);
+
+      // 1200 items / 500 chunk size = 3 transaction calls
+      expect(mockDb.$transaction).toHaveBeenCalledTimes(3);
+    });
+
+    it('should use single transaction for small datasets', async () => {
+      await service.syncDataType(DataType.PROPOSITIONS);
+
+      expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -3,6 +3,7 @@ import {
   Inject,
   Injectable,
   Logger,
+  OnModuleDestroy,
   OnModuleInit,
   Optional,
 } from '@nestjs/common';
@@ -20,11 +21,14 @@ import {
 import { ServiceInitializationException } from 'src/common/exceptions/app.exceptions';
 import {
   resolveConfigPlaceholders,
+  batchTransaction,
+  type ICache,
   type Proposition,
   type Meeting,
   type Representative,
   type CampaignFinanceResult,
 } from '@opuspopuli/common';
+import { REGION_CACHE } from './region.tokens';
 
 /**
  * Minimal interface for data fetching used by sync methods.
@@ -169,7 +173,7 @@ type IndependentExpenditureRecord = {
  * Syncs data from both plugins and stores in the database.
  */
 @Injectable()
-export class RegionDomainService implements OnModuleInit {
+export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(RegionDomainService.name, {
     timestamp: true,
   });
@@ -179,10 +183,15 @@ export class RegionDomainService implements OnModuleInit {
     private readonly pluginLoader: PluginLoaderService,
     private readonly pluginRegistry: PluginRegistryService,
     private readonly db: DbService,
+    @Inject(REGION_CACHE) private readonly cache: ICache<string>,
     @Optional()
     @Inject('SCRAPING_PIPELINE')
     private readonly pipeline?: IPipelineService,
   ) {}
+
+  async onModuleDestroy(): Promise<void> {
+    await this.cache.destroy();
+  }
 
   /**
    * Load region plugins at startup:
@@ -293,6 +302,36 @@ export class RegionDomainService implements OnModuleInit {
       `RegionDomainService initialized — local: ${this.regionService.getProviderName()} (${info.name}), ` +
         `federal: ${this.pluginRegistry.getFederal() ? 'loaded' : 'not loaded'}`,
     );
+  }
+
+  /**
+   * Cache-through helper: returns cached result or executes query and caches it.
+   */
+  private async cachedQuery<T>(
+    key: string,
+    queryFn: () => Promise<T>,
+  ): Promise<T> {
+    const cached = await this.cache.get(key);
+    if (cached) {
+      return JSON.parse(cached) as T;
+    }
+    const result = await queryFn();
+    await this.cache.set(key, JSON.stringify(result));
+    return result;
+  }
+
+  /**
+   * Invalidate all cache keys matching a prefix.
+   */
+  private async invalidateCache(prefix: string): Promise<void> {
+    const allKeys = await this.cache.keys();
+    const matching = allKeys.filter((k) => k.startsWith(prefix));
+    await Promise.all(matching.map((k) => this.cache.delete(k)));
+    if (matching.length > 0) {
+      this.logger.log(
+        `Invalidated ${matching.length} cache key(s) with prefix "${prefix}"`,
+      );
+    }
   }
 
   /**
@@ -445,8 +484,9 @@ export class RegionDomainService implements OnModuleInit {
       existingRecords.map((r: ExternalIdRecord) => r.externalId),
     );
 
-    // Batch upsert all propositions using database transaction
-    await this.db.$transaction(
+    // Batch upsert all propositions in chunked transactions (#476)
+    await batchTransaction(
+      this.db,
       propositions.map((prop) =>
         this.db.proposition.upsert({
           where: { externalId: prop.externalId },
@@ -470,6 +510,9 @@ export class RegionDomainService implements OnModuleInit {
         }),
       ),
     );
+
+    // Invalidate cached proposition queries (#459)
+    await this.invalidateCache('propositions:');
 
     const created = propositions.filter(
       (p) => !existingExternalIds.has(p.externalId),
@@ -510,8 +553,9 @@ export class RegionDomainService implements OnModuleInit {
       existingRecords.map((r: ExternalIdRecord) => r.externalId),
     );
 
-    // Batch upsert all meetings using database transaction
-    await this.db.$transaction(
+    // Batch upsert all meetings in chunked transactions (#476)
+    await batchTransaction(
+      this.db,
       meetings.map((meeting) =>
         this.db.meeting.upsert({
           where: { externalId: meeting.externalId },
@@ -535,6 +579,9 @@ export class RegionDomainService implements OnModuleInit {
         }),
       ),
     );
+
+    // Invalidate cached meeting queries (#459)
+    await this.invalidateCache('meetings:');
 
     const created = meetings.filter(
       (m) => !existingExternalIds.has(m.externalId),
@@ -575,8 +622,9 @@ export class RegionDomainService implements OnModuleInit {
       existingRecords.map((r: ExternalIdRecord) => r.externalId),
     );
 
-    // Batch upsert all representatives using database transaction
-    await this.db.$transaction(
+    // Batch upsert all representatives in chunked transactions (#476)
+    await batchTransaction(
+      this.db,
       reps.map((rep) =>
         this.db.representative.upsert({
           where: { externalId: rep.externalId },
@@ -600,6 +648,9 @@ export class RegionDomainService implements OnModuleInit {
         }),
       ),
     );
+
+    // Invalidate cached representative queries (#459)
+    await this.invalidateCache('representatives:');
 
     const created = reps.filter(
       (r) => !existingExternalIds.has(r.externalId),
@@ -640,7 +691,8 @@ export class RegionDomainService implements OnModuleInit {
         existing.map((r: ExternalIdRecord) => r.externalId),
       );
 
-      await this.db.$transaction(
+      await batchTransaction(
+        this.db,
         data.contributions.map((c) =>
           this.db.contribution.upsert({
             where: { externalId: c.externalId },
@@ -698,7 +750,8 @@ export class RegionDomainService implements OnModuleInit {
         existing.map((r: ExternalIdRecord) => r.externalId),
       );
 
-      await this.db.$transaction(
+      await batchTransaction(
+        this.db,
         data.expenditures.map((e) =>
           this.db.expenditure.upsert({
             where: { externalId: e.externalId },
@@ -752,7 +805,8 @@ export class RegionDomainService implements OnModuleInit {
         existing.map((r: ExternalIdRecord) => r.externalId),
       );
 
-      await this.db.$transaction(
+      await batchTransaction(
+        this.db,
         data.independentExpenditures.map((ie) =>
           this.db.independentExpenditure.upsert({
             where: { externalId: ie.externalId },
@@ -807,30 +861,32 @@ export class RegionDomainService implements OnModuleInit {
     skip: number = 0,
     take: number = 10,
   ): Promise<PaginatedPropositions> {
-    const [items, total] = await Promise.all([
-      this.db.proposition.findMany({
-        orderBy: [{ electionDate: 'desc' }, { createdAt: 'desc' }],
-        skip,
-        take: take + 1,
-      }),
-      this.db.proposition.count(),
-    ]);
+    return this.cachedQuery(`propositions:${skip}:${take}`, async () => {
+      const [items, total] = await Promise.all([
+        this.db.proposition.findMany({
+          orderBy: [{ electionDate: 'desc' }, { createdAt: 'desc' }],
+          skip,
+          take: take + 1,
+        }),
+        this.db.proposition.count(),
+      ]);
 
-    const hasMore = items.length > take;
-    const paginatedItems = items.slice(0, take);
+      const hasMore = items.length > take;
+      const paginatedItems = items.slice(0, take);
 
-    // Cast database types to GraphQL types - enum values are compatible at runtime
-    return {
-      items: paginatedItems.map((item: PropositionRecord) => ({
-        ...item,
-        fullText: item.fullText ?? undefined,
-        electionDate: item.electionDate ?? undefined,
-        sourceUrl: item.sourceUrl ?? undefined,
-        status: item.status as unknown as PropositionStatusGQL,
-      })),
-      total,
-      hasMore,
-    };
+      // Cast database types to GraphQL types - enum values are compatible at runtime
+      return {
+        items: paginatedItems.map((item: PropositionRecord) => ({
+          ...item,
+          fullText: item.fullText ?? undefined,
+          electionDate: item.electionDate ?? undefined,
+          sourceUrl: item.sourceUrl ?? undefined,
+          status: item.status as unknown as PropositionStatusGQL,
+        })),
+        total,
+        hasMore,
+      };
+    });
   }
 
   /**
@@ -847,29 +903,31 @@ export class RegionDomainService implements OnModuleInit {
     skip: number = 0,
     take: number = 10,
   ): Promise<PaginatedMeetings> {
-    const [items, total] = await Promise.all([
-      this.db.meeting.findMany({
-        orderBy: { scheduledAt: 'desc' },
-        skip,
-        take: take + 1,
-      }),
-      this.db.meeting.count(),
-    ]);
+    return this.cachedQuery(`meetings:${skip}:${take}`, async () => {
+      const [items, total] = await Promise.all([
+        this.db.meeting.findMany({
+          orderBy: { scheduledAt: 'desc' },
+          skip,
+          take: take + 1,
+        }),
+        this.db.meeting.count(),
+      ]);
 
-    const hasMore = items.length > take;
-    const paginatedItems = items.slice(0, take);
+      const hasMore = items.length > take;
+      const paginatedItems = items.slice(0, take);
 
-    // Cast database types to GraphQL types
-    return {
-      items: paginatedItems.map((item: MeetingRecord) => ({
-        ...item,
-        location: item.location ?? undefined,
-        agendaUrl: item.agendaUrl ?? undefined,
-        videoUrl: item.videoUrl ?? undefined,
-      })),
-      total,
-      hasMore,
-    };
+      // Cast database types to GraphQL types
+      return {
+        items: paginatedItems.map((item: MeetingRecord) => ({
+          ...item,
+          location: item.location ?? undefined,
+          agendaUrl: item.agendaUrl ?? undefined,
+          videoUrl: item.videoUrl ?? undefined,
+        })),
+        total,
+        hasMore,
+      };
+    });
   }
 
   /**
@@ -887,32 +945,37 @@ export class RegionDomainService implements OnModuleInit {
     take: number = 10,
     chamber?: string,
   ): Promise<PaginatedRepresentatives> {
-    const where = chamber ? { chamber } : undefined;
+    return this.cachedQuery(
+      `representatives:${skip}:${take}:${chamber ?? 'all'}`,
+      async () => {
+        const where = chamber ? { chamber } : undefined;
 
-    const [items, total] = await Promise.all([
-      this.db.representative.findMany({
-        where,
-        orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
-        skip,
-        take: take + 1,
-      }),
-      this.db.representative.count({ where }),
-    ]);
+        const [items, total] = await Promise.all([
+          this.db.representative.findMany({
+            where,
+            orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+            skip,
+            take: take + 1,
+          }),
+          this.db.representative.count({ where }),
+        ]);
 
-    const hasMore = items.length > take;
-    const paginatedItems = items.slice(0, take);
+        const hasMore = items.length > take;
+        const paginatedItems = items.slice(0, take);
 
-    // Cast database types to GraphQL types
-    return {
-      items: paginatedItems.map((item: RepresentativeRecord) => ({
-        ...item,
-        party: item.party ?? undefined,
-        photoUrl: item.photoUrl ?? undefined,
-        contactInfo: (item.contactInfo as ContactInfoModel) ?? undefined,
-      })),
-      total,
-      hasMore,
-    };
+        // Cast database types to GraphQL types
+        return {
+          items: paginatedItems.map((item: RepresentativeRecord) => ({
+            ...item,
+            party: item.party ?? undefined,
+            photoUrl: item.photoUrl ?? undefined,
+            contactInfo: (item.contactInfo as ContactInfoModel) ?? undefined,
+          })),
+          total,
+          hasMore,
+        };
+      },
+    );
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/region.tokens.ts
+++ b/apps/backend/src/apps/region/src/domains/region.tokens.ts
@@ -1,0 +1,7 @@
+/**
+ * Injection tokens for the Region module.
+ *
+ * Separated from region.module.ts to avoid circular imports
+ * (region.service.ts ↔ region.module.ts).
+ */
+export const REGION_CACHE = Symbol('REGION_CACHE');

--- a/packages/common/__tests__/batch-transaction.spec.ts
+++ b/packages/common/__tests__/batch-transaction.spec.ts
@@ -1,0 +1,74 @@
+import { batchTransaction } from "../src/utils/batch-transaction";
+
+describe("batchTransaction", () => {
+  let mockDb: { $transaction: jest.Mock };
+
+  beforeEach(() => {
+    mockDb = {
+      $transaction: jest
+        .fn()
+        .mockImplementation(async (ops: unknown[]) =>
+          Promise.all(ops as Promise<unknown>[]),
+        ),
+    };
+  });
+
+  it("should not call $transaction for empty operations", async () => {
+    await batchTransaction(mockDb, []);
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("should run a single transaction when operations fit in one chunk", async () => {
+    const ops = Array.from({ length: 3 }, (_, i) => Promise.resolve(i));
+    await batchTransaction(mockDb, ops, 500);
+
+    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockDb.$transaction).toHaveBeenCalledWith(ops);
+  });
+
+  it("should split into multiple transactions when operations exceed chunk size", async () => {
+    const ops = Array.from({ length: 1200 }, (_, i) => Promise.resolve(i));
+    await batchTransaction(mockDb, ops, 500);
+
+    expect(mockDb.$transaction).toHaveBeenCalledTimes(3);
+    expect(mockDb.$transaction.mock.calls[0][0]).toHaveLength(500);
+    expect(mockDb.$transaction.mock.calls[1][0]).toHaveLength(500);
+    expect(mockDb.$transaction.mock.calls[2][0]).toHaveLength(200);
+  });
+
+  it("should handle exact chunk size boundary", async () => {
+    const ops = Array.from({ length: 500 }, (_, i) => Promise.resolve(i));
+    await batchTransaction(mockDb, ops, 500);
+
+    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockDb.$transaction.mock.calls[0][0]).toHaveLength(500);
+  });
+
+  it("should use default chunk size of 500", async () => {
+    const ops = Array.from({ length: 501 }, (_, i) => Promise.resolve(i));
+    await batchTransaction(mockDb, ops);
+
+    expect(mockDb.$transaction).toHaveBeenCalledTimes(2);
+    expect(mockDb.$transaction.mock.calls[0][0]).toHaveLength(500);
+    expect(mockDb.$transaction.mock.calls[1][0]).toHaveLength(1);
+  });
+
+  it("should propagate transaction errors", async () => {
+    mockDb.$transaction.mockRejectedValueOnce(new Error("DB error"));
+    const ops = [Promise.resolve(1)];
+
+    await expect(batchTransaction(mockDb, ops)).rejects.toThrow("DB error");
+  });
+
+  it("should stop on first failed chunk", async () => {
+    const ops = Array.from({ length: 1000 }, (_, i) => Promise.resolve(i));
+    mockDb.$transaction
+      .mockResolvedValueOnce([]) // first chunk succeeds
+      .mockRejectedValueOnce(new Error("Chunk 2 failed")); // second fails
+
+    await expect(batchTransaction(mockDb, ops, 500)).rejects.toThrow(
+      "Chunk 2 failed",
+    );
+    expect(mockDb.$transaction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -8,3 +8,6 @@
 
 // Provider interfaces and types
 export * from "./providers/index.js";
+
+// Utilities
+export * from "./utils/index.js";

--- a/packages/common/src/utils/batch-transaction.ts
+++ b/packages/common/src/utils/batch-transaction.ts
@@ -1,0 +1,36 @@
+/**
+ * Batch Transaction Utility
+ *
+ * Chunks Prisma batch operations into smaller transactions to prevent
+ * timeouts and memory pressure with large datasets.
+ * See issue #476.
+ */
+
+/** Minimal interface satisfied by Prisma's $transaction method */
+interface TransactionClient {
+  $transaction(operations: unknown[]): Promise<unknown[]>;
+}
+
+const DEFAULT_CHUNK_SIZE = 500;
+
+/**
+ * Execute Prisma operations in batched transactions.
+ *
+ * Splits an array of PrismaPromise operations into chunks and runs each
+ * chunk in its own $transaction call. This prevents timeouts when syncing
+ * large datasets (e.g., thousands of upserts).
+ *
+ * @param db - Prisma client (or any object with $transaction)
+ * @param operations - Array of PrismaPromise operations
+ * @param chunkSize - Max operations per transaction (default: 500)
+ */
+export async function batchTransaction(
+  db: TransactionClient,
+  operations: unknown[],
+  chunkSize: number = DEFAULT_CHUNK_SIZE,
+): Promise<void> {
+  for (let i = 0; i < operations.length; i += chunkSize) {
+    const chunk = operations.slice(i, i + chunkSize);
+    await db.$transaction(chunk);
+  }
+}

--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { batchTransaction } from "./batch-transaction.js";


### PR DESCRIPTION
## Summary
- Add cache-through pattern (Redis primary + in-memory fallback) for region read queries — propositions, meetings, representatives (#459)
- Replace single large `$transaction` calls with chunked batch transactions (500 ops/chunk) to prevent Prisma timeouts on large dataset syncs (#476)
- Extract reusable `batchTransaction` utility and `ICache`/`MemoryCache` into `@opuspopuli/common`

Closes #459
Closes #476

## Test plan
- [x] Unit tests for `batchTransaction` utility (empty, single chunk, multi-chunk, boundary, error propagation)
- [x] Unit tests for cache hit/miss on all three query methods
- [x] Unit tests for cache invalidation after sync operations
- [x] Unit tests for chunked transaction behavior in region service
- [x] All 1276 unit tests pass
- [x] All 267 E2E integration tests pass (verified locally in Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)