### PR TITLE
fix(security): resolve critical and high audit vulnerabilities

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -38,7 +38,7 @@
     "preinstall": "npx only-allow pnpm"
   },
   "dependencies": {
-    "@apollo/gateway": "^2.12.2",
+    "@apollo/gateway": "^2.12.3",
     "@apollo/server": "^5.4.0",
     "@apollo/subgraph": "^2.12.2",
     "@as-integrations/express5": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,12 @@
       "tar": ">=7.5.11",
       "fast-xml-parser": ">=5.3.5",
       "lodash": ">=4.17.23",
-      "langsmith": ">=0.4.6"
+      "langsmith": ">=0.4.6",
+      "@apollo/gateway": ">=2.12.3",
+      "@apollo/query-planner": ">=2.12.3",
+      "@apollo/federation-internals": ">=2.12.3",
+      "undici": ">=7.24.0",
+      "flatted": ">=3.4.0"
     }
   }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -73,6 +73,6 @@
   },
   "dependencies": {
     "cockatiel": "^3.2.1",
-    "undici": "^7.3.0"
+    "undici": "^7.24.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,11 @@ overrides:
   fast-xml-parser: '>=5.3.5'
   lodash: '>=4.17.23'
   langsmith: '>=0.4.6'
+  '@apollo/gateway': '>=2.12.3'
+  '@apollo/query-planner': '>=2.12.3'
+  '@apollo/federation-internals': '>=2.12.3'
+  undici: '>=7.24.0'
+  flatted: '>=3.4.0'
 
 importers:
 
@@ -28,8 +33,8 @@ importers:
   apps/backend:
     dependencies:
       '@apollo/gateway':
-        specifier: ^2.12.2
-        version: 2.12.2(encoding@0.1.13)(graphql@16.13.1)
+        specifier: '>=2.12.3'
+        version: 2.13.2(encoding@0.1.13)(graphql@16.13.1)
       '@apollo/server':
         specifier: ^5.4.0
         version: 5.4.0(graphql@16.13.1)
@@ -56,7 +61,7 @@ importers:
         version: 1.0.1(@langchain/core@1.1.31(@opentelemetry/api@1.9.0)(openai@6.27.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6)))
       '@nestjs/apollo':
         specifier: ^13.2.4
-        version: 13.2.4(@apollo/gateway@2.12.2(encoding@0.1.13)(graphql@16.13.1))(@apollo/server@5.4.0(graphql@16.13.1))(@apollo/subgraph@2.12.2(graphql@16.13.1))(@as-integrations/express5@1.1.2(@apollo/server@5.4.0(graphql@16.13.1))(express@5.2.1))(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@nestjs/graphql@13.2.4(@apollo/subgraph@2.12.2(graphql@16.13.1))(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(bufferutil@4.1.0)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.13.1)(reflect-metadata@0.2.2))(graphql@16.13.1)
+        version: 13.2.4(@apollo/gateway@2.13.2(encoding@0.1.13)(graphql@16.13.1))(@apollo/server@5.4.0(graphql@16.13.1))(@apollo/subgraph@2.12.2(graphql@16.13.1))(@as-integrations/express5@1.1.2(@apollo/server@5.4.0(graphql@16.13.1))(express@5.2.1))(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@nestjs/graphql@13.2.4(@apollo/subgraph@2.12.2(graphql@16.13.1))(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(bufferutil@4.1.0)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.13.1)(reflect-metadata@0.2.2))(graphql@16.13.1)
       '@nestjs/common':
         specifier: ^11.1.16
         version: 11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -553,8 +558,8 @@ importers:
         specifier: ^3.2.1
         version: 3.2.1
       undici:
-        specifier: ^7.3.0
-        version: 7.22.0
+        specifier: '>=7.24.0'
+        version: 7.24.2
     devDependencies:
       '@types/jest':
         specifier: ^29.5.0
@@ -1274,20 +1279,20 @@ packages:
       subscriptions-transport-ws:
         optional: true
 
