### PR TITLE
fix: FEC API field mapping and party normalization (#528)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,7 +76,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.7",
+    "@opuspopuli/regions": "^1.0.10",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -216,6 +216,8 @@ export interface ApiSourceConfig {
   resultsPath?: string;
   /** Static query parameters appended to every request */
   queryParams?: Record<string, string>;
+  /** Field name mappings: API response field → domain model field (e.g., "committee_id" → "committeeId") */
+  fieldMappings?: Record<string, string>;
 }
 
 /**

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.7"
+    "@opuspopuli/regions": "^1.0.10"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/scraping-pipeline/__tests__/api-ingest.handler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/api-ingest.handler.spec.ts
@@ -411,6 +411,124 @@ describe("ApiIngestHandler", () => {
     });
   });
 
+  describe("execute — field remapping", () => {
+    it("should remap API response fields using fieldMappings", async () => {
+      const items = [
+        {
+          committee_id: "C00123",
+          contributor_name: "Jane Doe",
+          contribution_receipt_amount: 500,
+          sub_id: "12345",
+        },
+      ];
+
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: items }),
+      );
+
+      const source = createSource({
+        category: "FEC Contributions",
+        api: {
+          resultsPath: "results",
+          fieldMappings: {
+            committee_id: "committeeId",
+            contributor_name: "donorName",
+            contribution_receipt_amount: "amount",
+            sub_id: "externalId",
+          },
+        },
+      });
+
+      await handler.execute(source, "federal");
+
+      const rawResult = mapper.map.mock.calls[0][0];
+      expect(rawResult.items[0]).toMatchObject({
+        committeeId: "C00123",
+        donorName: "Jane Doe",
+        amount: 500,
+        externalId: "12345",
+      });
+      // Original keys should be removed
+      expect(rawResult.items[0].committee_id).toBeUndefined();
+      expect(rawResult.items[0].contributor_name).toBeUndefined();
+    });
+
+    it("should not remap when fieldMappings is not configured", async () => {
+      const items = [{ committee_id: "C00123" }];
+
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: items }),
+      );
+
+      await handler.execute(createSource(), "federal");
+
+      const rawResult = mapper.map.mock.calls[0][0];
+      expect(rawResult.items[0].committee_id).toBe("C00123");
+    });
+
+    it("should skip remapping for keys not present in the record", async () => {
+      const items = [{ name: "Test" }];
+
+      (global.fetch as jest.Mock).mockResolvedValue(
+        mockFetchResponse({ results: items }),
+      );
+
+      const source = createSource({
+        api: {
+          resultsPath: "results",
+          fieldMappings: { nonexistent_field: "mapped" },
+        },
+      });
+
+      await handler.execute(source, "federal");
+
+      const rawResult = mapper.map.mock.calls[0][0];
+      expect(rawResult.items[0]).toEqual({ name: "Test" });
+    });
+  });
+
+  describe("execute — cursor pagination with all last_indexes", () => {
+    it("should send all cursor values from last_indexes on next page", async () => {
+      const page1 = [{ id: "1" }];
+
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            results: page1,
+            pagination: {
+              last_indexes: {
+                last_index: "abc123",
+                last_contribution_receipt_date: "2025-01-01",
+                sort_null_only: "true",
+              },
+            },
+          }),
+        )
+        .mockResolvedValueOnce(
+          mockFetchResponse({
+            results: [],
+          }),
+        );
+
+      const source = createSource({
+        api: {
+          resultsPath: "results",
+          pagination: { type: "cursor", limit: 100 },
+        },
+      });
+
+      await handler.execute(source, "federal");
+
+      // Second fetch should include all cursor params
+      const secondUrl = new URL((global.fetch as jest.Mock).mock.calls[1][0]);
+      expect(secondUrl.searchParams.get("last_index")).toBe("abc123");
+      expect(secondUrl.searchParams.get("last_contribution_receipt_date")).toBe(
+        "2025-01-01",
+      );
+      expect(secondUrl.searchParams.get("sort_null_only")).toBe("true");
+    });
+  });
+
   describe("execute — network error", () => {
     it("should return error result when fetch throws", async () => {
       (global.fetch as jest.Mock).mockRejectedValue(

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -184,8 +184,39 @@ describe("DomainMapperService", () => {
         externalId: "ca-assembly-30",
         name: "Jane Doe",
         district: "District 30",
-        party: "Democrat",
+        party: "Democratic",
       });
+    });
+
+    it("should normalize party abbreviations", () => {
+      const testCases = [
+        { input: "(D)", expected: "Democratic" },
+        { input: "(R)", expected: "Republican" },
+        { input: "D", expected: "Democratic" },
+        { input: "R", expected: "Republican" },
+        { input: "Democrat", expected: "Democratic" },
+        { input: "Republican", expected: "Republican" },
+        { input: "Independent", expected: "Independent" },
+        { input: "I", expected: "Independent" },
+        { input: "Green", expected: "Green" },
+      ];
+
+      for (const { input, expected } of testCases) {
+        const result = mapper.map(
+          createRawResult({
+            items: [
+              {
+                externalId: "test-1",
+                name: "Test Rep",
+                district: "1",
+                party: input,
+              },
+            ],
+          }),
+          createSource({ dataType: DataType.REPRESENTATIVES }),
+        );
+        expect(result.items[0]).toMatchObject({ party: expected });
+      }
     });
 
     it("should inject category as chamber", () => {

--- a/packages/scraping-pipeline/src/handlers/api-ingest.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/api-ingest.handler.ts
@@ -21,8 +21,8 @@ import { DomainMapperService } from "../mapping/domain-mapper.service.js";
 /** Maximum pages to fetch in a single pipeline run (safety limit) */
 const MAX_PAGES = 10;
 
-/** Request timeout in milliseconds */
-const REQUEST_TIMEOUT_MS = 60_000;
+/** Request timeout in milliseconds (FEC API can take 1-40s per page) */
+const REQUEST_TIMEOUT_MS = 120_000;
 
 /** Delay between paginated requests in milliseconds */
 const PAGE_DELAY_MS = 250;
@@ -58,7 +58,14 @@ export class ApiIngestHandler {
         `Fetched ${allItems.length} items from API ${source.url}`,
       );
 
-      // 3. Inject sourceSystem based on category
+      // 3. Remap field names (e.g., FEC snake_case → domain camelCase)
+      if (api.fieldMappings) {
+        for (const item of allItems) {
+          this.remapFields(item, api.fieldMappings);
+        }
+      }
+
+      // 4. Inject sourceSystem based on category
       const sourceSystem = this.inferSourceSystem(source);
       if (sourceSystem) {
         for (const item of allItems) {
@@ -359,6 +366,22 @@ export class ApiIngestHandler {
     }
     if (cat.includes("fec")) return "fec";
     return undefined;
+  }
+
+  /**
+   * Remap field names on a record using a mapping dictionary.
+   * Renames keys in-place (e.g., "committee_id" → "committeeId").
+   */
+  private remapFields(
+    record: Record<string, unknown>,
+    mappings: Record<string, string>,
+  ): void {
+    for (const [sourceKey, targetKey] of Object.entries(mappings)) {
+      if (sourceKey in record && sourceKey !== targetKey) {
+        record[targetKey] = record[sourceKey];
+        delete record[sourceKey];
+      }
+    }
   }
 
   private delay(ms: number): Promise<void> {

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -252,12 +252,22 @@ const MeetingSchema = z.object({
   videoUrl: z.string().url().optional(),
 });
 
+const partyTransform = (val: string | undefined) => {
+  if (!val) return "Unknown";
+  const cleaned = val.toUpperCase().replace(/[()]/g, "").trim();
+  if (cleaned === "D" || cleaned === "DEMOCRAT" || cleaned === "DEMOCRATIC")
+    return "Democratic";
+  if (cleaned === "R" || cleaned === "REPUBLICAN") return "Republican";
+  if (cleaned === "I" || cleaned === "INDEPENDENT") return "Independent";
+  return val;
+};
+
 const RepresentativeSchema = z.object({
   externalId: z.string().min(1),
   name: z.string().min(1),
   chamber: z.string().default("Unknown"),
   district: z.string().default("Unknown"),
-  party: z.string().default("Unknown"),
+  party: z.string().transform(partyTransform).default("Unknown"),
   photoUrl: z.string().optional(),
   contactInfo: z
     .object({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,8 +153,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.0.10
+        version: 1.0.10
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -902,8 +902,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.7
-        version: 1.0.7
+        specifier: ^1.0.10
+        version: 1.0.10
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4766,8 +4766,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.7':
-    resolution: {integrity: sha512-t0m0zyMLhlNeIgCeK6ZFpDTWYhnIBUR5Vj9s/BGWHsS14W12X4nbNJ79W+OnPbPWMBD0fkt/b0c/FZGNNBxcRA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.7/c0344f445852347c8a4f15c4a4538ed57e2be71b}
+  '@opuspopuli/regions@1.0.10':
+    resolution: {integrity: sha512-J0oMgy+wOS4GAYZCI7vdBw4s8+lkii+4+zlKTcABhKLpGqUxSaHmdLvcdAPAl0CDLhsTVF3b5+JrtlR508z8iQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.10/75fae8b90ab98b5bdbd462b69dfd37a4002debf7}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -16418,7 +16418,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.7': {}
+  '@opuspopuli/regions@1.0.10': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:


### PR DESCRIPTION
## Summary
- Add `fieldMappings` to `ApiSourceConfig` for API response → domain model field remapping
- `ApiIngestHandler` applies field remapping before domain mapper
- Increase FEC API timeout from 60s to 120s
- Add `partyTransform` to `RepresentativeSchema`: `(D)` → `Democratic`, `(R)` → `Republican`
- Updated `@opuspopuli/regions` package with FEC field mappings and schema

## Test plan
- [x] All 193 scraping-pipeline tests pass
- [x] All 1,290 backend tests pass
- [x] `pnpm audit --audit-level=high` clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)