### PR TITLE
feat: representative detail page with clickable cards (#565)

### DIFF
--- a/apps/frontend/__tests__/pages/region/representative-detail.test.tsx
+++ b/apps/frontend/__tests__/pages/region/representative-detail.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import RepresentativeDetailPage from "@/app/region/representatives/[id]/page";
+
+const mockRepresentative = {
+  id: "rep-1",
+  externalId: "rep-1",
+  name: "Jane Smith",
+  chamber: "Senate",
+  district: "5",
+  party: "Democrat",
+  photoUrl: "https://example.com/photo.jpg",
+  contactInfo: {
+    email: "jane@example.gov",
+    phone: "555-1234",
+    office: "State Capitol, Room 100",
+    website: "https://example.gov/jane",
+  },
+  bio: "Jane Smith has served in the Senate since 2020.",
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-01T00:00:00Z",
+};
+
+// Mock next/navigation
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ id: "rep-1" }),
+}));
+
+// Mock Apollo
+let mockQueryResult: {
+  data: { representative: typeof mockRepresentative | null } | undefined;
+  loading: boolean;
+  error: Error | undefined;
+};
+
+jest.mock("@apollo/client/react", () => ({
+  useQuery: () => mockQueryResult,
+}));
+
+describe("RepresentativeDetailPage", () => {
+  beforeEach(() => {
+    mockQueryResult = {
+      data: { representative: mockRepresentative },
+      loading: false,
+      error: undefined,
+    };
+  });
+
+  it("should render representative name as heading", () => {
+    render(<RepresentativeDetailPage />);
+
+    expect(
+      screen.getByRole("heading", { name: "Jane Smith" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render party badge", () => {
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.getByText("Democrat")).toBeInTheDocument();
+  });
+
+  it("should render chamber and district", () => {
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.getByText("Senate")).toBeInTheDocument();
+    expect(screen.getByText("District 5")).toBeInTheDocument();
+  });
+
+  it("should render bio when available", () => {
+    render(<RepresentativeDetailPage />);
+
+    expect(
+      screen.getByText("Jane Smith has served in the Senate since 2020."),
+    ).toBeInTheDocument();
+  });
+
+  it("should render contact information", () => {
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.getByText("jane@example.gov")).toBeInTheDocument();
+    expect(screen.getByText("555-1234")).toBeInTheDocument();
+    expect(screen.getByText("State Capitol, Room 100")).toBeInTheDocument();
+    expect(screen.getByText("https://example.gov/jane")).toBeInTheDocument();
+  });
+
+  it("should render contact button", () => {
+    render(<RepresentativeDetailPage />);
+
+    expect(
+      screen.getByRole("button", { name: /Contact Jane/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("should render campaign finance placeholder", () => {
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.getByText("Coming Soon")).toBeInTheDocument();
+  });
+
+  it("should render breadcrumb navigation", () => {
+    render(<RepresentativeDetailPage />);
+
+    expect(
+      screen.getByRole("link", { name: "Representatives" }),
+    ).toHaveAttribute("href", "/region/representatives");
+  });
+
+  it("should show not found when representative is null", () => {
+    mockQueryResult = {
+      data: { representative: null },
+      loading: false,
+      error: undefined,
+    };
+
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.getByText("Representative not found.")).toBeInTheDocument();
+  });
+
+  it("should not render bio section when bio is null", () => {
+    mockQueryResult = {
+      data: {
+        representative: {
+          ...mockRepresentative,
+          bio: null as unknown as string,
+        },
+      },
+      loading: false,
+      error: undefined,
+    };
+
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.queryByText("Biography")).not.toBeInTheDocument();
+  });
+
+  it("should not render contact section when contactInfo is null", () => {
+    mockQueryResult = {
+      data: {
+        representative: {
+          ...mockRepresentative,
+          contactInfo: null as unknown as typeof mockRepresentative.contactInfo,
+        },
+      },
+      loading: false,
+      error: undefined,
+    };
+
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.queryByText("Contact Information")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/pages/region/representatives.test.tsx
+++ b/apps/frontend/__tests__/pages/region/representatives.test.tsx
@@ -208,12 +208,11 @@ describe("RepresentativesPage", () => {
       expect(screen.getByText("Independent")).toBeInTheDocument();
     });
 
-    it("should render contact information when available", () => {
+    it("should link representative cards to detail page", () => {
       render(<RepresentativesPage />);
 
-      expect(screen.getByText("jane.smith@example.gov")).toBeInTheDocument();
-      expect(screen.getByText("555-1234")).toBeInTheDocument();
-      expect(screen.getByText("State Capitol, Room 100")).toBeInTheDocument();
+      const janeLink = screen.getByRole("link", { name: /Jane Smith/i });
+      expect(janeLink).toHaveAttribute("href", "/region/representatives/1");
     });
 
     it("should render photos when available", () => {

--- a/apps/frontend/app/region/representatives/[id]/page.tsx
+++ b/apps/frontend/app/region/representatives/[id]/page.tsx
@@ -1,0 +1,323 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_REPRESENTATIVE,
+  RepresentativeData,
+  IdVars,
+} from "@/lib/graphql/region";
+import { ContactRepresentativeForm } from "@/components/email/ContactRepresentativeForm";
+import { Breadcrumb } from "@/components/region/Breadcrumb";
+import { LoadingSkeleton, ErrorState } from "@/components/region/ListStates";
+
+const PARTY_COLORS: Record<string, { bg: string; text: string }> = {
+  Democrat: { bg: "bg-blue-100", text: "text-blue-800" },
+  Democratic: { bg: "bg-blue-100", text: "text-blue-800" },
+  Republican: { bg: "bg-red-100", text: "text-red-800" },
+  Independent: { bg: "bg-purple-100", text: "text-purple-800" },
+  Green: { bg: "bg-green-100", text: "text-green-800" },
+  Libertarian: { bg: "bg-yellow-100", text: "text-yellow-800" },
+};
+
+function PartyBadge({ party }: { readonly party: string }) {
+  const colors = PARTY_COLORS[party] || {
+    bg: "bg-gray-100",
+    text: "text-gray-800",
+  };
+  return (
+    <span
+      className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${colors.bg} ${colors.text}`}
+    >
+      {party}
+    </span>
+  );
+}
+
+function ContactSection({
+  label,
+  icon,
+  children,
+}: {
+  readonly label: string;
+  readonly icon: React.ReactNode;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="flex-shrink-0 w-5 h-5 mt-0.5 text-gray-400">{icon}</div>
+      <div>
+        <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-0.5">
+          {label}
+        </p>
+        <div className="text-sm text-[#222222]">{children}</div>
+      </div>
+    </div>
+  );
+}
+
+export default function RepresentativeDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [showContactForm, setShowContactForm] = useState(false);
+
+  const { data, loading, error } = useQuery<RepresentativeData, IdVars>(
+    GET_REPRESENTATIVE,
+    { variables: { id } },
+  );
+
+  if (loading) {
+    return (
+      <div className="max-w-4xl mx-auto px-8 py-12">
+        <LoadingSkeleton count={1} height="h-64" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto px-8 py-12">
+        <ErrorState entity="representative" />
+      </div>
+    );
+  }
+
+  const rep = data?.representative;
+
+  if (!rep) {
+    return (
+      <div className="max-w-4xl mx-auto px-8 py-12">
+        <div className="bg-gray-50 border border-gray-200 rounded-xl p-8 text-center">
+          <p className="text-[#4d4d4d] mb-4">Representative not found.</p>
+          <Link
+            href="/region/representatives"
+            className="text-blue-600 hover:text-blue-700 hover:underline text-sm font-medium"
+          >
+            Back to Representatives
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const contact = rep.contactInfo;
+  const hasContact =
+    contact?.email || contact?.phone || contact?.office || contact?.website;
+
+  return (
+    <div className="max-w-4xl mx-auto px-8 py-12">
+      <Breadcrumb
+        segments={[
+          { label: "Region", href: "/region" },
+          { label: "Representatives", href: "/region/representatives" },
+          { label: rep.name },
+        ]}
+      />
+
+      {/* Hero Section */}
+      <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8 mb-6">
+        <div className="flex flex-col sm:flex-row items-start gap-6">
+          {/* Photo */}
+          <div className="flex-shrink-0">
+            {rep.photoUrl ? (
+              <Image
+                src={rep.photoUrl}
+                alt={rep.name}
+                width={120}
+                height={120}
+                className="w-28 h-28 rounded-full object-cover shadow-md"
+                unoptimized
+              />
+            ) : (
+              <div className="w-28 h-28 rounded-full bg-gray-200 flex items-center justify-center shadow-md">
+                <svg
+                  className="w-14 h-14 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              </div>
+            )}
+          </div>
+
+          {/* Name & Details */}
+          <div className="flex-1">
+            <h1 className="text-2xl font-extrabold text-[#222222] mb-2">
+              {rep.name}
+            </h1>
+            <div className="flex flex-wrap items-center gap-3 mb-3">
+              <PartyBadge party={rep.party} />
+              <span className="text-sm text-[#4d4d4d] font-medium">
+                {rep.chamber}
+              </span>
+              <span className="text-sm text-[#4d4d4d]">
+                District {rep.district}
+              </span>
+            </div>
+
+            {/* Contact Button */}
+            {contact?.email && (
+              <button
+                onClick={() => setShowContactForm(true)}
+                className="mt-2 px-5 py-2.5 text-sm font-medium text-white bg-[#222222] rounded-lg hover:bg-[#333333] transition-colors"
+              >
+                Contact {rep.name.split(" ")[0]}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Bio Section */}
+      {rep.bio && (
+        <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8 mb-6">
+          <h2 className="text-xs font-bold uppercase tracking-[1.5px] text-[#595959] mb-3">
+            Biography
+          </h2>
+          <p className="text-[#334155] leading-relaxed">{rep.bio}</p>
+        </div>
+      )}
+
+      {/* Contact Information */}
+      {hasContact && (
+        <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8 mb-6">
+          <h2 className="text-xs font-bold uppercase tracking-[1.5px] text-[#595959] mb-4">
+            Contact Information
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+            {contact?.email && (
+              <ContactSection
+                label="Email"
+                icon={
+                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                    />
+                  </svg>
+                }
+              >
+                <a
+                  href={`mailto:${contact.email}`}
+                  className="text-blue-600 hover:text-blue-700 hover:underline"
+                >
+                  {contact.email}
+                </a>
+              </ContactSection>
+            )}
+            {contact?.phone && (
+              <ContactSection
+                label="Phone"
+                icon={
+                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z"
+                    />
+                  </svg>
+                }
+              >
+                <a
+                  href={`tel:${contact.phone}`}
+                  className="text-blue-600 hover:text-blue-700 hover:underline"
+                >
+                  {contact.phone}
+                </a>
+              </ContactSection>
+            )}
+            {contact?.office && (
+              <ContactSection
+                label="Office"
+                icon={
+                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
+                    />
+                  </svg>
+                }
+              >
+                {contact.office}
+              </ContactSection>
+            )}
+            {contact?.website && (
+              <ContactSection
+                label="Website"
+                icon={
+                  <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9m-9 9a9 9 0 019-9"
+                    />
+                  </svg>
+                }
+              >
+                <a
+                  href={contact.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:text-blue-700 hover:underline"
+                >
+                  {contact.website}
+                </a>
+              </ContactSection>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Campaign Finance - Coming Soon */}
+      <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8 mb-6">
+        <h2 className="text-xs font-bold uppercase tracking-[1.5px] text-[#595959] mb-4">
+          Campaign Finance
+        </h2>
+        <div className="bg-slate-50 border border-dashed border-slate-300 rounded-xl p-6 text-center">
+          <p className="text-xs font-semibold uppercase tracking-wider text-slate-600 mb-1">
+            Coming Soon
+          </p>
+          <p className="text-sm text-slate-700">
+            Campaign contributions, expenditures, and independent spending data
+            will be linked here.
+          </p>
+        </div>
+      </div>
+
+      {/* Contact Modal */}
+      {showContactForm && contact?.email && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-xl shadow-xl max-w-lg w-full max-h-[90vh] overflow-y-auto p-6">
+            <ContactRepresentativeForm
+              representative={{
+                id: rep.id,
+                name: rep.name,
+                email: contact.email,
+                chamber: rep.chamber,
+              }}
+              onSuccess={() => {
+                setShowContactForm(false);
+              }}
+              onCancel={() => setShowContactForm(false)}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/app/region/representatives/[id]/page.tsx
+++ b/apps/frontend/app/region/representatives/[id]/page.tsx
@@ -13,29 +13,7 @@ import {
 import { ContactRepresentativeForm } from "@/components/email/ContactRepresentativeForm";
 import { Breadcrumb } from "@/components/region/Breadcrumb";
 import { LoadingSkeleton, ErrorState } from "@/components/region/ListStates";
-
-const PARTY_COLORS: Record<string, { bg: string; text: string }> = {
-  Democrat: { bg: "bg-blue-100", text: "text-blue-800" },
-  Democratic: { bg: "bg-blue-100", text: "text-blue-800" },
-  Republican: { bg: "bg-red-100", text: "text-red-800" },
-  Independent: { bg: "bg-purple-100", text: "text-purple-800" },
-  Green: { bg: "bg-green-100", text: "text-green-800" },
-  Libertarian: { bg: "bg-yellow-100", text: "text-yellow-800" },
-};
-
-function PartyBadge({ party }: { readonly party: string }) {
-  const colors = PARTY_COLORS[party] || {
-    bg: "bg-gray-100",
-    text: "text-gray-800",
-  };
-  return (
-    <span
-      className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${colors.bg} ${colors.text}`}
-    >
-      {party}
-    </span>
-  );
-}
+import { PartyBadge } from "@/components/region/PartyBadge";
 
 function ContactSection({
   label,
@@ -155,7 +133,7 @@ export default function RepresentativeDetailPage() {
               {rep.name}
             </h1>
             <div className="flex flex-wrap items-center gap-3 mb-3">
-              <PartyBadge party={rep.party} />
+              <PartyBadge party={rep.party} size="md" />
               <span className="text-sm text-[#4d4d4d] font-medium">
                 {rep.chamber}
               </span>

--- a/apps/frontend/app/region/representatives/page.tsx
+++ b/apps/frontend/app/region/representatives/page.tsx
@@ -16,30 +16,9 @@ import {
   ErrorState,
   EmptyState,
 } from "@/components/region/ListStates";
+import { PartyBadge } from "@/components/region/PartyBadge";
 
 const PAGE_SIZE = 12;
-
-const PARTY_COLORS: Record<string, { bg: string; text: string }> = {
-  Democrat: { bg: "bg-blue-100", text: "text-blue-800" },
-  Republican: { bg: "bg-red-100", text: "text-red-800" },
-  Independent: { bg: "bg-purple-100", text: "text-purple-800" },
-  Green: { bg: "bg-green-100", text: "text-green-800" },
-  Libertarian: { bg: "bg-yellow-100", text: "text-yellow-800" },
-};
-
-function PartyBadge({ party }: { readonly party: string }) {
-  const colors = PARTY_COLORS[party] || {
-    bg: "bg-gray-100",
-    text: "text-gray-800",
-  };
-  return (
-    <span
-      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colors.bg} ${colors.text}`}
-    >
-      {party}
-    </span>
-  );
-}
 
 function RepresentativeCard({
   representative,

--- a/apps/frontend/app/region/representatives/page.tsx
+++ b/apps/frontend/app/region/representatives/page.tsx
@@ -2,13 +2,13 @@
 
 import { useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import { useQuery } from "@apollo/client/react";
 import {
   GET_REPRESENTATIVES,
   RepresentativesData,
   Representative,
 } from "@/lib/graphql/region";
-import { ContactRepresentativeForm } from "@/components/email/ContactRepresentativeForm";
 import { Breadcrumb } from "@/components/region/Breadcrumb";
 import { Pagination } from "@/components/region/Pagination";
 import {
@@ -43,10 +43,12 @@ function PartyBadge({ party }: { readonly party: string }) {
 
 function RepresentativeCard({
   representative,
-  onContact,
-}: Readonly<{ representative: Representative; onContact: () => void }>) {
+}: Readonly<{ representative: Representative }>) {
   return (
-    <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6 hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-shadow">
+    <Link
+      href={`/region/representatives/${representative.id}`}
+      className="block bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6 hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-shadow"
+    >
       <div className="flex items-start gap-4">
         {/* Photo */}
         <div className="flex-shrink-0">
@@ -93,64 +95,30 @@ function RepresentativeCard({
             District {representative.district}
           </p>
         </div>
+
+        {/* Arrow indicator */}
+        <svg
+          className="w-5 h-5 text-gray-400 flex-shrink-0 mt-1"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 5l7 7-7 7"
+          />
+        </svg>
       </div>
-
-      {/* Contact Info */}
-      {representative.contactInfo && (
-        <div className="mt-4 pt-4 border-t border-gray-100 grid grid-cols-2 gap-2 text-sm">
-          {representative.contactInfo.email && (
-            <a
-              href={`mailto:${representative.contactInfo.email}`}
-              className="text-blue-600 hover:text-blue-700 hover:underline truncate"
-            >
-              {representative.contactInfo.email}
-            </a>
-          )}
-          {representative.contactInfo.phone && (
-            <a
-              href={`tel:${representative.contactInfo.phone}`}
-              className="text-blue-600 hover:text-blue-700 hover:underline"
-            >
-              {representative.contactInfo.phone}
-            </a>
-          )}
-          {representative.contactInfo.office && (
-            <span className="text-[#4d4d4d] col-span-2 truncate">
-              {representative.contactInfo.office}
-            </span>
-          )}
-          {representative.contactInfo.website && (
-            <a
-              href={representative.contactInfo.website}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-blue-600 hover:text-blue-700 hover:underline truncate"
-            >
-              Website
-            </a>
-          )}
-        </div>
-      )}
-
-      {/* Contact Button */}
-      {representative.contactInfo?.email && (
-        <div className="mt-4 pt-4 border-t border-gray-100">
-          <button
-            onClick={onContact}
-            className="w-full px-4 py-2 text-sm font-medium text-white bg-[#222222] rounded-lg hover:bg-[#333333] transition-colors"
-          >
-            Contact {representative.name.split(" ")[0]}
-          </button>
-        </div>
-      )}
-    </div>
+    </Link>
   );
 }
 
 export default function RepresentativesPage() {
   const [page, setPage] = useState(0);
   const [chamber, setChamber] = useState<string | undefined>(undefined);
-  const [contactRep, setContactRep] = useState<Representative | null>(null);
 
   const { data, loading, error } = useQuery<RepresentativesData>(
     GET_REPRESENTATIVES,
@@ -159,9 +127,15 @@ export default function RepresentativesPage() {
     },
   );
 
-  // Get unique chambers from data for filter
-  const chambers = data?.representatives.items
-    ? Array.from(new Set(data.representatives.items.map((r) => r.chamber)))
+  // Fetch all reps (unfiltered) to build complete chamber list
+  const { data: allData } = useQuery<RepresentativesData>(GET_REPRESENTATIVES, {
+    variables: { skip: 0, take: 200 },
+  });
+
+  const chambers = allData?.representatives.items
+    ? Array.from(
+        new Set(allData.representatives.items.map((r) => r.chamber)),
+      ).sort()
     : [];
 
   const renderContent = () => {
@@ -174,11 +148,7 @@ export default function RepresentativesPage() {
       <>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           {data?.representatives.items.map((rep) => (
-            <RepresentativeCard
-              key={rep.id}
-              representative={rep}
-              onContact={() => setContactRep(rep)}
-            />
+            <RepresentativeCard key={rep.id} representative={rep} />
           ))}
         </div>
         <Pagination
@@ -241,27 +211,6 @@ export default function RepresentativesPage() {
 
       {/* Content */}
       {renderContent()}
-
-      {/* Contact Modal */}
-      {contactRep && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-xl shadow-xl max-w-lg w-full max-h-[90vh] overflow-y-auto p-6">
-            <ContactRepresentativeForm
-              representative={{
-                id: contactRep.id,
-                name: contactRep.name,
-                email: contactRep.contactInfo?.email || "",
-                chamber: contactRep.chamber,
-              }}
-              onSuccess={() => {
-                setContactRep(null);
-                alert("Message sent successfully!");
-              }}
-              onCancel={() => setContactRep(null)}
-            />
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/apps/frontend/app/region/representatives/page.tsx
+++ b/apps/frontend/app/region/representatives/page.tsx
@@ -114,7 +114,7 @@ export default function RepresentativesPage() {
   const chambers = allData?.representatives.items
     ? Array.from(
         new Set(allData.representatives.items.map((r) => r.chamber)),
-      ).sort()
+      ).sort((a, b) => a.localeCompare(b))
     : [];
 
   const renderContent = () => {

--- a/apps/frontend/components/region/PartyBadge.tsx
+++ b/apps/frontend/components/region/PartyBadge.tsx
@@ -1,0 +1,32 @@
+const PARTY_COLORS: Record<string, { bg: string; text: string }> = {
+  Democrat: { bg: "bg-blue-100", text: "text-blue-800" },
+  Democratic: { bg: "bg-blue-100", text: "text-blue-800" },
+  Republican: { bg: "bg-red-100", text: "text-red-800" },
+  Independent: { bg: "bg-purple-100", text: "text-purple-800" },
+  Green: { bg: "bg-green-100", text: "text-green-800" },
+  Libertarian: { bg: "bg-yellow-100", text: "text-yellow-800" },
+};
+
+export function PartyBadge({
+  party,
+  size = "sm",
+}: {
+  readonly party: string;
+  readonly size?: "sm" | "md";
+}) {
+  const colors = PARTY_COLORS[party] || {
+    bg: "bg-gray-100",
+    text: "text-gray-800",
+  };
+  const sizeClass =
+    size === "md"
+      ? "px-3 py-1 rounded-full text-sm"
+      : "px-2.5 py-0.5 rounded-full text-xs";
+  return (
+    <span
+      className={`inline-flex items-center font-medium ${sizeClass} ${colors.bg} ${colors.text}`}
+    >
+      {party}
+    </span>
+  );
+}

--- a/apps/frontend/e2e/email.spec.ts
+++ b/apps/frontend/e2e/email.spec.ts
@@ -498,7 +498,9 @@ test.describe("Contact Representative Form", () => {
       .first();
     await contactButton.click();
 
-    await expect(page.getByText(/Contact Jane/)).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /Contact Jane Smith/ }),
+    ).toBeVisible();
   });
 
   test("should have subject and message fields", async ({ page }) => {
@@ -606,10 +608,14 @@ test.describe("Contact Representative Form", () => {
       .getByRole("button", { name: /Contact/i })
       .first()
       .click();
-    await expect(page.getByText(/Contact Jane/)).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /Contact Jane Smith/ }),
+    ).toBeVisible();
 
     await page.getByRole("button", { name: /Cancel/i }).click();
-    await expect(page.getByText(/Contact Jane/)).not.toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /Contact Jane Smith/ }),
+    ).not.toBeVisible();
   });
 });
 

--- a/apps/frontend/e2e/email.spec.ts
+++ b/apps/frontend/e2e/email.spec.ts
@@ -489,7 +489,9 @@ test.describe("Contact Representative Form", () => {
   }) => {
     await page.goto("/region/representatives/rep-1");
 
-    await expect(page.getByText("Jane Smith")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Jane Smith" }),
+    ).toBeVisible();
 
     const contactButton = page
       .getByRole("button", { name: /Contact/i })
@@ -501,7 +503,9 @@ test.describe("Contact Representative Form", () => {
 
   test("should have subject and message fields", async ({ page }) => {
     await page.goto("/region/representatives/rep-1");
-    await expect(page.getByText("Jane Smith")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Jane Smith" }),
+    ).toBeVisible();
 
     await page
       .getByRole("button", { name: /Contact/i })
@@ -514,7 +518,9 @@ test.describe("Contact Representative Form", () => {
 
   test("should have send method toggle", async ({ page }) => {
     await page.goto("/region/representatives/rep-1");
-    await expect(page.getByText("Jane Smith")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Jane Smith" }),
+    ).toBeVisible();
 
     await page
       .getByRole("button", { name: /Contact/i })
@@ -527,7 +533,9 @@ test.describe("Contact Representative Form", () => {
 
   test("should have include address checkbox", async ({ page }) => {
     await page.goto("/region/representatives/rep-1");
-    await expect(page.getByText("Jane Smith")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Jane Smith" }),
+    ).toBeVisible();
 
     await page
       .getByRole("button", { name: /Contact/i })
@@ -539,7 +547,9 @@ test.describe("Contact Representative Form", () => {
 
   test("should show character count for message", async ({ page }) => {
     await page.goto("/region/representatives/rep-1");
-    await expect(page.getByText("Jane Smith")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Jane Smith" }),
+    ).toBeVisible();
 
     await page
       .getByRole("button", { name: /Contact/i })
@@ -553,7 +563,9 @@ test.describe("Contact Representative Form", () => {
     page,
   }) => {
     await page.goto("/region/representatives/rep-1");
-    await expect(page.getByText("Jane Smith")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Jane Smith" }),
+    ).toBeVisible();
 
     await page
       .getByRole("button", { name: /Contact/i })
@@ -566,7 +578,9 @@ test.describe("Contact Representative Form", () => {
 
   test("should enable submit button when form is valid", async ({ page }) => {
     await page.goto("/region/representatives/rep-1");
-    await expect(page.getByText("Jane Smith")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Jane Smith" }),
+    ).toBeVisible();
 
     await page
       .getByRole("button", { name: /Contact/i })
@@ -584,7 +598,9 @@ test.describe("Contact Representative Form", () => {
 
   test("should close form when cancel is clicked", async ({ page }) => {
     await page.goto("/region/representatives/rep-1");
-    await expect(page.getByText("Jane Smith")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Jane Smith" }),
+    ).toBeVisible();
 
     await page
       .getByRole("button", { name: /Contact/i })

--- a/apps/frontend/e2e/email.spec.ts
+++ b/apps/frontend/e2e/email.spec.ts
@@ -165,6 +165,17 @@ async function mockEmailGraphQL(page: import("@playwright/test").Page) {
           },
         }),
       });
+    } else if (
+      postData?.query?.includes("representative(") ||
+      postData?.query?.includes("GetRepresentative")
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: { representative: mockRepresentatives.items[0] },
+        }),
+      });
     } else if (postData?.query?.includes("representatives")) {
       await route.fulfill({
         status: 200,
@@ -473,26 +484,23 @@ test.describe("Contact Representative Form", () => {
     await mockEmailGraphQL(page);
   });
 
-  test("should display contact form on representatives page", async ({
+  test("should display contact form on representative detail page", async ({
     page,
   }) => {
-    await page.goto("/region/representatives");
+    await page.goto("/region/representatives/rep-1");
 
-    // Wait for representatives to load
     await expect(page.getByText("Jane Smith")).toBeVisible();
 
-    // Click contact button
     const contactButton = page
       .getByRole("button", { name: /Contact/i })
       .first();
     await contactButton.click();
 
-    // Form should be visible
-    await expect(page.getByText(/Contact Jane Smith/)).toBeVisible();
+    await expect(page.getByText(/Contact Jane/)).toBeVisible();
   });
 
   test("should have subject and message fields", async ({ page }) => {
-    await page.goto("/region/representatives");
+    await page.goto("/region/representatives/rep-1");
     await expect(page.getByText("Jane Smith")).toBeVisible();
 
     await page
@@ -505,7 +513,7 @@ test.describe("Contact Representative Form", () => {
   });
 
   test("should have send method toggle", async ({ page }) => {
-    await page.goto("/region/representatives");
+    await page.goto("/region/representatives/rep-1");
     await expect(page.getByText("Jane Smith")).toBeVisible();
 
     await page
@@ -518,7 +526,7 @@ test.describe("Contact Representative Form", () => {
   });
 
   test("should have include address checkbox", async ({ page }) => {
-    await page.goto("/region/representatives");
+    await page.goto("/region/representatives/rep-1");
     await expect(page.getByText("Jane Smith")).toBeVisible();
 
     await page
@@ -530,7 +538,7 @@ test.describe("Contact Representative Form", () => {
   });
 
   test("should show character count for message", async ({ page }) => {
-    await page.goto("/region/representatives");
+    await page.goto("/region/representatives/rep-1");
     await expect(page.getByText("Jane Smith")).toBeVisible();
 
     await page
@@ -544,7 +552,7 @@ test.describe("Contact Representative Form", () => {
   test("should disable submit button when form is incomplete", async ({
     page,
   }) => {
-    await page.goto("/region/representatives");
+    await page.goto("/region/representatives/rep-1");
     await expect(page.getByText("Jane Smith")).toBeVisible();
 
     await page
@@ -557,7 +565,7 @@ test.describe("Contact Representative Form", () => {
   });
 
   test("should enable submit button when form is valid", async ({ page }) => {
-    await page.goto("/region/representatives");
+    await page.goto("/region/representatives/rep-1");
     await expect(page.getByText("Jane Smith")).toBeVisible();
 
     await page
@@ -565,7 +573,6 @@ test.describe("Contact Representative Form", () => {
       .first()
       .click();
 
-    // Fill out the form
     await page.getByLabel(/Subject/i).fill("Test Subject");
     await page
       .getByLabel(/Message/i)
@@ -576,17 +583,17 @@ test.describe("Contact Representative Form", () => {
   });
 
   test("should close form when cancel is clicked", async ({ page }) => {
-    await page.goto("/region/representatives");
+    await page.goto("/region/representatives/rep-1");
     await expect(page.getByText("Jane Smith")).toBeVisible();
 
     await page
       .getByRole("button", { name: /Contact/i })
       .first()
       .click();
-    await expect(page.getByText(/Contact Jane Smith/)).toBeVisible();
+    await expect(page.getByText(/Contact Jane/)).toBeVisible();
 
     await page.getByRole("button", { name: /Cancel/i }).click();
-    await expect(page.getByText(/Contact Jane Smith/)).not.toBeVisible();
+    await expect(page.getByText(/Contact Jane/)).not.toBeVisible();
   });
 });
 

--- a/apps/frontend/e2e/region.spec.ts
+++ b/apps/frontend/e2e/region.spec.ts
@@ -753,11 +753,12 @@ test.describe("Representatives Page", () => {
     await expect(page.getByText("Republican")).toBeVisible();
   });
 
-  test("should display contact information", async ({ page }) => {
+  test("should link cards to representative detail page", async ({ page }) => {
     await page.goto("/region/representatives");
 
-    await expect(page.getByText("jane.smith@example.gov")).toBeVisible();
-    await expect(page.getByText("555-1234")).toBeVisible();
+    const card = page.getByRole("link", { name: /Jane Smith/i });
+    await expect(card).toBeVisible();
+    await expect(card).toHaveAttribute("href", /\/region\/representatives\/.+/);
   });
 
   test("should have chamber filter dropdown", async ({ page }) => {

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -67,6 +67,7 @@ export interface Representative {
   party: string;
   photoUrl?: string;
   contactInfo?: ContactInfo;
+  bio?: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -434,6 +435,7 @@ export const GET_REPRESENTATIVE = gql`
         office
         website
       }
+      bio
       createdAt
       updatedAt
     }


### PR DESCRIPTION
## Summary
- **Detail page**: New `/region/representatives/[id]` page with hero section, bio, contact info, and campaign finance placeholder
- **Clickable cards**: Representative list cards now link to detail pages with arrow indicator
- **Chamber filter**: Fixed to show all chambers (Assembly + Senate) by querying full dataset
- **Contact form**: Moved from list cards to detail page
- Added `bio` field to `Representative` interface and `GET_REPRESENTATIVE` query

## Test plan
- [x] 22 representative tests pass (updated card link test)
- [x] Full pre-commit test suite passes
- [x] Live UAT: cards clickable, detail page renders, chamber filter shows both options

Closes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)