### PR TITLE
feat: track active sessions in user_sessions table on login (#564)

### DIFF
--- a/apps/backend/src/apps/users/src/domains/auth/auth.resolver.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.resolver.spec.ts
@@ -13,6 +13,14 @@ import { AuthService } from './auth.service';
 import { PasskeyService } from './services/passkey.service';
 import { AccountLockoutService } from './services/account-lockout.service';
 import { UsersService } from '../user/users.service';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+const mockDbService = {
+  userSession: {
+    create: jest.fn().mockResolvedValue({}),
+    updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+  },
+};
 
 import {
   confirmForgotPasswordDto,
@@ -62,6 +70,7 @@ describe('AuthResolver', () => {
           provide: AccountLockoutService,
           useValue: createMockLockoutService(),
         },
+        { provide: DbService, useValue: mockDbService },
       ],
     }).compile();
 
@@ -213,6 +222,7 @@ describe('AuthResolver', () => {
             provide: AccountLockoutService,
             useValue: createMockLockoutService(),
           },
+          { provide: DbService, useValue: mockDbService },
         ],
       }).compile();
 
@@ -283,6 +293,7 @@ describe('AuthResolver', () => {
             provide: AccountLockoutService,
             useValue: createMockLockoutService(),
           },
+          { provide: DbService, useValue: mockDbService },
         ],
       }).compile();
 
@@ -371,6 +382,7 @@ describe('AuthResolver', () => {
             provide: AccountLockoutService,
             useValue: createMockLockoutService(),
           },
+          { provide: DbService, useValue: mockDbService },
         ],
       }).compile();
 
@@ -436,6 +448,7 @@ describe('AuthResolver', () => {
             provide: AccountLockoutService,
             useValue: createMockLockoutService(),
           },
+          { provide: DbService, useValue: mockDbService },
         ],
       }).compile();
 
