### PR TITLE
Merge develop to main: committee assignments (#594)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/models/representative.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/representative.model.ts
@@ -34,6 +34,21 @@ export class ContactInfoModel {
 }
 
 /**
+ * A legislative committee assignment
+ */
+@ObjectType()
+export class CommitteeAssignmentModel {
+  @Field()
+  name!: string;
+
+  @Field({ nullable: true })
+  role?: string;
+
+  @Field({ nullable: true })
+  url?: string;
+}
+
+/**
  * Representative GraphQL model
  */
 @ObjectType()
@@ -61,6 +76,9 @@ export class RepresentativeModel {
 
   @Field(() => ContactInfoModel, { nullable: true })
   contactInfo?: ContactInfoModel;
+
+  @Field(() => [CommitteeAssignmentModel], { nullable: true })
+  committees?: CommitteeAssignmentModel[];
 
   @Field({ nullable: true })
   bio?: string;

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -25,6 +25,7 @@ import {
 } from './models/proposition.model';
 import { MeetingModel, PaginatedMeetings } from './models/meeting.model';
 import {
+  CommitteeAssignmentModel,
   ContactInfoModel,
   RepresentativeModel,
   PaginatedRepresentatives,
@@ -152,6 +153,9 @@ export class RegionResolver {
       ...result,
       photoUrl: result.photoUrl ?? undefined,
       contactInfo: (result.contactInfo as ContactInfoModel) ?? undefined,
+      committees:
+        (result.committees as unknown as CommitteeAssignmentModel[]) ??
+        undefined,
       bio: result.bio ?? undefined,
     };
   }
@@ -181,6 +185,7 @@ export class RegionResolver {
       party: r.party ?? undefined,
       photoUrl: r.photoUrl ?? undefined,
       contactInfo: (r.contactInfo as ContactInfoModel) ?? undefined,
+      committees: (r.committees as CommitteeAssignmentModel[]) ?? undefined,
       bio: r.bio ?? undefined,
     })) as RepresentativeModel[];
   }

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -52,6 +52,7 @@ import {
 } from './models/proposition.model';
 import { PaginatedMeetings } from './models/meeting.model';
 import {
+  CommitteeAssignmentModel,
   ContactInfoModel,
   PaginatedRepresentatives,
 } from './models/representative.model';
@@ -104,6 +105,7 @@ type RepresentativeRecord = {
   party: string | null;
   photoUrl: string | null;
   contactInfo: unknown;
+  committees: unknown;
   bio: string | null;
   createdAt: Date;
   updatedAt: Date;
@@ -692,6 +694,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
             party: rep.party,
             photoUrl: rep.photoUrl,
             contactInfo: rep.contactInfo as object | undefined,
+            committees: rep.committees as object[] | undefined,
             bio: rep.bio,
           },
           create: {
@@ -702,6 +705,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
             party: rep.party,
             photoUrl: rep.photoUrl,
             contactInfo: rep.contactInfo as object | undefined,
+            committees: rep.committees as object[] | undefined,
             bio: rep.bio,
           },
         }),
@@ -1120,6 +1124,8 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
             party: item.party ?? undefined,
             photoUrl: item.photoUrl ?? undefined,
             contactInfo: (item.contactInfo as ContactInfoModel) ?? undefined,
+            committees:
+              (item.committees as CommitteeAssignmentModel[]) ?? undefined,
             bio: item.bio ?? undefined,
           })),
           total,

--- a/apps/frontend/__tests__/pages/region/representative-detail.test.tsx
+++ b/apps/frontend/__tests__/pages/region/representative-detail.test.tsx
@@ -157,4 +157,99 @@ describe("RepresentativeDetailPage", () => {
 
     expect(screen.queryByText("Contact Information")).not.toBeInTheDocument();
   });
