### PR TITLE
Merge develop to main: auto-logout + redirect on 403/expired session

### DIFF
--- a/apps/frontend/__tests__/apollo-client.test.ts
+++ b/apps/frontend/__tests__/apollo-client.test.ts
@@ -1,3 +1,4 @@
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
 import {
   apolloClient,
   setDemoUser,
@@ -5,6 +6,13 @@ import {
   clearDemoUser,
   DemoUser,
 } from "../lib/apollo-client";
+import {
+  isAuthExpiredError,
+  resetLogoutInProgressForTests,
+  setPerformRedirectForTests,
+  triggerAuthExpiredRedirect,
+} from "../lib/auth-logout";
+import { USER_KEY } from "../lib/auth-context";
 
 describe("apollo-client", () => {
   beforeEach(() => {
@@ -22,6 +30,77 @@ describe("apollo-client", () => {
 
     it("should have a link configured", () => {
       expect(apolloClient.link).toBeDefined();
+    });
+  });
+
+  describe("authExpiryLink behavior", () => {
+    // The errorLink handler is a simple decision:
+    //   if operationName === "Logout" → skip
+    //   else if isAuthExpiredError → triggerAuthExpiredRedirect
+    //   else → skip
+    // We replicate that decision locally here (keeping it in sync with
+    // the errorLink in lib/apollo-client.ts is cheap — it's 3 lines) and
+    // assert the decision is correct for each scenario. This avoids
+    // fighting ApolloLink.execute's context requirements.
+    function handle(
+      error: unknown,
+      operationName: string | undefined,
+    ): boolean {
+      if (operationName === "Logout") return false;
+      if (!isAuthExpiredError(error as never)) return false;
+      triggerAuthExpiredRedirect("/settings/privacy");
+      return true;
+    }
+
+    let assignMock: jest.Mock;
+    let originalFetch: typeof fetch;
+
+    beforeEach(() => {
+      resetLogoutInProgressForTests();
+      localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+      originalFetch = globalThis.fetch;
+      globalThis.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+      }) as unknown as typeof fetch;
+      assignMock = jest.fn();
+      setPerformRedirectForTests(assignMock);
+    });
+
+    afterEach(() => {
+      setPerformRedirectForTests((url) => {
+        window.location.assign(url);
+      });
+      globalThis.fetch = originalFetch;
+      localStorage.clear();
+    });
+
+    it("redirects on 403 network error", () => {
+      const err = Object.assign(new Error("Forbidden"), { statusCode: 403 });
+      expect(handle(err, "Me")).toBe(true);
+      expect(assignMock).toHaveBeenCalledWith(
+        "/login?redirect=%2Fsettings%2Fprivacy&reason=expired",
+      );
+    });
+
+    it("redirects on GraphQL FORBIDDEN error", () => {
+      const err = new CombinedGraphQLErrors({ data: null }, [
+        { message: "Forbidden", extensions: { code: "FORBIDDEN" } },
+      ]);
+      expect(handle(err, "Me")).toBe(true);
+      expect(assignMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT redirect when operation is named Logout", () => {
+      const err = Object.assign(new Error("Forbidden"), { statusCode: 403 });
+      expect(handle(err, "Logout")).toBe(false);
+      expect(assignMock).not.toHaveBeenCalled();
+    });
+
+    it("does NOT redirect on non-auth errors (5xx)", () => {
+      const err = Object.assign(new Error("Server error"), { statusCode: 500 });
+      expect(handle(err, "Me")).toBe(false);
+      expect(assignMock).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/frontend/__tests__/apollo-client.test.ts
+++ b/apps/frontend/__tests__/apollo-client.test.ts
@@ -69,7 +69,7 @@ describe("apollo-client", () => {
 
     afterEach(() => {
       setPerformRedirectForTests((url) => {
-        window.location.assign(url);
+        globalThis.location.assign(url);
       });
       globalThis.fetch = originalFetch;
       localStorage.clear();

--- a/apps/frontend/__tests__/auth-logout.test.ts
+++ b/apps/frontend/__tests__/auth-logout.test.ts
@@ -1,0 +1,148 @@
+import { CombinedGraphQLErrors } from "@apollo/client/errors";
+import {
+  isAuthExpiredError,
+  resetLogoutInProgressForTests,
+  setPerformRedirectForTests,
+  triggerAuthExpiredRedirect,
+} from "../lib/auth-logout";
+import { USER_KEY } from "../lib/auth-context";
+
+describe("auth-logout", () => {
+  describe("isAuthExpiredError", () => {
+    it("returns false for undefined / null", () => {
+      expect(isAuthExpiredError(undefined)).toBe(false);
+      // @ts-expect-error — runtime guard covers null too
+      expect(isAuthExpiredError(null)).toBe(false);
+    });
+
+    it("returns true for GraphQL FORBIDDEN error", () => {
+      const err = new CombinedGraphQLErrors({ data: null }, [
+        { message: "Forbidden resource", extensions: { code: "FORBIDDEN" } },
+      ]);
+      expect(isAuthExpiredError(err)).toBe(true);
+    });
+
+    it("returns true for GraphQL UNAUTHENTICATED error", () => {
+      const err = new CombinedGraphQLErrors({ data: null }, [
+        {
+          message: "Not authenticated",
+          extensions: { code: "UNAUTHENTICATED" },
+        },
+      ]);
+      expect(isAuthExpiredError(err)).toBe(true);
+    });
+
+    it("returns false for BAD_USER_INPUT or other business errors", () => {
+      const err = new CombinedGraphQLErrors({ data: null }, [
+        { message: "Invalid", extensions: { code: "BAD_USER_INPUT" } },
+      ]);
+      expect(isAuthExpiredError(err)).toBe(false);
+    });
+
+    it("returns true for 403 network error", () => {
+      const err = Object.assign(new Error("Request failed"), {
+        statusCode: 403,
+      });
+      expect(isAuthExpiredError(err)).toBe(true);
+    });
+
+    it("returns true for 401 network error", () => {
+      const err = Object.assign(new Error("Unauthorized"), {
+        statusCode: 401,
+      });
+      expect(isAuthExpiredError(err)).toBe(true);
+    });
+
+    it("returns false for 500 network error", () => {
+      const err = Object.assign(new Error("Server error"), {
+        statusCode: 500,
+      });
+      expect(isAuthExpiredError(err)).toBe(false);
+    });
+  });
+
+  describe("triggerAuthExpiredRedirect", () => {
+    let assignMock: jest.Mock;
+    let fetchMock: jest.Mock;
+    let originalFetch: typeof fetch;
+
+    beforeEach(() => {
+      resetLogoutInProgressForTests();
+      localStorage.clear();
+
+      originalFetch = globalThis.fetch;
+      fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+      globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+      assignMock = jest.fn();
+      setPerformRedirectForTests(assignMock);
+    });
+
+    afterEach(() => {
+      // Restore the production implementation
+      setPerformRedirectForTests((url) => {
+        window.location.assign(url);
+      });
+      globalThis.fetch = originalFetch;
+    });
+
+    it("clears localStorage, fires backend Logout, and redirects", () => {
+      localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+
+      triggerAuthExpiredRedirect("/settings/privacy");
+
+      expect(localStorage.getItem(USER_KEY)).toBeNull();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [, init] = fetchMock.mock.calls[0];
+      const body = JSON.parse((init as RequestInit).body as string);
+      expect(body.operationName).toBe("Logout");
+      expect(body.query).toContain("mutation Logout");
+      expect(assignMock).toHaveBeenCalledWith(
+        "/login?redirect=%2Fsettings%2Fprivacy&reason=expired",
+      );
+    });
+
+    it("is idempotent — concurrent calls collapse to one navigation", () => {
+      localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+
+      triggerAuthExpiredRedirect("/a");
+      triggerAuthExpiredRedirect("/b");
+      triggerAuthExpiredRedirect("/c");
+
+      expect(assignMock).toHaveBeenCalledTimes(1);
+      expect(assignMock).toHaveBeenCalledWith(
+        "/login?redirect=%2Fa&reason=expired",
+      );
+    });
+
+    it("is a no-op when user is not logged in (public-page gate)", () => {
+      // localStorage deliberately empty — user was never logged in
+      triggerAuthExpiredRedirect("/region/propositions");
+
+      expect(assignMock).not.toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("encodes special characters in the redirect path", () => {
+      localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+
+      triggerAuthExpiredRedirect("/settings?tab=privacy&mode=view");
+
+      expect(assignMock).toHaveBeenCalledWith(
+        "/login?redirect=%2Fsettings%3Ftab%3Dprivacy%26mode%3Dview&reason=expired",
+      );
+    });
+
+    it("swallows backend logout fetch failures silently", async () => {
+      localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+      fetchMock.mockRejectedValueOnce(new Error("network unreachable"));
+
+      // Should not throw
+      expect(() => triggerAuthExpiredRedirect("/x")).not.toThrow();
+      // And redirect still happens
+      expect(assignMock).toHaveBeenCalledTimes(1);
+      // Let the fire-and-forget resolve without unhandled rejection
+      await Promise.resolve();
+    });
+  });
+});

--- a/apps/frontend/__tests__/auth-logout.test.ts
+++ b/apps/frontend/__tests__/auth-logout.test.ts
@@ -144,5 +144,48 @@ describe("auth-logout", () => {
       // Let the fire-and-forget resolve without unhandled rejection
       await Promise.resolve();
     });
+
+    describe("auth-route loop guard", () => {
+      it("does NOT redirect when already on /login", () => {
+        localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+
+        triggerAuthExpiredRedirect("/login");
+
+        // Stale auth state still cleared for safety
+        expect(localStorage.getItem(USER_KEY)).toBeNull();
+        // But no navigation — we're already on the login page
+        expect(assignMock).not.toHaveBeenCalled();
+        // And no backend logout POST — we're on a public route
+        expect(fetchMock).not.toHaveBeenCalled();
+      });
+
+      it("does NOT redirect when on /login with query params", () => {
+        localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+        triggerAuthExpiredRedirect("/login?redirect=%2Fsettings");
+        expect(assignMock).not.toHaveBeenCalled();
+      });
+
+      it("does NOT redirect when already on /register", () => {
+        localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+        triggerAuthExpiredRedirect("/register");
+        expect(assignMock).not.toHaveBeenCalled();
+      });
+
+      it("does NOT redirect when on /auth/callback", () => {
+        localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+        triggerAuthExpiredRedirect("/auth/callback");
+        expect(assignMock).not.toHaveBeenCalled();
+      });
+
+      it("DOES redirect from a non-auth route with auth_user set", () => {
+        localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
+
+        triggerAuthExpiredRedirect("/settings/privacy");
+
+        expect(assignMock).toHaveBeenCalledWith(
+          "/login?redirect=%2Fsettings%2Fprivacy&reason=expired",
+        );
+      });
+    });
   });
 });

--- a/apps/frontend/__tests__/auth-logout.test.ts
+++ b/apps/frontend/__tests__/auth-logout.test.ts
@@ -81,7 +81,7 @@ describe("auth-logout", () => {
     afterEach(() => {
       // Restore the production implementation
       setPerformRedirectForTests((url) => {
-        window.location.assign(url);
+        globalThis.location.assign(url);
       });
       globalThis.fetch = originalFetch;
     });

--- a/apps/frontend/__tests__/pages/login.test.tsx
+++ b/apps/frontend/__tests__/pages/login.test.tsx
@@ -3,12 +3,22 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import LoginPage from "@/app/(auth)/login/page";
 
-// Mock Next.js router
+// Mock Next.js router + search params
 const mockPush = jest.fn();
+let mockSearchParamsMap = new Map<string, string>();
 jest.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
   }),
+  useSearchParams: () => ({
+    get: (key: string) => mockSearchParamsMap.get(key) ?? null,
+  }),
+}));
+
+// Mock toast system
+const mockShowToast = jest.fn();
+jest.mock("@/lib/toast", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
 }));
 
 // Mock auth context
@@ -48,6 +58,7 @@ describe("LoginPage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAuthContextValue = { ...defaultAuthContext };
+    mockSearchParamsMap = new Map();
   });
 
   describe("rendering", () => {
@@ -395,6 +406,95 @@ describe("LoginPage", () => {
 
       const button = screen.getByRole("button", { name: /Authenticating/i });
       expect(button).toBeDisabled();
+    });
+  });
+
+  describe("session-expired handling (#610)", () => {
+    it('shows "session expired" toast when reason=expired', () => {
+      mockSearchParamsMap.set("reason", "expired");
+      render(<LoginPage />);
+
+      expect(mockShowToast).toHaveBeenCalledWith(
+        "Your session expired. Please sign in again.",
+        "warning",
+        5000,
+      );
+    });
+
+    it("does NOT show the toast when reason query param is absent", () => {
+      render(<LoginPage />);
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+
+    it("does NOT show the toast for unknown reason values", () => {
+      mockSearchParamsMap.set("reason", "something-else");
+      render(<LoginPage />);
+      expect(mockShowToast).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("redirect param (#610)", () => {
+    it("redirects to the redirect= path after password login", async () => {
+      mockSearchParamsMap.set("redirect", "/settings/privacy");
+      mockLogin.mockResolvedValueOnce(undefined);
+      const user = userEvent.setup();
+      render(<LoginPage />);
+
+      await user.click(screen.getByRole("button", { name: "Password" }));
+      await user.type(screen.getByLabelText("Email Address"), "a@example.com");
+      await user.type(screen.getByLabelText("Password"), "password123");
+      await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith("/settings/privacy");
+      });
+    });
+
+    it("defaults to /onboarding when redirect param is absent", async () => {
+      mockLogin.mockResolvedValueOnce(undefined);
+      const user = userEvent.setup();
+      render(<LoginPage />);
+
+      await user.click(screen.getByRole("button", { name: "Password" }));
+      await user.type(screen.getByLabelText("Email Address"), "a@example.com");
+      await user.type(screen.getByLabelText("Password"), "password123");
+      await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith("/onboarding");
+      });
+    });
+
+    it("rejects absolute URLs in redirect (open-redirect guard)", async () => {
+      mockSearchParamsMap.set("redirect", "https://evil.example.com");
+      mockLogin.mockResolvedValueOnce(undefined);
+      const user = userEvent.setup();
+      render(<LoginPage />);
+
+      await user.click(screen.getByRole("button", { name: "Password" }));
+      await user.type(screen.getByLabelText("Email Address"), "a@example.com");
+      await user.type(screen.getByLabelText("Password"), "password123");
+      await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith("/onboarding");
+      });
+    });
+
+    it("rejects protocol-relative URLs in redirect", async () => {
+      mockSearchParamsMap.set("redirect", "//evil.example.com");
+      mockLogin.mockResolvedValueOnce(undefined);
+      const user = userEvent.setup();
+      render(<LoginPage />);
+
+      await user.click(screen.getByRole("button", { name: "Password" }));
+      await user.type(screen.getByLabelText("Email Address"), "a@example.com");
+      await user.type(screen.getByLabelText("Password"), "password123");
+      await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith("/onboarding");
+      });
     });
   });
 });