@@ -603,6 +616,42 @@ describe('AuthResolver', () => {
 
       expect(result).toEqual(mockAuth);
       expect(mockContext.res?.cookie).toHaveBeenCalled();
+    });
+
+    it('should create session record on successful exchange', async () => {
+      // Build a real JWT with sub claim
+      const payload = Buffer.from(
+        JSON.stringify({ sub: 'user-abc', email: 'test@test.com' }),
+      ).toString('base64');
+      const fakeJwt = `header.${payload}.signature`;
+      const mockAuth = {
+        accessToken: fakeJwt,
+        refreshToken: 'refresh-token',
+      };
+      authService.exchangeSupabaseSession = jest
+        .fn()
+        .mockResolvedValue(mockAuth);
+
+      const mockContext = createMockContext();
+      mockContext.req.headers = {
+        'user-agent': 'Mozilla/5.0 Chrome/120.0',
+      };
+
+      await resolver.exchangeSupabaseSession(
+        { accessToken: fakeJwt, refreshToken: 'refresh' },
+        mockContext,
+      );
+
+      // Wait for fire-and-forget promise
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(mockDbService.userSession.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          userId: 'user-abc',
+          isActive: true,
+          browser: 'Chrome/120.0',
+        }),
+      });
     });
 
     it('should throw error on invalid token', async () => {

--- a/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
@@ -19,6 +19,7 @@ import {
   createAuditContext,
 } from 'src/common/utils/graphql-context';
 import { setAuthCookies } from 'src/common/utils/cookie.utils';
+import { DbService } from '@opuspopuli/relationaldb-provider';
 import { AUTH_THROTTLE } from 'src/config/auth-throttle.config';
 import { AccountLockoutService } from './services/account-lockout.service';
 import { AuditLogService } from 'src/common/services/audit-log.service';
@@ -69,8 +70,75 @@ export class AuthResolver {
     private readonly usersService: UsersService,
     private readonly configService: ConfigService,
     private readonly lockoutService: AccountLockoutService,
+    private readonly db: DbService,
     @Optional() private readonly auditLogService?: AuditLogService,
   ) {}
+
+  /**
+   * Create a session record for tracking active logins.
+   * Fire-and-forget — failures are logged but don't affect login.
+   */
+  private createSession(
+    userId: string | undefined,
+    accessToken: string,
+    refreshToken: string | undefined,
+    context: GqlContext,
+  ): void {
+    const headers = context.req?.headers as Record<string, string> | undefined;
+    const userAgent =
+      headers?.['x-original-user-agent'] || headers?.['user-agent'] || '';
+    const ipAddress = headers?.['x-forwarded-for'] || context.req?.ip;
+
+    // Parse user agent for device info (simple extraction)
+    const isMobile = /mobile|android|iphone/i.test(userAgent);
+    const browserMatch = userAgent.match(
+      /(Chrome|Firefox|Safari|Edge|Opera)\/[\d.]+/,
+    );
+    const osMatch = userAgent.match(
+      /(Windows|Mac OS X|Linux|Android|iOS)[\s/]?[\d._]*/,
+    );
+
+    // Extract user ID from JWT sub claim
+    let jwtUserId = userId;
+    if (!jwtUserId) {
+      try {
+        const parts = accessToken.split('.');
+        if (parts.length === 3) {
+          const payload = JSON.parse(
+            Buffer.from(parts[1], 'base64').toString(),
+          );
+          jwtUserId = payload.sub;
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    if (!jwtUserId) return;
+
+    // Use last 32 chars as token identifier (don't store full JWT)
+    const tokenHash = accessToken.slice(-32);
+
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours
+
+    this.db.userSession
+      .create({
+        data: {
+          userId: jwtUserId,
+          sessionToken: tokenHash,
+          refreshToken: refreshToken?.slice(-32),
+          deviceType: isMobile ? 'mobile' : 'desktop',
+          browser: browserMatch?.[0] || undefined,
+          operatingSystem: osMatch?.[0] || undefined,
+          ipAddress: ipAddress || undefined,
+          isActive: true,
+          lastActivityAt: new Date(),
+          expiresAt,
+        },
+      })
+      .catch((err: Error) => {
+        this.logger.warn(`Failed to create session: ${err.message}`);
+      });
+  }
 
   /**
    * Register a new user account
@@ -177,6 +245,14 @@ export class AuthResolver {
           auth.refreshToken,
         );
       }
+
+      // Track session
+      this.createSession(
+        undefined,
+        auth.accessToken,
+        auth.refreshToken,
+        context,
+      );
 
       // Audit: Login success
       this.auditLogService?.log({
@@ -456,6 +532,9 @@ export class AuthResolver {
         );
       }
 
+      // Track session
+      this.createSession(user.id, auth.accessToken, auth.refreshToken, context);
+
       // Audit: Passkey authentication success
       this.auditLogService?.log({
         ...auditContext,
@@ -551,6 +630,14 @@ export class AuthResolver {
         );
       }
 
+      // Track session
+      this.createSession(
+        undefined,
+        auth.accessToken,
+        auth.refreshToken,
+        context,
+      );
+
       // Audit: Magic link verified (login success)
       this.auditLogService?.log({
         ...auditContext,
@@ -638,6 +725,14 @@ export class AuthResolver {
           auth.refreshToken,
         );
       }
+
+      // Track session
+      this.createSession(
+        undefined,
+        auth.accessToken,
+        auth.refreshToken,
+        context,
+      );
 
       // Audit: Supabase session exchange success
       this.auditLogService?.log({

--- a/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
@@ -75,9 +75,25 @@ export class AuthResolver {
   ) {}
 
   /**
-   * Create a session record for tracking active logins.
-   * Fire-and-forget — failures are logged but don't affect login.
+   * Set auth cookies and create a session record after successful login.
+   * Session creation is fire-and-forget — failures don't affect login.
    */
+  private establishSession(
+    auth: Auth,
+    context: GqlContext,
+    userId?: string,
+  ): void {
+    if (context.res) {
+      setAuthCookies(
+        context.res,
+        this.configService,
+        auth.accessToken,
+        auth.refreshToken,
+      );
+    }
+    this.createSession(userId, auth.accessToken, auth.refreshToken, context);
+  }
+
   private createSession(
     userId: string | undefined,
     accessToken: string,
@@ -236,23 +252,7 @@ export class AuthResolver {
       // Clear lockout on successful login
       this.lockoutService.clearLockout(email);
 
-      // Set httpOnly cookies for browser clients
-      if (context.res) {
-        setAuthCookies(
-          context.res,
-          this.configService,
-          auth.accessToken,
-          auth.refreshToken,
-        );
-      }
-
-      // Track session
-      this.createSession(
-        undefined,
-        auth.accessToken,
-        auth.refreshToken,
-        context,
-      );
+      this.establishSession(auth, context);
 
       // Audit: Login success
       this.auditLogService?.log({
@@ -522,18 +522,7 @@ export class AuthResolver {
       // Generate tokens for the authenticated user
       const auth = await this.authService.generateTokensForUser(user);
 
-      // Set httpOnly cookies for browser clients
-      if (context.res) {
-        setAuthCookies(
-          context.res,
-          this.configService,
-          auth.accessToken,
-          auth.refreshToken,
-        );
-      }
-
-      // Track session
-      this.createSession(user.id, auth.accessToken, auth.refreshToken, context);
+      this.establishSession(auth, context, user.id);
 
       // Audit: Passkey authentication success
       this.auditLogService?.log({
@@ -620,23 +609,7 @@ export class AuthResolver {
         input.token,
       );
 
-      // Set httpOnly cookies for browser clients
-      if (context.res) {
-        setAuthCookies(
-          context.res,
-          this.configService,
-          auth.accessToken,
-          auth.refreshToken,
-        );
-      }
-
-      // Track session
-      this.createSession(
-        undefined,
-        auth.accessToken,
-        auth.refreshToken,
-        context,
-      );
+      this.establishSession(auth, context);
 
       // Audit: Magic link verified (login success)
       this.auditLogService?.log({
@@ -716,23 +689,7 @@ export class AuthResolver {
         input.refreshToken,
       );
 
-      // Set httpOnly cookies for browser clients
-      if (context.res) {
-        setAuthCookies(
-          context.res,
-          this.configService,
-          auth.accessToken,
-          auth.refreshToken,
-        );
-      }
-
-      // Track session
-      this.createSession(
-        undefined,
-        auth.accessToken,
-        auth.refreshToken,
-        context,
-      );
+      this.establishSession(auth, context);
 
       // Audit: Supabase session exchange success
       this.auditLogService?.log({

--- a/apps/backend/src/apps/users/src/domains/auth/session.resolver.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/session.resolver.spec.ts
@@ -7,6 +7,7 @@ import { createMock } from '@golevelup/ts-jest';
 import { SessionResolver } from './session.resolver';
 import { AuthService } from './auth.service';
 import { PasskeyService } from './services/passkey.service';
+import { DbService } from '@opuspopuli/relationaldb-provider';
 
 import { ChangePasswordDto } from './dto/change-password.dto';
 import { changePasswordDto } from '../../../../data.spec';
@@ -37,6 +38,15 @@ describe('SessionResolver', () => {
         { provide: AuthService, useValue: createMock<AuthService>() },
         { provide: PasskeyService, useValue: createMock<PasskeyService>() },
         { provide: ConfigService, useValue: createMock<ConfigService>() },
+        {
+          provide: DbService,
+          useValue: {
+            userSession: {
+              create: jest.fn().mockResolvedValue({}),
+              updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+            },
+          },
+        },
       ],
     }).compile();
 
@@ -171,6 +181,48 @@ describe('SessionResolver', () => {
       const result = await resolver.logout(contextWithoutRes);
 
       expect(result).toBe(true);
+    });
+
+    it('should deactivate all active sessions on logout', async () => {
+      const mockContext = createMockContext();
+      mockContext.req.user = {
+        id: 'user-123',
+        email: 'test@example.com',
+        roles: ['User'],
+        department: '',
+        clearance: '',
+      };
+
+      const module = await Test.createTestingModule({
+        providers: [
+          SessionResolver,
+          { provide: AuthService, useValue: createMock<AuthService>() },
+          { provide: PasskeyService, useValue: createMock<PasskeyService>() },
+          { provide: ConfigService, useValue: createMock<ConfigService>() },
+          {
+            provide: DbService,
+            useValue: {
+              userSession: {
+                create: jest.fn().mockResolvedValue({}),
+                updateMany: jest.fn().mockResolvedValue({ count: 2 }),
+              },
+            },
+          },
+        ],
+      }).compile();
+
+      const logoutResolver = module.get<SessionResolver>(SessionResolver);
+      const db = module.get<DbService>(DbService);
+
+      await logoutResolver.logout(mockContext);
+
+      expect(db.userSession.updateMany).toHaveBeenCalledWith({
+        where: { userId: 'user-123', isActive: true },
+        data: expect.objectContaining({
+          isActive: false,
+          revokedReason: 'user_logout',
+        }),
+      });
     });
   });
 });

--- a/apps/backend/src/apps/users/src/domains/auth/session.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/session.resolver.ts
@@ -20,6 +20,7 @@ import {
 } from 'src/common/utils/graphql-context';
 import { clearAuthCookies } from 'src/common/utils/cookie.utils';
 import { AuditLogService } from 'src/common/services/audit-log.service';
+import { DbService } from '@opuspopuli/relationaldb-provider';
 
 /**
  * Session Resolver
@@ -40,6 +41,7 @@ export class SessionResolver {
     private readonly authService: AuthService,
     private readonly passkeyService: PasskeyService,
     private readonly configService: ConfigService,
+    private readonly db: DbService,
     @Optional() private readonly auditLogService?: AuditLogService,
   ) {}
 
@@ -137,6 +139,21 @@ export class SessionResolver {
     // Clear httpOnly auth cookies
     if (context.res) {
       clearAuthCookies(context.res, this.configService);
+    }
+
+    // Deactivate all active sessions for the user
+    const user = context.req?.user;
+    if (user?.id) {
+      this.db.userSession
+        .updateMany({
+          where: { userId: user.id, isActive: true },
+          data: {
+            isActive: false,
+            revokedAt: new Date(),
+            revokedReason: 'user_logout',
+          },
+        })
+        .catch(() => {}); // Fire-and-forget
     }
 
     // Audit: Logout


### PR DESCRIPTION
## Summary
- **Session creation**: Records a session on all 4 login flows (password, passkey, magic link, Supabase exchange)
- **Session deactivation**: Marks all active sessions as revoked on logout
- **Device info**: Parses user agent for device type, browser, OS
- **User ID from JWT**: Extracts `sub` claim to link session to user
- **Fire-and-forget**: Session tracking never blocks authentication
- **Full test coverage**: JWT decode path, session creation assertion, logout deactivation

## Test plan
- [x] 40 auth/session resolver tests pass
- [x] Session resolver: 100% statement coverage
- [x] Auth resolver: 95.25% (uncovered lines are pre-existing password reset flows)
- [x] Full `pnpm -r test` passes

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)