### PR TITLE
Merge develop to main: sync dataTypes filter (#582)

### DIFF
--- a/apps/backend/region-schema.gql
+++ b/apps/backend/region-schema.gql
@@ -115,5 +115,5 @@ type Query {
 }
 
 type Mutation {
-  syncRegionData: [SyncResultModel!]!
+  syncRegionData(dataTypes: [DataType!]): [SyncResultModel!]!
 }

--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -688,7 +688,25 @@ describe('RegionResolver', () => {
 
       expect(result).toHaveLength(2);
       expect(result[0].itemsProcessed).toBe(10);
-      expect(regionService.syncAll).toHaveBeenCalled();
+      expect(regionService.syncAll).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should pass dataTypes filter to syncAll', async () => {
+      regionService.syncAll.mockResolvedValue([
+        {
+          dataType: DataType.PROPOSITIONS,
+          itemsProcessed: 3,
+          itemsCreated: 3,
+          itemsUpdated: 0,
+          errors: [],
+          syncedAt: new Date(),
+        },
+      ]);
+
+      const result = await resolver.syncRegionData([DataTypeGQL.PROPOSITIONS]);
+
+      expect(result).toHaveLength(1);
+      expect(regionService.syncAll).toHaveBeenCalledWith(['propositions']);
     });
 
     it('should include errors in sync results', async () => {

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -347,14 +347,20 @@ export class RegionResolver {
   }
 
   /**
-   * Trigger a full data sync (admin only)
+   * Trigger a data sync (admin only).
+   * Optionally filter by data types — when omitted, syncs all.
    */
   @Mutation(() => [SyncResultModel])
   @UseGuards(AuthGuard)
   @Roles(Role.Admin)
   @Extensions({ complexity: 100 }) // Full data sync - expensive operation
-  async syncRegionData(): Promise<SyncResultModel[]> {
-    const results = await this.regionService.syncAll();
+  async syncRegionData(
+    @Args('dataTypes', { type: () => [DataTypeGQL], nullable: true })
+    dataTypes?: DataTypeGQL[],
+  ): Promise<SyncResultModel[]> {
+    const results = await this.regionService.syncAll(
+      dataTypes as unknown as string[],
+    );
     return results.map((r) => ({
       ...r,
       dataType: r.dataType as unknown as DataTypeGQL,

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -260,6 +260,33 @@ describe('RegionDomainService', () => {
       expect(mockRegistry.getAll).toHaveBeenCalled();
     });
 
+    it('should only sync specified data types when filter is provided', async () => {
+      const results = await service.syncAll([DataType.PROPOSITIONS]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].dataType).toBe(DataType.PROPOSITIONS);
+      expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('should sync multiple specified data types', async () => {
+      const results = await service.syncAll([
+        DataType.PROPOSITIONS,
+        DataType.MEETINGS,
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].dataType).toBe(DataType.PROPOSITIONS);
+      expect(results[1].dataType).toBe(DataType.MEETINGS);
+      expect(mockDb.$transaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('should return empty results when filter matches no supported types', async () => {
+      const results = await service.syncAll(['nonexistent_type']);
+
+      expect(results).toHaveLength(0);
+      expect(mockDb.$transaction).not.toHaveBeenCalled();
+    });
+
     it('should handle sync errors gracefully', async () => {
       mockPlugin.fetchPropositions.mockRejectedValue(
         new Error('Network error'),

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -392,16 +392,24 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Sync all data types from all loaded plugins (federal + local).
+   * Sync data types from all loaded plugins (federal + local).
+   * When dataTypes is provided, only those types are synced.
    */
-  async syncAll(): Promise<SyncResult[]> {
-    this.logger.log('Starting full data sync');
+  async syncAll(dataTypes?: string[]): Promise<SyncResult[]> {
+    this.logger.log(
+      dataTypes
+        ? `Starting data sync for: ${dataTypes.join(', ')}`
+        : 'Starting full data sync',
+    );
     const results: SyncResult[] = [];
 
     for (const registered of this.pluginRegistry.getAll()) {
       const supported = registered.instance.getSupportedDataTypes();
+      const filtered = dataTypes
+        ? supported.filter((dt) => dataTypes.includes(dt))
+        : supported;
 
-      for (const dataType of supported) {
+      for (const dataType of filtered) {
         try {
           const result = await this.syncDataTypeFrom(
             registered.instance,

--- a/docs/guides/region-setup-and-validation-guide.md
+++ b/docs/guides/region-setup-and-validation-guide.md
@@ -297,6 +297,7 @@ Now we will sync all civic data from California's official government sources. T
 2. Paste this mutation and click **Play**:
 
 ```graphql
+# Sync all data types (default)
 mutation {
   syncRegionData {
     dataType
@@ -307,7 +308,21 @@ mutation {
     syncedAt
   }
 }
+
+# Sync specific data types only
+mutation {
+  syncRegionData(dataTypes: [PROPOSITIONS, MEETINGS]) {
+    dataType
+    itemsProcessed
+    itemsCreated
+    itemsUpdated
+    errors
+    syncedAt
+  }
+}
 ```
+
+> **Available data types:** `PROPOSITIONS`, `MEETINGS`, `REPRESENTATIVES`, `CAMPAIGN_FINANCE`
 
 > **What happens during sync:**
 >

--- a/postman/OpusPopuli.postman_collection.json
+++ b/postman/OpusPopuli.postman_collection.json
@@ -534,7 +534,8 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "mutation {\n  syncRegionData {\n    dataType\n    itemsProcessed\n    itemsCreated\n    itemsUpdated\n    errors\n    syncedAt\n  }\n}"
+                "query": "mutation SyncRegionData($dataTypes: [DataType!]) {\n  syncRegionData(dataTypes: $dataTypes) {\n    dataType\n    itemsProcessed\n    itemsCreated\n    itemsUpdated\n    errors\n    syncedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": null\n}"
               }
             },
             "url": {


### PR DESCRIPTION
## Summary
- Add optional `dataTypes` argument to `syncRegionData` mutation for filtered syncs
- Reduces propositions-only sync from 30+ minutes to ~60 seconds
- Updated GraphQL schema, Postman collection, and docs

## Commits
- `cb5f703` feat: add dataTypes filter to syncRegionData mutation (#582)

## Test plan
- [x] 72 suites, 1319 tests passing (4 new)
- [x] Verified filtered sync in UAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)