--- a/apps/frontend/app/(auth)/auth/callback/page.tsx
+++ b/apps/frontend/app/(auth)/auth/callback/page.tsx
@@ -36,6 +36,23 @@ function CallbackLoading() {
   );
 }
 
+/**
+ * Validate a `?redirect=` query param so we only accept same-origin paths.
+ * Mirrors the helper in the login page. Keeps this auth callback safe
+ * from open-redirect attacks on the magic-link round-trip.
+ *
+ * Callers pass their own default because the two buttons on this page
+ * have different natural destinations: "Skip for now" → /onboarding
+ * (completes first-time setup), "Continue to App" → /region (returning
+ * users). Both honor an explicit `?redirect=` first.
+ */
+function resolveRedirect(raw: string | null, fallback: string): string {
+  if (!raw) return fallback;
+  if (!raw.startsWith("/")) return fallback;
+  if (raw.startsWith("//")) return fallback;
+  return raw;
+}
+
 // Main callback content component that uses useSearchParams
 function AuthCallbackContent() {
   const router = useRouter();
@@ -47,6 +64,9 @@ function AuthCallbackContent() {
     error,
     supportsPasskeys,
   } = useAuth();
+  const rawRedirect = searchParams.get("redirect");
+  const skipTarget = resolveRedirect(rawRedirect, "/onboarding");
+  const continueTarget = resolveRedirect(rawRedirect, "/region");
 
   const [status, setStatus] = useState<"verifying" | "success" | "error">(
     "verifying",
@@ -254,7 +274,7 @@ function AuthCallbackContent() {
           </Link>
           <button
             type="button"
-            onClick={() => router.push("/onboarding")}
+            onClick={() => router.push(skipTarget)}
             className="inline-block w-full py-3 px-6 bg-white text-[#4d4d4d] font-semibold rounded-lg border border-[#DDDDDD] hover:bg-[#FFFFFF] transition-colors"
           >
             Skip for now
@@ -288,7 +308,7 @@ function AuthCallbackContent() {
       <p className="text-[#4d4d4d] mb-6">Redirecting you to the app...</p>
       <button
         type="button"
-        onClick={() => router.push("/region")}
+        onClick={() => router.push(continueTarget)}
         className="inline-block w-full py-3 px-6 bg-[#222222] text-white font-semibold rounded-lg hover:bg-[#333333] transition-colors"
       >
         Continue to App

--- a/apps/frontend/app/(auth)/login/page.tsx
+++ b/apps/frontend/app/(auth)/login/page.tsx
@@ -75,9 +75,7 @@ function LoginPageContent() {
     }
   };
 
-  const handleMagicLinkLogin: React.FormEventHandler<HTMLFormElement> = async (
-    e,
-  ) => {
+  const handleMagicLinkLogin: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
     clearError();
     // Preserve the redirect target through the magic-link round-trip so
@@ -87,20 +85,26 @@ function LoginPageContent() {
     if (redirect !== "/onboarding") {
       callbackUrl.searchParams.set("redirect", redirect);
     }
-    await sendMagicLink(email, callbackUrl.toString());
+    // React onSubmit expects a void-returning handler, so fire the async
+    // work as a fire-and-forget IIFE. sendMagicLink handles its own
+    // errors via auth-context state.
+    void sendMagicLink(email, callbackUrl.toString());
   };
 
-  const handlePasswordLogin: React.FormEventHandler<HTMLFormElement> = async (
-    e,
-  ) => {
+  const handlePasswordLogin: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
     clearError();
-    try {
-      await login({ email, password });
-      postLoginRedirect();
-    } catch {
-      // Error is handled in context
-    }
+    // React onSubmit expects a void-returning handler; wrap the async
+    // flow so the outer handler returns void and errors don't bubble as
+    // unhandled rejections. login() surfaces errors via auth-context.
+    void (async () => {
+      try {
+        await login({ email, password });
+        postLoginRedirect();
+      } catch {
+        // Error is handled in context
+      }
+    })();
   };
 
   const switchMode = (mode: AuthMode) => {

--- a/apps/frontend/app/(auth)/login/page.tsx
+++ b/apps/frontend/app/(auth)/login/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, FormEvent } from "react";
+import { Suspense, useState, useEffect, useRef, FormEvent } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
+import { useToast } from "@/lib/toast";
 import {
   AuthCard,
   AuthHeader,
@@ -15,8 +16,22 @@ import {
 
 type AuthMode = "passkey" | "magic-link" | "password";
 
-export default function LoginPage() {
+/**
+ * Validate a `?redirect=` query param so we only accept same-origin paths.
+ * Rejects absolute URLs and protocol-relative `//host/...` forms that
+ * could be used for open-redirect attacks. Defaults to `/onboarding`.
+ */
+function resolveRedirect(raw: string | null): string {
+  if (!raw) return "/onboarding";
+  if (!raw.startsWith("/")) return "/onboarding";
+  if (raw.startsWith("//")) return "/onboarding";
+  return raw;
+}
+
+function LoginPageContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const { showToast } = useToast();
   const {
     login,
     loginWithPasskey,
@@ -36,11 +51,25 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
 
+  // Show a "session expired" toast when the errorLink redirected us here.
+  // useRef guards against React StrictMode double-invoking the effect.
+  const expiredToastShown = useRef(false);
+  useEffect(() => {
+    if (expiredToastShown.current) return;
+    if (searchParams.get("reason") === "expired") {
+      expiredToastShown.current = true;
+      showToast("Your session expired. Please sign in again.", "warning", 5000);
+    }
+  }, [searchParams, showToast]);
+
+  const postLoginRedirect = () =>
+    router.push(resolveRedirect(searchParams.get("redirect")));
+
   const handlePasskeyLogin = async () => {
     clearError();
     try {
       await loginWithPasskey(email || undefined);
-      router.push("/onboarding");
+      postLoginRedirect();
     } catch {
       // Error is handled in context
     }
@@ -49,7 +78,14 @@ export default function LoginPage() {
   const handleMagicLinkLogin = async (e: FormEvent) => {
     e.preventDefault();
     clearError();
-    await sendMagicLink(email, `${globalThis.location.origin}/auth/callback`);
+    // Preserve the redirect target through the magic-link round-trip so
+    // /auth/callback can honor it on successful verification.
+    const redirect = resolveRedirect(searchParams.get("redirect"));
+    const callbackUrl = new URL("/auth/callback", globalThis.location.origin);
+    if (redirect !== "/onboarding") {
+      callbackUrl.searchParams.set("redirect", redirect);
+    }
+    await sendMagicLink(email, callbackUrl.toString());
   };
 
   const handlePasswordLogin = async (e: FormEvent) => {
@@ -57,7 +93,7 @@ export default function LoginPage() {
     clearError();
     try {
       await login({ email, password });
-      router.push("/onboarding");
+      postLoginRedirect();
     } catch {
       // Error is handled in context
     }
@@ -372,5 +408,18 @@ export default function LoginPage() {
         </Link>
       </p>
     </AuthCard>
+  );
+}
+
+/**
+ * Wrap the content in a Suspense boundary so `useSearchParams` doesn't
+ * bail out at build time — Next.js prerenders this route and needs to
+ * know where to show the fallback while the query params resolve.
+ */
+export default function LoginPage() {
+  return (
+    <Suspense fallback={<AuthCard>Loading…</AuthCard>}>
+      <LoginPageContent />
+    </Suspense>
   );
 }

--- a/apps/frontend/app/(auth)/login/page.tsx
+++ b/apps/frontend/app/(auth)/login/page.tsx
@@ -75,7 +75,9 @@ function LoginPageContent() {
     }
   };
 
-  const handleMagicLinkLogin = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handleMagicLinkLogin: React.FormEventHandler<HTMLFormElement> = async (
+    e,
+  ) => {
     e.preventDefault();
     clearError();
     // Preserve the redirect target through the magic-link round-trip so
@@ -88,7 +90,9 @@ function LoginPageContent() {
     await sendMagicLink(email, callbackUrl.toString());
   };
 
-  const handlePasswordLogin = async (e: React.FormEvent<HTMLFormElement>) => {
+  const handlePasswordLogin: React.FormEventHandler<HTMLFormElement> = async (
+    e,
+  ) => {
     e.preventDefault();
     clearError();
     try {

--- a/apps/frontend/app/(auth)/login/page.tsx
+++ b/apps/frontend/app/(auth)/login/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useState, useEffect, useRef, FormEvent } from "react";
+import { Suspense, useState, useEffect, useRef } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
@@ -75,7 +75,7 @@ function LoginPageContent() {
     }
   };
 
-  const handleMagicLinkLogin = async (e: FormEvent) => {
+  const handleMagicLinkLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     clearError();
     // Preserve the redirect target through the magic-link round-trip so
@@ -88,7 +88,7 @@ function LoginPageContent() {
     await sendMagicLink(email, callbackUrl.toString());
   };
 
-  const handlePasswordLogin = async (e: FormEvent) => {
+  const handlePasswordLogin = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     clearError();
     try {

--- a/apps/frontend/e2e/auth.spec.ts
+++ b/apps/frontend/e2e/auth.spec.ts
@@ -383,3 +383,97 @@ test.describe("Session Management", () => {
     await expect(page.locator("body")).toBeVisible();
   });
 });
+
+/**
+ * Session-expired handling (#610).
+ *
+ * When a 403 / FORBIDDEN response comes back while the user is logged
+ * in, the Apollo errorLink redirects to /login?redirect=…&reason=expired
+ * and the login page shows a toast. After re-login, the user is sent
+ * back to the original path.
+ *
+ * Public pages (no stored `auth_user`) do NOT redirect — a 403 on a
+ * public page is an expected permission error, not a session expiry.
+ */
+test.describe("Session expiry (#610)", () => {
+  test("/login?reason=expired shows the session-expired toast", async ({
+    page,
+  }) => {
+    await page.goto("/login?reason=expired");
+
+    await expect(
+      page.getByText(/session expired\. please sign in again/i),
+    ).toBeVisible();
+  });
+
+  test("redirect query param is preserved after successful login", async ({
+    page,
+  }) => {
+    // Mock the login mutation
+    await page.route("**/api", async (route) => {
+      const request = route.request();
+      const postData = request.postDataJSON();
+      if (
+        postData?.operationName === "LoginUser" ||
+        postData?.query?.includes("login(")
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: mockLoginResponse }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: {} }),
+        });
+      }
+    });
+
+    await page.goto("/login?redirect=%2Fsettings%2Fprivacy&reason=expired");
+    await page.getByRole("button", { name: "Password" }).click();
+    await page.locator("input#email").fill("test@example.com");
+    await page.locator("input#password").fill("password123");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    // After login, URL should be the redirect target (not /onboarding).
+    await page.waitForURL(/\/settings\/privacy$/, { timeout: 3000 });
+    await expect(page).toHaveURL(/\/settings\/privacy$/);
+  });
+
+  test("absolute-URL redirect is rejected and falls back to /onboarding", async ({
+    page,
+  }) => {
+    await page.route("**/api", async (route) => {
+      const request = route.request();
+      const postData = request.postDataJSON();
+      if (
+        postData?.operationName === "LoginUser" ||
+        postData?.query?.includes("login(")
+      ) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: mockLoginResponse }),
+        });
+      } else {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ data: {} }),
+        });
+      }
+    });
+
+    await page.goto("/login?redirect=https://evil.example.com");
+    await page.getByRole("button", { name: "Password" }).click();
+    await page.locator("input#email").fill("test@example.com");
+    await page.locator("input#password").fill("password123");
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    // Should NOT navigate off-origin; should land on /onboarding default.
+    await page.waitForURL(/\/onboarding$/, { timeout: 3000 });
+    await expect(page).toHaveURL(/\/onboarding$/);
+  });
+});

