### PR TITLE
docs: update region references and fix flatted CVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The `packages/` directory contains reusable workspace packages that provide plug
 | `@opuspopuli/ocr-provider` | OCR functionality | - |
 | `@opuspopuli/scraping-pipeline` | AI-powered schema-on-read web scraping with structural manifests | - |
 | `@opuspopuli/region-provider` | Civic data integration (declarative plugins, propositions, meetings, representatives) | - |
+| `@opuspopuli/regions` | Declarative region config files ([separate repo](https://github.com/OpusPopuli/opuspopuli-regions)) | - |
 | `@opuspopuli/prompt-client` | AI prompt template client with circuit breaker, HMAC auth, and caching | - |
 
 ## Development

--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -199,13 +199,16 @@ The platform software is free and open source (AGPL-3.0). These are infrastructu
 
 A "region" in Opus Populi is a jurisdiction (California, Texas, New York, etc.). Each region operator deploys **one node** with their region plugin configured. Region plugins are declarative JSON configuration; they do not affect deployment topology.
 
+Region configs live in the [`opuspopuli-regions`](https://github.com/OpusPopuli/opuspopuli-regions) repo and are published as the `@opuspopuli/regions` npm package. The platform installs this package as a dependency.
+
 ```
-                         +-- california.json (declarative config)
-Region Plugin Config --> +-- federal.json   (always loaded)
-                         +-- texas.json     (another operator's node)
+opuspopuli-regions repo → @opuspopuli/regions npm package
+  ├── california.json (declarative config)
+  ├── federal.json    (always loaded)
+  └── texas.json, ... (other regions)
 ```
 
-A single node runs one local region plugin + the always-on federal plugin. The region plugin declares data sources (URLs, APIs, bulk downloads), and the AI-powered scraping pipeline handles extraction. No code changes are needed to add or switch regions.
+A single node runs one local region plugin + the always-on federal plugin. The region plugin declares data sources (URLs, APIs, bulk downloads), and the AI-powered scraping pipeline handles extraction. No code changes are needed to add or switch regions — just add a JSON config to the regions repo.
 
 See [Region Provider Guide](../guides/region-provider.md) and [Region Setup and Validation](../guides/region-setup-and-validation-guide.md) for details.
 

--- a/docs/guides/region-provider.md
+++ b/docs/guides/region-provider.md
@@ -20,11 +20,11 @@ The platform uses **declarative region plugins** — JSON configuration that des
 │                         PLATFORM                                    │
 ├─────────────────────────────────────────────────────────────────────┤
 │                                                                     │
-│  packages/region-provider/regions/                                  │
+│  @opuspopuli/regions npm package (from opuspopuli-regions repo)     │
 │  ├── federal.json    (always loaded — federal campaign finance)     │
 │  ├── california.json (local plugin — state-specific civic data)     │
 │  └── texas.json, ... (other regions)                                │
-│       ↓ auto-discovered and synced to DB at startup                 │
+│       ↓ discovered via getRegionsDir(), synced to DB at startup     │
 │                                                                     │
 │  Database (region_plugins table)                                    │
 │  └── DeclarativeRegionConfig JSON + enabled flag + sync state       │
@@ -67,7 +67,7 @@ The platform uses **declarative region plugins** — JSON configuration that des
 
 ## How It Works
 
-1. **Config Discovery**: `RegionDomainService.onModuleInit()` auto-discovers JSON files from `packages/region-provider/regions/` and upserts them into the `region_plugins` table (config changes propagate on every restart; the `enabled` flag is never overwritten)
+1. **Config Discovery**: `RegionDomainService.onModuleInit()` discovers JSON config files from the `@opuspopuli/regions` npm package (via `getRegionsDir()`) and upserts them into the `region_plugins` table (config changes propagate on every restart; the `enabled` flag is never overwritten)
 2. **Local Config Read**: The service reads the enabled local region's `stateCode` (e.g., `"CA"`) from the database
 3. **Placeholder Resolution**: Federal config `${stateCode}` placeholders are resolved using `resolveConfigPlaceholders()` (e.g., `contributor_state: "${stateCode}"` becomes `contributor_state: "CA"`)
 4. **Federal Plugin Loading**: `PluginLoaderService.loadFederalPlugin()` creates a `DeclarativeRegionPlugin` from the resolved federal config and registers it in the `federal` slot

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
       "@apollo/query-planner": ">=2.12.3",
       "@apollo/federation-internals": ">=2.12.3",
       "undici": ">=7.24.0",
-      "flatted": ">=3.4.0",
+      "flatted": ">=3.4.2",
       "file-type": ">=21.3.1",
       "hono": ">=4.12.7",
       "next": ">=16.1.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   '@apollo/query-planner': '>=2.12.3'
   '@apollo/federation-internals': '>=2.12.3'
   undici: '>=7.24.0'
-  flatted: '>=3.4.0'
+  flatted: '>=3.4.2'
   file-type: '>=21.3.1'
   hono: '>=4.12.7'
   next: '>=16.1.7'
@@ -7150,8 +7150,8 @@ packages:
   flatbuffers@1.12.0:
     resolution: {integrity: sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==}
 
-  flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -18497,14 +18497,14 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
   flat@5.0.2: {}
 
   flatbuffers@1.12.0: {}
 
-  flatted@3.4.1: {}
+  flatted@3.4.2: {}
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Updated remaining documentation references to point to the `opuspopuli-regions` repo (region-provider guide, deployment docs, README)
- Bumped `flatted` override from `>=3.4.0` to `>=3.4.2` to fix prototype pollution CVE (GHSA-rf6f-7fwh-wjgh)

## Test plan
- [x] All unit tests pass
- [x] `pnpm audit --audit-level=high` passes clean (0 high vulnerabilities)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)