### PR TITLE
Release: My Representatives, address geocoding, representative detail pages and data extraction

### DIFF
--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -319,6 +319,59 @@ describe('RegionResolver', () => {
     });
   });
 
+  describe('representativesByDistricts', () => {
+    it('should call service with district strings', async () => {
+      regionService.getRepresentativesByDistricts.mockResolvedValue([
+        mockRepresentative,
+      ]);
+
+      const result = await resolver.representativesByDistricts(
+        'Congressional District 2',
+        'State Senate District 5',
+        'Assembly District 12',
+      );
+
+      expect(regionService.getRepresentativesByDistricts).toHaveBeenCalledWith(
+        'Congressional District 2',
+        'State Senate District 5',
+        'Assembly District 12',
+      );
+      expect(result).toHaveLength(1);
+    });
+
+    it('should convert null party/photoUrl/bio to undefined', async () => {
+      const repWithNulls = {
+        ...mockRepresentative,
+        party: null,
+        photoUrl: null,
+        bio: null,
+        contactInfo: null,
+      };
+      regionService.getRepresentativesByDistricts.mockResolvedValue([
+        repWithNulls,
+      ]);
+
+      const result = await resolver.representativesByDistricts(
+        undefined,
+        'State Senate District 5',
+        undefined,
+      );
+
+      expect(result[0].party).toBeUndefined();
+      expect(result[0].photoUrl).toBeUndefined();
+      expect(result[0].bio).toBeUndefined();
+      expect(result[0].contactInfo).toBeUndefined();
+    });
+
+    it('should return empty array when service returns empty', async () => {
+      regionService.getRepresentativesByDistricts.mockResolvedValue([]);
+
+      const result = await resolver.representativesByDistricts();
+
+      expect(result).toEqual([]);
+    });
+  });
+
   // ==========================================
   // CAMPAIGN FINANCE QUERIES
   // ==========================================

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -156,6 +156,35 @@ export class RegionResolver {
     };
   }
 
+  /**
+   * Find representatives matching a user's civic districts.
+   * Districts come from the user's geocoded address (Census API format).
+   */
+  @Public()
+  @Query(() => [RepresentativeModel])
+  async representativesByDistricts(
+    @Args({ name: 'congressionalDistrict', nullable: true })
+    congressionalDistrict?: string,
+    @Args({ name: 'stateSenatorialDistrict', nullable: true })
+    stateSenatorialDistrict?: string,
+    @Args({ name: 'stateAssemblyDistrict', nullable: true })
+    stateAssemblyDistrict?: string,
+  ): Promise<RepresentativeModel[]> {
+    const results = await this.regionService.getRepresentativesByDistricts(
+      congressionalDistrict,
+      stateSenatorialDistrict,
+      stateAssemblyDistrict,
+    );
+
+    return results.map((r) => ({
+      ...r,
+      party: r.party ?? undefined,
+      photoUrl: r.photoUrl ?? undefined,
+      contactInfo: (r.contactInfo as ContactInfoModel) ?? undefined,
+      bio: r.bio ?? undefined,
+    })) as RepresentativeModel[];
+  }
+
   // ==========================================
   // CAMPAIGN FINANCE QUERIES
   // ==========================================

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -593,6 +593,101 @@ describe('RegionDomainService', () => {
     });
   });
 
