### PR TITLE
feat: My Representatives section on region hub (#574)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -319,6 +319,59 @@ describe('RegionResolver', () => {
     });
   });
 
+  describe('representativesByDistricts', () => {
+    it('should call service with district strings', async () => {
+      regionService.getRepresentativesByDistricts.mockResolvedValue([
+        mockRepresentative,
+      ]);
+
+      const result = await resolver.representativesByDistricts(
+        'Congressional District 2',
+        'State Senate District 5',
+        'Assembly District 12',
+      );
+
+      expect(regionService.getRepresentativesByDistricts).toHaveBeenCalledWith(
+        'Congressional District 2',
+        'State Senate District 5',
+        'Assembly District 12',
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('should convert null party/photoUrl/bio to undefined', async () => {
+      const repWithNulls = {
+        ...mockRepresentative,
+        party: null,
+        photoUrl: null,
+        bio: null,
+        contactInfo: null,
+      };
+      regionService.getRepresentativesByDistricts.mockResolvedValue([
+        repWithNulls,
+      ]);
+
+      const result = await resolver.representativesByDistricts(
+        undefined,
+        'State Senate District 5',
+        undefined,
+      );
+
+      expect(result[0].party).toBeUndefined();
+      expect(result[0].photoUrl).toBeUndefined();
+      expect(result[0].bio).toBeUndefined();
+      expect(result[0].contactInfo).toBeUndefined();
+    });
+
+    it('should return empty array when service returns empty', async () => {
+      regionService.getRepresentativesByDistricts.mockResolvedValue([]);
+
+      const result = await resolver.representativesByDistricts();
+
+      expect(result).toEqual([]);
+    });
+  });
+
   // ==========================================
   // CAMPAIGN FINANCE QUERIES
   // ==========================================

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -156,6 +156,35 @@ export class RegionResolver {
     };
   }
 
+  /**
+   * Find representatives matching a user's civic districts.
+   * Districts come from the user's geocoded address (Census API format).
+   */
+  @Public()
+  @Query(() => [RepresentativeModel])
+  async representativesByDistricts(
+    @Args({ name: 'congressionalDistrict', nullable: true })
+    congressionalDistrict?: string,
+    @Args({ name: 'stateSenatorialDistrict', nullable: true })
+    stateSenatorialDistrict?: string,
+    @Args({ name: 'stateAssemblyDistrict', nullable: true })
+    stateAssemblyDistrict?: string,
+  ): Promise<RepresentativeModel[]> {
+    const results = await this.regionService.getRepresentativesByDistricts(
+      congressionalDistrict,
+      stateSenatorialDistrict,
+      stateAssemblyDistrict,
+    );
+
+    return results.map((r) => ({
+      ...r,
+      party: r.party ?? undefined,
+      photoUrl: r.photoUrl ?? undefined,
+      contactInfo: (r.contactInfo as ContactInfoModel) ?? undefined,
+      bio: r.bio ?? undefined,
+    })) as RepresentativeModel[];
+  }
+
   // ==========================================
   // CAMPAIGN FINANCE QUERIES
   // ==========================================

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -593,6 +593,101 @@ describe('RegionDomainService', () => {
     });
   });
 
