### PR TITLE
fix: UX, auth guard, and audit logging improvements

### DIFF
--- a/apps/backend/src/api/src/app.module.ts
+++ b/apps/backend/src/api/src/app.module.ts
@@ -57,12 +57,22 @@ import { WebSocketConnectionException } from 'src/common/exceptions/app.exceptio
 const handleAuth = ({ req, res }: { req: Request; res: Response }) => {
   // Only use the validated user from passport (set by AuthMiddleware after JWT validation)
   // req.user contains the ILogin object from JwtStrategy.validate()
-  const context: { user?: string; res: Response } = { res };
+  const context: {
+    user?: string;
+    res: Response;
+    clientIp?: string;
+    clientUserAgent?: string;
+  } = { res };
 
   if (req.user) {
     // Serialize user object to JSON string for propagation to subgraphs
     context.user = JSON.stringify(req.user);
   }
+
+  // Capture original client metadata for forwarding to subgraphs
+  context.clientIp =
+    (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.ip;
+  context.clientUserAgent = req.headers['user-agent'];
 
   return context;
 };

--- a/apps/backend/src/api/src/hmac-data-source.spec.ts
+++ b/apps/backend/src/api/src/hmac-data-source.spec.ts
@@ -50,5 +50,58 @@ describe('HmacRemoteGraphQLDataSource', () => {
 
       jest.restoreAllMocks();
     });
+
+    it('should forward client IP and user agent from gateway context', () => {
+      const mockHeaders = new Map<string, string>();
+      const mockRequest = {
+        http: {
+          url: 'http://localhost:4001/graphql',
+          headers: {
+            set: (key: string, value: string) => mockHeaders.set(key, value),
+          },
+        },
+      };
+
+      jest.spyOn(otelApi.propagation, 'inject').mockImplementation(() => {});
+
+      dataSource.willSendRequest({
+        request: mockRequest,
+        context: {
+          clientIp: '192.168.1.100',
+          clientUserAgent: 'Mozilla/5.0 Chrome/120',
+        },
+      } as unknown as Parameters<typeof dataSource.willSendRequest>[0]);
+
+      expect(mockHeaders.get('x-forwarded-for')).toBe('192.168.1.100');
+      expect(mockHeaders.get('x-original-user-agent')).toBe(
+        'Mozilla/5.0 Chrome/120',
+      );
+
+      jest.restoreAllMocks();
+    });
+
+    it('should not set forwarding headers when context lacks client info', () => {
+      const mockHeaders = new Map<string, string>();
+      const mockRequest = {
+        http: {
+          url: 'http://localhost:4001/graphql',
+          headers: {
+            set: (key: string, value: string) => mockHeaders.set(key, value),
+          },
+        },
+      };
+
+      jest.spyOn(otelApi.propagation, 'inject').mockImplementation(() => {});
+
+      dataSource.willSendRequest({
+        request: mockRequest,
+        context: {},
+      } as unknown as Parameters<typeof dataSource.willSendRequest>[0]);
+
+      expect(mockHeaders.has('x-forwarded-for')).toBe(false);
+      expect(mockHeaders.has('x-original-user-agent')).toBe(false);
+
+      jest.restoreAllMocks();
+    });
   });
 });