+  describe('getRepresentativesByDistricts', () => {
+    it('should return empty array when no districts provided', async () => {
+      // Reset call tracking so we only see calls from our method
+      mockDb.representative.findMany.mockClear();
+
+      const result = await service.getRepresentativesByDistricts();
+
+      expect(result).toEqual([]);
+      // Should not have called findMany at all (early return)
+      expect(mockDb.representative.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should build correct OR conditions for assembly and senate districts', async () => {
+      mockDb.representative.findMany.mockResolvedValue([]);
+
+      await service.getRepresentativesByDistricts(
+        undefined,
+        'State Senate District 5',
+        'Assembly District 12',
+      );
+
+      expect(mockDb.representative.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [
+            { chamber: 'Assembly', district: 'District: 12' },
+            { chamber: 'Senate', district: '05' },
+          ],
+        },
+        orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+      });
+    });
+
+    it('should zero-pad single-digit district numbers (Congressional District 2 -> "02")', async () => {
+      mockDb.representative.findMany.mockResolvedValue([]);
+
+      await service.getRepresentativesByDistricts(
+        undefined,
+        'State Senate District 2',
+        undefined,
+      );
+
+      expect(mockDb.representative.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [{ chamber: 'Senate', district: '02' }],
+        },
+        orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+      });
+    });
+
+    it('should preserve two-digit district numbers (Assembly District 12 -> "12")', async () => {
+      mockDb.representative.findMany.mockResolvedValue([]);
+
+      await service.getRepresentativesByDistricts(
+        undefined,
+        undefined,
+        'Assembly District 12',
+      );
+
+      expect(mockDb.representative.findMany).toHaveBeenCalledWith({
+        where: {
+          OR: [{ chamber: 'Assembly', district: 'District: 12' }],
+        },
+        orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+      });
+    });
+
+    it('should return matching representatives from db', async () => {
+      const mockReps = [
+        {
+          id: '1',
+          externalId: 'rep-1',
+          name: 'Jane Senator',
+          chamber: 'Senate',
+          district: '05',
+          party: 'Democratic',
+          photoUrl: null,
+          contactInfo: null,
+          bio: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          deletedAt: null,
+        },
+      ];
+      mockDb.representative.findMany.mockResolvedValue(mockReps as never);
+
+      const result = await service.getRepresentativesByDistricts(
+        undefined,
+        'State Senate District 5',
+        undefined,
+      );
+
+      expect(result).toEqual(mockReps);
+    });
+  });
+
   // ==========================================
   // CAMPAIGN FINANCE GETTER TESTS
   // ==========================================

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -93,6 +93,7 @@ type RepresentativeRecord = {
   party: string | null;
   photoUrl: string | null;
   contactInfo: unknown;
+  bio: string | null;
   createdAt: Date;
   updatedAt: Date;
 };
@@ -1088,6 +1089,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
             party: item.party ?? undefined,
             photoUrl: item.photoUrl ?? undefined,
             contactInfo: (item.contactInfo as ContactInfoModel) ?? undefined,
+            bio: item.bio ?? undefined,
           })),
           total,
           hasMore,
@@ -1101,6 +1103,55 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
    */
   async getRepresentative(id: string) {
     return this.db.representative.findUnique({ where: { id } });
+  }
+
+  /**
+   * Find representatives matching a user's civic districts.
+   * Normalizes district number formats between Census API output
+   * and scraped representative data.
+   */
+  async getRepresentativesByDistricts(
+    congressionalDistrict?: string,
+    stateSenatorialDistrict?: string,
+    stateAssemblyDistrict?: string,
+  ): Promise<RepresentativeRecord[]> {
+    const conditions: { chamber: string; district: string }[] = [];
+
+    // Extract district numbers and build match conditions
+    // Census: "Congressional District 2" → Assembly: "District: 02", Senate: "02"
+    if (stateAssemblyDistrict) {
+      const num = this.extractDistrictNumber(stateAssemblyDistrict);
+      if (num)
+        conditions.push({ chamber: 'Assembly', district: `District: ${num}` });
+    }
+    if (stateSenatorialDistrict) {
+      const num = this.extractDistrictNumber(stateSenatorialDistrict);
+      if (num) conditions.push({ chamber: 'Senate', district: num });
+    }
+
+    if (conditions.length === 0) return [];
+
+    return this.db.representative.findMany({
+      where: {
+        OR: conditions.map((c) => ({
+          chamber: c.chamber,
+          district: c.district,
+        })),
+      },
+      orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+    });
+  }
+
+  /**
+   * Extract and zero-pad a district number from Census format.
+   * "Congressional District 2" → "02"
+   * "State Senate District 12" → "12"
+   * "Assembly District 5" → "05"
+   */
+  private extractDistrictNumber(districtString: string): string | null {
+    const match = districtString.match(/(\d+)/);
+    if (!match) return null;
+    return match[1].padStart(2, '0');
   }
 
   // ==========================================