+  describe('getRepresentativesByDistricts', () => {
+    it('should return empty array when no districts provided', async () => {
+      // Reset call tracking so we only see calls from our method
+      mockDb.representative.findMany.mockClear();
+
+      const result = await service.getRepresentativesByDistricts();
+
+      expect(result).toEqual([]);
+      // Should not have called findMany at all (early return)
+      expect(mockDb.representative.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should build correct OR conditions for assembly and senate districts', async () => {
+      mockDb.representative.findMany.mockResolvedValue([]);
+
+      await service.getRepresentativesByDistricts(
+        undefined,
+        'State Senate District 5',
+        'Assembly District 12',
+      );
+
+      expect(mockDb.representative.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [
+            { chamber: 'Assembly', district: 'District: 12' },
+            { chamber: 'Senate', district: '05' },
+          ],
+        },
+        orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+      });
+    });
+
+    it('should zero-pad single-digit district numbers (Congressional District 2 -> "02")', async () => {
+      mockDb.representative.findMany.mockResolvedValue([]);
+
+      await service.getRepresentativesByDistricts(
+        undefined,
+        'State Senate District 2',
+        undefined,
+      );
+
+      expect(mockDb.representative.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [{ chamber: 'Senate', district: '02' }],
+        },
+        orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+      });
+    });
+
+    it('should preserve two-digit district numbers (Assembly District 12 -> "12")', async () => {
+      mockDb.representative.findMany.mockResolvedValue([]);
+
+      await service.getRepresentativesByDistricts(
+        undefined,
+        undefined,
+        'Assembly District 12',
+      );
+
+      expect(mockDb.representative.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [{ chamber: 'Assembly', district: 'District: 12' }],
+        },
+        orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+      });
+    });
+
+    it('should return matching representatives from db', async () => {
+      const mockReps = [
+        {
+          id: '1',
+          externalId: 'rep-1',
+          name: 'Jane Senator',
+          chamber: 'Senate',
+          district: '05',
+          party: 'Democratic',
+          photoUrl: null,
+          contactInfo: null,
+          bio: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+        },
+      ];
+      mockDb.representative.findMany.mockResolvedValue(mockReps as never);
+
+      const result = await service.getRepresentativesByDistricts(
+        undefined,
+        'State Senate District 5',
+        undefined,
+      );
+
+      expect(result).toEqual(mockReps);
+    });
+  });
+
   // ==========================================
   // CAMPAIGN FINANCE GETTER TESTS
   // ==========================================

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -93,6 +93,7 @@ type RepresentativeRecord = {
   party: string | null;
   photoUrl: string | null;
   contactInfo: unknown;
+  bio: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -1088,6 +1089,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
             party: item.party ?? undefined,
             photoUrl: item.photoUrl ?? undefined,
             contactInfo: (item.contactInfo as ContactInfoModel) ?? undefined,
+            bio: item.bio ?? undefined,
           })),
           total,
           hasMore,
@@ -1101,6 +1103,55 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
    */
   async getRepresentative(id: string) {
     return this.db.representative.findUnique({ where: { id } });
+  }
+
+  /**
+   * Find representatives matching a user's civic districts.
+   * Normalizes district number formats between Census API output
+   * and scraped representative data.
+   */
+  async getRepresentativesByDistricts(
+    congressionalDistrict?: string,
+    stateSenatorialDistrict?: string,
+    stateAssemblyDistrict?: string,
+  ): Promise<RepresentativeRecord[]> {
+    const conditions: { chamber: string; district: string }[] = [];
+
+    // Extract district numbers and build match conditions
+    // Census: "Congressional District 2" → Assembly: "District: 02", Senate: "02"
+    if (stateAssemblyDistrict) {
+      const num = this.extractDistrictNumber(stateAssemblyDistrict);
+      if (num)
+        conditions.push({ chamber: 'Assembly', district: `District: ${num}` });
+    }
+    if (stateSenatorialDistrict) {
+      const num = this.extractDistrictNumber(stateSenatorialDistrict);
+      if (num) conditions.push({ chamber: 'Senate', district: num });
+    }
+
+    if (conditions.length === 0) return [];
+
+    return this.db.representative.findMany({
+      where: {
+        OR: conditions.map((c) => ({
+          chamber: c.chamber,
+          district: c.district,
+        })),
+      },
+      orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+    });
+  }
+
+  /**
+   * Extract and zero-pad a district number from Census format.
+   * "Congressional District 2" → "02"
+   * "State Senate District 12" → "12"
+   * "Assembly District 5" → "05"
+   */
+  private extractDistrictNumber(districtString: string): string | null {
+    const match = districtString.match(/(\d+)/);
+    if (!match) return null;
+    return match[1].padStart(2, '0');
   }
 
   // ==========================================

--- a/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
@@ -1,6 +1,7 @@
 import {
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
   Optional,
 } from '@nestjs/common';
@@ -16,8 +17,6 @@ import {
 } from '@opuspopuli/relationaldb-provider';
 import { IFileConfig } from 'src/config';
 import { ConsentType, ConsentStatus } from 'src/common/enums/consent.enum';
-
-import { Logger } from '@nestjs/common';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { CreateAddressDto, UpdateAddressDto } from './dto/address.dto';
 import { UpdateNotificationPreferencesDto } from './dto/notification-preferences.dto';