--- a/apps/backend/src/api/src/hmac-data-source.ts
+++ b/apps/backend/src/api/src/hmac-data-source.ts
@@ -14,6 +14,8 @@ import { context as otelContext, propagation } from '@opentelemetry/api';
 interface GatewayContext {
   user?: string;
   res?: Response;
+  clientIp?: string;
+  clientUserAgent?: string;
 }
 
 /**
@@ -92,6 +94,17 @@ export class HmacRemoteGraphQLDataSource extends RemoteGraphQLDataSource<Gateway
     // Forward authenticated user to microservices
     if (context?.user) {
       request.http?.headers.set('user', context.user);
+    }
+
+    // Forward original client IP and user agent for accurate audit logging
+    if (context?.clientIp) {
+      request.http?.headers.set('x-forwarded-for', context.clientIp);
+    }
+    if (context?.clientUserAgent) {
+      request.http?.headers.set(
+        'x-original-user-agent',
+        context.clientUserAgent,
+      );
     }
 
     // Sign request with HMAC for microservice authentication

--- a/apps/backend/src/apps/region/src/domains/models/representative.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/representative.model.ts
@@ -50,6 +50,9 @@ export class RepresentativeModel {
   @Field(() => ContactInfoModel, { nullable: true })
   contactInfo?: ContactInfoModel;
 
+  @Field({ nullable: true })
+  bio?: string;
+
   @Field()
   createdAt!: Date;
 

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -152,6 +152,7 @@ export class RegionResolver {
       ...result,
       photoUrl: result.photoUrl ?? undefined,
       contactInfo: (result.contactInfo as ContactInfoModel) ?? undefined,
+      bio: result.bio ?? undefined,
     };
   }
 

--- a/apps/backend/src/apps/users/src/domains/activity/activity.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/activity/activity.resolver.ts
@@ -7,12 +7,14 @@ import {
   Int,
   ID,
 } from '@nestjs/graphql';
+import { UseGuards } from '@nestjs/common';
 
 import {
   GqlContext,
   getUserFromContext,
   getSessionTokenFromContext,
 } from 'src/common/utils/graphql-context';
+import { AuthGuard } from 'src/common/guards/auth.guard';
 
 import { ActivityService } from './activity.service';
 import {
@@ -24,6 +26,7 @@ import {
 } from './dto/activity.dto';
 
 @Resolver()
+@UseGuards(AuthGuard)
 export class ActivityResolver {
   constructor(private readonly activityService: ActivityService) {}
 

--- a/apps/backend/src/apps/users/src/domains/auth/session.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/session.resolver.ts
@@ -1,6 +1,7 @@
 import { Args, Mutation, Query, Resolver, Context } from '@nestjs/graphql';
 import { ConfigService } from '@nestjs/config';
-import { Optional } from '@nestjs/common';
+import { Optional, UseGuards } from '@nestjs/common';
+import { AuthGuard } from 'src/common/guards/auth.guard';
 
 import { UserInputError } from '@nestjs/apollo';
 
@@ -31,6 +32,7 @@ import { AuditLogService } from 'src/common/services/audit-log.service';
  * @see https://github.com/OpusPopuli/opuspopuli/issues/464
  */
 @Resolver(() => Boolean)
+@UseGuards(AuthGuard)
 export class SessionResolver {
   private readonly serviceName = 'users-service';
 

--- a/apps/backend/src/common/guards/auth.guard.spec.ts
+++ b/apps/backend/src/common/guards/auth.guard.spec.ts
@@ -280,6 +280,50 @@ describe('AuthGuard', () => {
     });
   });
 