--- a/apps/backend/src/apps/users/src/domains/profile/dto/address.dto.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/dto/address.dto.ts
@@ -15,7 +15,7 @@ import { AddressType } from 'src/common/enums/address.enum';
 @InputType()
 export class CreateAddressDto {
   @IsEnum(AddressType)
-  @Field(() => String)
+  @Field(() => AddressType)
   public addressType!: AddressType;
 
   @IsOptional()
@@ -74,7 +74,7 @@ export class UpdateAddressDto {
 
   @IsOptional()
   @IsEnum(AddressType)
-  @Field(() => String, { nullable: true })
+  @Field(() => AddressType, { nullable: true })
   public addressType?: AddressType;
 
   @IsOptional()

--- a/apps/backend/src/apps/users/src/domains/profile/geocoding.service.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/geocoding.service.spec.ts
@@ -1,0 +1,162 @@
+import { GeocodingService } from './geocoding.service';
+
+describe('GeocodingService', () => {
+  let service: GeocodingService;
+
+  beforeEach(() => {
+    service = new GeocodingService();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('geocode', () => {
+    it('should return null when Census API returns no matches', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            result: { addressMatches: [] },
+          }),
+      };
+      jest.spyOn(global, 'fetch').mockResolvedValue(mockResponse as Response);
+
+      const result = await service.geocode(
+        '999 Nonexistent St',
+        'Nowhere',
+        'XX',
+        '00000',
+      );
+
+      expect(result).toBeNull();
+      jest.restoreAllMocks();
+    });
+
+    it('should return geocoding result with coordinates and districts', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            result: {
+              addressMatches: [
+                {
+                  coordinates: { x: -121.495, y: 38.574 },
+                  matchedAddress: '1021 O ST, SACRAMENTO, CA, 95814',
+                  geographies: {
+                    '119th Congressional Districts': [
+                      { NAME: 'Congressional District 7' },
+                    ],
+                    '2024 State Legislative Districts - Upper': [
+                      { NAME: 'State Senate District 8' },
+                    ],
+                    '2024 State Legislative Districts - Lower': [
+                      { NAME: 'Assembly District 6' },
+                    ],
+                    Counties: [{ NAME: 'Sacramento County' }],
+                    'Incorporated Places': [{ NAME: 'Sacramento city' }],
+                  },
+                },
+              ],
+            },
+          }),
+      };
+      jest.spyOn(global, 'fetch').mockResolvedValue(mockResponse as Response);
+
+      const result = await service.geocode(
+        '1021 O Street',
+        'Sacramento',
+        'CA',
+        '95814',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.latitude).toBe(38.574);
+      expect(result!.longitude).toBe(-121.495);
+      expect(result!.formattedAddress).toBe('1021 O ST, SACRAMENTO, CA, 95814');
+      expect(result!.congressionalDistrict).toBe('Congressional District 7');
+      expect(result!.stateSenatorialDistrict).toBe('State Senate District 8');
+      expect(result!.stateAssemblyDistrict).toBe('Assembly District 6');
+      expect(result!.county).toBe('Sacramento County');
+      expect(result!.municipality).toBe('Sacramento city');
+      expect(result!.timezone).toBe('America/Los_Angeles');
+
+      jest.restoreAllMocks();
+    });
+
+    it('should return null when fetch fails', async () => {
+      jest.spyOn(global, 'fetch').mockRejectedValue(new Error('Network error'));
+
+      const result = await service.geocode(
+        '123 Main St',
+        'Anytown',
+        'CA',
+        '90210',
+      );
+
+      expect(result).toBeNull();
+      jest.restoreAllMocks();
+    });
+
+    it('should return null when API returns non-200', async () => {
+      const mockResponse = { ok: false, status: 500, statusText: 'Error' };
+      jest.spyOn(global, 'fetch').mockResolvedValue(mockResponse as Response);
+
+      const result = await service.geocode(
+        '123 Main St',
+        'Anytown',
+        'CA',
+        '90210',
+      );
+
+      expect(result).toBeNull();
+      jest.restoreAllMocks();
+    });
+
+    it('should derive correct timezone from longitude', async () => {
+      const makeMatch = (lng: number) => ({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            result: {
+              addressMatches: [
+                {
+                  coordinates: { x: lng, y: 40 },
+                  matchedAddress: 'Test',
+                  geographies: {},
+                },
+              ],
+            },
+          }),
+      });
+
+      // Eastern
+      jest.spyOn(global, 'fetch').mockResolvedValue(makeMatch(-74) as Response);
+      let result = await service.geocode('a', 'b', 'c', 'd');
+      expect(result!.timezone).toBe('America/New_York');
+      jest.restoreAllMocks();
+
+      // Central
+      jest.spyOn(global, 'fetch').mockResolvedValue(makeMatch(-90) as Response);
+      result = await service.geocode('a', 'b', 'c', 'd');
+      expect(result!.timezone).toBe('America/Chicago');
+      jest.restoreAllMocks();
+
+      // Mountain
+      jest
+        .spyOn(global, 'fetch')
+        .mockResolvedValue(makeMatch(-105) as Response);
+      result = await service.geocode('a', 'b', 'c', 'd');
+      expect(result!.timezone).toBe('America/Denver');
+      jest.restoreAllMocks();
+
+      // Pacific
+      jest
+        .spyOn(global, 'fetch')
+        .mockResolvedValue(makeMatch(-120) as Response);
+      result = await service.geocode('a', 'b', 'c', 'd');
+      expect(result!.timezone).toBe('America/Los_Angeles');
+      jest.restoreAllMocks();
+    });
+  });
+});