--- a/apps/frontend/__tests__/pages/region/page.test.tsx
+++ b/apps/frontend/__tests__/pages/region/page.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import RegionPage from "@/app/region/page";
+import { GET_REGION_INFO } from "@/lib/graphql/region";
+import { GET_MY_ADDRESSES } from "@/lib/graphql/profile";
 
 // Mock Apollo Client
 const mockRegionInfo = {
@@ -214,6 +216,102 @@ describe("RegionPage", () => {
       expect(screen.queryByText("Meetings")).not.toBeInTheDocument();
       expect(screen.queryByText("Representatives")).not.toBeInTheDocument();
       expect(screen.queryByText("Campaign Finance")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("MyRepresentativesSection", () => {
+    const mockAddress = {
+      id: "addr-1",
+      userId: "user-1",
+      addressType: "HOME",
+      isPrimary: true,
+      label: "Home",
+      addressLine1: "123 Main St",
+      city: "Sacramento",
+      state: "CA",
+      postalCode: "95814",
+      country: "US",
+      congressionalDistrict: "Congressional District 7",
+      stateSenatorialDistrict: "State Senate District 5",
+      stateAssemblyDistrict: "Assembly District 12",
+    };
+
+    const mockReps = [
+      {
+        id: "rep-1",
+        name: "Jane Senator",
+        chamber: "Senate",
+        district: "05",
+        party: "Democratic",
+        photoUrl: null,
+      },
+      {
+        id: "rep-2",
+        name: "John Assembly",
+        chamber: "Assembly",
+        district: "District: 12",
+        party: "Republican",
+        photoUrl: null,
+      },
+    ];
+
+    it("should render My Representatives heading and rep names as links", () => {
+      const { useQuery } = jest.requireMock("@apollo/client/react");
+      (useQuery as jest.Mock).mockImplementation((query: unknown) => {
+        if (query === GET_MY_ADDRESSES) {
+          return {
+            data: { myAddresses: [mockAddress] },
+            loading: false,
+            error: null,
+          };
+        }
+        if (query === GET_REGION_INFO) {
+          return {
+            data: { regionInfo: mockRegionInfo },
+            loading: false,
+            error: null,
+          };
+        }
+        // GET_REPRESENTATIVES_BY_DISTRICTS
+        return {
+          data: { representativesByDistricts: mockReps },
+          loading: false,
+          error: null,
+        };
+      });
+
+      render(<RegionPage />);
+
+      expect(screen.getByText("My Representatives")).toBeInTheDocument();
+      const janeLink = screen.getByRole("link", { name: /Jane Senator/i });
+      expect(janeLink).toHaveAttribute("href", "/region/representatives/rep-1");
+      const johnLink = screen.getByRole("link", { name: /John Assembly/i });
+      expect(johnLink).toHaveAttribute("href", "/region/representatives/rep-2");
+    });
+
+    it("should show add-address prompt when no primary address", () => {
+      const { useQuery } = jest.requireMock("@apollo/client/react");
+      (useQuery as jest.Mock).mockImplementation((query: unknown) => {
+        if (query === GET_MY_ADDRESSES) {
+          return { data: { myAddresses: [] }, loading: false, error: null };
+        }
+        if (query === GET_REGION_INFO) {
+          return {
+            data: { regionInfo: mockRegionInfo },
+            loading: false,
+            error: null,
+          };
+        }
+        return { data: null, loading: false, error: null };
+      });
+
+      render(<RegionPage />);
+
+      expect(screen.getByText("My Representatives")).toBeInTheDocument();
+      expect(screen.getByText(/Add an address/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /profile settings/i }),
+      ).toHaveAttribute("href", "/settings/addresses");
     });
   });
 });

--- a/apps/frontend/app/region/page.tsx
+++ b/apps/frontend/app/region/page.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useQuery } from "@apollo/client/react";
 import {
   GET_REGION_INFO,
+  GET_REPRESENTATIVES_BY_DISTRICTS,
   RegionInfoData,
+  RepresentativesByDistrictsData,
   DataType,
 } from "@/lib/graphql/region";
+import { GET_MY_ADDRESSES, type MyAddressesData } from "@/lib/graphql/profile";
+import { PartyBadge } from "@/components/region/PartyBadge";
 
 const DATA_TYPE_CARDS: Record<
   DataType,
@@ -109,6 +114,107 @@ function DataTypeIcon({ type }: { readonly type: string }) {
   }
 }
 
