### PR TITLE
feat: streaming bulk download handler to prevent OOM (#527)

### DIFF
--- a/packages/scraping-pipeline/__tests__/bulk-download.handler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/bulk-download.handler.spec.ts
@@ -1,5 +1,6 @@
 import { BulkDownloadHandler } from "../src/handlers/bulk-download.handler";
 import type { DomainMapperService } from "../src/mapping/domain-mapper.service";
+import { Readable } from "node:stream";
 import {
   DataType,
   type DataSourceConfig,
@@ -17,14 +18,7 @@ jest.mock("@nestjs/common", () => ({
   })),
 }));
 
-// Mock AdmZip
-const mockGetData = jest.fn();
-const mockGetEntries = jest.fn();
-jest.mock("adm-zip", () => {
-  return jest.fn().mockImplementation(() => ({
-    getEntries: mockGetEntries,
-  }));
-});
+// yauzl is NOT mocked — the ZIP integration tests use real yauzl extraction
 
 function createSource(
   overrides: Partial<DataSourceConfig> = {},
@@ -60,31 +54,39 @@ function createMockMapper(): jest.Mocked<DomainMapperService> {
 }
 
 /**
- * Convert a string to a clean ArrayBuffer.
- * Buffer.from(str).buffer returns the shared pool buffer which is too large,
- * so we need to slice it to the exact byte range.
+ * Create a mock fetch response with a readable stream body.
+ * The new handler uses response.body (stream) instead of arrayBuffer().
  */
-function toArrayBuffer(str: string): ArrayBuffer {
-  const buf = Buffer.from(str, "utf-8");
-  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+function mockStreamResponse(content: string, ok = true, status = 200) {
+  const stream = new Readable({
+    read() {
+      this.push(Buffer.from(content));
+      this.push(null);
+    },
+  });
+
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Not Found",
+    body: stream,
+  };
 }
 
 describe("BulkDownloadHandler", () => {
   let handler: BulkDownloadHandler;
   let mapper: jest.Mocked<DomainMapperService>;
-  let originalFetch: typeof global.fetch;
+  let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     mapper = createMockMapper();
     handler = new BulkDownloadHandler(mapper);
-    originalFetch = global.fetch;
-    global.fetch = jest.fn();
-    mockGetEntries.mockReset();
-    mockGetData.mockReset();
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = jest.fn();
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
+    globalThis.fetch = originalFetch;
   });
 
   describe("execute — successful CSV download", () => {
@@ -92,10 +94,9 @@ describe("BulkDownloadHandler", () => {
       const csvContent =
         "CMTE_ID,NAME,AMOUNT\nC001,Jane Doe,500\nC002,John Smith,1000";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(csvContent)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(csvContent),
+      );
 
       const result = await handler.execute(createSource(), "california");
 
@@ -103,7 +104,6 @@ describe("BulkDownloadHandler", () => {
       expect(result.items).toHaveLength(2);
       expect(mapper.map).toHaveBeenCalledTimes(1);
 
-      // Verify mapped field names
       const rawItems = mapper.map.mock.calls[0][0].items;
       expect(rawItems[0]).toMatchObject({
         committeeId: "C001",
@@ -120,7 +120,7 @@ describe("BulkDownloadHandler", () => {
 
   describe("execute — HTTP error", () => {
     it("should return success: false with error message", async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({
+      (globalThis.fetch as jest.Mock).mockResolvedValue({
         ok: false,
         status: 404,
         statusText: "Not Found",
@@ -135,125 +135,19 @@ describe("BulkDownloadHandler", () => {
     });
   });
 
-  describe("extractFromZip — file found by exact name", () => {
-    it("should extract file matching exact filePattern from ZIP", async () => {
-      const csvContent = "CMTE_ID|NAME|AMOUNT\nC001|Jane|500";
-
-      mockGetData.mockReturnValue(Buffer.from(csvContent));
-      mockGetEntries.mockReturnValue([
-        {
-          entryName: "itcont.txt",
-          isDirectory: false,
-          header: { size: csvContent.length },
-          getData: mockGetData,
-        },
-      ]);
-
-      (global.fetch as jest.Mock).mockResolvedValue({
+  describe("execute — no response body", () => {
+    it("should return error when response has no body", async () => {
+      (globalThis.fetch as jest.Mock).mockResolvedValue({
         ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer("zip")),
+        status: 200,
+        body: null,
       });
 
-      const source = createSource({
-        bulk: {
-          format: "zip_csv",
-          filePattern: "itcont.txt",
-          delimiter: "|",
-          columnMappings: { CMTE_ID: "committeeId" },
-        },
-      });
-
-      const result = await handler.execute(source, "california");
-
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe("extractFromZip — case-insensitive match", () => {
-    it("should find file by case-insensitive match", async () => {
-      const csvContent = "CMTE_ID\nC001";
-
-      mockGetData.mockReturnValue(Buffer.from(csvContent));
-      mockGetEntries.mockReturnValue([
-        {
-          entryName: "ITCONT.TXT",
-          isDirectory: false,
-          header: { size: csvContent.length },
-          getData: mockGetData,
-        },
-      ]);
-
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer("zip")),
-      });
-
-      const source = createSource({
-        bulk: {
-          format: "zip_csv",
-          filePattern: "itcont.txt",
-          columnMappings: { CMTE_ID: "committeeId" },
-        },
-      });
-
-      const result = await handler.execute(source, "california");
-
-      expect(result.success).toBe(true);
-    });
-  });
-
-  describe("extractFromZip — file not found", () => {
-    it("should return error when filePattern not found in ZIP", async () => {
-      mockGetEntries.mockReturnValue([
-        {
-          entryName: "other-file.csv",
-          isDirectory: false,
-        },
-      ]);
-
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer("zip")),
-      });
-
-      const source = createSource({
-        bulk: {
-          format: "zip_csv",
-          filePattern: "itcont.txt",
-          columnMappings: { CMTE_ID: "committeeId" },
-        },
-      });
-
-      const result = await handler.execute(source, "california");
+      const result = await handler.execute(createSource(), "california");
 
       expect(result.success).toBe(false);
       expect(result.errors).toEqual(
-        expect.arrayContaining([expect.stringContaining("not found in ZIP")]),
-      );
-    });
-  });
-
-  describe("extractFromZip — no filePattern for ZIP", () => {
-    it("should return error when no filePattern provided for ZIP format", async () => {
-      mockGetEntries.mockReturnValue([]);
-
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer("zip")),
-      });
-
-      const source = createSource({
-        bulk: {
-          format: "zip_csv",
-          columnMappings: { CMTE_ID: "committeeId" },
-        } as BulkDownloadConfig,
-      });
-
-      const result = await handler.execute(source, "california");
-
-      expect(result.success).toBe(false);
-      expect(result.errors).toEqual(
-        expect.arrayContaining([expect.stringContaining("filePattern")]),
+        expect.arrayContaining([expect.stringContaining("no body")]),
       );
     });
   });
@@ -262,10 +156,9 @@ describe("BulkDownloadHandler", () => {
     it("should parse pipe-delimited content and apply column mappings", async () => {
       const content = "CMTE_ID|NAME|STATE\nC001|Jane|CA\nC002|John|NY";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
       const source = createSource({
         bulk: {
@@ -296,10 +189,9 @@ describe("BulkDownloadHandler", () => {
       const content =
         "CMTE_ID,NAME,STATE\nC001,Jane,CA\nC002,John,NY\nC003,Bob,CA";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
       const source = createSource({
         bulk: {
@@ -325,10 +217,9 @@ describe("BulkDownloadHandler", () => {
     it("should skip empty lines in the content", async () => {
       const content = "CMTE_ID,NAME\nC001,Jane\n\n\nC002,John\n";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
       const source = createSource({
         bulk: {
@@ -348,10 +239,9 @@ describe("BulkDownloadHandler", () => {
     it("should use config delimiter when provided", async () => {
       const content = "CMTE_ID|NAME\nC001|Jane";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
       const source = createSource({
         bulk: {
@@ -370,10 +260,9 @@ describe("BulkDownloadHandler", () => {
     it("should default to tab for TSV format", async () => {
       const content = "CMTE_ID\tNAME\nC001\tJane";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
       const source = createSource({
         bulk: {
@@ -391,10 +280,9 @@ describe("BulkDownloadHandler", () => {
     it("should default to comma for CSV format", async () => {
       const content = "CMTE_ID,NAME\nC001,Jane";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
       const source = createSource({
         bulk: {
@@ -414,10 +302,9 @@ describe("BulkDownloadHandler", () => {
     it("should inject cal_access sourceSystem for cal-access category", async () => {
       const content = "CMTE_ID,NAME\nC001,Jane";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
       const source = createSource({
         category: "cal-access-contributions",
@@ -436,10 +323,9 @@ describe("BulkDownloadHandler", () => {
     it("should inject fec sourceSystem for FEC category", async () => {
       const content = "CMTE_ID,NAME\nC001,Jane";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
       const source = createSource({
         category: "fec-individual-contributions",
@@ -460,12 +346,10 @@ describe("BulkDownloadHandler", () => {
     it("should still parse available columns when some headers are missing", async () => {
       const content = "CMTE_ID,NAME\nC001,Jane";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
-      // Map a column that doesn't exist in the CSV
       const source = createSource({
         bulk: {
           format: "csv",
@@ -486,7 +370,7 @@ describe("BulkDownloadHandler", () => {
 
   describe("execute — network error", () => {
     it("should return error result when fetch throws", async () => {
-      (global.fetch as jest.Mock).mockRejectedValue(
+      (globalThis.fetch as jest.Mock).mockRejectedValue(
         new TypeError("Failed to fetch"),
       );
 
@@ -503,10 +387,9 @@ describe("BulkDownloadHandler", () => {
     it("should skip specified number of header lines", async () => {
       const content = "# Comment line\nCMTE_ID,NAME\nC001,Jane";
 
-      (global.fetch as jest.Mock).mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(content)),
-      });
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
 
       const source = createSource({
         bulk: {
@@ -521,6 +404,156 @@ describe("BulkDownloadHandler", () => {
       const rawItems = mapper.map.mock.calls[0][0].items;
       expect(rawItems).toHaveLength(1);
       expect(rawItems[0]).toMatchObject({ committeeId: "C001" });
+    });
+  });
+
+  describe("execute — ZIP without filePattern", () => {
+    it("should return error when no filePattern provided for ZIP format", async () => {
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse("dummy"),
+      );
+
+      const source = createSource({
+        bulk: {
+          format: "zip_csv",
+          columnMappings: { CMTE_ID: "committeeId" },
+        } as BulkDownloadConfig,
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining("filePattern")]),
+      );
+    });
+  });
+
+  describe("execute — real ZIP extraction (integration)", () => {
+    // These tests use adm-zip to create real ZIP test fixtures,
+    // then verify the streaming yauzl extraction path end-to-end.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const AdmZip = require("adm-zip");
+
+    function createZipStream(fileName: string, content: string): Readable {
+      const zip = new AdmZip();
+      zip.addFile(fileName, Buffer.from(content));
+      const zipBuffer = zip.toBuffer();
+
+      return new Readable({
+        read() {
+          this.push(zipBuffer);
+          this.push(null);
+        },
+      });
+    }
+
+    it("should extract and parse a CSV file from a real ZIP", async () => {
+      const csvContent = "CMTE_ID,NAME,AMOUNT\nC001,Jane,500\nC002,John,1000";
+
+      (globalThis.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: createZipStream("data.csv", csvContent),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "zip_csv",
+          filePattern: "data.csv",
+          columnMappings: {
+            CMTE_ID: "committeeId",
+            NAME: "donorName",
+            AMOUNT: "amount",
+          },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.success).toBe(true);
+      expect(result.items).toHaveLength(2);
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0]).toMatchObject({
+        committeeId: "C001",
+        donorName: "Jane",
+        amount: "500",
+      });
+    });
+
+    it("should find file by case-insensitive match in ZIP", async () => {
+      const csvContent = "CMTE_ID\nC001";
+
+      (globalThis.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: createZipStream("ITCONT.TXT", csvContent),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "zip_csv",
+          filePattern: "itcont.txt",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.success).toBe(true);
+    });
+
+    it("should return error when file not found in ZIP", async () => {
+      const csvContent = "CMTE_ID\nC001";
+
+      (globalThis.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: createZipStream("other-file.csv", csvContent),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "zip_csv",
+          filePattern: "itcont.txt",
+          columnMappings: { CMTE_ID: "committeeId" },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.stringContaining("not found in ZIP")]),
+      );
+    });
+
+    it("should parse pipe-delimited TSV from ZIP", async () => {
+      const tsvContent = "CMTE_ID|NAME\nC001|Jane";
+
+      (globalThis.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: createZipStream("data.tsv", tsvContent),
+      });
+
+      const source = createSource({
+        bulk: {
+          format: "zip_tsv",
+          filePattern: "data.tsv",
+          delimiter: "|",
+          columnMappings: { CMTE_ID: "committeeId", NAME: "donorName" },
+        },
+      });
+
+      const result = await handler.execute(source, "california");
+
+      expect(result.success).toBe(true);
+      const rawItems = mapper.map.mock.calls[0][0].items;
+      expect(rawItems[0]).toMatchObject({
+        committeeId: "C001",
+        donorName: "Jane",
+      });
     });
   });
 });

--- a/packages/scraping-pipeline/__tests__/pipeline.integration.spec.ts
+++ b/packages/scraping-pipeline/__tests__/pipeline.integration.spec.ts
@@ -108,12 +108,19 @@ function createSource(
 }
 
 // ==========================================
-// Helper to convert string to ArrayBuffer
+// Helper to create a mock streaming fetch response
 // ==========================================
 
-function toArrayBuffer(str: string): ArrayBuffer {
-  const buf = Buffer.from(str, "utf-8");
-  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+import { Readable } from "node:stream";
+
+function mockStreamResponse(content: string) {
+  const stream = new Readable({
+    read() {
+      this.push(Buffer.from(content));
+      this.push(null);
+    },
+  });
+  return { ok: true, status: 200, statusText: "OK", body: stream };
 }
 
 describe("Pipeline Integration Tests", () => {
@@ -246,10 +253,9 @@ describe("Pipeline Integration Tests", () => {
         "CONTRIB-002,C002,John Smith,1000.00,02/20/2025",
       ].join("\n");
 
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(csvContent)),
-      });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(mockStreamResponse(csvContent));
 
       const source = createSource({
         sourceType: "bulk_download",
@@ -291,10 +297,9 @@ describe("Pipeline Integration Tests", () => {
         "C-003,C003,Bob,CA,750,03/10/2025",
       ].join("\n");
 
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(csvContent)),
-      });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(mockStreamResponse(csvContent));
 
       const source = createSource({
         sourceType: "bulk_download",
@@ -329,10 +334,9 @@ describe("Pipeline Integration Tests", () => {
         "TSV-001\tC001\tJane\t500\t01/15/2025",
       ].join("\n");
 
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        arrayBuffer: jest.fn().mockResolvedValue(toArrayBuffer(tsvContent)),
-      });
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue(mockStreamResponse(tsvContent));
 
       const source = createSource({
         sourceType: "bulk_download",

--- a/packages/scraping-pipeline/package.json
+++ b/packages/scraping-pipeline/package.json
@@ -30,12 +30,13 @@
     "@opuspopuli/prompt-client": "workspace:*",
     "adm-zip": "^0.5.16",
     "cheerio": "^1.1.2",
+    "yauzl": "^3.3.0",
     "zod": "^3.23.0"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",
-    "@opuspopuli/llm-provider": "workspace:*",
     "@opuspopuli/extraction-provider": "workspace:*",
+    "@opuspopuli/llm-provider": "workspace:*",
     "@opuspopuli/relationaldb-provider": "workspace:*"
   },
   "devDependencies": {
@@ -47,6 +48,7 @@
     "@types/adm-zip": "^0.5.7",
     "@types/jest": "^30.0.0",
     "@types/node": "^22.0.0",
+    "@types/yauzl": "^2.10.3",
     "domhandler": "^5.0.3",
     "jest": "^30.0.0",
     "reflect-metadata": "^0.2.2",

--- a/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
@@ -4,11 +4,25 @@
  * Downloads ZIP/CSV/TSV files, extracts target files from archives,
  * parses rows using column mappings, applies filters, and maps to domain types.
  *
+ * Uses streaming to avoid loading entire files into memory:
+ * - Downloads stream to a temp file on disk
+ * - Uses yauzl for streaming ZIP extraction (reads central directory from disk)
+ * - Parses lines one-at-a-time via readline
+ * - Cleans up temp file after processing
+ *
  * No AI analysis needed — the schema is defined declaratively in the config.
  */
 
 import { Injectable, Logger } from "@nestjs/common";
-import AdmZip from "adm-zip";
+import { createWriteStream, createReadStream } from "node:fs";
+import { unlink, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+import { createInterface } from "node:readline";
+import yauzl from "yauzl";
 import type {
   BulkDownloadConfig,
   DataSourceConfig,
@@ -16,6 +30,9 @@ import type {
   RawExtractionResult,
 } from "@opuspopuli/common";
 import { DomainMapperService } from "../mapping/domain-mapper.service.js";
+
+/** Download timeout: 10 minutes for very large files */
+const DOWNLOAD_TIMEOUT_MS = 600_000;
 
 @Injectable()
 export class BulkDownloadHandler {
@@ -31,36 +48,54 @@ export class BulkDownloadHandler {
     const bulk = source.bulk!;
     const warnings: string[] = [];
     const errors: string[] = [];
+    const tmpPath = join(tmpdir(), `opus-bulk-${randomUUID()}.tmp`);
 
     try {
-      // 1. Download the file
+      // 1. Stream download to temp file (no memory buffering)
       this.logger.log(`Downloading ${source.url}...`);
       const response = await fetch(source.url, {
-        signal: AbortSignal.timeout(300_000), // 5 min timeout for large files
+        signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
       });
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      const buffer = Buffer.from(await response.arrayBuffer());
+      if (!response.body) {
+        throw new Error("Response has no body");
+      }
+
+      // Convert web ReadableStream to Node Readable if needed
+      const bodyStream =
+        response.body instanceof Readable
+          ? response.body
+          : Readable.fromWeb(
+              response.body as import("node:stream/web").ReadableStream,
+            );
+
+      await pipeline(bodyStream, createWriteStream(tmpPath));
+
+      const fileSize = (await stat(tmpPath)).size;
       this.logger.log(
-        `Downloaded ${(buffer.length / 1024 / 1024).toFixed(1)}MB`,
+        `Downloaded ${(fileSize / 1024 / 1024).toFixed(1)}MB to temp file`,
       );
 
-      // 2. Get the target file content
-      let content: string;
+      // 2. Get a readable stream for the target content
+      let contentStream: Readable;
       const isZip = bulk.format.startsWith("zip_");
 
       if (isZip) {
-        content = this.extractFromZip(buffer, bulk);
+        contentStream = await this.extractZipEntryStream(tmpPath, bulk);
       } else {
-        content = buffer.toString("utf-8");
+        contentStream = createReadStream(tmpPath, { encoding: "utf-8" });
       }
 
-      // 3. Parse delimited rows and apply column mappings + filters
-      const delimiter = this.getDelimiter(bulk);
-      const rawRecords = this.parseDelimited(content, delimiter, bulk, source);
+      // 3. Parse delimited rows line-by-line (streaming)
+      const rawRecords = await this.parseDelimitedStream(
+        contentStream,
+        bulk,
+        source,
+      );
 
       this.logger.log(
         `Parsed ${rawRecords.length} records from ${bulk.filePattern ?? source.url}`,
@@ -87,46 +122,176 @@ export class BulkDownloadHandler {
         errors,
         extractionTimeMs: Date.now() - pipelineStart,
       };
+    } finally {
+      // Always clean up temp file
+      await unlink(tmpPath).catch(() => {});
     }
   }
 
+  /** Maximum uncompressed file size: 10GB (safety limit against zip bombs) */
+  private static readonly MAX_UNCOMPRESSED_SIZE = 10 * 1024 * 1024 * 1024;
+
   /**
-   * Extract a target file from a ZIP archive.
+   * Extract a target file from a ZIP archive as a readable stream.
+   * Uses yauzl for streaming extraction — reads central directory from disk,
+   * not memory. Only the decompressed entry is streamed.
+   *
+   * SECURITY: Validates entry names for path traversal and enforces a max
+   * uncompressed size to protect against zip bombs.
    */
-  private extractFromZip(buffer: Buffer, bulk: BulkDownloadConfig): string {
+  private extractZipEntryStream(
+    zipPath: string,
+    bulk: BulkDownloadConfig,
+  ): Promise<Readable> {
     const pattern = bulk.filePattern;
     if (!pattern) {
-      throw new Error("ZIP format requires filePattern in bulk config");
-    }
-
-    const zip = new AdmZip(buffer);
-    const entries = zip.getEntries();
-
-    // Find entry matching the file pattern (exact match or path suffix)
-    const entry = entries.find(
-      (e) =>
-        e.entryName === pattern ||
-        e.entryName.endsWith(`/${pattern}`) ||
-        e.entryName.toUpperCase() === pattern.toUpperCase(),
-    );
-
-    if (!entry) {
-      const available = entries
-        .filter((e) => !e.isDirectory)
-        .map((e) => e.entryName)
-        .slice(0, 20)
-        .join(", ");
-      throw new Error(
-        `File '${pattern}' not found in ZIP. Available: ${available}${entries.length > 20 ? "..." : ""}`,
+      return Promise.reject(
+        new Error("ZIP format requires filePattern in bulk config"),
       );
     }
 
-    const uncompressedSize = entry.header.size;
-    this.logger.log(
-      `Extracting ${entry.entryName} (${(uncompressedSize / 1024 / 1024).toFixed(1)}MB uncompressed)`,
-    );
+    return new Promise((resolve, reject) => {
+      // SECURITY: Archive expansion is safe here because:
+      // 1. lazyEntries: true prevents automatic iteration — we validate each entry
+      // 2. Path traversal check rejects entries containing ".." or starting with "/"
+      // 3. Zip bomb check rejects entries exceeding MAX_UNCOMPRESSED_SIZE (10GB)
+      // 4. Only a single whitelisted entry (matching filePattern) is extracted
+      yauzl.open(zipPath, { lazyEntries: true }, (err, zipfile) => {
+        // NOSONAR
+        if (err || !zipfile) {
+          reject(err ?? new Error("Failed to open ZIP"));
+          return;
+        }
 
-    return entry.getData().toString("utf-8");
+        zipfile.readEntry();
+
+        zipfile.on("entry", (entry) => {
+          const name = entry.fileName;
+
+          // SECURITY: Reject path traversal attempts (e.g., "../../../etc/passwd")
+          if (name.includes("..") || name.startsWith("/")) {
+            this.logger.warn(
+              `Skipping ZIP entry with suspicious path: ${name}`,
+            );
+            zipfile.readEntry();
+            return;
+          }
+
+          const matches =
+            name === pattern ||
+            name.endsWith(`/${pattern}`) ||
+            name.toUpperCase() === pattern.toUpperCase();
+
+          if (matches) {
+            // SECURITY: Reject entries that exceed max uncompressed size (zip bomb protection)
+            if (
+              entry.uncompressedSize > BulkDownloadHandler.MAX_UNCOMPRESSED_SIZE
+            ) {
+              reject(
+                new Error(
+                  `ZIP entry ${name} exceeds max size: ${(entry.uncompressedSize / 1024 / 1024 / 1024).toFixed(1)}GB`,
+                ),
+              );
+              return;
+            }
+
+            this.logger.log(
+              `Extracting ${name} (${(entry.uncompressedSize / 1024 / 1024).toFixed(1)}MB uncompressed)`,
+            );
+
+            zipfile.openReadStream(entry, (streamErr, readStream) => {
+              if (streamErr || !readStream) {
+                reject(streamErr ?? new Error("Failed to open entry stream"));
+                return;
+              }
+              readStream.on("end", () => zipfile.close());
+              resolve(readStream);
+            });
+          } else {
+            zipfile.readEntry();
+          }
+        });
+
+        zipfile.on("end", () => {
+          reject(new Error(`File '${pattern}' not found in ZIP archive`));
+        });
+
+        zipfile.on("error", reject);
+      });
+    });
+  }
+
+  /**
+   * Parse delimited content from a stream, line-by-line.
+   * Applies column mappings and filters without loading the entire file.
+   */
+  private async parseDelimitedStream(
+    stream: Readable,
+    bulk: BulkDownloadConfig,
+    source: DataSourceConfig,
+  ): Promise<Record<string, unknown>[]> {
+    const delimiter = this.getDelimiter(bulk);
+    const mappings = bulk.columnMappings;
+    const filters = bulk.filters ?? {};
+    const sourceSystem = this.inferSourceSystem(source);
+    const headerSkip = bulk.headerLines ?? 0;
+
+    const records: Record<string, unknown>[] = [];
+    let lineNum = 0;
+    let headers: string[] = [];
+    let colIndices: Record<string, number> = {};
+    let filterIndices: Record<string, number> = {};
+
+    const rl = createInterface({ input: stream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+      if (lineNum < headerSkip) {
+        lineNum++;
+        continue;
+      }
+
+      if (lineNum === headerSkip) {
+        // Parse header line
+        headers = line
+          .split(delimiter)
+          .map((h) => BulkDownloadHandler.stripQuotes(h));
+        colIndices = this.buildColumnIndices(headers, mappings);
+        filterIndices = this.buildColumnIndices(
+          headers,
+          filters as Record<string, string>,
+        );
+        lineNum++;
+        continue;
+      }
+
+      if (!line.trim()) {
+        lineNum++;
+        continue;
+      }
+
+      const values = line.split(delimiter);
+
+      if (!this.passesFilters(values, filters, filterIndices)) {
+        lineNum++;
+        continue;
+      }
+
+      const record = this.mapRow(values, mappings, colIndices);
+
+      if (sourceSystem && !record["sourceSystem"]) {
+        record["sourceSystem"] = sourceSystem;
+      }
+
+      const fieldCount = Object.keys(record).length;
+      const minFields = sourceSystem ? 2 : 1;
+      if (fieldCount >= minFields) {
+        records.push(record);
+      }
+
+      lineNum++;
+    }
+
+    return records;
   }
 
   /**
@@ -200,63 +365,6 @@ export class BulkDownloadHandler {
       if (val) record[targetField] = val;
     }
     return record;
-  }
-
-  /**
-   * Parse delimited text into records using column mappings.
-   * Applies filters to skip irrelevant rows.
-   */
-  private parseDelimited(
-    content: string,
-    delimiter: string,
-    bulk: BulkDownloadConfig,
-    source: DataSourceConfig,
-  ): Record<string, unknown>[] {
-    const lines = content.split("\n");
-    if (lines.length === 0) return [];
-
-    // Get header line (skip any leading header lines as configured)
-    const headerSkip = bulk.headerLines ?? 0;
-    const headerLine = lines[headerSkip];
-    if (!headerLine) return [];
-
-    const headers = headerLine
-      .split(delimiter)
-      .map((h) => BulkDownloadHandler.stripQuotes(h));
-
-    const mappings = bulk.columnMappings;
-    const filters = bulk.filters ?? {};
-    const colIndices = this.buildColumnIndices(headers, mappings);
-    const filterIndices = this.buildColumnIndices(
-      headers,
-      filters as Record<string, string>,
-    );
-    const sourceSystem = this.inferSourceSystem(source);
-
-    const records: Record<string, unknown>[] = [];
-
-    for (let i = headerSkip + 1; i < lines.length; i++) {
-      const line = lines[i];
-      if (!line?.trim()) continue;
-
-      const values = line.split(delimiter);
-
-      if (!this.passesFilters(values, filters, filterIndices)) continue;
-
-      const record = this.mapRow(values, mappings, colIndices);
-
-      if (sourceSystem && !record["sourceSystem"]) {
-        record["sourceSystem"] = sourceSystem;
-      }
-
-      const fieldCount = Object.keys(record).length;
-      const minFields = sourceSystem ? 2 : 1;
-      if (fieldCount >= minFields) {
-        records.push(record);
-      }
-    }
-
-    return records;
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -513,7 +513,7 @@ importers:
         version: 16.5.0
       jest:
         specifier: ^30.2.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       jest-axe:
         specifier: ^10.0.0
         version: 10.0.0
@@ -531,7 +531,7 @@ importers:
         version: 4.2.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.28.5))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.28.5))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -571,7 +571,7 @@ importers:
         version: 7.0.11
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -580,7 +580,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -648,7 +648,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -657,7 +657,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -688,7 +688,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -697,7 +697,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -737,7 +737,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -746,7 +746,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -771,7 +771,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -780,7 +780,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -839,7 +839,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -848,7 +848,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -876,10 +876,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -888,7 +888,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -916,7 +916,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -925,7 +925,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -953,10 +953,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       prisma:
         specifier: '5'
         version: 5.22.0
@@ -968,7 +968,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -987,6 +987,9 @@ importers:
       cheerio:
         specifier: ^1.1.2
         version: 1.2.0
+      yauzl:
+        specifier: ^3.3.0
+        version: 3.3.0
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -1015,12 +1018,15 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.15
+      '@types/yauzl':
+        specifier: ^2.10.3
+        version: 2.10.3
       domhandler:
         specifier: ^5.0.3
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1029,7 +1035,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1060,7 +1066,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1069,7 +1075,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1106,7 +1112,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1115,7 +1121,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1143,13 +1149,13 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -11803,6 +11809,10 @@ packages:
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
+  yauzl@3.3.0:
+    resolution: {integrity: sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==}
+    engines: {node: '>=12'}
+
   yn@3.1.1:
     resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
     engines: {node: '>=6'}
@@ -14507,7 +14517,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -14554,6 +14564,41 @@ snapshots:
       strip-ansi: 6.0.1
     transitivePeerDependencies:
       - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 25.5.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.3.0
+      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-haste-map: 30.3.0
+      jest-message-util: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-resolve-dependencies: 30.3.0
+      jest-runner: 30.3.0
+      jest-runtime: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      jest-watcher: 30.3.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
       - supports-color
       - ts-node
 
@@ -14611,7 +14656,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       jest-mock: 29.7.0
 
   '@jest/environment@30.3.0':
@@ -14651,7 +14696,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -14698,7 +14743,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -17495,7 +17540,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
   '@types/graphql-depth-limit@1.1.6':
     dependencies:
@@ -17673,7 +17718,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -17684,7 +17729,6 @@ snapshots:
   '@types/yauzl@2.10.3':
     dependencies:
       '@types/node': 25.5.0
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.49.0(@typescript-eslint/parser@8.49.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -18690,8 +18734,7 @@ snapshots:
     dependencies:
       node-int64: 0.4.0
 
-  buffer-crc32@0.2.13:
-    optional: true
+  buffer-crc32@0.2.13: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -21056,7 +21099,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -21121,34 +21164,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@22.19.15):
+  jest-cli@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.19.15)
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest-cli@30.3.0(@types/node@25.5.0):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -21209,7 +21233,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@22.19.15):
+  jest-config@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -21236,6 +21260,39 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.15
+      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.5.0
+      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21332,7 +21389,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -21352,7 +21409,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -21460,17 +21517,10 @@ snapshots:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
-  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3):
-    dependencies:
-      '@jest/globals': 30.3.0
-      jest: 30.3.0
-      ts-essentials: 10.1.1(typescript@5.9.3)
-      typescript: 5.9.3
-
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       jest-util: 29.7.0
 
   jest-mock@30.2.0:
@@ -21541,7 +21591,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -21596,7 +21646,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -21695,7 +21745,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -21741,7 +21791,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -21767,7 +21817,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.19.15
+      '@types/node': 25.5.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -21792,38 +21842,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.3.0:
+  jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@22.19.15):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.19.15)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.5.0):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)
+      jest-cli: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -23031,8 +23055,7 @@ snapshots:
 
   peberminta@0.9.0: {}
 
-  pend@1.2.0:
-    optional: true
+  pend@1.2.0: {}
 
   perfect-debounce@1.0.0:
     optional: true
@@ -24474,12 +24497,12 @@ snapshots:
 
   ts-graphviz@1.8.2: {}
 
-  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.28.5))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.28.5))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.5.0)
+      jest: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24514,12 +24537,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@22.19.15)
+      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24540,26 +24563,6 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
       jest: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.3
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      jest-util: 30.3.0
-
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.9
-      jest: 30.3.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -25251,6 +25254,11 @@ snapshots:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
     optional: true
+
+  yauzl@3.3.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
 
   yn@3.1.1: {}
 


### PR DESCRIPTION
## Summary
Replace in-memory buffering with streaming to prevent OOM on large files:
- Download streams to temp file via `pipeline()` (zero memory pressure)
- Use `yauzl` for streaming ZIP extraction (reads central directory from disk)
- Parse lines one-at-a-time via `readline.createInterface()`
- Always clean up temp file in `finally` block

Closes #527

## Test plan
- [x] All 205 scraping-pipeline tests pass (mocks updated for streaming)
- [x] All 1,293 backend tests pass
- [x] 87% coverage on handler (uncovered: yauzl callback code, tested live)
- [ ] CI pipeline passes
- [ ] Re-add bulk sources to configs and test with real ~1GB files

🤖 Generated with [Claude Code](https://claude.com/claude-code)