### PR TITLE
feat: resolve API keys from Supabase Vault (#526)

### DIFF
--- a/apps/backend/src/apps/region/src/app.module.ts
+++ b/apps/backend/src/apps/region/src/app.module.ts
@@ -36,6 +36,7 @@ import { AuditModule } from 'src/common/audit/audit.module';
 import { CaslModule } from 'src/permissions/casl.module';
 import { HealthModule } from 'src/common/health';
 import { MetricsModule } from 'src/common/metrics';
+import { SecretsModule } from '@opuspopuli/secrets-provider';
 
 /**
  * Region App Module
@@ -68,6 +69,7 @@ import { MetricsModule } from 'src/common/metrics';
       context: ({ req, res }: { req: unknown; res: unknown }) => ({ req, res }),
     }),
     CaslModule.forRoot(),
+    SecretsModule,
     RegionDomainModule,
     HealthModule.forRoot({ serviceName: 'region-service', hasDatabase: true }),
     MetricsModule.forRoot({ serviceName: 'region-service' }),

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -1541,3 +1541,210 @@ describe('RegionDomainService — caching and batch transactions', () => {
     });
   });
 });
+
+describe('RegionDomainService — Vault API key resolution', () => {
+  // Test the resolveApiKeysFromVault logic by accessing the private method
+  // through the service instance. This avoids the complex onModuleInit flow.
+  it('should resolve API key from secrets provider when env var is not set', async () => {
+    const originalKey = process.env.FEC_API_KEY;
+    delete process.env.FEC_API_KEY;
+
+    const mockSecretsProvider = {
+      getSecret: jest.fn().mockResolvedValue('vault-fec-key'),
+      getSecrets: jest.fn(),
+      getName: jest.fn().mockReturnValue('MockSecretsProvider'),
+    };
+
+    const mockDb = createMockDbService();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegionDomainService,
+        {
+          provide: PluginLoaderService,
+          useValue: {
+            loadPlugin: jest.fn(),
+            loadFederalPlugin: jest.fn(),
+            unloadPlugin: jest.fn(),
+          },
+        },
+        {
+          provide: PluginRegistryService,
+          useValue: {
+            register: jest.fn(),
+            unregister: jest.fn(),
+            getActive: jest.fn(),
+            registerLocal: jest.fn(),
+            registerFederal: jest.fn(),
+            getLocal: jest.fn(),
+            getFederal: jest.fn(),
+            getAll: jest.fn().mockReturnValue([]),
+            getActiveName: jest.fn(),
+            hasActive: jest.fn(),
+            getHealth: jest.fn(),
+            getStatus: jest.fn(),
+            onModuleDestroy: jest.fn(),
+          },
+        },
+        { provide: DbService, useValue: mockDb },
+        {
+          provide: REGION_CACHE,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            delete: jest.fn(),
+            destroy: jest.fn(),
+            keys: jest.fn().mockResolvedValue([]),
+          },
+        },
+        { provide: 'SECRETS_PROVIDER', useValue: mockSecretsProvider },
+      ],
+    }).compile();
+
+    const service = module.get<RegionDomainService>(RegionDomainService);
+    // Call the private method directly
+    await (service as unknown as Record<string, () => Promise<void>>)[
+      'resolveApiKeysFromVault'
+    ]();
+
+    expect(mockSecretsProvider.getSecret).toHaveBeenCalledWith('FEC_API_KEY');
+    expect(process.env.FEC_API_KEY).toBe('vault-fec-key');
+
+    if (originalKey) process.env.FEC_API_KEY = originalKey;
+    else delete process.env.FEC_API_KEY;
+  });
+
+  it('should skip vault resolution when env var is already set', async () => {
+    const originalKey = process.env.FEC_API_KEY;
+    process.env.FEC_API_KEY = 'existing-key';
+
+    const mockSecretsProvider = {
+      getSecret: jest.fn(),
+      getSecrets: jest.fn(),
+      getName: jest.fn().mockReturnValue('MockSecretsProvider'),
+    };
+
+    const mockDb = createMockDbService();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegionDomainService,
+        {
+          provide: PluginLoaderService,
+          useValue: {
+            loadPlugin: jest.fn(),
+            loadFederalPlugin: jest.fn(),
+            unloadPlugin: jest.fn(),
+          },
+        },
+        {
+          provide: PluginRegistryService,
+          useValue: {
+            register: jest.fn(),
+            unregister: jest.fn(),
+            getActive: jest.fn(),
+            registerLocal: jest.fn(),
+            registerFederal: jest.fn(),
+            getLocal: jest.fn(),
+            getFederal: jest.fn(),
+            getAll: jest.fn().mockReturnValue([]),
+            getActiveName: jest.fn(),
+            hasActive: jest.fn(),
+            getHealth: jest.fn(),
+            getStatus: jest.fn(),
+            onModuleDestroy: jest.fn(),
+          },
+        },
+        { provide: DbService, useValue: mockDb },
+        {
+          provide: REGION_CACHE,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            delete: jest.fn(),
+            destroy: jest.fn(),
+            keys: jest.fn().mockResolvedValue([]),
+          },
+        },
+        { provide: 'SECRETS_PROVIDER', useValue: mockSecretsProvider },
+      ],
+    }).compile();
+
+    const service = module.get<RegionDomainService>(RegionDomainService);
+    await (service as unknown as Record<string, () => Promise<void>>)[
+      'resolveApiKeysFromVault'
+    ]();
+
+    expect(mockSecretsProvider.getSecret).not.toHaveBeenCalled();
+    expect(process.env.FEC_API_KEY).toBe('existing-key');
+
+    if (originalKey) process.env.FEC_API_KEY = originalKey;
+    else delete process.env.FEC_API_KEY;
+  });
+
+  it('should handle vault errors gracefully', async () => {
+    const originalKey = process.env.FEC_API_KEY;
+    delete process.env.FEC_API_KEY;
+
+    const mockSecretsProvider = {
+      getSecret: jest.fn().mockRejectedValue(new Error('Vault unavailable')),
+      getSecrets: jest.fn(),
+      getName: jest.fn().mockReturnValue('MockSecretsProvider'),
+    };
+
+    const mockDb = createMockDbService();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegionDomainService,
+        {
+          provide: PluginLoaderService,
+          useValue: {
+            loadPlugin: jest.fn(),
+            loadFederalPlugin: jest.fn(),
+            unloadPlugin: jest.fn(),
+          },
+        },
+        {
+          provide: PluginRegistryService,
+          useValue: {
+            register: jest.fn(),
+            unregister: jest.fn(),
+            getActive: jest.fn(),
+            registerLocal: jest.fn(),
+            registerFederal: jest.fn(),
+            getLocal: jest.fn(),
+            getFederal: jest.fn(),
+            getAll: jest.fn().mockReturnValue([]),
+            getActiveName: jest.fn(),
+            hasActive: jest.fn(),
+            getHealth: jest.fn(),
+            getStatus: jest.fn(),
+            onModuleDestroy: jest.fn(),
+          },
+        },
+        { provide: DbService, useValue: mockDb },
+        {
+          provide: REGION_CACHE,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            delete: jest.fn(),
+            destroy: jest.fn(),
+            keys: jest.fn().mockResolvedValue([]),
+          },
+        },
+        { provide: 'SECRETS_PROVIDER', useValue: mockSecretsProvider },
+      ],
+    }).compile();
+
+    const service = module.get<RegionDomainService>(RegionDomainService);
+    // Should NOT throw
+    await expect(
+      (service as unknown as Record<string, () => Promise<void>>)[
+        'resolveApiKeysFromVault'
+      ](),
+    ).resolves.not.toThrow();
+    expect(process.env.FEC_API_KEY).toBeUndefined();
+
+    if (originalKey) process.env.FEC_API_KEY = originalKey;
+    else delete process.env.FEC_API_KEY;
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -23,11 +23,13 @@ import {
   resolveConfigPlaceholders,
   batchTransaction,
   type ICache,
+  type ISecretsProvider,
   type Proposition,
   type Meeting,
   type Representative,
   type CampaignFinanceResult,
 } from '@opuspopuli/common';
+import { SECRETS_PROVIDER } from '@opuspopuli/secrets-provider';
 import { REGION_CACHE } from './region.tokens';
 
 /**
@@ -187,10 +189,42 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     @Optional()
     @Inject('SCRAPING_PIPELINE')
     private readonly pipeline?: IPipelineService,
+    @Optional()
+    @Inject(SECRETS_PROVIDER)
+    private readonly secretsProvider?: ISecretsProvider,
   ) {}
 
   async onModuleDestroy(): Promise<void> {
     await this.cache.destroy();
+  }
+
+  /**
+   * Resolve API keys from Supabase Vault and set as environment variables.
+   * Falls back silently to existing env vars if Vault is unavailable.
+   * This runs before plugin loading so API keys are available when
+   * the scraping pipeline's ApiIngestHandler reads process.env.
+   */
+  private async resolveApiKeysFromVault(): Promise<void> {
+    if (!this.secretsProvider) return;
+
+    const apiKeyNames = ['FEC_API_KEY'];
+
+    for (const keyName of apiKeyNames) {
+      // Skip if already set in environment
+      if (process.env[keyName]) continue;
+
+      try {
+        const secret = await this.secretsProvider.getSecret(keyName);
+        if (secret) {
+          process.env[keyName] = secret;
+          this.logger.log(`Resolved ${keyName} from secrets vault`);
+        }
+      } catch (error) {
+        this.logger.warn(
+          `Failed to resolve ${keyName} from vault: ${(error as Error).message}. Falling back to env var.`,
+        );
+      }
+    }
   }
 
   /**
@@ -201,6 +235,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
    * Falls back to ExampleRegionProvider if no local plugin is configured.
    */
   async onModuleInit(): Promise<void> {
+    await this.resolveApiKeysFromVault();
     await this.syncRegionConfigs();
 
     // Read the local config's stateCode for resolving federal config placeholders.

--- a/packages/secrets-provider/__tests__/supabase-vault.provider.spec.ts
+++ b/packages/secrets-provider/__tests__/supabase-vault.provider.spec.ts
@@ -3,14 +3,24 @@ import { ConfigService } from "@nestjs/config";
 import { SupabaseVaultProvider } from "../src/providers/supabase-vault.provider";
 import { SecretsError } from "@opuspopuli/common";
 
-// Mock the Supabase client
-const mockRpc = jest.fn();
+// Mock the Supabase client with chainable query builder
+let mockQueryResult: { data: any; error: any } = { data: [], error: null };
+
+const mockLimit = jest.fn().mockImplementation(() => mockQueryResult);
+const mockEq = jest.fn().mockImplementation(() => ({ limit: mockLimit }));
+const mockSelect = jest.fn().mockImplementation(() => ({ eq: mockEq }));
+const mockFrom = jest.fn().mockImplementation(() => ({ select: mockSelect }));
+const mockSchema = jest.fn().mockImplementation(() => ({ from: mockFrom }));
 
 jest.mock("@supabase/supabase-js", () => ({
   createClient: jest.fn().mockImplementation(() => ({
-    rpc: mockRpc,
+    schema: mockSchema,
   })),
 }));
+
+function setMockResult(data: any, error: any = null) {
+  mockQueryResult = { data, error };
+}
 
 describe("SupabaseVaultProvider", () => {
   let provider: SupabaseVaultProvider;
@@ -32,6 +42,9 @@ describe("SupabaseVaultProvider", () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Reset the chainable mock to use the shared mockQueryResult
+    mockLimit.mockImplementation(() => mockQueryResult);
+    setMockResult([], null);
     configService = createConfigService();
     provider = new SupabaseVaultProvider(configService);
   });
@@ -55,24 +68,19 @@ describe("SupabaseVaultProvider", () => {
 
   describe("getSecret", () => {
     it("should retrieve secret successfully", async () => {
-      mockRpc.mockResolvedValue({
-        data: [{ decrypted_secret: "my-secret-value" }],
-        error: null,
-      });
+      setMockResult([{ decrypted_secret: "my-secret-value" }]);
 
       const result = await provider.getSecret("my-secret-id");
 
       expect(result).toBe("my-secret-value");
-      expect(mockRpc).toHaveBeenCalledWith("vault_read_secret", {
-        secret_name: "my-secret-id",
-      });
+      expect(mockSchema).toHaveBeenCalledWith("vault");
+      expect(mockFrom).toHaveBeenCalledWith("decrypted_secrets");
+      expect(mockSelect).toHaveBeenCalledWith("decrypted_secret");
+      expect(mockEq).toHaveBeenCalledWith("name", "my-secret-id");
     });
 
     it("should return undefined when secret not found (empty array)", async () => {
-      mockRpc.mockResolvedValue({
-        data: [],
-        error: null,
-      });
+      setMockResult([]);
 
       const result = await provider.getSecret("nonexistent-secret");
 
@@ -80,20 +88,17 @@ describe("SupabaseVaultProvider", () => {
     });
 
     it("should return undefined when secret not found (null data)", async () => {
-      mockRpc.mockResolvedValue({
-        data: null,
-        error: null,
-      });
+      setMockResult(null);
 
       const result = await provider.getSecret("nonexistent-secret");
 
       expect(result).toBeUndefined();
     });
 
-    it("should return undefined when RPC function does not exist", async () => {
-      mockRpc.mockResolvedValue({
-        data: null,
-        error: { message: "function does not exist", code: "PGRST116" },
+    it("should return undefined when vault view does not exist", async () => {
+      setMockResult(null, {
+        message: "relation does not exist",
+        code: "PGRST116",
       });
 
       const result = await provider.getSecret("my-secret-id");
@@ -102,10 +107,7 @@ describe("SupabaseVaultProvider", () => {
     });
 
     it("should throw SecretsError on other errors", async () => {
-      mockRpc.mockResolvedValue({
-        data: null,
-        error: { message: "Database connection failed" },
-      });
+      setMockResult(null, { message: "Database connection failed" });
 
       await expect(provider.getSecret("my-secret-id")).rejects.toThrow(
         SecretsError,
@@ -115,15 +117,15 @@ describe("SupabaseVaultProvider", () => {
 
   describe("getSecrets", () => {
     it("should retrieve multiple secrets successfully", async () => {
-      mockRpc
-        .mockResolvedValueOnce({
-          data: [{ decrypted_secret: "value1" }],
-          error: null,
-        })
-        .mockResolvedValueOnce({
-          data: [{ decrypted_secret: "value2" }],
-          error: null,
-        });
+      const results = [
+        [{ decrypted_secret: "value1" }],
+        [{ decrypted_secret: "value2" }],
+      ];
+      let callCount = 0;
+      mockLimit.mockImplementation(() => ({
+        data: results[callCount++],
+        error: null,
+      }));
 
       const result = await provider.getSecrets(["secret1", "secret2"]);
 
@@ -134,15 +136,14 @@ describe("SupabaseVaultProvider", () => {
     });
 
     it("should handle mixed results with some failures", async () => {
-      mockRpc
-        .mockResolvedValueOnce({
-          data: [{ decrypted_secret: "value1" }],
-          error: null,
-        })
-        .mockResolvedValueOnce({
-          data: null,
-          error: { message: "Access denied" },
-        });
+      let callCount = 0;
+      mockLimit.mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return { data: [{ decrypted_secret: "value1" }], error: null };
+        }
+        return { data: null, error: { message: "Access denied" } };
+      });
 
       const result = await provider.getSecrets(["secret1", "secret2"]);
 
@@ -159,17 +160,14 @@ describe("SupabaseVaultProvider", () => {
 
   describe("getSecretJson", () => {
     it("should parse JSON secret successfully", async () => {
-      mockRpc.mockResolvedValue({
-        data: [
-          {
-            decrypted_secret: JSON.stringify({
-              username: "admin",
-              password: "secret",
-            }),
-          },
-        ],
-        error: null,
-      });
+      setMockResult([
+        {
+          decrypted_secret: JSON.stringify({
+            username: "admin",
+            password: "secret",
+          }),
+        },
+      ]);
 
       const result = await provider.getSecretJson<{
         username: string;
@@ -180,10 +178,7 @@ describe("SupabaseVaultProvider", () => {
     });
 
     it("should return undefined when secret not found", async () => {
-      mockRpc.mockResolvedValue({
-        data: [],
-        error: null,
-      });
+      setMockResult([]);
 
       const result = await provider.getSecretJson("nonexistent-secret");
 
@@ -191,10 +186,7 @@ describe("SupabaseVaultProvider", () => {
     });
 
     it("should throw SecretsError when JSON is invalid", async () => {
-      mockRpc.mockResolvedValue({
-        data: [{ decrypted_secret: "not-valid-json" }],
-        error: null,
-      });
+      setMockResult([{ decrypted_secret: "not-valid-json" }]);
 
       await expect(
         provider.getSecretJson("invalid-json-secret"),

--- a/packages/secrets-provider/src/providers/supabase-vault.provider.ts
+++ b/packages/secrets-provider/src/providers/supabase-vault.provider.ts
@@ -35,9 +35,12 @@ export async function getSecrets(
     },
   });
 
-  const { data, error } = await supabase.rpc("vault_read_secret", {
-    secret_name: secretName,
-  });
+  const { data, error } = await supabase
+    .schema("vault")
+    .from("decrypted_secrets")
+    .select("decrypted_secret")
+    .eq("name", secretName)
+    .limit(1);
 
   if (error) {
     throw new Error(
@@ -49,32 +52,19 @@ export async function getSecrets(
     throw new Error(`Secret not found: ${secretName}`);
   }
 
-  return data[0]?.decrypted_secret || "";
+  return (data[0] as { decrypted_secret: string })?.decrypted_secret || "";
 }
 
 /**
  * Supabase Vault Provider
  *
  * Implements secrets retrieval using Supabase Vault (pgsodium).
- * Used for Supabase Cloud deployments.
+ * Queries the `vault.decrypted_secrets` view directly via PostgREST.
  *
  * Prerequisites:
- * - Supabase project with Vault enabled
- * - Database function `vault_read_secret` to read from vault.decrypted_secrets
- *
- * SQL to create the function:
- * ```sql
- * CREATE OR REPLACE FUNCTION vault_read_secret(secret_name text)
- * RETURNS TABLE (decrypted_secret text)
- * LANGUAGE plpgsql SECURITY DEFINER AS $$
- * BEGIN
- *   RETURN QUERY
- *   SELECT vault.decrypted_secrets.decrypted_secret
- *   FROM vault.decrypted_secrets
- *   WHERE vault.decrypted_secrets.name = secret_name;
- * END;
- * $$;
- * ```
+ * - Supabase project with Vault enabled (pgsodium extension)
+ * - Secrets created via Supabase Studio or `vault.create_secret()`
+ * - PostgREST must expose the `vault` schema (default in self-hosted setups)
  */
 @Injectable()
 export class SupabaseVaultProvider implements ISecretsProvider {
@@ -116,13 +106,17 @@ export class SupabaseVaultProvider implements ISecretsProvider {
 
   async getSecret(secretId: string): Promise<string | undefined> {
     try {
-      // Call the database function to read from vault.decrypted_secrets
-      const { data, error } = await this.supabase.rpc("vault_read_secret", {
-        secret_name: secretId,
-      });
+      // Query the vault.decrypted_secrets view directly via PostgREST schema()
+      // This avoids needing a custom vault_read_secret() database function.
+      const { data, error } = await this.supabase
+        .schema("vault")
+        .from("decrypted_secrets")
+        .select("decrypted_secret")
+        .eq("name", secretId)
+        .limit(1);
 
       if (error) {
-        // Handle not found case
+        // Handle not found / permission errors
         if (
           error.message.includes("does not exist") ||
           error.code === "PGRST116"
@@ -133,14 +127,13 @@ export class SupabaseVaultProvider implements ISecretsProvider {
         throw error;
       }
 
-      // The RPC returns an array of rows
       if (!data || data.length === 0) {
         this.logger.warn(`Secret not found: ${secretId}`);
         return undefined;
       }
 
       this.logger.log(`Retrieved secret: ${secretId}`);
-      return data[0]?.decrypted_secret;
+      return (data[0] as { decrypted_secret: string })?.decrypted_secret;
     } catch (error) {
       this.logger.error(`Error retrieving secret: ${(error as Error).message}`);
       throw new SecretsError(


### PR DESCRIPTION
## Summary
- Region service resolves API keys from Supabase Vault on startup, falls back to env vars
- Supabase Vault provider updated to query `vault.decrypted_secrets` directly via PostgREST (no custom DB function needed)
- SecretsModule imported in region app module
- 3 new vault resolution tests

## Test plan
- [x] All backend tests pass (1,290 + 3 new vault tests)
- [x] All secrets-provider tests pass (28)
- [x] `pnpm audit --audit-level=high` clean
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)