--- a/apps/backend/src/apps/users/src/domains/profile/geocoding.service.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/geocoding.service.ts
@@ -1,0 +1,148 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+/**
+ * Geocoding result from Census Geocoder API
+ */
+export interface GeocodingResult {
+  latitude: number;
+  longitude: number;
+  formattedAddress: string;
+  congressionalDistrict?: string;
+  stateSenatorialDistrict?: string;
+  stateAssemblyDistrict?: string;
+  county?: string;
+  municipality?: string;
+  timezone?: string;
+}
+
+/**
+ * Geocoding service using the US Census Geocoder API.
+ *
+ * Free, no API key required. Returns lat/lng + civic districts
+ * (congressional, state senate, state assembly, county).
+ */
+const DEFAULT_GEOCODER_URL =
+  'https://geocoding.geo.census.gov/geocoder/geographies/address';
+
+@Injectable()
+export class GeocodingService {
+  private readonly logger = new Logger(GeocodingService.name);
+  private readonly baseUrl: string;
+
+  constructor(@Optional() configService?: ConfigService) {
+    this.baseUrl =
+      configService?.get<string>('GEOCODER_URL') || DEFAULT_GEOCODER_URL;
+  }
+
+  /**
+   * Geocode a US address and return coordinates + civic districts.
+   * Returns null if the address cannot be geocoded.
+   */
+  async geocode(
+    addressLine1: string,
+    city: string,
+    state: string,
+    postalCode: string,
+  ): Promise<GeocodingResult | null> {
+    const params = new URLSearchParams({
+      street: addressLine1,
+      city,
+      state,
+      zip: postalCode,
+      benchmark: 'Public_AR_Current',
+      vintage: 'Current_Current',
+      format: 'json',
+    });
+
+    const url = `${this.baseUrl}?${params}`;
+
+    try {
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(10_000),
+      });
+
+      if (!response.ok) {
+        this.logger.warn(
+          `Census Geocoder returned ${response.status} for ${addressLine1}, ${city}, ${state}`,
+        );
+        return null;
+      }
+
+      const data = await response.json();
+      const matches = data?.result?.addressMatches;
+
+      if (!matches || matches.length === 0) {
+        this.logger.debug(
+          `No geocoding match for ${addressLine1}, ${city}, ${state}`,
+        );
+        return null;
+      }
+
+      const match = matches[0];
+      const geographies = match.geographies || {};
+
+      return {
+        latitude: match.coordinates?.y,
+        longitude: match.coordinates?.x,
+        formattedAddress: match.matchedAddress || '',
+        congressionalDistrict: this.extractGeography(
+          geographies,
+          '119th Congressional Districts',
+          'NAME',
+        ),
+        stateSenatorialDistrict: this.extractGeography(
+          geographies,
+          '2024 State Legislative Districts - Upper',
+          'NAME',
+        ),
+        stateAssemblyDistrict: this.extractGeography(
+          geographies,
+          '2024 State Legislative Districts - Lower',
+          'NAME',
+        ),
+        county: this.extractGeography(geographies, 'Counties', 'NAME'),
+        municipality: this.extractGeography(
+          geographies,
+          'Incorporated Places',
+          'NAME',
+        ),
+        timezone: this.deriveTimezone(match.coordinates?.x),
+      };
+    } catch (error) {
+      this.logger.warn(
+        `Geocoding failed for ${addressLine1}, ${city}, ${state}: ${(error as Error).message}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Extract a geography name from the Census response.
+   */
+  private extractGeography(
+    geographies: Record<string, unknown[]>,
+    key: string,
+    field: string,
+  ): string | undefined {
+    const entries = geographies[key] as Record<string, string>[] | undefined;
+    return entries?.[0]?.[field] || undefined;
+  }
+
+  /**
+   * Derive timezone from longitude (simple US-only approximation).
+   * For production, use a proper timezone lookup library.
+   */
+  private deriveTimezone(longitude?: number): string | undefined {
+    if (longitude === undefined || longitude === null) return undefined;
+
+    // US timezone boundaries (approximate, by longitude)
+    if (longitude > -67.5) return 'America/New_York'; // Eastern + Atlantic
+    if (longitude > -82.5) return 'America/New_York'; // Eastern
+    if (longitude > -97.5) return 'America/Chicago'; // Central
+    if (longitude > -112.5) return 'America/Denver'; // Mountain
+    if (longitude > -127.5) return 'America/Los_Angeles'; // Pacific
+    if (longitude > -145) return 'America/Anchorage'; // Alaska
+    return 'Pacific/Honolulu'; // Hawaii
+  }
+}

--- a/apps/backend/src/apps/users/src/domains/profile/profile.module.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.module.ts
@@ -5,10 +5,11 @@ import { StorageModule } from '@opuspopuli/storage-provider';
 
 import { ProfileService } from './profile.service';
 import { ProfileResolver } from './profile.resolver';
+import { GeocodingService } from './geocoding.service';
 
 @Module({
   imports: [StorageModule],
-  providers: [ProfileService, ProfileResolver],
+  providers: [ProfileService, ProfileResolver, GeocodingService],
   exports: [ProfileService],
 })
 export class ProfileModule {}

--- a/apps/backend/src/apps/users/src/domains/profile/profile.service.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.service.spec.ts
@@ -20,10 +20,12 @@ import {
 import { ConsentType, ConsentStatus } from 'src/common/enums/consent.enum';
 import { AddressType } from 'src/common/enums/address.enum';
 import { CreateAddressDto } from './dto/address.dto';
+import { GeocodingService } from './geocoding.service';
 
 describe('ProfileService', () => {
   let service: ProfileService;
   let mockDb: MockDbClient;
+  let mockGeocodingService: jest.Mocked<GeocodingService>;
 
   const mockUserId = 'test-user-id';
 
@@ -141,6 +143,9 @@ describe('ProfileService', () => {
 
   beforeEach(async () => {
     mockDb = createMockDbClient();
+    mockGeocodingService = {
+      geocode: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<GeocodingService>;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -148,6 +153,10 @@ describe('ProfileService', () => {
         {
           provide: DbService,
           useValue: mockDb,
+        },
+        {
+          provide: GeocodingService,
+          useValue: mockGeocodingService,
         },
       ],
     }).compile();

--- a/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
@@ -17,18 +17,23 @@ import {
 import { IFileConfig } from 'src/config';
 import { ConsentType, ConsentStatus } from 'src/common/enums/consent.enum';
 
+import { Logger } from '@nestjs/common';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { CreateAddressDto, UpdateAddressDto } from './dto/address.dto';
 import { UpdateNotificationPreferencesDto } from './dto/notification-preferences.dto';
 import { UpdateConsentDto } from './dto/consent.dto';
 import { ProfileCompletionResult } from './models/profile-completion.model';
+import { GeocodingService } from './geocoding.service';
 
 @Injectable()
 export class ProfileService {
   private fileConfig?: IFileConfig;
 
+  private readonly logger = new Logger(ProfileService.name);
+
   constructor(
     private readonly db: DbService,
+    private readonly geocodingService: GeocodingService,
     @Optional()
     @Inject('STORAGE_PROVIDER')
     private readonly storage?: IStorageProvider,
@@ -214,12 +219,17 @@ export class ProfileService {
       });
     }
 
-    return this.db.userAddress.create({
+    const address = await this.db.userAddress.create({
       data: {
         userId,
         ...createDto,
       },
     });
+
+    // Geocode async — don't block address creation
+    this.geocodeAndUpdate(userId, address.id, createDto).catch(() => {});
+
+    return address;
   }
 
   async updateAddress(
@@ -246,10 +256,78 @@ export class ProfileService {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { id: _id, ...updateData } = updateDto;
 
-    return this.db.userAddress.update({
+    const updated = await this.db.userAddress.update({
       where: { id: address.id },
       data: updateData,
     });
+
+    // Re-geocode if address fields changed
+    if (
+      updateDto.addressLine1 ||
+      updateDto.city ||
+      updateDto.state ||
+      updateDto.postalCode
+    ) {
+      this.geocodeAndUpdate(userId, updated.id, updated).catch(() => {});
+    }
+
+    return updated;
+  }
+
+  /**
+   * Geocode an address and update the record with coordinates and civic districts.
+   * Also updates the user's profile timezone from the primary address.
+   * Fire-and-forget — failures are logged but don't affect the caller.
+   */
+  private async geocodeAndUpdate(
+    userId: string,
+    addressId: string,
+    address: {
+      addressLine1: string;
+      city: string;
+      state: string;
+      postalCode: string;
+      isPrimary?: boolean;
+    },
+  ): Promise<void> {
+    const result = await this.geocodingService.geocode(
+      address.addressLine1,
+      address.city,
+      address.state,
+      address.postalCode,
+    );
+
+    if (!result) return;
+
+    await this.db.userAddress.update({
+      where: { id: addressId },
+      data: {
+        latitude: result.latitude,
+        longitude: result.longitude,
+        formattedAddress: result.formattedAddress,
+        congressionalDistrict: result.congressionalDistrict,
+        stateSenatorialDistrict: result.stateSenatorialDistrict,
+        stateAssemblyDistrict: result.stateAssemblyDistrict,
+        county: result.county,
+        municipality: result.municipality,
+        isVerified: true,
+        geocodedAt: new Date(),
+      },
+    });
+
+    this.logger.log(
+      `Geocoded address ${addressId}: ${result.formattedAddress} → ${result.congressionalDistrict}`,
+    );
+
+    // Auto-set timezone on user profile from primary address
+    if (address.isPrimary && result.timezone) {
+      await this.db.userProfile
+        .update({
+          where: { userId },
+          data: { timezone: result.timezone },
+        })
+        .catch(() => {}); // Profile may not exist yet
+    }
   }
 
   async deleteAddress(userId: string, addressId: string): Promise<boolean> {

--- a/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
@@ -1,6 +1,7 @@
 import {
   Inject,
   Injectable,
+  Logger,
   NotFoundException,
   Optional,
 } from '@nestjs/common';
@@ -16,8 +17,6 @@ import {
 } from '@opuspopuli/relationaldb-provider';
 import { IFileConfig } from 'src/config';
 import { ConsentType, ConsentStatus } from 'src/common/enums/consent.enum';
-
-import { Logger } from '@nestjs/common';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { CreateAddressDto, UpdateAddressDto } from './dto/address.dto';
 import { UpdateNotificationPreferencesDto } from './dto/notification-preferences.dto';

--- a/apps/frontend/__tests__/pages/region/page.test.tsx
+++ b/apps/frontend/__tests__/pages/region/page.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import RegionPage from "@/app/region/page";
+import { GET_REGION_INFO } from "@/lib/graphql/region";
+import { GET_MY_ADDRESSES } from "@/lib/graphql/profile";
 
 // Mock Apollo Client
 const mockRegionInfo = {
@@ -214,6 +216,102 @@ describe("RegionPage", () => {
       expect(screen.queryByText("Meetings")).not.toBeInTheDocument();
       expect(screen.queryByText("Representatives")).not.toBeInTheDocument();
       expect(screen.queryByText("Campaign Finance")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("MyRepresentativesSection", () => {
+    const mockAddress = {
+      id: "addr-1",
+      userId: "user-1",
+      addressType: "HOME",
+      isPrimary: true,
+      label: "Home",
+      addressLine1: "123 Main St",
+      city: "Sacramento",
+      state: "CA",
+      postalCode: "95814",
+      country: "US",
+      congressionalDistrict: "Congressional District 7",
+      stateSenatorialDistrict: "State Senate District 5",
+      stateAssemblyDistrict: "Assembly District 12",
+    };
+
+    const mockReps = [
+      {
+        id: "rep-1",
+        name: "Jane Senator",
+        chamber: "Senate",
+        district: "05",
+        party: "Democratic",
+        photoUrl: null,
+      },
+      {
+        id: "rep-2",
+        name: "John Assembly",
+        chamber: "Assembly",
+        district: "District: 12",
+        party: "Republican",
+        photoUrl: null,
+      },
+    ];
+
+    it("should render My Representatives heading and rep names as links", () => {
+      const { useQuery } = jest.requireMock("@apollo/client/react");
+      (useQuery as jest.Mock).mockImplementation((query: unknown) => {
+        if (query === GET_MY_ADDRESSES) {
+          return {
+            data: { myAddresses: [mockAddress] },
+            loading: false,
+            error: null,
+          };
+        }
+        if (query === GET_REGION_INFO) {
+          return {
+            data: { regionInfo: mockRegionInfo },
+            loading: false,
+            error: null,
+          };
+        }
+        // GET_REPRESENTATIVES_BY_DISTRICTS
+        return {
+          data: { representativesByDistricts: mockReps },
+          loading: false,
+          error: null,
+        };
+      });
+
+      render(<RegionPage />);
+
+      expect(screen.getByText("My Representatives")).toBeInTheDocument();
+      const janeLink = screen.getByRole("link", { name: /Jane Senator/i });
+      expect(janeLink).toHaveAttribute("href", "/region/representatives/rep-1");
+      const johnLink = screen.getByRole("link", { name: /John Assembly/i });
+      expect(johnLink).toHaveAttribute("href", "/region/representatives/rep-2");
+    });
+
+    it("should show add-address prompt when no primary address", () => {
+      const { useQuery } = jest.requireMock("@apollo/client/react");
+      (useQuery as jest.Mock).mockImplementation((query: unknown) => {
+        if (query === GET_MY_ADDRESSES) {
+          return { data: { myAddresses: [] }, loading: false, error: null };
+        }
+        if (query === GET_REGION_INFO) {
+          return {
+            data: { regionInfo: mockRegionInfo },
+            loading: false,
+            error: null,
+          };
+        }
+        return { data: null, loading: false, error: null };
+      });
+
+      render(<RegionPage />);
+
+      expect(screen.getByText("My Representatives")).toBeInTheDocument();
+      expect(screen.getByText(/Add an address/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /profile settings/i }),
+      ).toHaveAttribute("href", "/settings/addresses");
     });
   });
 });

--- a/apps/frontend/app/region/page.tsx
+++ b/apps/frontend/app/region/page.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useQuery } from "@apollo/client/react";
 import {
   GET_REGION_INFO,
+  GET_REPRESENTATIVES_BY_DISTRICTS,
   RegionInfoData,
+  RepresentativesByDistrictsData,
   DataType,
 } from "@/lib/graphql/region";
+import { GET_MY_ADDRESSES, type MyAddressesData } from "@/lib/graphql/profile";
+import { PartyBadge } from "@/components/region/PartyBadge";
 
 const DATA_TYPE_CARDS: Record<
   DataType,
@@ -109,6 +114,107 @@ function DataTypeIcon({ type }: { readonly type: string }) {
   }
 }
 
+function MyRepresentativesSection() {
+  // Get user's primary address with district info
+  const { data: addressData } = useQuery<MyAddressesData>(GET_MY_ADDRESSES);
+
+  const primaryAddress = addressData?.myAddresses?.find((a) => a.isPrimary);
+  const hasDistricts =
+    primaryAddress?.congressionalDistrict ||
+    primaryAddress?.stateSenatorialDistrict ||
+    primaryAddress?.stateAssemblyDistrict;
+
+  // Fetch matching representatives
+  const { data: repData } = useQuery<RepresentativesByDistrictsData>(
+    GET_REPRESENTATIVES_BY_DISTRICTS,
+    {
+      variables: {
+        congressionalDistrict: primaryAddress?.congressionalDistrict,
+        stateSenatorialDistrict: primaryAddress?.stateSenatorialDistrict,
+        stateAssemblyDistrict: primaryAddress?.stateAssemblyDistrict,
+      },
+      skip: !hasDistricts,
+    },
+  );
+
+  const reps = repData?.representativesByDistricts;
+
+  // Don't show section if no address or no districts
+  if (!hasDistricts || !reps || reps.length === 0) {
+    if (!primaryAddress) {
+      return (
+        <div className="mb-10 bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6">
+          <h2 className="text-lg font-semibold text-[#222222] mb-2">
+            My Representatives
+          </h2>
+          <p className="text-sm text-[#4d4d4d] mb-3">
+            Add an address in your{" "}
+            <Link
+              href="/settings/addresses"
+              className="text-blue-600 hover:underline"
+            >
+              profile settings
+            </Link>{" "}
+            to see your elected representatives.
+          </p>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  return (
+    <div className="mb-10">
+      <h2 className="text-lg font-semibold text-[#222222] mb-4">
+        My Representatives
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {reps.map((rep) => (
+          <Link
+            key={rep.id}
+            href={`/region/representatives/${rep.id}`}
+            className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-4 hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-shadow flex items-center gap-3"
+          >
+            {rep.photoUrl ? (
+              <Image
+                src={rep.photoUrl}
+                alt={rep.name}
+                width={48}
+                height={48}
+                className="w-12 h-12 rounded-full object-cover"
+                unoptimized
+              />
+            ) : (
+              <div className="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0">
+                <svg
+                  className="w-6 h-6 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={1.5}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+              </div>
+            )}
+            <div className="flex-1 min-w-0">
+              <p className="font-medium text-[#222222] truncate">{rep.name}</p>
+              <div className="flex items-center gap-2 mt-0.5">
+                <PartyBadge party={rep.party} />
+                <span className="text-xs text-[#4d4d4d]">{rep.chamber}</span>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function RegionPage() {
   const { data, loading, error } = useQuery<RegionInfoData>(GET_REGION_INFO);
 
@@ -146,6 +252,9 @@ export default function RegionPage() {
 
   return (
     <div className="max-w-4xl mx-auto px-8 py-12">
+      {/* My Representatives */}
+      <MyRepresentativesSection />
+
       {/* Region Header */}
       <div className="mb-10">
         <h1 className="text-3xl font-bold text-[#222222]">

--- a/apps/frontend/app/region/page.tsx
+++ b/apps/frontend/app/region/page.tsx
@@ -151,7 +151,7 @@ function MyRepresentativesSection() {
             Add an address in your{" "}
             <Link
               href="/settings/addresses"
-              className="text-blue-600 hover:underline"
+              className="text-[#222222] underline font-medium"
             >
               profile settings
             </Link>{" "}

--- a/apps/frontend/e2e/region.spec.ts
+++ b/apps/frontend/e2e/region.spec.ts
@@ -411,7 +411,9 @@ test.describe("Region Page", () => {
 
     await expect(page.getByText("Propositions")).toBeVisible();
     await expect(page.getByText("Meetings")).toBeVisible();
-    await expect(page.getByText("Representatives")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: /Representatives.*Elected/i }),
+    ).toBeVisible();
     await expect(page.getByText("Campaign Finance")).toBeVisible();
   });
 

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -442,6 +442,31 @@ export const GET_REPRESENTATIVE = gql`
   }
 `;
 
+export const GET_REPRESENTATIVES_BY_DISTRICTS = gql`
+  query GetRepresentativesByDistricts(
+    $congressionalDistrict: String
+    $stateSenatorialDistrict: String
+    $stateAssemblyDistrict: String
+  ) {
+    representativesByDistricts(
+      congressionalDistrict: $congressionalDistrict
+      stateSenatorialDistrict: $stateSenatorialDistrict
+      stateAssemblyDistrict: $stateAssemblyDistrict
+    ) {
+      id
+      name
+      chamber
+      district
+      party
+      photoUrl
+    }
+  }
+`;
+
+export interface RepresentativesByDistrictsData {
+  representativesByDistricts: Representative[];
+}
+
 // ============================================
 // Campaign Finance Queries
 // ============================================


### PR DESCRIPTION
## Summary
- **My Representatives (#574)**: Region hub shows user's Assembly member and Senator based on geocoded primary address
- **Address geocoding (#561)**: Census Geocoder API populates lat/lng, congressional/state districts, county, municipality, auto-timezone
- **Representative detail pages (#565)**: Clickable cards, hero section with bio/contact, shared PartyBadge
- **Representative data extraction (#569)**: Senate photos from data-src, detail page crawling for bios (73/120), constant extraction method
- **District matching**: Normalizes Census format to scraped format for representative lookup
- **WCAG accessibility**: Link contrast fixes for profile settings prompt

## Test plan
- [x] Full pnpm -r test passes (1305+ backend, all frontend)
- [x] E2E: 259 passed
- [x] SonarCloud: coverage and accessibility fixes
- [x] Live UAT: geocoding, My Representatives, detail pages, bios all working

🤖 Generated with [Claude Code](https://claude.com/claude-code)