### PR TITLE
feat: warm DB cache from successful remote prompt fetches (#524)

### DIFF
--- a/packages/prompt-client/__tests__/prompt-client.service.spec.ts
+++ b/packages/prompt-client/__tests__/prompt-client.service.spec.ts
@@ -24,6 +24,7 @@ describe("PromptClientService", () => {
     mockDb = {
       promptTemplate: {
         findFirst: jest.fn(),
+        upsert: jest.fn().mockResolvedValue({}),
       },
     };
 
@@ -497,6 +498,61 @@ describe("PromptClientService", () => {
       expect(health!.serviceName).toBe("PromptService");
       expect(health!.state).toBe("closed");
       expect(health!.isHealthy).toBe(true);
+    });
+
+    it("should warm DB cache on successful remote fetch", async () => {
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "remote prompt text",
+            promptHash: "abc123",
+            promptVersion: "v2",
+          }),
+      });
+
+      await remoteService.getRAGPrompt({ context: "test", query: "test" });
+
+      // Allow fire-and-forget warmDbCache to complete
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(mockDb.promptTemplate.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { name: "rag" },
+          create: expect.objectContaining({
+            name: "rag",
+            category: "rag",
+            templateText: "remote prompt text",
+          }),
+        }),
+      );
+
+      const metrics = remoteService.getMetrics();
+      expect(metrics.cacheWarms).toBe(1);
+    });
+
+    it("should not fail when DB cache warming fails", async () => {
+      mockDb.promptTemplate.upsert.mockRejectedValue(
+        new Error("DB write failed"),
+      );
+
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            promptText: "remote prompt",
+            promptHash: "abc",
+            promptVersion: "v1",
+          }),
+      });
+
+      // Should not throw despite DB upsert failure
+      const result = await remoteService.getRAGPrompt({
+        context: "test",
+        query: "test",
+      });
+
+      expect(result.promptText).toBe("remote prompt");
     });
   });
 

--- a/packages/prompt-client/src/metrics.ts
+++ b/packages/prompt-client/src/metrics.ts
@@ -19,6 +19,8 @@ export interface PromptClientMetrics {
   dbFallbacks: number;
   /** Requests that used hardcoded fallback templates */
   hardcodedFallbacks: number;
+  /** Successful DB cache warm operations (remote → DB sync) */
+  cacheWarms: number;
   /** Average remote call latency in ms (0 if no remote calls) */
   avgRemoteLatencyMs: number;
   /** Current circuit breaker state */
@@ -38,6 +40,7 @@ export class MetricsCollector {
   private remoteCalls = 0;
   private dbFallbacks = 0;
   private hardcodedFallbacks = 0;
+  private cacheWarms = 0;
   private totalRemoteLatencyMs = 0;
 
   recordCacheHit(): void {
@@ -61,6 +64,10 @@ export class MetricsCollector {
     this.hardcodedFallbacks++;
   }
 
+  recordCacheWarm(): void {
+    this.cacheWarms++;
+  }
+
   getMetrics(circuitBreakerState: string): PromptClientMetrics {
     return {
       totalRequests: this.totalRequests,
@@ -68,6 +75,7 @@ export class MetricsCollector {
       remoteCalls: this.remoteCalls,
       dbFallbacks: this.dbFallbacks,
       hardcodedFallbacks: this.hardcodedFallbacks,
+      cacheWarms: this.cacheWarms,
       avgRemoteLatencyMs:
         this.remoteCalls > 0
           ? Math.round(this.totalRemoteLatencyMs / this.remoteCalls)
@@ -88,6 +96,7 @@ export class MetricsCollector {
     this.remoteCalls = 0;
     this.dbFallbacks = 0;
     this.hardcodedFallbacks = 0;
+    this.cacheWarms = 0;
     this.totalRemoteLatencyMs = 0;
   }
 }

--- a/packages/prompt-client/src/prompt-client.service.ts
+++ b/packages/prompt-client/src/prompt-client.service.ts
@@ -386,12 +386,56 @@ export class PromptClientService implements OnModuleInit, OnModuleDestroy {
       );
 
       this.metrics.recordRemoteCall(Date.now() - startMs);
+
+      // Warm the DB cache so fallback has the latest prompt
+      this.warmDbCache(endpoint, result).catch(() => {});
+
       return result;
     } catch (error) {
       this.logger.warn(
         `Remote prompt service failed for ${endpoint}, falling back to DB: ${(error as Error).message}`,
       );
       return this.composeFromDb(endpoint, params);
+    }
+  }
+
+  /**
+   * Upsert a successful remote prompt response into the local DB.
+   * Keeps the DB cache warm so the fallback path always has the latest prompts.
+   * Fire-and-forget — failures are logged but don't affect the caller.
+   */
+  private async warmDbCache(
+    endpoint: string,
+    response: PromptServiceResponse,
+  ): Promise<void> {
+    const categoryMap: Record<string, string> = {
+      "structural-analysis": "structural_analysis",
+      "document-analysis": "document_analysis",
+      rag: "rag",
+    };
+    const category = categoryMap[endpoint] ?? "structural_analysis";
+
+    try {
+      await this.db.promptTemplate.upsert({
+        where: { name: endpoint },
+        update: {
+          templateText: response.promptText,
+          updatedAt: new Date(),
+        },
+        create: {
+          name: endpoint,
+          category: category as never,
+          templateText: response.promptText,
+          version: 1,
+          isActive: true,
+        },
+      });
+      this.metrics.recordCacheWarm();
+      this.logger.debug(`Warmed DB cache for template: ${endpoint}`);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to warm DB cache for ${endpoint}: ${(error as Error).message}`,
+      );
     }
   }
 


### PR DESCRIPTION
## Summary
- On successful remote prompt fetch, upsert response into local DB (fire-and-forget)
- Keeps fallback path warm with latest prompts when circuit breaker opens
- Add `cacheWarms` metric to track DB warm operations
- Non-fatal: DB write failures are logged but don't affect the caller

## Test plan
- [x] All 73 prompt-client tests pass (2 new cache warming tests)
- [x] All 1,293 backend tests pass
- [ ] CI pipeline passes

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)