### PR TITLE
feat: URL redirect detection in extraction provider (#525)

### DIFF
--- a/packages/extraction-provider/__tests__/extraction.provider.spec.ts
+++ b/packages/extraction-provider/__tests__/extraction.provider.spec.ts
@@ -107,6 +107,39 @@ describe("ExtractionProvider", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
+    it("should detect URL redirect and include redirect info in result", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "https://example.com/new-path",
+        text: () => Promise.resolve("<html>redirected</html>"),
+        headers: new Map([["content-type", "text/html"]]),
+      });
+
+      const result = await provider.fetchUrl("https://example.com/old-path");
+
+      expect(result.redirectedFrom).toBe("https://example.com/old-path");
+      expect(result.finalUrl).toBe("https://example.com/new-path");
+      expect(result.content).toBe("<html>redirected</html>");
+    });
+
+    it("should not set redirect fields when URL is unchanged", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "https://example.com",
+        text: () => Promise.resolve("content"),
+        headers: new Map([["content-type", "text/html"]]),
+      });
+
+      const result = await provider.fetchUrl("https://example.com");
+
+      expect(result.redirectedFrom).toBeUndefined();
+      expect(result.finalUrl).toBeUndefined();
+    });
+
     it("should throw FetchError on non-ok response", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,

--- a/packages/extraction-provider/src/extraction.provider.ts
+++ b/packages/extraction-provider/src/extraction.provider.ts
@@ -182,11 +182,22 @@ export class ExtractionProvider {
       const content = await response.text();
       const contentType = response.headers.get("content-type") || "unknown";
 
+      // Detect permanent redirects (fetch follows them automatically)
+      const finalUrl = response.url;
+      const wasRedirected = finalUrl && finalUrl !== url;
+
+      if (wasRedirected) {
+        this.logger.warn(
+          `URL redirect detected: ${url} → ${finalUrl}. Consider updating the data source config.`,
+        );
+      }
+
       const result: CachedFetchResult = {
         content,
         fromCache: false,
         statusCode: response.status,
         contentType,
+        ...(wasRedirected && { redirectedFrom: url, finalUrl }),
       };
 
       // Cache the result

--- a/packages/extraction-provider/src/types.ts
+++ b/packages/extraction-provider/src/types.ts
@@ -113,6 +113,10 @@ export interface CachedFetchResult {
   statusCode?: number;
   /** Content-Type header value */
   contentType?: string;
+  /** If the URL was permanently redirected, the original requested URL */
+  redirectedFrom?: string;
+  /** The final URL after any redirects (differs from original on redirect) */
+  finalUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Detect URL redirects after fetch by comparing `response.url` with original URL
- Log warning with old → new URL so operators can update config
- Include `redirectedFrom` and `finalUrl` in `CachedFetchResult`

## Test plan
- [x] All extraction-provider tests pass (106 including 2 new)
- [x] Full monorepo test suite passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)