### PR TITLE
feat: container signing, SBOM generation and verification (#427)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,118 @@
+# =============================================================================
+# Release — Build, Push, Sign & SBOM
+# =============================================================================
+#
+# Triggered on push to main (after CI passes). Builds Docker images for each
+# microservice, pushes to GHCR, signs with Sigstore keyless cosign, and
+# generates + attaches SPDX SBOMs.
+#
+# See docs/container-verification.md for how to verify images.
+# =============================================================================
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: release-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/opuspopuli
+
+jobs:
+  build-sign-publish:
+    name: Build, Sign & Publish — ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: api
+            dockerfile: apps/backend/docker/Dockerfile.api
+          - service: users
+            dockerfile: apps/backend/docker/Dockerfile.users
+          - service: documents
+            dockerfile: apps/backend/docker/Dockerfile.documents
+          - service: knowledge
+            dockerfile: apps/backend/docker/Dockerfile.knowledge
+          - service: region
+            dockerfile: apps/backend/docker/Dockerfile.region
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            NODE_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@3454372f43399081ed03b604cb2d021dabca52bb # v3
+
+      - name: Sign image with cosign (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${DIGEST}"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e11c554f704a0b820cbf8c51673f6945e0731532 # v0
+        with:
+          image: ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom-${{ matrix.service }}.spdx.json
+
+      - name: Attest SBOM
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign attest --yes \
+            --predicate sbom-${{ matrix.service }}.spdx.json \
+            --type spdxjson \
+            "${{ env.IMAGE_PREFIX }}/${{ matrix.service }}@${DIGEST}"
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4
+        with:
+          name: sbom-${{ matrix.service }}
+          path: sbom-${{ matrix.service }}.spdx.json
+          retention-days: 90

--- a/docs/guides/container-verification.md
+++ b/docs/guides/container-verification.md
@@ -1,0 +1,94 @@
+# Container Signing & Verification
+
+Opus Populi uses [Sigstore](https://www.sigstore.dev/) keyless signing to ensure container images haven't been tampered with. Every image pushed to GitHub Container Registry (GHCR) is automatically signed and accompanied by an SBOM (Software Bill of Materials).
+
+## How It Works
+
+When code is merged to `main`, the [release workflow](../../.github/workflows/release.yml) runs:
+
+1. **Build** — Docker images are built for each microservice (api, users, documents, knowledge, region)
+2. **Push** — Images are pushed to `ghcr.io/opuspopuli/<service>`
+3. **Sign** — Each image is signed using cosign with Sigstore keyless signing (GitHub Actions OIDC identity)
+4. **SBOM** — An SPDX SBOM is generated with syft and attached as a cosign attestation
+
+No signing keys are stored or managed — the signing identity is derived from the GitHub Actions workflow run via OIDC.
+
+## Prerequisites
+
+Install cosign:
+
+```bash
+# macOS
+brew install cosign
+
+# Go
+go install github.com/sigstore/cosign/v2/cmd/cosign@latest
+```
+
+## Verifying Images
+
+### Using the verification script
+
+```bash
+# Verify all services
+./scripts/verify-images.sh
+
+# Verify a single service
+./scripts/verify-images.sh --service users
+
+# Verify a specific image tag
+./scripts/verify-images.sh --tag sha-abc1234
+
+# View SBOM for a service
+./scripts/verify-images.sh --sbom api
+```
+
+### Manual verification with cosign
+
+```bash
+# Verify signature
+cosign verify \
+  --certificate-identity-regexp "https://github\.com/OpusPopuli/opuspopuli/\.github/workflows/release\.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/opuspopuli/api:latest
+
+# Verify SBOM attestation
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-identity-regexp "https://github\.com/OpusPopuli/opuspopuli/\.github/workflows/release\.yml@.*" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  ghcr.io/opuspopuli/api:latest
+```
+
+## Production Deployment
+
+The production startup script supports optional image verification:
+
+```bash
+# Start without verification (default — builds locally)
+./scripts/start-prod.sh
+
+# Start with image signature verification
+./scripts/start-prod.sh --verify
+```
+
+When `--verify` is passed, the script runs `verify-images.sh` before starting Docker Compose. If any image fails verification, the startup is aborted.
+
+## Image Tags
+
+Each release produces two tags per service:
+
+| Tag | Description |
+|-----|-------------|
+| `latest` | Most recent release |
+| `sha-<commit>` | Pinned to a specific commit |
+
+For production, prefer pinning to a specific `sha-*` tag rather than `latest`.
+
+## Trust Model
+
+The verification proves:
+- The image was built by the `release.yml` workflow in the `OpusPopuli/opuspopuli` repository
+- The build ran on GitHub Actions (verified via OIDC issuer)
+- The image contents match the signed digest (tamper detection)
+- The SBOM accurately reflects the image contents at build time

--- a/scripts/start-prod.sh
+++ b/scripts/start-prod.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 ENV_FILE=".env.production"
 SKIP_PULL=false
 BUILD_FLAG=""
+VERIFY_IMAGES=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -37,9 +38,13 @@ while [[ $# -gt 0 ]]; do
       BUILD_FLAG="--build"
       shift
       ;;
+    --verify)
+      VERIFY_IMAGES=true
+      shift
+      ;;
     *)
       echo "Unknown option: $1"
-      echo "Usage: $0 [--env-file <file>] [--skip-pull] [--build]"
+      echo "Usage: $0 [--env-file <file>] [--skip-pull] [--build] [--verify]"
       exit 1
       ;;
   esac
@@ -53,7 +58,7 @@ echo ""
 # ---------------------------------------------------------------------------
 # 1. Check Ollama is installed
 # ---------------------------------------------------------------------------
-echo "[1/5] Checking Ollama installation..."
+echo "[1/6] Checking Ollama installation..."
 if ! command -v ollama &> /dev/null; then
   echo "ERROR: Ollama is not installed."
   echo ""
@@ -66,7 +71,7 @@ echo "      Ollama installed: $(ollama --version 2>/dev/null || echo 'unknown ve
 # ---------------------------------------------------------------------------
 # 2. Check Ollama is running
 # ---------------------------------------------------------------------------
-echo "[2/5] Checking Ollama is running..."
+echo "[2/6] Checking Ollama is running..."
 if curl -sf http://localhost:11434/ > /dev/null 2>&1; then
   echo "      Ollama is running on port 11434"
 else
@@ -105,7 +110,7 @@ fi
 # ---------------------------------------------------------------------------
 # 3. Check required models
 # ---------------------------------------------------------------------------
-echo "[3/5] Checking required models..."
+echo "[3/6] Checking required models..."
 
 # Read LLM_MODEL from env file, default to qwen3.5:35b
 LLM_MODEL="qwen3.5:35b"
@@ -131,7 +136,7 @@ fi
 # ---------------------------------------------------------------------------
 # 4. Health check
 # ---------------------------------------------------------------------------
-echo "[4/5] Running Ollama health check..."
+echo "[4/6] Running Ollama health check..."
 if curl -sf http://localhost:11434/api/tags > /dev/null 2>&1; then
   MODEL_COUNT=$(curl -sf http://localhost:11434/api/tags | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('models',[])))" 2>/dev/null || echo "?")
   echo "      Ollama API healthy ($MODEL_COUNT model(s) loaded)"
@@ -141,9 +146,26 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 5. Start Docker Compose
+# 5. Verify container image signatures (optional)
 # ---------------------------------------------------------------------------
-echo "[5/5] Starting production stack..."
+if [[ "$VERIFY_IMAGES" == "true" ]]; then
+  echo "[5/6] Verifying container image signatures..."
+  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [[ -x "${SCRIPT_DIR}/verify-images.sh" ]]; then
+    "${SCRIPT_DIR}/verify-images.sh"
+  else
+    echo "ERROR: verify-images.sh not found or not executable."
+    echo "       Expected at: ${SCRIPT_DIR}/verify-images.sh"
+    exit 1
+  fi
+else
+  echo "[5/6] Skipping image verification (use --verify to enable)"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Start Docker Compose
+# ---------------------------------------------------------------------------
+echo "[6/6] Starting production stack..."
 echo ""
 
 if [[ ! -f "$ENV_FILE" ]]; then

--- a/scripts/verify-images.sh
+++ b/scripts/verify-images.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# =============================================================================
+# Container Image Verification Script
+# =============================================================================
+#
+# Verifies Opus Populi container image signatures and SBOM attestations
+# using Sigstore keyless cosign. No signing keys required — verification
+# uses the GitHub Actions OIDC certificate identity.
+#
+# Prerequisites:
+#   brew install cosign   (macOS)
+#   go install github.com/sigstore/cosign/v2/cmd/cosign@latest   (Go)
+#
+# Usage:
+#   ./scripts/verify-images.sh                     # verify all services
+#   ./scripts/verify-images.sh --service users     # verify one service
+#   ./scripts/verify-images.sh --sbom users        # show SBOM for a service
+#   ./scripts/verify-images.sh --tag sha-abc1234   # verify a specific tag
+#
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+REGISTRY="ghcr.io/opuspopuli"
+SERVICES=(api users documents knowledge region)
+CERT_IDENTITY_REGEXP="https://github\\.com/OpusPopuli/opuspopuli/\\.github/workflows/release\\.yml@.*"
+CERT_OIDC_ISSUER="https://token.actions.githubusercontent.com"
+
+TAG="latest"
+TARGET_SERVICE=""
+SHOW_SBOM=""
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --service)
+      TARGET_SERVICE="$2"
+      shift 2
+      ;;
+    --sbom)
+      SHOW_SBOM="$2"
+      shift 2
+      ;;
+    --tag)
+      TAG="$2"
+      shift 2
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--service <name>] [--sbom <name>] [--tag <tag>]"
+      echo ""
+      echo "Options:"
+      echo "  --service <name>   Verify a single service (api|users|documents|knowledge|region)"
+      echo "  --sbom <name>      Show SBOM for a service"
+      echo "  --tag <tag>        Image tag to verify (default: latest)"
+      echo ""
+      echo "Examples:"
+      echo "  $0                          # verify all services"
+      echo "  $0 --service users          # verify one service"
+      echo "  $0 --sbom api               # show SBOM for api service"
+      echo "  $0 --tag sha-abc1234        # verify a specific tag"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1 (use --help for usage)"
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+if ! command -v cosign &> /dev/null; then
+  echo -e "${RED}ERROR: cosign is not installed.${NC}"
+  echo ""
+  echo "Install with:"
+  echo "  brew install cosign          (macOS)"
+  echo "  go install github.com/sigstore/cosign/v2/cmd/cosign@latest"
+  echo ""
+  echo "See: https://docs.sigstore.dev/cosign/system_config/installation/"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# SBOM display mode
+# ---------------------------------------------------------------------------
+if [[ -n "$SHOW_SBOM" ]]; then
+  IMAGE="${REGISTRY}/${SHOW_SBOM}:${TAG}"
+  echo "Fetching SBOM attestation for ${IMAGE} ..."
+  echo ""
+  cosign verify-attestation \
+    --type spdxjson \
+    --certificate-identity-regexp "$CERT_IDENTITY_REGEXP" \
+    --certificate-oidc-issuer "$CERT_OIDC_ISSUER" \
+    "$IMAGE" 2>/dev/null \
+    | jq -r '.payload' | base64 -d | jq '.predicate'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+if [[ -n "$TARGET_SERVICE" ]]; then
+  SERVICES=("$TARGET_SERVICE")
+fi
+
+echo "============================================"
+echo "  Opus Populi — Image Verification"
+echo "============================================"
+echo ""
+echo "Registry:  ${REGISTRY}"
+echo "Tag:       ${TAG}"
+echo "Services:  ${SERVICES[*]}"
+echo ""
+
+PASS=0
+FAIL=0
+
+for service in "${SERVICES[@]}"; do
+  IMAGE="${REGISTRY}/${service}:${TAG}"
+  printf "  %-12s " "${service}:"
+
+  # Verify signature
+  if cosign verify \
+    --certificate-identity-regexp "$CERT_IDENTITY_REGEXP" \
+    --certificate-oidc-issuer "$CERT_OIDC_ISSUER" \
+    "$IMAGE" > /dev/null 2>&1; then
+    echo -e "${GREEN}SIGNED ✓${NC}"
+    PASS=$((PASS + 1))
+  else
+    echo -e "${RED}UNSIGNED ✗${NC}"
+    FAIL=$((FAIL + 1))
+  fi
+
+  # Verify SBOM attestation
+  printf "  %-12s " ""
+  if cosign verify-attestation \
+    --type spdxjson \
+    --certificate-identity-regexp "$CERT_IDENTITY_REGEXP" \
+    --certificate-oidc-issuer "$CERT_OIDC_ISSUER" \
+    "$IMAGE" > /dev/null 2>&1; then
+    echo -e "${GREEN}SBOM ATTESTED ✓${NC}"
+  else
+    echo -e "${YELLOW}SBOM MISSING ⚠${NC}"
+  fi
+done
+
+echo ""
+echo "--------------------------------------------"
+echo "  Results: ${PASS} passed, ${FAIL} failed"
+echo "--------------------------------------------"
+
+if [[ $FAIL -gt 0 ]]; then
+  echo ""
+  echo -e "${RED}WARNING: ${FAIL} image(s) failed signature verification.${NC}"
+  echo "Do NOT deploy unsigned images in production."
+  exit 1
+fi
+
+echo ""
+echo -e "${GREEN}All images verified successfully.${NC}"


### PR DESCRIPTION
## Summary
- **Release workflow** (`.github/workflows/release.yml`): On push to `main`, builds all 5 microservice images, pushes to GHCR, signs with Sigstore keyless cosign, generates SPDX SBOMs with syft, and attaches them as cosign attestations
- **Verification script** (`scripts/verify-images.sh`): Standalone tool for node operators to verify image signatures and inspect SBOMs — no signing keys needed
- **Production startup** (`scripts/start-prod.sh`): New `--verify` flag runs signature verification before starting the stack

Closes #427

## Test plan
- [ ] Merge to `main` and confirm `release.yml` runs — images appear in GHCR packages tab, signed
- [ ] Run `./scripts/verify-images.sh` locally and confirm cosign verification passes
- [ ] Run `./scripts/verify-images.sh --sbom api` and confirm SPDX output lists dependencies
- [ ] Run `./scripts/start-prod.sh --verify` and confirm it verifies before starting
- [ ] Run `./scripts/start-prod.sh` (without `--verify`) and confirm existing flow is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)