--- a/apps/frontend/e2e/utils/test-helpers.ts
+++ b/apps/frontend/e2e/utils/test-helpers.ts
@@ -163,6 +163,32 @@ export async function setupAuthSession(page: Page, user = mockUser) {
   await page.addInitScript((userData) => {
     localStorage.setItem("auth_user", JSON.stringify(userData));
   }, user);
+
+  // Install a catch-all GraphQL mock so pages that run authenticated
+  // queries don't accidentally hit the real backend and 403 — which,
+  // since #610 shipped, correctly triggers a redirect to /login and
+  // breaks unrelated assertions.
+  //
+  // Tests that need specific query responses can still call
+  // mockGraphQL() or mockGraphQLError() afterwards; Playwright routes
+  // are LIFO, so later-registered handlers intercept first. The
+  // catch-all below only runs if no test-specific handler matched.
+  await page.route("**/api", async (route) => {
+    const request = route.request();
+    if (request.method() !== "POST") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: {} }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: {} }),
+    });
+  });
 }
 
 /**

--- a/apps/frontend/lib/apollo-client.ts
+++ b/apps/frontend/lib/apollo-client.ts
@@ -5,10 +5,12 @@ import {
   InMemoryCache,
   split,
 } from "@apollo/client";
+import { ErrorLink } from "@apollo/client/link/error";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
 import { getMainDefinition } from "@apollo/client/utilities";
 import { createClient } from "graphql-ws";
 import { persistCache, LocalStorageWrapper } from "apollo3-cache-persist";
+import { isAuthExpiredError, triggerAuthExpiredRedirect } from "./auth-logout";
 
 const GRAPHQL_URL =
   process.env.NEXT_PUBLIC_GRAPHQL_URL || "http://localhost:3000/api";
@@ -128,19 +130,35 @@ function createWsLink(): ApolloLink | null {
 }
 
 /**
+ * Error link that detects expired-session responses and redirects to
+ * `/login?redirect=<prev>&reason=expired`. See issue #610 and
+ * [lib/auth-logout.ts](./auth-logout.ts) for the side-effect logic.
+ *
+ * Placed at the HEAD of the link chain so it observes every failure from
+ * the HTTP/WS links below it. Excludes the `Logout` mutation itself so a
+ * 403 on logout doesn't recurse.
+ */
+const authExpiryLink = new ErrorLink(({ error, operation }) => {
+  if (operation.operationName === "Logout") return;
+  if (!isAuthExpiredError(error)) return;
+  if (typeof window === "undefined") return;
+  triggerAuthExpiredRedirect(window.location.pathname + window.location.search);
+});
+
+/**
  * Create the Apollo Link that routes subscriptions to WebSocket
- * and queries/mutations to HTTP
+ * and queries/mutations to HTTP, with the auth-expiry link at the head.
  */
 function createLink(): ApolloLink {
   const wsLink = createWsLink();
 
   // If no WebSocket link (SSR), use HTTP only
   if (!wsLink) {
-    return httpLink;
+    return ApolloLink.from([authExpiryLink, httpLink]);
   }
 
   // Split traffic: subscriptions go to WebSocket, rest to HTTP
-  return split(
+  const transportLink = split(
     ({ query }) => {
       const definition = getMainDefinition(query);
       return (
@@ -151,6 +169,8 @@ function createLink(): ApolloLink {
     wsLink,
     httpLink,
   );
+
+  return ApolloLink.from([authExpiryLink, transportLink]);
 }
 
 /**

--- a/apps/frontend/lib/apollo-client.ts
+++ b/apps/frontend/lib/apollo-client.ts
@@ -3,7 +3,6 @@ import {
   ApolloLink,
   HttpLink,
   InMemoryCache,
-  split,
 } from "@apollo/client";
 import { ErrorLink } from "@apollo/client/link/error";
 import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
@@ -141,8 +140,10 @@ function createWsLink(): ApolloLink | null {
 const authExpiryLink = new ErrorLink(({ error, operation }) => {
   if (operation.operationName === "Logout") return;
   if (!isAuthExpiredError(error)) return;
-  if (typeof window === "undefined") return;
-  triggerAuthExpiredRedirect(window.location.pathname + window.location.search);
+  if (typeof globalThis.window === "undefined") return;
+  triggerAuthExpiredRedirect(
+    globalThis.location.pathname + globalThis.location.search,
+  );
 });
 
 /**
@@ -158,7 +159,7 @@ function createLink(): ApolloLink {
   }
 
   // Split traffic: subscriptions go to WebSocket, rest to HTTP
-  const transportLink = split(
+  const transportLink = ApolloLink.split(
     ({ query }) => {
       const definition = getMainDefinition(query);
       return (

--- a/apps/frontend/lib/apollo-client.ts
+++ b/apps/frontend/lib/apollo-client.ts
@@ -140,7 +140,7 @@ function createWsLink(): ApolloLink | null {
 const authExpiryLink = new ErrorLink(({ error, operation }) => {
   if (operation.operationName === "Logout") return;
   if (!isAuthExpiredError(error)) return;
-  if (typeof globalThis.window === "undefined") return;
+  if (globalThis.window === undefined) return;
   triggerAuthExpiredRedirect(
     globalThis.location.pathname + globalThis.location.search,
   );

--- a/apps/frontend/lib/auth-context.tsx
+++ b/apps/frontend/lib/auth-context.tsx
@@ -89,7 +89,7 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 // SECURITY: Only store user info, NOT tokens
 // Tokens are now stored in httpOnly cookies by the backend
 // @see https://github.com/OpusPopuli/opuspopuli/issues/186
-const USER_KEY = "auth_user";
+export const USER_KEY = "auth_user";
 
 function decodeToken(idToken: string): User | null {
   try {

--- a/apps/frontend/lib/auth-logout.ts
+++ b/apps/frontend/lib/auth-logout.ts
@@ -69,7 +69,7 @@ let logoutInProgress = false;
  * `window.location`.
  */
 let performRedirect: (url: string) => void = (url) => {
-  window.location.assign(url);
+  globalThis.location.assign(url);
 };
 
 /** Test-only: swap the navigation implementation. */
@@ -87,7 +87,7 @@ export function setPerformRedirectForTests(fn: (url: string) => void): void {
  *   page. No redirect, no-op.
  */
 export function triggerAuthExpiredRedirect(pathname: string): void {
-  if (logoutInProgress || typeof window === "undefined") return;
+  if (logoutInProgress || typeof globalThis.window === "undefined") return;
   if (localStorage.getItem(USER_KEY) === null) return;
   logoutInProgress = true;
 

--- a/apps/frontend/lib/auth-logout.ts
+++ b/apps/frontend/lib/auth-logout.ts
@@ -86,9 +86,28 @@ export function setPerformRedirectForTests(fn: (url: string) => void): void {
  *   never logged in, so a 403 is an expected permission error on a public
  *   page. No redirect, no-op.
  */
+/**
+ * Paths that are themselves the re-authentication flow — redirecting
+ * here from a 403 would cause an infinite loop (e.g. if the login page
+ * makes an authenticated query). Both `pathname` and the location
+ * check short-circuit if we're already on one of these.
+ */
+const AUTH_ROUTE_PREFIXES = ["/login", "/register", "/auth/"] as const;
+
+function isAuthRoute(pathname: string): boolean {
+  return AUTH_ROUTE_PREFIXES.some((p) => pathname.startsWith(p));
+}
+
 export function triggerAuthExpiredRedirect(pathname: string): void {
   if (logoutInProgress || globalThis.window === undefined) return;
   if (localStorage.getItem(USER_KEY) === null) return;
+  // Already on an auth route? A 403 here doesn't need to redirect us
+  // anywhere — we're already where we'd send the user. Clear stale
+  // state (they may be mid-expiry) but don't navigate.
+  if (isAuthRoute(pathname)) {
+    localStorage.removeItem(USER_KEY);
+    return;
+  }
   logoutInProgress = true;
 
   localStorage.removeItem(USER_KEY);

--- a/apps/frontend/lib/auth-logout.ts
+++ b/apps/frontend/lib/auth-logout.ts
@@ -87,7 +87,7 @@ export function setPerformRedirectForTests(fn: (url: string) => void): void {
  *   page. No redirect, no-op.
  */
 export function triggerAuthExpiredRedirect(pathname: string): void {
-  if (logoutInProgress || typeof globalThis.window === "undefined") return;
+  if (logoutInProgress || globalThis.window === undefined) return;
   if (localStorage.getItem(USER_KEY) === null) return;
   logoutInProgress = true;
 

--- a/apps/frontend/lib/auth-logout.ts
+++ b/apps/frontend/lib/auth-logout.ts
@@ -1,0 +1,112 @@
+/**
+ * Terminal auth-expired side-effect module.
+ *
+ * When a GraphQL response indicates the user's session is no longer valid
+ * (HTTP 403, or `extensions.code` === `FORBIDDEN` / `UNAUTHENTICATED`), the
+ * Apollo `authExpiryLink` calls `triggerAuthExpiredRedirect` here. We
+ * intentionally do NOT bridge back into the React AuthContext — the
+ * `AuthProvider` lives inside the `ApolloProvider`, so a React-aware bridge
+ * would be a circular-dependency hazard. Instead we perform the side effects
+ * directly (clear localStorage, fire a best-effort backend logout, full-page
+ * navigate to `/login`), and `AuthProvider` rehydrates as unauthenticated on
+ * the next page load.
+ *
+ * See issue #610 and plan at plans/composed-dancing-jellyfish.md.
+ */
+import type { ErrorLike } from "@apollo/client";
+import {
+  CombinedGraphQLErrors,
+  CombinedProtocolErrors,
+} from "@apollo/client/errors";
+import { USER_KEY } from "./auth-context";
+
+const GRAPHQL_URL =
+  process.env.NEXT_PUBLIC_GRAPHQL_URL || "http://localhost:3000/api";
+
+/** Error codes that mean "your session is no longer valid, sign in again". */
+const EXPIRED_SESSION_CODES = new Set(["FORBIDDEN", "UNAUTHENTICATED"]);
+
+/**
+ * Returns true when the Apollo error indicates an expired/invalid session.
+ * Matches HTTP 403 on network errors and `FORBIDDEN`/`UNAUTHENTICATED` on
+ * GraphQL errors. Returns false for business-logic errors, 5xx, missing
+ * data, etc.
+ */
+export function isAuthExpiredError(error: ErrorLike | undefined): boolean {
+  if (!error) return false;
+
+  if (CombinedGraphQLErrors.is(error)) {
+    return error.errors.some((e) => {
+      const code = e.extensions?.code;
+      return typeof code === "string" && EXPIRED_SESSION_CODES.has(code);
+    });
+  }
+
+  if (CombinedProtocolErrors.is(error)) return false;
+
+  // Network-level error. Apollo surfaces the original fetch Response as
+  // `statusCode` on certain link failures; check defensively.
+  const statusCode = (error as { statusCode?: number }).statusCode;
+  return statusCode === 403 || statusCode === 401;
+}
+
+/**
+ * Module-level idempotency flag. Once the first 403 triggers a navigation,
+ * subsequent in-flight 403s are no-ops — we've already committed to redirect
+ * and the page is about to unload.
+ *
+ * Exported for testing only; production callers should treat it as private.
+ */
+export function resetLogoutInProgressForTests(): void {
+  logoutInProgress = false;
+}
+let logoutInProgress = false;
+
+/**
+ * Navigation seam. Production uses a full-page navigation so the whole
+ * app unmounts and AuthProvider rehydrates fresh as unauthenticated on
+ * the next load. Tests override this to avoid jsdom's non-configurable
+ * `window.location`.
+ */
+let performRedirect: (url: string) => void = (url) => {
+  window.location.assign(url);
+};
+
+/** Test-only: swap the navigation implementation. */
+export function setPerformRedirectForTests(fn: (url: string) => void): void {
+  performRedirect = fn;
+}
+
+/**
+ * Clear local auth state, fire-and-forget the backend logout mutation, and
+ * navigate to `/login` with `?redirect=<prev-path>&reason=expired`.
+ *
+ * - Idempotent: concurrent calls collapse to a single navigation.
+ * - Public-page gate: if `USER_KEY` isn't in localStorage, the user was
+ *   never logged in, so a 403 is an expected permission error on a public
+ *   page. No redirect, no-op.
+ */
+export function triggerAuthExpiredRedirect(pathname: string): void {
+  if (logoutInProgress || typeof window === "undefined") return;
+  if (localStorage.getItem(USER_KEY) === null) return;
+  logoutInProgress = true;
+
+  localStorage.removeItem(USER_KEY);
+
+  // Best-effort backend logout to clear httpOnly cookies. Fire via raw
+  // fetch (not Apollo) so we don't re-enter the link chain during an
+  // auth-failure path. Failures are ignored — the navigation below is
+  // the user-visible outcome either way.
+  void fetch(GRAPHQL_URL, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      query: "mutation Logout { logout }",
+      operationName: "Logout",
+    }),
+  }).catch(() => {});
+
+  const redirect = encodeURIComponent(pathname || "/");
+  performRedirect(`/login?redirect=${redirect}&reason=expired`);
+}


### PR DESCRIPTION
## Summary

Promotes [#623](https://github.com/OpusPopuli/opuspopuli/pull/623) from develop to main — the auto-logout-on-403 feature closing [#610](https://github.com/OpusPopuli/opuspopuli/issues/610).

## What's going to main

When a user's JWT expires mid-session, every authenticated GraphQL query silently returns \`403 FORBIDDEN\` and the app breaks (profile, notifications, privacy, activity). Users had to close the tab and log in manually — a launch blocker for real sessions.

### Fix

- **\`lib/auth-logout.ts\`** (new) — terminal side-effect module. On 403 / FORBIDDEN / UNAUTHENTICATED: clear local auth state, fire best-effort backend logout, full-page navigate to \`/login?redirect=<prev>&reason=expired\`.
- **\`lib/apollo-client.ts\`** — new Apollo v4 \`ErrorLink\` at the head of the link chain, consulting the above module.
- **Login page + auth callback** — honor \`?redirect=\` (with open-redirect guard), show \`?reason=expired\` toast on mount, Suspense-wrap for \`useSearchParams\` prerender.
- **Auth-route loop guard** — if the current path is already \`/login\`, \`/register\`, or \`/auth/*\`, don't redirect. Prevents infinite recursion if the login page itself ever encounters a 403.
- **Test infrastructure** — \`setupAuthSession(page)\` now installs a catch-all GraphQL mock so tests that set \`auth_user\` but don't explicitly mock GraphQL don't accidentally 403 against the real backend (surfaced as test failures after this change correctly stopped silently absorbing 403s).

### Design calls

- errorLink does side effects directly — AuthProvider lives INSIDE ApolloProvider, so a React bridge would be a circular-dep hazard
- Debounce concurrent 403s via module-level flag (first 403 wins, rest are no-ops — page about to unload)
- Public-page gate via \`localStorage[auth_user] === null\` — no pathname allowlist needed
- Open-redirect guard rejects absolute URLs and protocol-relative \`//host/...\` forms
- Honors existing \`?redirect=\` convention from ProtectedRoute instead of introducing \`?returnTo=\`

## Deployment

Frontend-only. After merge:

\`\`\`
docker compose -f docker-compose-frontend.yml build frontend
docker compose -f docker-compose-frontend.yml up -d frontend
\`\`\`

Backend untouched.

## Test plan

| Suite | Count | Status |
|---|---:|---|
| \`auth-logout.test.ts\` | 17 | ✅ (12 core + 5 auth-route guard) |
| \`apollo-client.test.ts\` (+4) | 4 | ✅ errorLink decision matrix |
| \`login.test.tsx\` (+7) | 7 | ✅ reason=expired toast, redirect, open-redirect guard |
| \`e2e/auth.spec.ts\` (+3) | 3 | ✅ Playwright session-expiry scenarios |
| Full frontend unit suite | 1146 | ✅ all pass |
| Full chromium E2E suite | 251 | ✅ all pass after test-helper fix |

## Out of scope — separate follow-ups

- Silent refresh-token rotation (the real fix at the source; separate architectural work)
- WebSocket link 403 handling (different error surface)
- Unifying \`AuthContext.logout()\` with \`apolloClient.clearStore()\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)