+function MyRepresentativesSection() {
+  // Get user's primary address with district info
+  const { data: addressData } = useQuery<MyAddressesData>(GET_MY_ADDRESSES);
+
+  const primaryAddress = addressData?.myAddresses?.find((a) => a.isPrimary);
+  const hasDistricts =
+    primaryAddress?.congressionalDistrict ||
+    primaryAddress?.stateSenatorialDistrict ||
+    primaryAddress?.stateAssemblyDistrict;
+
+  // Fetch matching representatives
+  const { data: repData } = useQuery<RepresentativesByDistrictsData>(
+    GET_REPRESENTATIVES_BY_DISTRICTS,
+    {
+      variables: {
+        congressionalDistrict: primaryAddress?.congressionalDistrict,
+        stateSenatorialDistrict: primaryAddress?.stateSenatorialDistrict,
+        stateAssemblyDistrict: primaryAddress?.stateAssemblyDistrict,
+      },
+      skip: !hasDistricts,
+    },
+  );
+
+  const reps = repData?.representativesByDistricts;
+
+  // Don't show section if no address or no districts
+  if (!hasDistricts || !reps || reps.length === 0) {
+    if (!primaryAddress) {
+      return (
+        <div className="mb-10 bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6">
+          <h2 className="text-lg font-semibold text-[#222222] mb-2">
+            My Representatives
+          </h2>
+          <p className="text-sm text-[#4d4d4d] mb-3">
+            Add an address in your{" "}
+            <Link
+              href="/settings/addresses"
+              className="text-blue-600 hover:underline"
+            >
+              profile settings
+            </Link>{" "}
+            to see your elected representatives.
+          </p>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  return (
+    <div className="mb-10">
+      <h2 className="text-lg font-semibold text-[#222222] mb-4">
+        My Representatives
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {reps.map((rep) => (
+          <Link
+            key={rep.id}
+            href={`/region/representatives/${rep.id}`}
+            className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-4 hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-shadow flex items-center gap-3"
+          >
+            {rep.photoUrl ? (
+              <Image
+                src={rep.photoUrl}
+                alt={rep.name}
+                width={48}
+                height={48}
+                className="w-12 h-12 rounded-full object-cover"
+                unoptimized
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0">
+                <svg
+                  className="w-6 h-6 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              </div>
+            )}
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-[#222222] truncate">{rep.name}</p>
+              <div className="flex items-center gap-2 mt-0.5">
+                <PartyBadge party={rep.party} />
+                <span className="text-xs text-[#4d4d4d]">{rep.chamber}</span>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function RegionPage() {
   const { data, loading, error } = useQuery<RegionInfoData>(GET_REGION_INFO);
 
@@ -146,6 +252,9 @@ export default function RegionPage() {
 
   return (
     <div className="max-w-4xl mx-auto px-8 py-12">
+      {/* My Representatives */}
+      <MyRepresentativesSection />
+
       {/* Region Header */}
       <div className="mb-10">
         <h1 className="text-3xl font-bold text-[#222222]">

--- a/apps/frontend/app/region/page.tsx
+++ b/apps/frontend/app/region/page.tsx
@@ -151,7 +151,7 @@ function MyRepresentativesSection() {
             Add an address in your{" "}
             <Link
               href="/settings/addresses"
-              className="text-blue-600 hover:underline"
+              className="text-[#222222] underline font-medium"
             >
               profile settings
             </Link>{" "}

--- a/apps/frontend/e2e/region.spec.ts
+++ b/apps/frontend/e2e/region.spec.ts
@@ -411,7 +411,9 @@ test.describe("Region Page", () => {
 
     await expect(page.getByText("Propositions")).toBeVisible();
     await expect(page.getByText("Meetings")).toBeVisible();
-    await expect(page.getByText("Representatives")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Representatives.*Elected/i }),
+    ).toBeVisible();
     await expect(page.getByText("Campaign Finance")).toBeVisible();
   });
 

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -442,6 +442,31 @@ export const GET_REPRESENTATIVE = gql`
   }
 `;
 
+export const GET_REPRESENTATIVES_BY_DISTRICTS = gql`
+  query GetRepresentativesByDistricts(
+    $congressionalDistrict: String
+    $stateSenatorialDistrict: String
+    $stateAssemblyDistrict: String
+  ) {
+    representativesByDistricts(
+      congressionalDistrict: $congressionalDistrict
+      stateSenatorialDistrict: $stateSenatorialDistrict
+      stateAssemblyDistrict: $stateAssemblyDistrict
+    ) {
+      id
+      name
+      chamber
+      district
+      party
+      photoUrl
+    }
+  }
+`;
+
+export interface RepresentativesByDistrictsData {
+  representativesByDistricts: Representative[];
+}
+
 // ============================================
 // Campaign Finance Queries
 // ============================================


### PR DESCRIPTION
## Summary
- **My Representatives**: Region hub shows user's specific Assembly member and Senator based on geocoded primary address
- **representativesByDistricts query**: New GraphQL query matching user's civic districts to representatives
- **District normalization**: Extracts and zero-pads district numbers to match between Census and scraped formats
- **Bio field**: Added to RepresentativeRecord type for null→undefined conversion
- **Import fix**: Consolidated duplicate @nestjs/common import in profile service

## Test plan
- [x] Full `pnpm -r test` passes
- [x] Live UAT: My Representatives shows correct Assembly member and Senator for geocoded address
- [x] Prompts to add address when none exists

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)