### PR TITLE
feat: detail page crawling for rich content extraction (#531)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,7 +76,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.10",
+    "@opuspopuli/regions": "^1.0.12",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/docs/guides/region-provider.md
+++ b/docs/guides/region-provider.md
@@ -47,6 +47,7 @@ The platform uses **declarative region plugins** — JSON configuration that des
 │  │   ├── api → ApiIngestHandler (paginated REST)                   │
 │  │   ├── bulk_download → BulkDownloadHandler (ZIP/CSV/TSV)         │
 │  │   └── pdf → PdfExtractHandler (text extraction + AI analysis)   │
+│  ├── DetailCrawlerService (fetches detail pages for rich content)    │
 │  ├── DomainMapperService (raw records → typed models)               │
 │  └── SelfHealingService (re-analyzes when extraction fails)         │
 │                                                                     │
@@ -427,6 +428,7 @@ The AI-powered scraping pipeline for web pages. Use for government websites with
 2. **Manifest Caching** — Manifests are versioned and stored in the database. Cached manifests are reused when the page structure hasn't changed
 3. **Cheerio Extraction** — The manifest's CSS selectors extract raw records from the HTML
 4. **Self-Healing** — If extraction fails (e.g., the website changed its layout), the pipeline re-analyzes and creates a new manifest version
+5. **Detail Crawling** (optional) — If items have a `detailUrl` field, the pipeline fetches each detail page to extract rich content (full text, bios, minutes). AI analyzes the first detail page and reuses rules for the rest. Failures are soft — listing data is preserved even if a detail page can't be fetched
 
 ### api
 
@@ -598,6 +600,7 @@ Region config files use a `version` field (semver) to track the config format. T
 | `1.0.0` | 0.1.0+ | Initial format: `regionId`, `dataSources`, `contentGoal`, `sourceType` (`html_scrape`, `api`, `bulk_download`) |
 | `1.1.0` | 0.1.0+ | Added `stateCode` for federal placeholder resolution, `category` field on data sources |
 | `1.2.0` | 0.1.0+ | Added `sourceType: "pdf"` with `PdfSourceConfig`, `TextExtractionRuleSet` types |
+| `1.3.0` | 0.1.0+ | Detail page crawling: items with `detailUrl` get rich content. Meeting `minutes`, Representative `bio` fields added |
 
 ### Required Fields (all versions)
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "overrides": {
       "tar": ">=7.5.11",
       "fast-xml-parser": ">=5.5.6",
-      "lodash": ">=4.17.23",
+      "lodash": ">=4.18.0",
       "langsmith": ">=0.4.6",
       "@apollo/gateway": ">=2.12.3",
       "@apollo/query-planner": ">=2.12.3",

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -72,6 +72,7 @@ export interface Meeting {
   location?: string;
   agendaUrl?: string;
   videoUrl?: string;
+  minutes?: string;
 }
 
 /**
@@ -85,6 +86,7 @@ export interface Representative {
   party: string;
   photoUrl?: string;
   contactInfo?: ContactInfo;
+  bio?: string;
 }
 
 // ============================================

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.10"
+    "@opuspopuli/regions": "^1.0.12"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -572,6 +572,7 @@ model Representative {
   party       String
   photoUrl    String?   @map("photo_url")
   contactInfo Json?     @map("contact_info")
+  bio         String?   @db.Text
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
@@ -638,6 +639,7 @@ model Meeting {
   location    String?
   agendaUrl   String?   @map("agenda_url")
   videoUrl    String?   @map("video_url")
+  minutes     String?   @db.Text
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz

--- a/packages/scraping-pipeline/__tests__/detail-crawler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/detail-crawler.spec.ts
@@ -1,0 +1,277 @@
+import { DetailCrawlerService } from "../src/crawling/detail-crawler.service";
+
+// Use type-only import — real ExtractionProvider needs NestJS DI
+type ExtractionProvider = {
+  fetchWithRetry: (
+    url: string,
+  ) => Promise<{ content: string; fromCache: boolean }>;
+};
+import {
+  DataType,
+  type DataSourceConfig,
+  type RawExtractionResult,
+  type ILLMProvider,
+} from "@opuspopuli/common";
+
+// Mock NestJS decorators
+jest.mock("@nestjs/common", () => ({
+  Injectable: () => (target: any) => target,
+  Optional: () => () => {},
+  Inject: () => () => {},
+  Logger: jest.fn().mockImplementation(() => ({
+    log: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  })),
+}));
+
+// Mock extraction provider module to avoid NestJS DI issues
+jest.mock("@opuspopuli/extraction-provider", () => ({
+  ExtractionProvider: jest.fn(),
+}));
+
+function createSource(
+  overrides: Partial<DataSourceConfig> = {},
+): DataSourceConfig {
+  return {
+    url: "https://example.com/propositions",
+    dataType: DataType.PROPOSITIONS,
+    contentGoal: "Extract ballot measures with full text",
+    ...overrides,
+  };
+}
+
+function createRawResult(
+  items: Record<string, unknown>[],
+): RawExtractionResult {
+  return {
+    items,
+    success: items.length > 0,
+    warnings: [],
+    errors: [],
+  };
+}
+
+function createMockExtraction(): jest.Mocked<ExtractionProvider> {
+  return {
+    fetchWithRetry: jest.fn().mockResolvedValue({
+      content:
+        "<html><body><main><p>Full bill text here about water policy reform.</p></main></body></html>",
+      fromCache: false,
+    }),
+  } as unknown as jest.Mocked<ExtractionProvider>;
+}
+
+function createMockLlm(): jest.Mocked<ILLMProvider> {
+  return {
+    generate: jest.fn().mockResolvedValue({
+      text: '["fullText"]',
+      tokensUsed: 50,
+    }),
+    getName: jest.fn().mockReturnValue("mock"),
+    getModelName: jest.fn().mockReturnValue("mock-model"),
+  } as unknown as jest.Mocked<ILLMProvider>;
+}
+
+describe("DetailCrawlerService", () => {
+  let crawler: DetailCrawlerService;
+  let mockExtraction: jest.Mocked<ExtractionProvider>;
+  let mockLlm: jest.Mocked<ILLMProvider>;
+
+  beforeEach(() => {
+    mockExtraction = createMockExtraction();
+    mockLlm = createMockLlm();
+    crawler = new DetailCrawlerService(mockExtraction as any);
+  });
+
+  describe("enrichItems", () => {
+    it("should fetch detail pages and merge content into items", async () => {
+      const rawResult = createRawResult([
+        {
+          externalId: "prop-1",
+          title: "Water Policy",
+          detailUrl: "https://example.com/prop/1",
+        },
+        {
+          externalId: "prop-2",
+          title: "Education Act",
+          detailUrl: "https://example.com/prop/2",
+        },
+      ]);
+
+      const result = await crawler.enrichItems(
+        rawResult,
+        createSource(),
+        mockLlm,
+      );
+
+      expect(result.items[0].fullText).toContain("Full bill text");
+      expect(result.items[1].fullText).toContain("Full bill text");
+      expect(mockExtraction.fetchWithRetry).toHaveBeenCalledTimes(2);
+      expect(mockLlm.generate).toHaveBeenCalledTimes(1); // AI called once only
+    });
+
+    it("should pass through items without detailUrl unchanged", async () => {
+      const rawResult = createRawResult([
+        { externalId: "prop-1", title: "No Detail Link" },
+      ]);
+
+      const result = await crawler.enrichItems(
+        rawResult,
+        createSource(),
+        mockLlm,
+      );
+
+      expect(result.items[0]).toEqual({
+        externalId: "prop-1",
+        title: "No Detail Link",
+      });
+      expect(mockExtraction.fetchWithRetry).not.toHaveBeenCalled();
+    });
+
+    it("should handle mixed items (some with detailUrl, some without)", async () => {
+      const rawResult = createRawResult([
+        {
+          externalId: "prop-1",
+          title: "Has Link",
+          detailUrl: "https://example.com/1",
+        },
+        { externalId: "prop-2", title: "No Link" },
+      ]);
+
+      const result = await crawler.enrichItems(
+        rawResult,
+        createSource(),
+        mockLlm,
+      );
+
+      expect(result.items[0].fullText).toBeDefined();
+      expect(result.items[1].fullText).toBeUndefined();
+    });
+
+    it("should handle detail page fetch failure gracefully (soft failure)", async () => {
+      mockExtraction.fetchWithRetry.mockRejectedValue(
+        new Error("Connection timeout"),
+      );
+
+      const rawResult = createRawResult([
+        {
+          externalId: "prop-1",
+          title: "Test",
+          detailUrl: "https://example.com/1",
+        },
+      ]);
+
+      const result = await crawler.enrichItems(
+        rawResult,
+        createSource(),
+        mockLlm,
+      );
+
+      // Item should still be present (with listing data only)
+      expect(result.items[0].externalId).toBe("prop-1");
+      expect(result.items[0].fullText).toBeUndefined();
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([expect.stringContaining("Connection timeout")]),
+      );
+    });
+
+    it("should use default content fields when AI derivation fails", async () => {
+      mockLlm.generate.mockRejectedValue(new Error("LLM unavailable"));
+
+      const rawResult = createRawResult([
+        {
+          externalId: "prop-1",
+          title: "Test",
+          detailUrl: "https://example.com/1",
+        },
+      ]);
+
+      const result = await crawler.enrichItems(
+        rawResult,
+        createSource(),
+        mockLlm,
+      );
+
+      // Should still extract using default fields
+      expect(result.items[0].fullText).toBeDefined();
+    });
+
+    it("should not overwrite existing item fields with detail content", async () => {
+      const rawResult = createRawResult([
+        {
+          externalId: "prop-1",
+          title: "Original Title",
+          fullText: "Already has full text",
+          detailUrl: "https://example.com/1",
+        },
+      ]);
+
+      const result = await crawler.enrichItems(
+        rawResult,
+        createSource(),
+        mockLlm,
+      );
+
+      // Existing fullText should NOT be overwritten
+      expect(result.items[0].fullText).toBe("Already has full text");
+    });
+
+    it("should warn when items exceed MAX_DETAIL_PAGES limit", async () => {
+      // Create 55 items — exceeds the 50 limit
+      const items = Array.from({ length: 55 }, (_, i) => ({
+        externalId: `prop-${i}`,
+        title: `Prop ${i}`,
+        detailUrl: `https://example.com/${i}`,
+      }));
+
+      const rawResult = createRawResult(items);
+
+      // Don't await the full run — just check the warning is added
+      const result = await crawler.enrichItems(
+        rawResult,
+        createSource(),
+        mockLlm,
+      );
+
+      expect(result.warnings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("Only enriching first 50"),
+        ]),
+      );
+    }, 60000);
+
+    it("should derive correct default fields per data type", async () => {
+      mockLlm.generate.mockRejectedValue(new Error("fail"));
+
+      // Test meetings
+      const meetingResult = createRawResult([
+        { externalId: "m-1", detailUrl: "https://example.com/m/1" },
+      ]);
+      await crawler.enrichItems(
+        meetingResult,
+        createSource({ dataType: DataType.MEETINGS }),
+        mockLlm,
+      );
+      expect(meetingResult.items[0].minutes).toBeDefined();
+
+      // Test representatives
+      mockExtraction.fetchWithRetry.mockResolvedValue({
+        content:
+          "<html><body><main><p>Bio content here.</p></main></body></html>",
+        fromCache: false,
+      } as any);
+
+      const repResult = createRawResult([
+        { externalId: "r-1", detailUrl: "https://example.com/r/1" },
+      ]);
+      await crawler.enrichItems(
+        repResult,
+        createSource({ dataType: DataType.REPRESENTATIVES }),
+        mockLlm,
+      );
+      expect(repResult.items[0].bio).toBeDefined();
+    });
+  });
+});

--- a/packages/scraping-pipeline/__tests__/pipeline.integration.spec.ts
+++ b/packages/scraping-pipeline/__tests__/pipeline.integration.spec.ts
@@ -182,6 +182,7 @@ describe("Pipeline Integration Tests", () => {
       bulkDownload,
       apiIngest,
       {} as any,
+      { enrichItems: jest.fn().mockImplementation((r: any) => r) } as any,
     );
   });
 

--- a/packages/scraping-pipeline/__tests__/pipeline.spec.ts
+++ b/packages/scraping-pipeline/__tests__/pipeline.spec.ts
@@ -134,6 +134,7 @@ describe("ScrapingPipelineService", () => {
       {} as unknown as BulkDownloadHandler,
       {} as unknown as ApiIngestHandler,
       {} as any,
+      { enrichItems: jest.fn().mockImplementation((r: any) => r) } as any,
     );
   });
 
@@ -315,6 +316,7 @@ describe("ScrapingPipelineService", () => {
         mockBulkDownload,
         mockApiIngest,
         {} as any,
+        { enrichItems: jest.fn().mockImplementation((r: any) => r) } as any,
       );
     });
 

--- a/packages/scraping-pipeline/src/crawling/detail-crawler.service.ts
+++ b/packages/scraping-pipeline/src/crawling/detail-crawler.service.ts
@@ -1,0 +1,231 @@
+/**
+ * Detail Crawler Service
+ *
+ * Enriches extracted listing items by fetching their detail pages
+ * and extracting rich content (full text, bios, minutes, etc.).
+ *
+ * Flow:
+ * 1. Filter items that have a `detailUrl` field
+ * 2. Fetch the first detail page to derive extraction rules (AI, one-time)
+ * 3. Apply the same rules to all remaining detail pages (deterministic)
+ * 4. Merge extracted content back into the listing items
+ *
+ * Key behaviors:
+ * - Soft failures: if a detail page fetch fails, the listing item is kept as-is
+ * - Rate limited: uses ExtractionProvider (already rate-limited + cached)
+ * - AI analysis once: all detail pages for a source share the same structure
+ */
+
+import { Injectable, Logger } from "@nestjs/common";
+import * as cheerio from "cheerio";
+import type {
+  DataSourceConfig,
+  RawExtractionResult,
+  ILLMProvider,
+} from "@opuspopuli/common";
+import { ExtractionProvider } from "@opuspopuli/extraction-provider";
+
+/** Maximum detail pages to fetch per sync run (safety limit) */
+const MAX_DETAIL_PAGES = 50;
+
+/** Delay between detail page fetches in milliseconds */
+const DETAIL_FETCH_DELAY_MS = 500;
+
+@Injectable()
+export class DetailCrawlerService {
+  private readonly logger = new Logger(DetailCrawlerService.name);
+
+  constructor(private readonly extraction: ExtractionProvider) {}
+
+  /**
+   * Enrich extracted items by fetching their detail pages.
+   * Items without a `detailUrl` field pass through unchanged.
+   *
+   * @param rawResult - Raw extraction result from the listing page
+   * @param source - Data source configuration (for hints, content goal)
+   * @param llm - LLM provider for AI content extraction
+   * @returns Enriched raw result with detail page content merged into items
+   */
+  async enrichItems(
+    rawResult: RawExtractionResult,
+    source: DataSourceConfig,
+    llm: ILLMProvider,
+  ): Promise<RawExtractionResult> {
+    const itemsWithDetail = rawResult.items.filter(
+      (item) => item.detailUrl && typeof item.detailUrl === "string",
+    );
+
+    if (itemsWithDetail.length === 0) {
+      return rawResult;
+    }
+
+    this.logger.log(
+      `Enriching ${itemsWithDetail.length} items with detail page content from ${source.url}`,
+    );
+
+    // Limit to prevent excessive fetching
+    const toFetch = itemsWithDetail.slice(0, MAX_DETAIL_PAGES);
+    if (itemsWithDetail.length > MAX_DETAIL_PAGES) {
+      rawResult.warnings.push(
+        `Only enriching first ${MAX_DETAIL_PAGES} of ${itemsWithDetail.length} items with detail pages`,
+      );
+    }
+
+    // Derive content extraction rules from the first detail page
+    let contentFields: string[] | null = null;
+
+    for (const item of toFetch) {
+      const detailUrl = item.detailUrl as string;
+
+      try {
+        const fetchResult = await this.extraction.fetchWithRetry(detailUrl);
+        const html = fetchResult.content;
+
+        // On first successful fetch, ask AI what content to extract
+        if (!contentFields) {
+          contentFields = await this.deriveContentFields(html, source, llm);
+          this.logger.log(
+            `AI derived ${contentFields.length} content fields from detail page`,
+          );
+        }
+
+        // Extract content from the detail page
+        const content = this.extractContent(html, contentFields);
+
+        // Merge extracted content into the listing item
+        for (const [key, value] of Object.entries(content)) {
+          if (value && !item[key]) {
+            item[key] = value;
+          }
+        }
+      } catch (error) {
+        // Soft failure — keep listing item, log warning
+        rawResult.warnings.push(
+          `Detail page fetch failed for ${detailUrl}: ${(error as Error).message}`,
+        );
+      }
+
+      // Rate limit between fetches
+      if (toFetch.indexOf(item) < toFetch.length - 1) {
+        await this.delay(DETAIL_FETCH_DELAY_MS);
+      }
+    }
+
+    return rawResult;
+  }
+
+  /**
+   * Ask the AI to identify which content fields to extract from a detail page.
+   * Returns field names that map to domain model fields (fullText, bio, minutes, etc.).
+   */
+  private async deriveContentFields(
+    html: string,
+    source: DataSourceConfig,
+    llm: ILLMProvider,
+  ): Promise<string[]> {
+    // Simplify HTML for the AI
+    const $ = cheerio.load(html);
+    $("script, style, noscript, svg, iframe, nav, footer, header").remove();
+    const simplified = $.text().replaceAll(/\s+/g, " ").trim();
+    const truncated =
+      simplified.length > 8000
+        ? simplified.slice(0, 8000) + "\n[... truncated ...]"
+        : simplified;
+
+    const prompt = `You are a civic data extraction specialist. Given a detail page from a government website, identify what content fields can be extracted.
+
+## Source Data Type
+${source.dataType}
+
+## Content Goal
+${source.contentGoal}
+
+## Page Text (simplified)
+${truncated}
+
+## Instructions
+Return a JSON array of field names to extract. Use these domain model field names:
+- For propositions: "fullText" (full bill/measure text), "summary" (brief description)
+- For meetings: "minutes" (meeting minutes/notes), "agendaItems" (list of agenda topics)
+- For representatives: "bio" (biography), "committees" (committee assignments)
+
+Only include fields where the page actually contains that content.
+Respond with ONLY a JSON array, no explanation. Example: ["fullText", "summary"]`;
+
+    try {
+      const result = await llm.generate(prompt, {
+        maxTokens: 256,
+        temperature: 0.1,
+      });
+
+      let json = result.text.trim();
+      if (json.startsWith("```")) {
+        json = json.replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "");
+      }
+
+      const fields = JSON.parse(json) as string[];
+      if (Array.isArray(fields) && fields.every((f) => typeof f === "string")) {
+        return fields;
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Failed to derive content fields from detail page: ${(error as Error).message}`,
+      );
+    }
+
+    // Fallback: extract common fields based on data type
+    return this.defaultContentFields(source.dataType);
+  }
+
+  /**
+   * Default content fields per data type when AI derivation fails.
+   */
+  private defaultContentFields(dataType: string): string[] {
+    switch (dataType) {
+      case "propositions":
+        return ["fullText"];
+      case "meetings":
+        return ["minutes"];
+      case "representatives":
+        return ["bio"];
+      default:
+        return ["fullText"];
+    }
+  }
+
+  /**
+   * Extract content from a detail page HTML.
+   * Uses a simple approach: extract the main text content from the page body.
+   */
+  private extractContent(
+    html: string,
+    fields: string[],
+  ): Record<string, string> {
+    const $ = cheerio.load(html);
+
+    // Remove non-content elements
+    $("script, style, noscript, svg, iframe, nav, footer, header").remove();
+
+    // Try to find the main content area
+    const mainContent =
+      $("main").text() ||
+      $("article").text() ||
+      $('[role="main"]').text() ||
+      $(".content, .main-content, #content, #main-content").text() ||
+      $("body").text();
+
+    const cleanedText = mainContent.replaceAll(/\s+/g, " ").trim();
+
+    // Assign the content to the first requested field
+    const result: Record<string, string> = {};
+    if (cleanedText && fields.length > 0) {
+      result[fields[0]] = cleanedText;
+    }
+
+    return result;
+  }
+
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+}

--- a/packages/scraping-pipeline/src/index.ts
+++ b/packages/scraping-pipeline/src/index.ts
@@ -41,6 +41,7 @@ export { BulkDownloadHandler } from "./handlers/bulk-download.handler.js";
 export { ApiIngestHandler } from "./handlers/api-ingest.handler.js";
 export { PdfExtractHandler } from "./handlers/pdf-extract.handler.js";
 export { TextExtractorService } from "./extraction/text-extractor.service.js";
+export { DetailCrawlerService } from "./crawling/detail-crawler.service.js";
 
 // Validation
 export { ConfigValidator } from "./validation/config-validator.js";

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -250,6 +250,7 @@ const MeetingSchema = z.object({
   location: z.string().optional(),
   agendaUrl: z.string().url().optional(),
   videoUrl: z.string().url().optional(),
+  minutes: z.string().optional(),
 });
 
 const partyTransform = (val: string | undefined) => {
@@ -277,6 +278,7 @@ const RepresentativeSchema = z.object({
       website: z.string().optional(),
     })
     .optional(),
+  bio: z.string().optional(),
 });
 
 // ============================================

--- a/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
+++ b/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
@@ -29,6 +29,7 @@ import { SelfHealingService } from "../healing/self-healing.service.js";
 import { BulkDownloadHandler } from "../handlers/bulk-download.handler.js";
 import { ApiIngestHandler } from "../handlers/api-ingest.handler.js";
 import { PdfExtractHandler } from "../handlers/pdf-extract.handler.js";
+import { DetailCrawlerService } from "../crawling/detail-crawler.service.js";
 
 @Injectable()
 export class ScrapingPipelineService {
@@ -45,6 +46,7 @@ export class ScrapingPipelineService {
     private readonly bulkDownload: BulkDownloadHandler,
     private readonly apiIngest: ApiIngestHandler,
     private readonly pdfExtract: PdfExtractHandler,
+    private readonly detailCrawler: DetailCrawlerService,
   ) {}
 
   /**
@@ -136,6 +138,15 @@ export class ScrapingPipelineService {
       // Original manifest worked — record success and update timestamps
       await this.manifestStore.incrementSuccess(manifest.id);
       await this.manifestStore.markChecked(manifest.id);
+    }
+
+    // Stage 3.5: Enrich items with detail page content (if detailUrl extracted)
+    if (rawResult.items.some((item) => item.detailUrl)) {
+      rawResult = await this.detailCrawler.enrichItems(
+        rawResult,
+        source,
+        this.llm,
+      );
     }
 
     // Stage 4: Map to domain types

--- a/packages/scraping-pipeline/src/scraping-pipeline.module.ts
+++ b/packages/scraping-pipeline/src/scraping-pipeline.module.ts
@@ -20,6 +20,7 @@ import { BulkDownloadHandler } from "./handlers/bulk-download.handler.js";
 import { ApiIngestHandler } from "./handlers/api-ingest.handler.js";
 import { PdfExtractHandler } from "./handlers/pdf-extract.handler.js";
 import { TextExtractorService } from "./extraction/text-extractor.service.js";
+import { DetailCrawlerService } from "./crawling/detail-crawler.service.js";
 
 export interface ScrapingPipelineModuleOptions {
   /** Modules that provide required tokens (LLM_PROVIDER, ExtractionProvider, etc.) */
@@ -65,6 +66,7 @@ export class ScrapingPipelineModule {
         ApiIngestHandler,
         PdfExtractHandler,
         TextExtractorService,
+        DetailCrawlerService,
         ScrapingPipelineService,
       ],
       exports: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   tar: '>=7.5.11'
   fast-xml-parser: '>=5.5.6'
-  lodash: '>=4.17.23'
+  lodash: '>=4.18.0'
   langsmith: '>=0.4.6'
   '@apollo/gateway': '>=2.12.3'
   '@apollo/query-planner': '>=2.12.3'
@@ -55,7 +55,7 @@ importers:
         version: 6.8.0
       '@langchain/community':
         specifier: ^1.1.22
-        version: 1.1.25(kuaxrguapag6ivdaf7n5sho5iu)
+        version: 1.1.25(ebju5z7hskaxpbcfp5vmul7h74)
       '@langchain/core':
         specifier: ^1.1.31
         version: 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))
@@ -153,8 +153,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.10
-        version: 1.0.10
+        specifier: ^1.0.12
+        version: 1.0.12
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -225,8 +225,8 @@ importers:
         specifier: ^3.1.0
         version: 3.2.2
       lodash:
-        specifier: '>=4.17.23'
-        version: 4.17.23
+        specifier: '>=4.18.0'
+        version: 4.18.1
       passport:
         specifier: ^0.7.0
         version: 0.7.0
@@ -513,7 +513,7 @@ importers:
         version: 16.5.0
       jest:
         specifier: ^30.2.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-axe:
         specifier: ^10.0.0
         version: 10.0.0
@@ -531,7 +531,7 @@ importers:
         version: 4.2.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.28.5))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.28.5))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -571,7 +571,7 @@ importers:
         version: 7.0.11
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -580,7 +580,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -648,7 +648,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -657,7 +657,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -688,7 +688,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -697,7 +697,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -737,7 +737,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -746,7 +746,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -771,7 +771,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -780,7 +780,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -839,7 +839,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -848,7 +848,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -876,10 +876,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -888,7 +888,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -902,8 +902,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.10
-        version: 1.0.10
+        specifier: ^1.0.12
+        version: 1.0.12
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -916,7 +916,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -925,7 +925,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -953,10 +953,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       prisma:
         specifier: '5'
         version: 5.22.0
@@ -968,7 +968,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1026,7 +1026,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1035,7 +1035,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1066,7 +1066,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1075,7 +1075,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1112,7 +1112,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1121,7 +1121,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1149,13 +1149,13 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -3428,7 +3428,7 @@ packages:
       it-all: ^3.0.4
       jsdom: '*'
       jsonwebtoken: ^9.0.3
-      lodash: '>=4.17.23'
+      lodash: '>=4.18.0'
       lunary: ^0.7.10
       mammoth: ^1.11.0
       mariadb: ^3.5.1
@@ -4772,8 +4772,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.10':
-    resolution: {integrity: sha512-J0oMgy+wOS4GAYZCI7vdBw4s8+lkii+4+zlKTcABhKLpGqUxSaHmdLvcdAPAl0CDLhsTVF3b5+JrtlR508z8iQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.10/75fae8b90ab98b5bdbd462b69dfd37a4002debf7}
+  '@opuspopuli/regions@1.0.12':
+    resolution: {integrity: sha512-ca5VCSVWWG74dvU8falsnj/1tGUyTLNPSWIpvrf1z/rP572EVmRy83MZjOAs8b1c3sm8wgXBVQuc3CMbYbBRUQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.12/dacf7db25166dc046bd6913f349c82d1ba47d791}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -6379,14 +6379,6 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  b4a@1.7.3:
-    resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
-    peerDependencies:
-      react-native-b4a: '*'
-    peerDependenciesMeta:
-      react-native-b4a:
-        optional: true
-
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
     peerDependencies:
@@ -6458,15 +6450,6 @@ packages:
       bare-abort-controller:
         optional: true
 
-  bare-fs@4.5.2:
-    resolution: {integrity: sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==}
-    engines: {bare: '>=1.16.0'}
-    peerDependencies:
-      bare-buffer: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-
   bare-fs@4.5.6:
     resolution: {integrity: sha512-1QovqDrR80Pmt5HPAsMsXTCFcDYr+NSUKW6nd6WO5v0JBmnItc/irNRzm2KOQ5oZ69P37y+AMujNyNtG+1Rggw==}
     engines: {bare: '>=1.16.0'}
@@ -6496,20 +6479,6 @@ packages:
         optional: true
       bare-events:
         optional: true
-
-  bare-stream@2.7.0:
-    resolution: {integrity: sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==}
-    peerDependencies:
-      bare-buffer: '*'
-      bare-events: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-      bare-events:
-        optional: true
-
-  bare-url@2.3.2:
-    resolution: {integrity: sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==}
 
   bare-url@2.4.0:
     resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
@@ -8264,10 +8233,6 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  iconv-lite@0.7.1:
-    resolution: {integrity: sha512-2Tth85cXwGFHfvRgZWszZSvdo+0Xsqmw8k8ZwxScfcBneNUraK+dxRxRm24nszx80Y0TVio8kKLt5sLE7ZCLlw==}
-    engines: {node: '>=0.10.0'}
-
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -9257,8 +9222,8 @@ packages:
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -10811,9 +10776,6 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
-  streamx@2.23.0:
-    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
-
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
@@ -11005,9 +10967,6 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar-stream@3.1.7:
-    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-
   tar-stream@3.1.8:
     resolution: {integrity: sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==}
 
@@ -11077,9 +11036,6 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
-
-  text-decoder@1.2.3:
-    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
   text-decoder@1.2.7:
     resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
@@ -14567,41 +14523,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 25.5.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.3.0
@@ -14974,7 +14895,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.25(kuaxrguapag6ivdaf7n5sho5iu)':
+  '@langchain/community@1.1.25(ebju5z7hskaxpbcfp5vmul7h74)':
     dependencies:
       '@browserbasehq/stagehand': 3.2.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(deepmerge@4.3.1)(encoding@0.1.13)(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.7.10(typescript@5.9.3)
@@ -15012,7 +14933,7 @@ snapshots:
       ioredis: 5.10.1
       jsdom: 29.0.1(@noble/hashes@2.0.1)
       jsonwebtoken: 9.0.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       mysql2: 3.20.0(@types/node@25.5.0)
       pdf-parse: 2.4.5
       pg: 8.20.0
@@ -15404,7 +15325,7 @@ snapshots:
       '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       dotenv: 17.2.3
       dotenv-expand: 12.0.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       rxjs: 7.8.2
 
   '@nestjs/config@4.0.3(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(rxjs@7.8.2)':
@@ -15412,7 +15333,7 @@ snapshots:
       '@nestjs/common': 11.1.17(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       dotenv: 17.2.3
       dotenv-expand: 12.0.3
-      lodash: 4.17.23
+      lodash: 4.18.1
       rxjs: 7.8.2
 
   '@nestjs/core@11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)':
@@ -15456,7 +15377,7 @@ snapshots:
       graphql: 16.13.2
       graphql-tag: 2.12.6(graphql@16.13.2)
       graphql-ws: 6.0.7(graphql@16.13.2)(ws@8.19.0(bufferutil@4.1.0))
-      lodash: 4.17.23
+      lodash: 4.18.1
       normalize-path: 3.0.0
       reflect-metadata: 0.2.2
       subscriptions-transport-ws: 0.11.0(bufferutil@4.1.0)(graphql@16.13.2)
@@ -15534,7 +15455,7 @@ snapshots:
       '@nestjs/core': 11.1.17(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.17)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/mapped-types': 2.1.0(@nestjs/common@11.1.17(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       path-to-regexp: 8.4.0
       reflect-metadata: 0.2.2
       swagger-ui-dist: 5.31.0
@@ -16463,7 +16384,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.10': {}
+  '@opuspopuli/regions@1.0.12': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -18144,7 +18065,7 @@ snapshots:
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   acorn@8.15.0: {}
 
@@ -18418,10 +18339,7 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  b4a@1.7.3: {}
-
-  b4a@1.8.0:
-    optional: true
+  b4a@1.8.0: {}
 
   babel-jest@29.7.0(@babel/core@7.29.0):
     dependencies:
@@ -18560,18 +18478,6 @@ snapshots:
 
   bare-events@2.8.2: {}
 
-  bare-fs@4.5.2:
-    dependencies:
-      bare-events: 2.8.2
-      bare-path: 3.0.0
-      bare-stream: 2.7.0(bare-events@2.8.2)
-      bare-url: 2.3.2
-      fast-fifo: 1.3.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-    optional: true
-
   bare-fs@4.5.6:
     dependencies:
       bare-events: 2.8.2
@@ -18582,15 +18488,12 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-    optional: true
 
-  bare-os@3.6.2:
-    optional: true
+  bare-os@3.6.2: {}
 
   bare-path@3.0.0:
     dependencies:
       bare-os: 3.6.2
-    optional: true
 
   bare-stream@2.11.0(bare-events@2.8.2):
     dependencies:
@@ -18600,27 +18503,10 @@ snapshots:
       bare-events: 2.8.2
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
-
-  bare-stream@2.7.0(bare-events@2.8.2):
-    dependencies:
-      streamx: 2.23.0
-    optionalDependencies:
-      bare-events: 2.8.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-    optional: true
-
-  bare-url@2.3.2:
-    dependencies:
-      bare-path: 3.0.0
-    optional: true
 
   bare-url@2.4.0:
     dependencies:
       bare-path: 3.0.0
-    optional: true
 
   base64-js@1.5.1: {}
 
@@ -18674,7 +18560,7 @@ snapshots:
       content-type: 1.0.5
       debug: 4.4.3
       http-errors: 2.0.1
-      iconv-lite: 0.7.1
+      iconv-lite: 0.7.2
       on-finished: 2.4.1
       qs: 6.15.0
       raw-body: 3.0.2
@@ -20742,10 +20628,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  iconv-lite@0.7.1:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -21164,15 +21046,34 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@22.19.15):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.15)
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.3.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -21233,7 +21134,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@22.19.15):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -21260,39 +21161,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.15
-      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.5.0
-      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21514,6 +21382,13 @@ snapshots:
     dependencies:
       '@jest/globals': 30.3.0
       jest: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      ts-essentials: 10.1.1(typescript@5.9.3)
+      typescript: 5.9.3
+
+  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3):
+    dependencies:
+      '@jest/globals': 30.3.0
+      jest: 30.3.0
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -21842,12 +21717,38 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest@30.3.0:
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@25.5.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@22.19.15):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22249,7 +22150,7 @@ snapshots:
 
   lodash.sortby@4.7.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   log-symbols@4.1.0:
     dependencies:
@@ -22647,7 +22548,7 @@ snapshots:
 
   node-emoji@1.11.0:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
 
   node-fetch-native@1.6.7:
     optional: true
@@ -23431,7 +23332,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
-      iconv-lite: 0.7.1
+      iconv-lite: 0.7.2
       unpipe: 1.0.0
 
   rc9@2.1.2:
@@ -24034,15 +23935,6 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
-  streamx@2.23.0:
-    dependencies:
-      events-universal: 1.0.1
-      fast-fifo: 1.3.2
-      text-decoder: 1.2.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
   streamx@2.25.0:
     dependencies:
       events-universal: 1.0.1
@@ -24051,7 +23943,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-    optional: true
 
   string-argv@0.3.2: {}
 
@@ -24260,9 +24151,9 @@ snapshots:
   tar-fs@3.1.1:
     dependencies:
       pump: 3.0.3
-      tar-stream: 3.1.7
+      tar-stream: 3.1.8
     optionalDependencies:
-      bare-fs: 4.5.2
+      bare-fs: 4.5.6
       bare-path: 3.0.0
     transitivePeerDependencies:
       - bare-abort-controller
@@ -24290,15 +24181,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar-stream@3.1.7:
-    dependencies:
-      b4a: 1.7.3
-      fast-fifo: 1.3.2
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
   tar-stream@3.1.8:
     dependencies:
       b4a: 1.8.0
@@ -24309,7 +24191,6 @@ snapshots:
       - bare-abort-controller
       - bare-buffer
       - react-native-b4a
-    optional: true
 
   tar@7.5.11:
     dependencies:
@@ -24329,7 +24210,6 @@ snapshots:
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
-    optional: true
 
   terser-webpack-plugin@5.3.17(webpack@5.104.1):
     dependencies:
@@ -24393,18 +24273,11 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.5
 
-  text-decoder@1.2.3:
-    dependencies:
-      b4a: 1.7.3
-    transitivePeerDependencies:
-      - react-native-b4a
-
   text-decoder@1.2.7:
     dependencies:
       b4a: 1.8.0
     transitivePeerDependencies:
       - react-native-b4a
-    optional: true
 
   thread-stream@3.1.0:
     dependencies:
@@ -24497,12 +24370,12 @@ snapshots:
 
   ts-graphviz@1.8.2: {}
 
-  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.28.5))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.28.5))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@25.5.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24537,12 +24410,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@22.19.15)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24563,6 +24436,26 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
       jest: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.3
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      jest-util: 30.3.0
+
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 30.3.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6


### PR DESCRIPTION
## Summary
New pipeline stage (3.5) that enriches listing items with detail page content:

- **DetailCrawlerService**: fetches detail pages for items with `detailUrl` field
- AI analyzes first detail page, reuses rules for remaining pages
- Merges extracted content (fullText, bio, minutes) into listing items
- Soft failures: detail page fetch failures don't lose listing data

Schema: Meeting `minutes`, Representative `bio` fields added.
Updated region-provider guide with detail crawling documentation.

## Test plan
- [x] 8 detail crawler tests
- [x] All 217 scraping-pipeline tests pass
- [x] All 1,293 backend tests pass
- [ ] CI pipeline passes

Closes #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)