+  describe('forwarded client metadata', () => {
+    it('should use x-forwarded-for and x-original-user-agent in audit log on denial', async () => {
+      const mockRequest = {
+        user: null,
+        ip: '172.18.0.21',
+        headers: {
+          'x-forwarded-for': '192.168.1.100',
+          'x-original-user-agent': 'Mozilla/5.0 Chrome/120',
+          'user-agent': 'minipass-fetch/3.0.5',
+        },
+      };
+      const mockGqlContext = {
+        getContext: () => ({ req: mockRequest }),
+        getInfo: () => ({
+          fieldName: 'myProfile',
+          parentType: { name: 'Query' },
+        }),
+      };
+
+      (GqlExecutionContext.create as jest.Mock).mockReturnValue(mockGqlContext);
+
+      const mockAuditLogService = { logSync: jest.fn() };
+      const guardWithAudit = new AuthGuard(
+        mockReflector as Reflector,
+        mockAuditLogService as never,
+      );
+
+      const context = {
+        getHandler: jest.fn(),
+        getClass: jest.fn(),
+      } as unknown as ExecutionContext;
+
+      const result = await guardWithAudit.canActivate(context);
+
+      expect(result).toBe(false);
+      expect(mockAuditLogService.logSync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ipAddress: '192.168.1.100',
+          userAgent: 'Mozilla/5.0 Chrome/120',
+        }),
+      );
+    });
+  });
+
   describe('security: deny by default', () => {
     it('should deny access when no user is present on request', async () => {
       const context = createMockContext(null);

--- a/apps/backend/src/common/guards/auth.guard.ts
+++ b/apps/backend/src/common/guards/auth.guard.ts
@@ -108,9 +108,11 @@ export class AuthGuard implements CanActivate {
           | 'mutation'
           | 'subscription',
         ipAddress:
-          request?.ip ||
-          (request?.headers as Record<string, string>)?.['x-forwarded-for'],
-        userAgent: request?.headers?.['user-agent'],
+          (request?.headers as Record<string, string>)?.['x-forwarded-for'] ||
+          request?.ip,
+        userAgent:
+          request?.headers?.['x-original-user-agent'] ||
+          request?.headers?.['user-agent'],
         errorMessage: 'Unauthenticated access attempt',
       });
 

--- a/apps/backend/src/common/utils/graphql-context.ts
+++ b/apps/backend/src/common/utils/graphql-context.ts
@@ -100,9 +100,12 @@ export function createAuditContext(
     userId: user?.id,
     userEmail: userEmail || user?.email,
     ipAddress:
-      context.req?.ip ||
-      (context.req?.headers as Record<string, string>)?.['x-forwarded-for'],
-    userAgent: context.req?.headers?.['user-agent'],
+      (context.req?.headers as Record<string, string>)?.['x-forwarded-for'] ||
+      context.req?.ip,
+    userAgent:
+      (context.req?.headers as Record<string, string>)?.[
+        'x-original-user-agent'
+      ] || context.req?.headers?.['user-agent'],
     serviceName,
   };
 }

--- a/apps/frontend/__tests__/components/Header.test.tsx
+++ b/apps/frontend/__tests__/components/Header.test.tsx
@@ -85,10 +85,12 @@ describe("Header", () => {
       };
     });
 
-    it("should show user email", () => {
+    it("should show profile icon link to settings", () => {
       render(<Header />);
 
-      expect(screen.getByText("test@example.com")).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /profile settings/i }),
+      ).toHaveAttribute("href", "/settings");
     });
 
     it("should show region link", () => {
@@ -98,14 +100,6 @@ describe("Header", () => {
         "href",
         "/region",
       );
-    });
-
-    it("should show settings link with user email", () => {
-      render(<Header />);
-
-      expect(
-        screen.getByRole("link", { name: "test@example.com" }),
-      ).toHaveAttribute("href", "/settings");
     });
 
     it("should show sign out button", () => {

--- a/apps/frontend/app/region/layout.tsx
+++ b/apps/frontend/app/region/layout.tsx
@@ -1,11 +1,17 @@
 "use client";
 
 import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { Header } from "@/components/Header";
 
 export default function RegionLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return <ProtectedRoute>{children}</ProtectedRoute>;
+  return (
+    <ProtectedRoute>
+      <Header />
+      {children}
+    </ProtectedRoute>
+  );
 }

--- a/apps/frontend/app/settings/layout.tsx
+++ b/apps/frontend/app/settings/layout.tsx
@@ -155,7 +155,7 @@ export default function SettingsLayout({
                 </span>
               </Link>
               <Link
-                href="/"
+                href="/region"
                 className="text-sm text-[#4d4d4d] hover:text-[#222222] transition-colors"
               >
                 {t("common:navigation.backToApp")}

--- a/apps/frontend/components/Header.tsx
+++ b/apps/frontend/components/Header.tsx
@@ -47,8 +47,26 @@ export function Header() {
               <Link href="/petition" className={navLinkClass}>
                 Petitions
               </Link>
-              <Link href="/settings" className={navLinkClass}>
-                {user.email}
+              <Link
+                href="/settings"
+                className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+                aria-label="Profile settings"
+                title={user.email}
+              >
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
               </Link>
               <button
                 onClick={logout}
@@ -145,10 +163,24 @@ export function Header() {
                 </Link>
                 <Link
                   href="/settings"
-                  className={navLinkClass}
+                  className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
                   onClick={closeMenu}
                 >
-                  {user.email}
+                  <svg
+                    className="w-5 h-5"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M5.121 17.804A13.937 13.937 0 0112 16c2.5 0 4.847.655 6.879 1.804M15 10a3 3 0 11-6 0 3 3 0 016 0zm6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                  Profile
                 </Link>
                 <button
                   onClick={() => {

--- a/apps/frontend/e2e/region.spec.ts
+++ b/apps/frontend/e2e/region.spec.ts
@@ -463,7 +463,13 @@ test.describe("Propositions Page", () => {
   test("should display breadcrumb navigation", async ({ page }) => {
     await page.goto("/region/propositions");
 
-    await expect(page.getByRole("link", { name: /Region/i })).toBeVisible();
+    const breadcrumb = page
+      .getByRole("navigation")
+      .filter({ hasText: "Region" })
+      .last();
+    await expect(
+      breadcrumb.getByRole("link", { name: /Region/i }),
+    ).toBeVisible();
   });
 
   test("should display proposition cards", async ({ page }) => {
@@ -499,7 +505,11 @@ test.describe("Propositions Page", () => {
   }) => {
     await page.goto("/region/propositions");
 
-    await page.getByRole("link", { name: /Region/i }).click();
+    const breadcrumb = page
+      .getByRole("navigation")
+      .filter({ hasText: "Region" })
+      .last();
+    await breadcrumb.getByRole("link", { name: /Region/i }).click();
     await expect(page).toHaveURL(/\/region$/);
   });
 });
@@ -1229,7 +1239,13 @@ test.describe("Campaign Finance Hub Page", () => {
   test("should display breadcrumb navigation", async ({ page }) => {
     await page.goto("/region/campaign-finance");
 
-    await expect(page.getByRole("link", { name: /Region/i })).toBeVisible();
+    const breadcrumb = page
+      .getByRole("navigation")
+      .filter({ hasText: "Region" })
+      .last();
+    await expect(
+      breadcrumb.getByRole("link", { name: /Region/i }),
+    ).toBeVisible();
   });
 
   test("should display four sub-category cards", async ({ page }) => {
@@ -1264,7 +1280,11 @@ test.describe("Campaign Finance Hub Page", () => {
   }) => {
     await page.goto("/region/campaign-finance");
 
-    await page.getByRole("link", { name: /Region/i }).click();
+    const breadcrumb = page
+      .getByRole("navigation")
+      .filter({ hasText: "Region" })
+      .last();
+    await breadcrumb.getByRole("link", { name: /Region/i }).click();
     await expect(page).toHaveURL(/\/region$/);
   });
 });


### PR DESCRIPTION
## Summary
- **Header nav on region pages**: Users can now navigate to profile/settings from any region page
- **Profile icon**: Replaced user email with a clean profile icon in the header
- **Settings nav**: "Back to App" links to `/region` instead of `/`
- **Auth guards**: Added `AuthGuard` to `ActivityResolver` and `SessionResolver` (fixes "User not authenticated" errors)
- **Audit logging**: Gateway forwards real client IP and user agent to subgraphs instead of Docker internal addresses
- **Representative bio**: Exposed `bio` field on `RepresentativeModel` for upcoming detail pages (#565)

## Test plan
- [x] All backend tests pass (1265 tests)
- [x] All frontend Header tests pass (35 tests)
- [x] Live UAT: activity page loads, header nav works, profile accessible from region pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)