### PR TITLE
Release: merge develop to main

### DIFF
--- a/docs/architecture/deployment.md
+++ b/docs/architecture/deployment.md
@@ -139,7 +139,7 @@ INTERNET --> Nginx/Caddy (port 443, TLS) --> localhost:8080 (API Gateway)
 | **UAT** | `docker-compose-uat.yml` + Tunnel | Supabase Cloud (free tier) + local PG | Cloudflare Tunnel | Workers preview | ~$0 |
 | **Prod** | `docker-compose-prod.yml` + Tunnel | Supabase Cloud (Pro) + local PG | Tunnel + Workers | Workers (custom domain) | ~$100-150 |
 
-The Terraform infrastructure (`infra/cloudflare/`) uses workspaces for state isolation. Each environment gets its own `tfvars` file with feature toggles:
+The Terraform infrastructure (`infra/cloudflare/`) uses [Terraform Cloud](https://app.terraform.io) for remote state with locking and encryption. Workspaces provide state isolation per environment, each with its own `tfvars` file and feature toggles:
 
 ```bash
 terraform workspace select prod

--- a/infra/aws-legacy/README.md
+++ b/infra/aws-legacy/README.md
@@ -1,4 +1,6 @@
-# OPUSPOPULI AWS Infrastructure
+# OPUSPOPULI AWS Infrastructure (Deprecated)
+
+> **Note:** This infrastructure is deprecated and preserved for reference only. The active infrastructure uses Cloudflare — see [`infra/cloudflare/`](../cloudflare/). Terraform state for the active stack is managed via [Terraform Cloud](https://app.terraform.io).
 
 Simple, cost-effective AWS infrastructure for running Opus Populi with self-hosted AI services.
 
@@ -56,54 +58,9 @@ aws ec2 create-key-pair \
 chmod 400 opuspopuli-key.pem
 ```
 
-## Remote State Management (Recommended)
+## Remote State Management
 
-For team collaboration and disaster recovery, migrate Terraform state to S3.
-
-### 1. Create State Backend
-
-```bash
-cd backend-bootstrap
-
-# Initialize and apply
-terraform init
-terraform apply
-
-# Note the output values (bucket name, etc.)
-```
-
-### 2. Enable Remote State
-
-Edit `main.tf` and uncomment the backend block:
-
-```hcl
-terraform {
-  backend "s3" {
-    bucket         = "opuspopuli-terraform-state-ACCOUNT_ID"  # From bootstrap output
-    key            = "env/dev/terraform.tfstate"
-    region         = "us-east-1"
-    encrypt        = true
-    dynamodb_table = "opuspopuli-terraform-locks"
-  }
-  # ...
-}
-```
-
-### 3. Migrate State
-
-```bash
-cd ..  # Back to infra/
-terraform init -migrate-state
-```
-
-When prompted, type `yes` to migrate the state.
-
-### Benefits
-
-- **Team collaboration**: Multiple developers can work safely
-- **State locking**: DynamoDB prevents concurrent modifications
-- **Versioning**: S3 versioning enables state recovery
-- **Security**: Encryption at rest and in transit
+> **Deprecated:** The S3 + DynamoDB remote state backend described here is no longer used. The active Cloudflare infrastructure uses [Terraform Cloud](https://app.terraform.io) for remote state with locking and encryption. See [`infra/cloudflare/README.md`](../cloudflare/README.md) for setup instructions.
 
 ---
 
@@ -445,4 +402,4 @@ sudo certbot renew --force-renewal
 | `Makefile` | Convenience commands |
 | `scripts/app-server.sh` | App server bootstrap script |
 | `scripts/gpu-server.sh` | GPU server bootstrap script |
-| `backend-bootstrap/` | S3 + DynamoDB for remote state |
+| `backend-bootstrap/` | S3 + DynamoDB for remote state (deprecated — see `infra/cloudflare/`) |

--- a/infra/aws-legacy/main.tf
+++ b/infra/aws-legacy/main.tf
@@ -28,22 +28,8 @@
 terraform {
   required_version = ">= 1.0"
 
-  # ---------------------------------------------------------------------------
-  # Remote State Backend (S3 + DynamoDB)
-  # ---------------------------------------------------------------------------
-  # To enable remote state:
-  #   1. cd backend-bootstrap && terraform init && terraform apply
-  #   2. Uncomment the backend block below
-  #   3. Replace ACCOUNT_ID with your AWS account ID from bootstrap output
-  #   4. Run: terraform init -migrate-state
-  # ---------------------------------------------------------------------------
-  # backend "s3" {
-  #   bucket         = "opuspopuli-terraform-state-ACCOUNT_ID"
-  #   key            = "env/dev/terraform.tfstate"
-  #   region         = "us-east-1"
-  #   encrypt        = true
-  #   dynamodb_table = "opuspopuli-terraform-locks"
-  # }
+  # NOTE: This AWS infrastructure is deprecated. Remote state for the active
+  # Cloudflare infrastructure uses Terraform Cloud — see infra/cloudflare/.
 
   required_providers {
     aws = {

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -23,6 +23,7 @@ The dev environment creates no cloud resources — everything runs locally via `
    - Account > Cloudflare Tunnel > Edit
    - Account > R2 > Edit (prod only)
 4. **Terraform** >= 1.0 installed
+5. **Terraform Cloud account** (free tier — up to 500 managed resources)
 
 ### Gather Your IDs
 
@@ -30,27 +31,43 @@ From the Cloudflare dashboard:
 - **Account ID**: Overview page (right sidebar)
 - **Zone ID**: Domain overview page (right sidebar)
 
+## Terraform Cloud Setup
+
+State is stored remotely in [Terraform Cloud](https://app.terraform.io) with locking, encryption, and run history. No AWS resources required.
+
+```bash
+# 1. Create a free Terraform Cloud account at https://app.terraform.io
+# 2. Create an organization named "opuspopuli"
+# 3. Log in from CLI
+terraform login
+
+# 4. Initialize — this migrates local state to Terraform Cloud
+cd infra/cloudflare
+terraform init
+```
+
+In Terraform Cloud, create workspaces tagged with `opuspopuli` and `cloudflare` for each environment (e.g., `opuspopuli-prod`, `opuspopuli-uat`). Set variables in each workspace:
+
+| Variable | Category | Sensitive |
+|----------|----------|-----------|
+| `cloudflare_api_token` | Terraform | Yes |
+| `cloudflare_account_id` | Terraform | No |
+| `cloudflare_zone_id` | Terraform | No |
+| `domain_name` | Terraform | No |
+
 ## Quick Start
 
 ```bash
 cd infra/cloudflare
 
-# Initialize Terraform
+# Initialize (connects to Terraform Cloud)
 terraform init
 
-# Create and select a workspace
-terraform workspace new prod        # or: uat, dev
-terraform workspace select prod
-
 # Apply with environment-specific variables
-terraform apply -var-file=environments/prod.tfvars \
-  -var="cloudflare_api_token=YOUR_TOKEN" \
-  -var="cloudflare_account_id=YOUR_ACCOUNT_ID" \
-  -var="cloudflare_zone_id=YOUR_ZONE_ID" \
-  -var="domain_name=yourdomain.org"
+terraform apply -var-file=environments/prod.tfvars
 ```
 
-> **Tip:** Store sensitive variables in a `terraform.tfvars` file (gitignored) or use environment variables (`TF_VAR_cloudflare_api_token`).
+> **Tip:** Sensitive variables (API tokens) should be set in Terraform Cloud workspace settings rather than passed on the command line or stored in local files.
 
 ## Environments
 
@@ -114,7 +131,7 @@ docker compose -f docker-compose-prod.yml up -d --build
 
 ```
 infra/cloudflare/
-├── main.tf          # Provider config, workspace-aware naming
+├── main.tf          # Provider config, Terraform Cloud backend, workspace-aware naming
 ├── variables.tf     # Input variables
 ├── outputs.tf       # Tunnel token, URLs, next steps
 ├── tunnel.tf        # Cloudflare Tunnel + ingress rules

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -21,6 +21,29 @@
 terraform {
   required_version = ">= 1.0"
 
+  # ---------------------------------------------------------------------------
+  # Remote State — Terraform Cloud (free tier)
+  # ---------------------------------------------------------------------------
+  # Provides remote state storage, locking, encryption, and run history.
+  # No AWS resources required.
+  #
+  # Setup:
+  #   1. Create a Terraform Cloud account at https://app.terraform.io
+  #   2. Create an organization (e.g., "opuspopuli")
+  #   3. Run: terraform login
+  #   4. Run: terraform init   (migrates local state to Terraform Cloud)
+  #
+  # Workspace mapping uses Terraform workspaces (dev, uat, prod) mapped to
+  # Terraform Cloud workspaces prefixed with "opuspopuli-".
+  # ---------------------------------------------------------------------------
+  cloud {
+    organization = "opuspopuli"
+
+    workspaces {
+      tags = ["opuspopuli", "cloudflare"]
+    }
+  }
+
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"


### PR DESCRIPTION
## Summary
- **Terraform Cloud remote state (#462)**: Replace local-only Terraform state with Terraform Cloud backend (free tier) for remote storage, locking, and encryption. Remove deprecated S3/DynamoDB references from aws-legacy. Update all related documentation.

## Test plan
- [ ] CI passes on this PR
- [ ] Terraform Cloud backend verified working (plan ran successfully against Cloudflare)

🤖 Generated with [Claude Code](https://claude.com/claude-code)