-  '@apollo/composition@2.12.2':
-    resolution: {integrity: sha512-wE5YwoZhf4tAfTPwp0xSUDrBQnUE/2QFB7UkEisX/PdBgh8ZqRAFhV29LA1jv1AqZkrS0UTWDnAv8Ley2iHzcQ==}
-    engines: {node: '>=14.15.0'}
+  '@apollo/composition@2.13.2':
+    resolution: {integrity: sha512-E44BbSKuKkDdsNBtQzSU12D9FdggiOZzNR1TghqPjSPEyB1fl9Io1m2gMP0nkwrJUaftsBSP6ZSFF3SgYJfTVg==}
+    engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.5.0
 
-  '@apollo/federation-internals@2.12.2':
-    resolution: {integrity: sha512-8L3gsYkiwLJhiRVRMzXhJOV6oVMYGdCioYcio66yjaXevfcfsnEUVXfC378ma7+9GBjBjp0YzbDargOg+0FXJA==}
-    engines: {node: '>=14.15.0'}
+  '@apollo/federation-internals@2.13.2':
+    resolution: {integrity: sha512-m9waen8iZhrzn23qkemlytqBCPoKU6AMv5k3eFYnu6yzoJ5/ONh6SMGE7CvrWsECcpnOLYOinxD19igEHm6Azw==}
+    engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.5.0
 