+
+  it("should render committee assignments grouped by leadership and member", () => {
+    mockQueryResult = {
+      data: {
+        representative: {
+          ...mockRepresentative,
+          committees: [
+            {
+              name: "Budget",
+              role: "Chair",
+              url: "https://budget.example.gov",
+            },
+            {
+              name: "Judiciary",
+              role: "Vice Chair",
+              url: "https://judiciary.example.gov",
+            },
+            {
+              name: "Education",
+              role: "Member",
+              url: "https://education.example.gov",
+            },
+            { name: "Transportation", role: "Member" },
+          ],
+        },
+      },
+      loading: false,
+      error: undefined,
+    };
+
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.getByText("Committee Assignments")).toBeInTheDocument();
+    expect(screen.getByText("Leadership")).toBeInTheDocument();
+    expect(screen.getByText("Budget")).toBeInTheDocument();
+    expect(screen.getByText("Chair")).toBeInTheDocument();
+    expect(screen.getByText("Vice Chair")).toBeInTheDocument();
+    expect(screen.getByText("Education")).toBeInTheDocument();
+    expect(screen.getByText("Transportation")).toBeInTheDocument();
+  });
+
+  it("should render committee links when URL is provided", () => {
+    mockQueryResult = {
+      data: {
+        representative: {
+          ...mockRepresentative,
+          committees: [
+            {
+              name: "Budget",
+              role: "Member",
+              url: "https://budget.example.gov",
+            },
+          ],
+        },
+      },
+      loading: false,
+      error: undefined,
+    };
+
+    render(<RepresentativeDetailPage />);
+
+    const link = screen.getByRole("link", { name: "Budget" });
+    expect(link).toHaveAttribute("href", "https://budget.example.gov");
+  });
+
+  it("should not render committee section when committees is empty", () => {
+    mockQueryResult = {
+      data: {
+        representative: {
+          ...mockRepresentative,
+          committees: [],
+        },
+      },
+      loading: false,
+      error: undefined,
+    };
+
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.queryByText("Committee Assignments")).not.toBeInTheDocument();
+  });
+
+  it("should not render committee section when committees is undefined", () => {
+    render(<RepresentativeDetailPage />);
+
+    // mockRepresentative has no committees field
+    expect(screen.queryByText("Committee Assignments")).not.toBeInTheDocument();
+  });
+
+  it("should render source attribution on contact section", () => {
+    render(<RepresentativeDetailPage />);
+
+    expect(screen.getByText("California State Senate")).toBeInTheDocument();
+    expect(screen.getByText(/Last synced/)).toBeInTheDocument();
+  });
 });

--- a/apps/frontend/app/region/representatives/[id]/page.tsx
+++ b/apps/frontend/app/region/representatives/[id]/page.tsx
@@ -9,11 +9,89 @@ import {
   GET_REPRESENTATIVE,
   RepresentativeData,
   IdVars,
+  CommitteeAssignment,
 } from "@/lib/graphql/region";
 import { ContactRepresentativeForm } from "@/components/email/ContactRepresentativeForm";
 import { Breadcrumb } from "@/components/region/Breadcrumb";
 import { LoadingSkeleton, ErrorState } from "@/components/region/ListStates";
 import { PartyBadge } from "@/components/region/PartyBadge";
