### PR TITLE
feat: container-scoped field mappings for sibling data extraction (#558)

### DIFF
--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -105,6 +105,9 @@ export interface FieldMapping {
   required: boolean;
   /** Default value if extraction yields nothing */
   defaultValue?: string;
+  /** Search scope: 'item' (default) searches within the item element,
+   *  'container' searches from the container element (for sibling data like headings) */
+  scope?: "item" | "container";
 }
 
 export type ExtractionMethod =

--- a/packages/scraping-pipeline/__tests__/manifest-extractor.spec.ts
+++ b/packages/scraping-pipeline/__tests__/manifest-extractor.spec.ts
@@ -517,4 +517,82 @@ describe("ManifestExtractorService", () => {
       expect(result.items).toHaveLength(2);
     });
   });
+
+  describe("container-scoped field mappings", () => {
+    it("should extract fields from the container when scope is 'container'", () => {
+      const html = `
+        <div class="content">
+          <h2>November 3, 2026, Statewide Ballot Measures</h2>
+          <p><a href="/measure1.pdf">ACA 13 (Ward) Voting thresholds</a></p>
+          <p><a href="/measure2.pdf">SCA 1 (Newman) Elections: recall</a></p>
+        </div>
+      `;
+
+      const manifest = createTestManifest({
+        extractionRules: {
+          containerSelector: ".content",
+          itemSelector: "p",
+          fieldMappings: [
+            {
+              fieldName: "title",
+              selector: "a",
+              extractionMethod: "text",
+              required: true,
+            },
+            {
+              fieldName: "electionDate",
+              selector: "h2",
+              extractionMethod: "regex",
+              regexPattern: "(\\w+ \\d+, \\d{4})",
+              required: false,
+              scope: "container",
+            },
+          ],
+        },
+      });
+
+      const result = extractor.extract(html, manifest);
+
+      expect(result.success).toBe(true);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0]).toEqual({
+        title: "ACA 13 (Ward) Voting thresholds",
+        electionDate: "November 3, 2026",
+      });
+      expect(result.items[1]).toEqual({
+        title: "SCA 1 (Newman) Elections: recall",
+        electionDate: "November 3, 2026",
+      });
+    });
+
+    it("should default to item scope when scope is not specified", () => {
+      const html = `
+        <div class="content">
+          <h2>Heading outside items</h2>
+          <div class="item"><h2>Item heading</h2></div>
+        </div>
+      `;
+
+      const manifest = createTestManifest({
+        extractionRules: {
+          containerSelector: ".content",
+          itemSelector: ".item",
+          fieldMappings: [
+            {
+              fieldName: "heading",
+              selector: "h2",
+              extractionMethod: "text",
+              required: true,
+            },
+          ],
+        },
+      });
+
+      const result = extractor.extract(html, manifest);
+
+      expect(result.success).toBe(true);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toEqual({ heading: "Item heading" });
+    });
+  });
 });

--- a/packages/scraping-pipeline/src/extraction/manifest-extractor.service.ts
+++ b/packages/scraping-pipeline/src/extraction/manifest-extractor.service.ts
@@ -73,7 +73,8 @@ export class ManifestExtractorService {
     }
 
     // Find items within the container
-    const itemElements = container.first().find(rules.itemSelector);
+    const firstContainer = container.first() as Cheerio<Element>;
+    const itemElements = firstContainer.find(rules.itemSelector);
 
     if (itemElements.length === 0) {
       this.logger.warn(
@@ -103,6 +104,7 @@ export class ManifestExtractorService {
       const result = this.extractItem(
         $,
         $(el as Element),
+        firstContainer,
         rules.fieldMappings,
         baseUrl,
       );
@@ -138,6 +140,7 @@ export class ManifestExtractorService {
   private extractItem(
     $: CheerioAPI,
     element: Cheerio<Element>,
+    container: Cheerio<Element>,
     mappings: FieldMapping[],
     baseUrl?: string,
   ): { data: Record<string, unknown>; warnings: string[] } | null {
@@ -151,7 +154,8 @@ export class ManifestExtractorService {
         requiredTotal++;
       }
 
-      const value = this.resolveFieldValue($, element, mapping, baseUrl);
+      const scope = mapping.scope === "container" ? container : element;
+      const value = this.resolveFieldValue($, scope, mapping, baseUrl);
 
       if (!value && mapping.required) {
         requiredMissing++;
@@ -244,7 +248,7 @@ export class ManifestExtractorService {
         }
         const rawText = first.text();
         try {
-          const match = rawText.match(new RegExp(mapping.regexPattern));
+          const match = new RegExp(mapping.regexPattern).exec(rawText);
           return match?.[mapping.regexGroup ?? 1] || undefined;
         } catch {
           return undefined;


### PR DESCRIPTION
## Summary
- Add `scope?: "item" | "container"` to `FieldMapping` type so fields can be extracted from the container element instead of each item's DOM subtree
- Pass container element through the extraction chain (`extractItem` → `resolveFieldValue` → `extractFieldValue`)
- Fix `RegExp.exec()` code smell in manifest-extractor.service.ts
- Add 2 tests: container-scope extraction (ballot measures pattern) and default item-scope behavior

## Why
Government sites commonly place shared metadata (election dates, category headings) as siblings above item lists, not inside each item. The extractor previously could only search within item elements, making these fields unreachable.

## Test plan
- [x] 224 scraping-pipeline tests passing (including 2 new)
- [x] Full monorepo build + lint + 1315 tests passing
- [x] Verified AI generates `"scope": "container"` on `electionDate` field in UAT
- [ ] Requires companion PR in prompt-service to teach AI about the `scope` option

Closes #558

🤖 Generated with [Claude Code](https://claude.com/claude-code)