-  '@apollo/gateway@2.12.2':
-    resolution: {integrity: sha512-LPQkoPDLBIsxX35B4Wp0hL4/Z13r8AZxZTF2zenSL3ZsVca+SI4sYg6zBPIUBglSh/hrMSnkSFcfqH4AVccUqg==}
+  '@apollo/gateway@2.13.2':
+    resolution: {integrity: sha512-IAX/u0b2QPbNmAtTGIfJZawjneCnOIcCvgRaEl7WdL8Ea6ck6S2ZAn1WaHlbHL3jFbpmBsZ4N39gFL7XwtzTqg==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       graphql: ^16.5.0
@@ -1296,14 +1301,14 @@ packages:
     resolution: {integrity: sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==}
     hasBin: true
 
-  '@apollo/query-graphs@2.12.2':
-    resolution: {integrity: sha512-IeuNXbQUuwfYCa3PJJFBFvlnH11CFfYaKzR5IZcZB0uLc5iRC1NWNyUIXx0OtYXhUEgqIkmTHld+ME4tkvVw5Q==}
-    engines: {node: '>=14.15.0'}
+  '@apollo/query-graphs@2.13.2':
+    resolution: {integrity: sha512-iXb7Ut72BxOIKYT1Xbmmt5jONa/kB0iuQyWKhKIJdwIw+p8VSwJvaSFtzjDZ7tYTo/QH9l8yGzAdliJVR+/7cA==}
+    engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.5.0
 
-  '@apollo/query-planner@2.12.2':
-    resolution: {integrity: sha512-CY3vjbJhtxklml+ux9noOfOeGpyzR0n+HWf/VbFYz2xHhbKU7Q9xy/f+7FDLbcHYHiOUEG50qcLZgAVyPaglEA==}
+  '@apollo/query-planner@2.13.2':
+    resolution: {integrity: sha512-XlIz+kQg9M6aZyj5E9t9KNuptJr+uHcWdsTLq8SU1VzD//5c5qg9hUl8oz6uWGpff4rxBuSduPhuKyRguSOxIQ==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       graphql: ^16.5.0
@@ -3822,7 +3827,7 @@ packages:
   '@nestjs/apollo@13.2.4':
     resolution: {integrity: sha512-5gKyDQDm+E+AIYofFxXXUhi/4z9YgSjXtjlXUixCj+n6oVcJOilQ7zxlnu3vHiBZz8kEn2ZvVZTJ+i5V2xQ+ew==}
     peerDependencies:
-      '@apollo/gateway': ^2.0.0
+      '@apollo/gateway': '>=2.12.3'
       '@apollo/server': ^5.0.0
       '@apollo/subgraph': ^2.0.0
       '@as-integrations/express5': '*'
@@ -7138,8 +7143,8 @@ packages:
   flatbuffers@1.12.0:
     resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.1:
+    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -10593,12 +10598,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.18.2:
-    resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
-    engines: {node: '>=20.18.1'}
-
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.2:
+    resolution: {integrity: sha512-P9J1HWYV/ajFr8uCqk5QixwiRKmB1wOamgS0e+o2Z4A44Ej2+thFVRLG/eA7qprx88XXhnV5Bl8LHXTURpzB3Q==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -11235,13 +11236,13 @@ snapshots:
       subscriptions-transport-ws: 0.11.0(bufferutil@4.1.0)(graphql@16.13.1)
     optional: true
 
-  '@apollo/composition@2.12.2(graphql@16.13.1)':
+  '@apollo/composition@2.13.2(graphql@16.13.1)':
     dependencies:
-      '@apollo/federation-internals': 2.12.2(graphql@16.13.1)
-      '@apollo/query-graphs': 2.12.2(graphql@16.13.1)
+      '@apollo/federation-internals': 2.13.2(graphql@16.13.1)
+      '@apollo/query-graphs': 2.13.2(graphql@16.13.1)
       graphql: 16.13.1
 
-  '@apollo/federation-internals@2.12.2(graphql@16.13.1)':
+  '@apollo/federation-internals@2.13.2(graphql@16.13.1)':
     dependencies:
       '@types/uuid': 9.0.8
       chalk: 4.1.2
@@ -11249,11 +11250,11 @@ snapshots:
       js-levenshtein: 1.1.6
       uuid: 9.0.1
 
-  '@apollo/gateway@2.12.2(encoding@0.1.13)(graphql@16.13.1)':
+  '@apollo/gateway@2.13.2(encoding@0.1.13)(graphql@16.13.1)':
     dependencies:
-      '@apollo/composition': 2.12.2(graphql@16.13.1)
-      '@apollo/federation-internals': 2.12.2(graphql@16.13.1)
-      '@apollo/query-planner': 2.12.2(graphql@16.13.1)
+      '@apollo/composition': 2.13.2(graphql@16.13.1)
+      '@apollo/federation-internals': 2.13.2(graphql@16.13.1)
+      '@apollo/query-planner': 2.13.2(graphql@16.13.1)
       '@apollo/server-gateway-interface': 1.1.1(graphql@16.13.1)
       '@apollo/usage-reporting-protobuf': 4.1.1
       '@apollo/utils.createhash': 2.0.2
@@ -11289,18 +11290,18 @@ snapshots:
       '@types/long': 4.0.2
       long: 4.0.0
 
-  '@apollo/query-graphs@2.12.2(graphql@16.13.1)':
+  '@apollo/query-graphs@2.13.2(graphql@16.13.1)':
     dependencies:
-      '@apollo/federation-internals': 2.12.2(graphql@16.13.1)
+      '@apollo/federation-internals': 2.13.2(graphql@16.13.1)
       deep-equal: 2.2.3
       graphql: 16.13.1
       ts-graphviz: 1.8.2
       uuid: 9.0.1
 
-  '@apollo/query-planner@2.12.2(graphql@16.13.1)':
+  '@apollo/query-planner@2.13.2(graphql@16.13.1)':
     dependencies:
-      '@apollo/federation-internals': 2.12.2(graphql@16.13.1)
-      '@apollo/query-graphs': 2.12.2(graphql@16.13.1)
+      '@apollo/federation-internals': 2.13.2(graphql@16.13.1)
+      '@apollo/query-graphs': 2.13.2(graphql@16.13.1)
       '@apollo/utils.keyvaluecache': 2.1.1
       chalk: 4.1.2
       deep-equal: 2.2.3
@@ -11358,7 +11359,7 @@ snapshots:
   '@apollo/subgraph@2.12.2(graphql@16.13.1)':
     dependencies:
       '@apollo/cache-control-types': 1.0.3(graphql@16.13.1)
-      '@apollo/federation-internals': 2.12.2(graphql@16.13.1)
+      '@apollo/federation-internals': 2.13.2(graphql@16.13.1)
       graphql: 16.13.1
 
   '@apollo/usage-reporting-protobuf@4.1.1':
@@ -14446,7 +14447,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@nestjs/apollo@13.2.4(@apollo/gateway@2.12.2(encoding@0.1.13)(graphql@16.13.1))(@apollo/server@5.4.0(graphql@16.13.1))(@apollo/subgraph@2.12.2(graphql@16.13.1))(@as-integrations/express5@1.1.2(@apollo/server@5.4.0(graphql@16.13.1))(express@5.2.1))(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@nestjs/graphql@13.2.4(@apollo/subgraph@2.12.2(graphql@16.13.1))(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(bufferutil@4.1.0)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.13.1)(reflect-metadata@0.2.2))(graphql@16.13.1)':
+  '@nestjs/apollo@13.2.4(@apollo/gateway@2.13.2(encoding@0.1.13)(graphql@16.13.1))(@apollo/server@5.4.0(graphql@16.13.1))(@apollo/subgraph@2.12.2(graphql@16.13.1))(@as-integrations/express5@1.1.2(@apollo/server@5.4.0(graphql@16.13.1))(express@5.2.1))(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(@nestjs/graphql@13.2.4(@apollo/subgraph@2.12.2(graphql@16.13.1))(@nestjs/common@11.1.16(class-transformer@0.5.1)(class-validator@0.14.3)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.16)(bufferutil@4.1.0)(class-transformer@0.5.1)(class-validator@0.14.3)(graphql@16.13.1)(reflect-metadata@0.2.2))(graphql@16.13.1)':
     dependencies:
       '@apollo/server': 5.4.0(graphql@16.13.1)
       '@apollo/server-plugin-landing-page-graphql-playground': 4.0.1(@apollo/server@5.4.0(graphql@16.13.1))
@@ -14458,7 +14459,7 @@ snapshots:
       lodash.omit: 4.5.0
       tslib: 2.8.1
     optionalDependencies:
-      '@apollo/gateway': 2.12.2(encoding@0.1.13)(graphql@16.13.1)
+      '@apollo/gateway': 2.13.2(encoding@0.1.13)(graphql@16.13.1)
       '@apollo/subgraph': 2.12.2(graphql@16.13.1)
       '@as-integrations/express5': 1.1.2(@apollo/server@5.4.0(graphql@16.13.1))(express@5.2.1)
 
@@ -17213,7 +17214,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.22.0
+      undici: 7.24.2
       whatwg-mimetype: 4.0.0
 
   chokidar@4.0.3:
@@ -18524,14 +18525,14 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.1
       keyv: 4.5.4
 
   flat@5.0.2: {}
 
   flatbuffers@1.12.0: {}
 
-  flatted@3.3.3: {}
+  flatted@3.4.1: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
@@ -20710,7 +20711,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.18.2
+      undici: 7.24.2
       workerd: 1.20260217.0
       ws: 8.18.0(bufferutil@4.1.0)
       youch: 4.1.0-beta.10
@@ -23003,9 +23004,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.18.2: {}
-
-  undici@7.22.0: {}
+  undici@7.24.2: {}
 
   unenv@2.0.0-rc.24:
     dependencies:


### PR DESCRIPTION
## Summary
- **Critical**: Bump `@apollo/gateway` to >=2.12.3 — prototype pollution via incomplete key sanitization (GHSA-pfjj-6f4p-rvmh)
- **High**: Bump `undici` to >=7.24.0 — WebSocket memory consumption and unhandled exception (GHSA-vrm6-8vpv-qv8q, GHSA-v9p9-hfj2-hcw8)
- **High**: Add `flatted` >=3.4.0 override — unbounded recursion DoS in parse() (GHSA-25h7-pfq9-p65f)
- Add pnpm overrides for `@apollo/query-planner` and `@apollo/federation-internals` to patch transitive deps

## Test plan
- [x] `pnpm audit --audit-level=high` passes (0 high/critical)
- [x] All 1276 backend tests pass
- [x] All frontend and package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)