+
+const SOURCE_URLS: Record<string, { label: string; url: string }> = {
+  Assembly: {
+    label: "California State Assembly",
+    url: "https://www.assembly.ca.gov/assemblymembers",
+  },
+  Senate: {
+    label: "California State Senate",
+    url: "https://www.senate.ca.gov/senators",
+  },
+};
+
+function SourceAttribution({
+  chamber,
+  updatedAt,
+}: {
+  readonly chamber: string;
+  readonly updatedAt?: string;
+}) {
+  const source = SOURCE_URLS[chamber];
+  if (!source) return null;
+
+  return (
+    <div className="mt-4 pt-3 border-t border-gray-100 flex items-center justify-between text-[11px] text-[#94a3b8]">
+      <span>
+        Source:{" "}
+        <a
+          href={source.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:text-[#64748b] hover:underline"
+        >
+          {source.label}
+        </a>
+      </span>
+      {updatedAt && (
+        <span>Last synced: {new Date(updatedAt).toLocaleDateString()}</span>
+      )}
+    </div>
+  );
+}
+
+function isLeadershipRole(role?: string): boolean {
+  return !!role && /chair|ranking/i.test(role);
+}
+
+function CommitteeRow({ c }: { readonly c: CommitteeAssignment }) {
+  return (
+    <div className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0">
+      <div className="flex items-center gap-2">
+        {c.url ? (
+          <a
+            href={c.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-blue-600 hover:text-blue-700 hover:underline"
+          >
+            {c.name}
+          </a>
+        ) : (
+          <span className="text-sm text-[#334155]">{c.name}</span>
+        )}
+      </div>
+      {c.role && (
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+            isLeadershipRole(c.role)
+              ? "bg-blue-50 text-blue-700"
+              : "bg-gray-100 text-[#64748b]"
+          }`}
+        >
+          {c.role}
+        </span>
+      )}
+    </div>
+  );
+}
 
 function ContactSection({
   label,
@@ -294,8 +372,59 @@ export default function RepresentativeDetailPage() {
               ))}
             </div>
           )}
+          <SourceAttribution chamber={rep.chamber} updatedAt={rep.updatedAt} />
         </div>
       )}
+
+      {/* Committee Assignments */}
+      {rep.committees &&
+        rep.committees.length > 0 &&
+        (() => {
+          const leadership = rep.committees.filter((c) =>
+            isLeadershipRole(c.role),
+          );
+          const membership = rep.committees.filter(
+            (c) => !isLeadershipRole(c.role),
+          );
+
+          return (
+            <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8 mb-6">
+              <h2 className="text-xs font-bold uppercase tracking-[1.5px] text-[#595959] mb-4">
+                Committee Assignments
+              </h2>
+
+              {leadership.length > 0 && (
+                <div className="mb-5">
+                  <h3 className="text-xs font-semibold text-[#334155] uppercase tracking-wider mb-2">
+                    Leadership
+                  </h3>
+                  <div className="space-y-1">
+                    {leadership.map((c) => (
+                      <CommitteeRow key={c.name} c={c} />
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {membership.length > 0 && (
+                <div>
+                  <h3 className="text-xs font-semibold text-[#334155] uppercase tracking-wider mb-2">
+                    Member
+                  </h3>
+                  <div className="space-y-1">
+                    {membership.map((c) => (
+                      <CommitteeRow key={c.name} c={c} />
+                    ))}
+                  </div>
+                </div>
+              )}
+              <SourceAttribution
+                chamber={rep.chamber}
+                updatedAt={rep.updatedAt}
+              />
+            </div>
+          );
+        })()}
 
       {/* Campaign Finance - Coming Soon */}
       <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8 mb-6">

--- a/apps/frontend/e2e/region.spec.ts
+++ b/apps/frontend/e2e/region.spec.ts
@@ -97,6 +97,19 @@ const mockRepresentatives = {
           },
         ],
       },
+      committees: [
+        {
+          name: "Judiciary",
+          role: "Chair",
+          url: "https://judiciary.example.gov",
+        },
+        {
+          name: "Budget",
+          role: "Member",
+          url: "https://budget.example.gov",
+        },
+      ],
+      bio: "Jane Smith has served in the Senate since 2020.",
       createdAt: "2024-01-01T00:00:00Z",
       updatedAt: "2024-01-01T00:00:00Z",
     },
@@ -331,6 +344,14 @@ async function mockRegionGraphQL(page: import("@playwright/test").Page) {
         contentType: "application/json",
         body: JSON.stringify({
           data: { meetings: mockMeetings },
+        }),
+      });
+    } else if (postData?.operationName === "GetRepresentative") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: { representative: mockRepresentatives.items[0] },
         }),
       });
     } else if (postData?.query?.includes("representatives")) {
@@ -782,6 +803,53 @@ test.describe("Representatives Page", () => {
     await select.selectOption("Senate");
 
     await expect(select).toHaveValue("Senate");
+  });
+});
+
+test.describe("Representative Detail Page", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockRegionGraphQL(page);
+  });
+
+  test("should display committee assignments with leadership grouping", async ({
+    page,
+  }) => {
+    await page.goto("/region/representatives/1");
+
+    await expect(page.getByText("Committee Assignments")).toBeVisible();
+    await expect(page.getByText("Leadership")).toBeVisible();
+    await expect(page.getByText("Judiciary")).toBeVisible();
+    await expect(page.getByText("Chair")).toBeVisible();
+    await expect(page.getByText("Budget")).toBeVisible();
+  });
+
+  test("should display source attribution on contact section", async ({
+    page,
+  }) => {
+    await page.goto("/region/representatives/1");
+
+    // Source attribution link at the bottom of the contact section
+    const attribution = page
+      .getByRole("link", { name: "California State Senate" })
+      .first();
+    await attribution.scrollIntoViewIfNeeded();
+    await expect(attribution).toBeVisible();
+  });
+
+  test("should display office contact information", async ({ page }) => {
+    await page.goto("/region/representatives/1");
+
+    await expect(page.getByText("Capitol Office")).toBeVisible();
+    await expect(page.getByText("State Capitol, Room 100")).toBeVisible();
+    await expect(page.getByText("555-1234")).toBeVisible();
+  });
+
+  test("should display bio when available", async ({ page }) => {
+    await page.goto("/region/representatives/1");
+
+    await expect(
+      page.getByText("Jane Smith has served in the Senate since 2020."),
+    ).toBeVisible();
   });
 });
 

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -58,6 +58,12 @@ export interface PaginatedMeetings {
   hasMore: boolean;
 }
 
+export interface CommitteeAssignment {
+  name: string;
+  role?: string;
+  url?: string;
+}
+
 export interface Representative {
   id: string;
   externalId: string;
@@ -67,6 +73,7 @@ export interface Representative {
   party: string;
   photoUrl?: string;
   contactInfo?: ContactInfo;
+  committees?: CommitteeAssignment[];
   bio?: string;
   createdAt: string;
   updatedAt: string;
@@ -448,6 +455,11 @@ export const GET_REPRESENTATIVE = gql`
           phone
           fax
         }
+      }
+      committees {
+        name
+        role
+        url
       }
       bio
       createdAt

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -85,6 +85,15 @@ export interface Meeting {
 }
 
 /**
+ * A legislative committee assignment for a representative
+ */
+export interface CommitteeAssignment {
+  name: string;
+  role?: string;
+  url?: string;
+}
+
+/**
  * Elected representative data
  */
 export interface Representative {
@@ -95,6 +104,7 @@ export interface Representative {
   party: string;
   photoUrl?: string;
   contactInfo?: ContactInfo;
+  committees?: CommitteeAssignment[];
   bio?: string;
 }
 

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.24"
+    "@opuspopuli/regions": "^1.0.25"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -572,6 +572,7 @@ model Representative {
   party       String
   photoUrl    String?   @map("photo_url")
   contactInfo Json?     @map("contact_info")
+  committees  Json?     @map("committees")       /// CommitteeAssignment[] as JSON
   bio         String?   @db.Text
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -371,6 +371,15 @@ const RepresentativeSchema = z.object({
         .optional(),
     })
     .optional(),
+  committees: z
+    .array(
+      z.object({
+        name: z.string(),
+        role: z.string().optional(),
+        url: z.string().optional(),
+      }),
+    )
+    .optional(),
   bio: z.string().optional(),
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -905,8 +905,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.24
-        version: 1.0.24
+        specifier: ^1.0.25
+        version: 1.0.25
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -1519,8 +1519,8 @@ packages:
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  '@asamuzakjp/dom-selector@7.1.0':
-    resolution: {integrity: sha512-ASf825+5vsGuYWoyFyNsex2mNtPTXpCvYTR942+w/eNw7PqS0Lhl/PE1hC7bajneI3m/Oxi+yrP3vTOPxfwM8A==}
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   '@asamuzakjp/generational-cache@1.0.1':
@@ -4870,8 +4870,8 @@ packages:
   '@opuspopuli/regions@1.0.22':
     resolution: {integrity: sha512-7/4WoFkaz1/Q5OTfWZT/5X8RIPN6yZaFZAp8lNxXZAep1+iZ83C3C0XPIZ36kVdLNzYNXUhGYPntcsVR87F61w==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.22/17a1666cdf708f202c2e086dbe1de1f1484d1298}
 
-  '@opuspopuli/regions@1.0.24':
-    resolution: {integrity: sha512-pNJfCXyxDRcmIUUyWXalf3iIXRtw+RXC3yZ0XapRhNysyj7ll5IgjxErrxQRwV9ClEWsMNX5m9TWkqTvxOSF9w==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.24/d1c395f107f0f83703fcec905b2781f70470e1f8}
+  '@opuspopuli/regions@1.0.25':
+    resolution: {integrity: sha512-Ze4zTZ1wGYv40jwbT5VIi/tGFxO3cn302Y1b7Sph9SAxIHby4B/asuXA1D/Uh/fzYQBwWNy50gZ2sVHJoNG+yg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.25/60d187f29d4ccb26e0313bc45b3ff6b690521911}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -12571,7 +12571,7 @@ snapshots:
       '@csstools/css-tokenizer': 4.0.0
     optional: true
 
-  '@asamuzakjp/dom-selector@7.1.0':
+  '@asamuzakjp/dom-selector@7.1.1':
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
       '@asamuzakjp/nwsapi': 2.3.9
@@ -17013,7 +17013,7 @@ snapshots:
 
   '@opuspopuli/regions@1.0.22': {}
 
-  '@opuspopuli/regions@1.0.24': {}
+  '@opuspopuli/regions@1.0.25': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -22840,7 +22840,7 @@ snapshots:
   jsdom@29.0.1(@noble/hashes@2.0.1):
     dependencies:
       '@asamuzakjp/css-color': 5.1.11
-      '@asamuzakjp/dom-selector': 7.1.0
+      '@asamuzakjp/dom-selector': 7.1.1
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
       '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)


### PR DESCRIPTION
## Summary
- Add structured committee assignment data (name, role, URL) to representative profiles
- Extract from Assembly detail pages via StructuredFieldConfig in region config
- Display on detail page grouped by Leadership (Chair/Vice Chair) vs Member
- Source attribution component on Contact and Committee sections
- Prisma schema: `committees` JSON column on representatives table

## Validated in UAT
- Assembly members show 9-19 committee assignments each
- Leadership roles correctly identified and grouped with blue badges
- Source attribution links to official government source with sync date

## Test plan
- [x] 1108 frontend unit tests, 87 e2e tests, 1319 backend tests — all passing
- [x] 5 new unit tests for committee display, links, empty states, attribution
- [x] 4 new e2e tests for representative detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)