### PR TITLE
feat: connect campaign finance to propositions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ node_modules
 
 *.tfvars
 
+# NestJS GraphQL autoSchemaFile output (region service) — regenerated on every build
+region-schema.gql
+
 # Build outputs
 dist/
 *.tsbuildinfo

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,7 +76,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.22",
+    "@opuspopuli/regions": "^1.0.28",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/models/proposition-funding.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/proposition-funding.model.ts
@@ -1,0 +1,88 @@
+import { Field, Float, ID, Int, ObjectType } from '@nestjs/graphql';
+
+/**
+ * A single donor's aggregated giving to one side of a measure.
+ * Grouped by donor name with names normalized at aggregation time.
+ */
+@ObjectType()
+export class TopDonorModel {
+  @Field()
+  donorName!: string;
+
+  @Field(() => Float)
+  totalAmount!: number;
+
+  @Field(() => Int)
+  contributionCount!: number;
+}
+
+/**
+ * Compact summary of a primarily-formed committee for a measure: enough
+ * for the funding section to render a clickable name with a money figure
+ * without a second round-trip.
+ */
+@ObjectType()
+export class CommitteeSummaryModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  name!: string;
+
+  @Field(() => Float)
+  totalRaised!: number;
+}
+
+/**
+ * Funding totals for one side of a ballot measure (support OR oppose).
+ * `totalRaised` includes contributions to all committees declaring this
+ * position plus independent expenditures targeting the measure with this
+ * support/oppose code. `totalSpent` mirrors that scope for outflows.
+ *
+ * NOTE on multi-measure attribution: when a committee has positions on
+ * multiple measures, each measure's `totalRaised` includes the full
+ * contribution amount — i.e. we don't fractionally split contributions
+ * across measures yet. UI surfaces `committeeCount` so readers can see
+ * when a side is concentrated in a few primarily-formed committees vs.
+ * spread across general-purpose ones.
+ */
+@ObjectType()
+export class SidedFundingModel {
+  @Field(() => Float)
+  totalRaised!: number;
+
+  @Field(() => Float)
+  totalSpent!: number;
+
+  @Field(() => Int)
+  donorCount!: number;
+
+  @Field(() => Int)
+  committeeCount!: number;
+
+  @Field(() => [TopDonorModel])
+  topDonors!: TopDonorModel[];
+
+  @Field(() => [CommitteeSummaryModel])
+  primaryCommittees!: CommitteeSummaryModel[];
+}
+
+/**
+ * Aggregated funding for a single proposition: support + oppose sides,
+ * each summarized. `asOf` is the wall-clock time the aggregation was
+ * computed (cache key) so the UI can show an "as of" timestamp.
+ */
+@ObjectType()
+export class PropositionFundingModel {
+  @Field(() => ID)
+  propositionId!: string;
+
+  @Field()
+  asOf!: Date;
+
+  @Field(() => SidedFundingModel)
+  support!: SidedFundingModel;
+
+  @Field(() => SidedFundingModel)
+  oppose!: SidedFundingModel;
+}

--- a/apps/backend/src/apps/region/src/domains/proposition-analysis.service.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-analysis.service.ts
@@ -427,7 +427,8 @@ export class PropositionAnalysisService {
     for (let i = 0; i < snapped.length - 1; i++) {
       snapped[i].endOffset = snapped[i + 1].startOffset;
     }
-    snapped[snapped.length - 1].endOffset = textLen;
+    const last = snapped.at(-1);
+    if (last) last.endOffset = textLen;
 
     // Drop empty/inverted sections that survived (rare but possible if
     // two snapped headings landed on the same offset).

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.spec.ts
@@ -1,0 +1,627 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
+
+interface PropRow {
+  id: string;
+  externalId: string;
+  title: string;
+  electionDate: Date | null;
+}
+
+interface ContribRow {
+  externalId: string;
+  committeeId: string;
+}
+
+interface ExpRow {
+  id: string;
+  externalId: string;
+  committeeId: string;
+  propositionTitle: string | null;
+  propositionId: string | null;
+  supportOrOppose: string | null;
+}
+
+interface IeRow {
+  id: string;
+  externalId: string;
+  committeeId: string;
+  propositionTitle: string | null;
+  propositionId: string | null;
+  supportOrOppose: string | null;
+}
+
+interface Cvr2Row {
+  filingId: string;
+  ballotName: string | null;
+  ballotNumber: string | null;
+  supportOrOppose: string | null;
+}
+
+/**
+ * Mock for db.expenditure.findMany. The linker calls it three ways:
+ *   1) buildFilingToCommitteeIndex — no `where` filter, selects externalId/committeeId
+ *   2) linkExpenditures — `where: { propositionId: null, propositionTitle: { not: null } }`
+ *   3) upsertInferredPositions — `where: { propositionId: { not: null } }`, distinct + select
+ * Discriminate by `args.distinct` (only branch 3 sets it) and by whether
+ * propositionTitle is in the where clause.
+ */
+function expenditureFindMany(args: any, rows: ExpRow[]): unknown[] {
+  if (args?.distinct) {
+    return rows
+      .filter((e) => e.propositionId !== null)
+      .map((e) => ({
+        committeeId: e.committeeId,
+        propositionId: e.propositionId!,
+        supportOrOppose: e.supportOrOppose,
+      }));
+  }
+  if (args?.where?.propositionTitle !== undefined) {
+    return rows
+      .filter((e) => e.propositionId === null && e.propositionTitle)
+      .map((e) => ({ id: e.id, propositionTitle: e.propositionTitle }));
+  }
+  return rows.map((e) => ({
+    externalId: e.externalId,
+    committeeId: e.committeeId,
+  }));
+}
+
+/** Same shape as expenditureFindMany but for IndependentExpenditure rows. */
+function ieFindMany(args: any, rows: IeRow[]): unknown[] {
+  if (args?.distinct) {
+    return rows
+      .filter((ie) => ie.propositionId !== null)
+      .map((ie) => ({
+        committeeId: ie.committeeId,
+        propositionId: ie.propositionId!,
+        supportOrOppose: ie.supportOrOppose,
+      }));
+  }
+  if (args?.where?.propositionTitle !== undefined) {
+    return rows
+      .filter((ie) => ie.propositionId === null && ie.propositionTitle)
+      .map((ie) => ({ id: ie.id, propositionTitle: ie.propositionTitle }));
+  }
+  return rows;
+}
+
+describe('PropositionFinanceLinkerService', () => {
+  /**
+   * Build a service with mocked DB. The mock holds in-memory tables that
+   * mirror the relevant Prisma model methods used by the linker. Tests
+   * mutate the table contents to set up scenarios; the service reads
+   * through the mock as it would in production.
+   */
+  async function buildService(
+    opts: {
+      propositions?: PropRow[];
+      contributions?: ContribRow[];
+      expenditures?: ExpRow[];
+      independentExpenditures?: IeRow[];
+      cvr2Filings?: Cvr2Row[];
+      configValues?: Record<string, string | undefined>;
+      withDb?: boolean;
+    } = {},
+  ) {
+    const {
+      propositions = [],
+      contributions = [],
+      expenditures = [],
+      independentExpenditures = [],
+      cvr2Filings = [],
+      configValues = {},
+      withDb = true,
+    } = opts;
+
+    const positionsTable: Array<{
+      committeeId: string;
+      propositionId: string;
+      position: 'support' | 'oppose';
+      isPrimaryFormation: boolean;
+      sourceFiling: string | null;
+      createdAt: Date;
+      updatedAt: Date;
+    }> = [];
+
+    const expRows = [...expenditures];
+    const ieRows = [...independentExpenditures];
+
+    const upsertPosition = jest.fn(async (args: any) => {
+      const key = args.where.committeeId_propositionId_position;
+      const existing = positionsTable.find(
+        (p) =>
+          p.committeeId === key.committeeId &&
+          p.propositionId === key.propositionId &&
+          p.position === key.position,
+      );
+      if (existing) {
+        const update = args.update ?? {};
+        if (update.isPrimaryFormation !== undefined) {
+          existing.isPrimaryFormation = update.isPrimaryFormation;
+        }
+        if (update.sourceFiling !== undefined) {
+          existing.sourceFiling = update.sourceFiling;
+        }
+        existing.updatedAt = new Date(existing.updatedAt.getTime() + 1);
+        return { createdAt: existing.createdAt, updatedAt: existing.updatedAt };
+      }
+      const now = new Date();
+      const row = {
+        committeeId: args.create.committeeId,
+        propositionId: args.create.propositionId,
+        position: args.create.position,
+        isPrimaryFormation: args.create.isPrimaryFormation,
+        sourceFiling: args.create.sourceFiling,
+        createdAt: now,
+        updatedAt: now,
+      };
+      positionsTable.push(row);
+      return { createdAt: now, updatedAt: now };
+    });
+
+    const mockDb = {
+      proposition: {
+        findMany: jest.fn(async (args?: any) => {
+          // Honor the electionDate window so the cutoff test exercises
+          // the real filter path. The linker passes:
+          //   where: { OR: [{ electionDate: null }, { electionDate: { gte: cutoff } }] }
+          const cutoff: Date | undefined =
+            args?.where?.OR?.[1]?.electionDate?.gte;
+          return propositions
+            .filter(
+              (p) =>
+                !cutoff || p.electionDate === null || p.electionDate >= cutoff,
+            )
+            .map((p) => ({
+              id: p.id,
+              externalId: p.externalId,
+              title: p.title,
+              electionDate: p.electionDate,
+            }));
+        }),
+      },
+      contribution: {
+        findMany: jest.fn(async () =>
+          contributions.map((c) => ({
+            externalId: c.externalId,
+            committeeId: c.committeeId,
+          })),
+        ),
+      },
+      expenditure: {
+        findMany: jest.fn(async (args?: any) =>
+          expenditureFindMany(args, expRows),
+        ),
+        update: jest.fn(async (args: any) => {
+          const row = expRows.find((e) => e.id === args.where.id);
+          if (row) {
+            row.propositionId = args.data.propositionId ?? null;
+          }
+          return row ?? null;
+        }),
+      },
+      independentExpenditure: {
+        findMany: jest.fn(async (args?: any) => ieFindMany(args, ieRows)),
+        update: jest.fn(async (args: any) => {
+          const row = ieRows.find((ie) => ie.id === args.where.id);
+          if (row) {
+            row.propositionId = args.data.propositionId ?? null;
+          }
+          return row ?? null;
+        }),
+      },
+      cvr2Filing: {
+        findMany: jest.fn(async () => cvr2Filings),
+      },
+      committeeMeasurePosition: {
+        upsert: upsertPosition,
+      },
+    } as unknown as DbService;
+
+    const mockConfig = {
+      get: jest.fn((k: string) => configValues[k]),
+    } as unknown as ConfigService;
+
+    const providers: unknown[] = [PropositionFinanceLinkerService];
+    providers.push({ provide: ConfigService, useValue: mockConfig });
+    if (withDb) providers.push({ provide: DbService, useValue: mockDb });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: providers as Parameters<
+        typeof Test.createTestingModule
+      >[0]['providers'],
+    }).compile();
+
+    return {
+      service: module.get(PropositionFinanceLinkerService),
+      positionsTable,
+      expRows,
+      ieRows,
+      mockDb,
+      upsertPosition,
+    };
+  }
+
+  describe('when db is unavailable', () => {
+    it('returns zeroed counts and does no work', async () => {
+      const built = await buildService({ withDb: false });
+      const result = await built.service.linkAll();
+      expect(result).toEqual({
+        cvr2Resolved: 0,
+        cvr2Skipped: 0,
+        expenditureLinked: 0,
+        independentExpenditureLinked: 0,
+        inferredPositions: 0,
+      });
+    });
+  });
+
+  describe('linkAll', () => {
+    it('no-ops when no propositions are in the election window', async () => {
+      const built = await buildService({ propositions: [] });
+      const result = await built.service.linkAll();
+      expect(result.cvr2Resolved).toBe(0);
+      expect(result.expenditureLinked).toBe(0);
+      expect(built.upsertPosition).not.toHaveBeenCalled();
+    });
+
+    it('writes a primary-formation position when CVR2 resolves both filing and ballot', async () => {
+      const built = await buildService({
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'ACA 13',
+            title: 'Voting thresholds',
+            electionDate: new Date(),
+          },
+        ],
+        contributions: [
+          // FILING_ID 12345 → committeeId C-A
+          { externalId: '12345:1', committeeId: 'committee-A' },
+        ],
+        cvr2Filings: [
+          {
+            filingId: '12345',
+            ballotName: 'Voting thresholds',
+            ballotNumber: 'ACA 13',
+            supportOrOppose: 'S',
+          },
+        ],
+      });
+
+      await built.service.linkAll();
+
+      const primary = built.positionsTable.find(
+        (p) => p.isPrimaryFormation === true,
+      );
+      expect(primary).toBeDefined();
+      expect(primary?.committeeId).toBe('committee-A');
+      expect(primary?.propositionId).toBe('prop-1');
+      expect(primary?.position).toBe('support');
+      expect(primary?.sourceFiling).toBe('12345');
+    });
+
+    it('skips CVR2 rows whose filing or ballot cannot be resolved', async () => {
+      const built = await buildService({
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'ACA 13',
+            title: 'Voting thresholds',
+            electionDate: new Date(),
+          },
+        ],
+        contributions: [],
+        cvr2Filings: [
+          {
+            filingId: '99999', // no committee for this filing
+            ballotName: 'Voting thresholds',
+            ballotNumber: 'ACA 13',
+            supportOrOppose: 'S',
+          },
+          {
+            filingId: '12345',
+            ballotName: 'A measure not in our DB',
+            ballotNumber: null,
+            supportOrOppose: 'S',
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+      expect(result.cvr2Resolved).toBe(0);
+      expect(result.cvr2Skipped).toBe(2);
+      expect(built.positionsTable).toHaveLength(0);
+    });
+
+    it('infers a non-primary position from a linked expenditure', async () => {
+      const built = await buildService({
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'ACA 13',
+            title: 'Voting thresholds',
+            electionDate: new Date(),
+          },
+        ],
+        expenditures: [
+          {
+            id: 'exp-1',
+            externalId: '88888:1',
+            committeeId: 'committee-X',
+            propositionTitle: 'Voting thresholds',
+            propositionId: null,
+            supportOrOppose: 'oppose',
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+
+      // Expenditure FK is populated via fuzzy title match
+      expect(result.expenditureLinked).toBe(1);
+      expect(built.expRows[0].propositionId).toBe('prop-1');
+
+      // And an inferred position row was upserted
+      const inferred = built.positionsTable.find(
+        (p) => p.isPrimaryFormation === false,
+      );
+      expect(inferred).toBeDefined();
+      expect(inferred?.committeeId).toBe('committee-X');
+      expect(inferred?.position).toBe('oppose');
+    });
+
+    it('infers a non-primary position from a linked independent expenditure', async () => {
+      const built = await buildService({
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'SCA 1',
+            title: 'Recall election reform',
+            electionDate: new Date(),
+          },
+        ],
+        independentExpenditures: [
+          {
+            id: 'ie-1',
+            externalId: '77777:1',
+            committeeId: 'committee-Y',
+            propositionTitle: 'Recall election reform',
+            propositionId: null,
+            supportOrOppose: 'support',
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+      expect(result.independentExpenditureLinked).toBe(1);
+      expect(built.ieRows[0].propositionId).toBe('prop-1');
+      expect(
+        built.positionsTable.find(
+          (p) => p.committeeId === 'committee-Y' && p.position === 'support',
+        ),
+      ).toBeDefined();
+    });
+
+    it('does not downgrade a CVR2 primary-formation row when an inferred row tries to overwrite', async () => {
+      const built = await buildService({
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'ACA 13',
+            title: 'Voting thresholds',
+            electionDate: new Date(),
+          },
+        ],
+        contributions: [{ externalId: '12345:1', committeeId: 'committee-A' }],
+        cvr2Filings: [
+          {
+            filingId: '12345',
+            ballotName: 'Voting thresholds',
+            ballotNumber: 'ACA 13',
+            supportOrOppose: 'S',
+          },
+        ],
+        // Same committee+prop with same position from an expenditure — would
+        // create the same key with isPrimaryFormation=false.
+        expenditures: [
+          {
+            id: 'exp-1',
+            externalId: '12345:2',
+            committeeId: 'committee-A',
+            propositionTitle: 'Voting thresholds',
+            propositionId: null,
+            supportOrOppose: 'support',
+          },
+        ],
+      });
+
+      await built.service.linkAll();
+
+      const row = built.positionsTable.find(
+        (p) => p.committeeId === 'committee-A' && p.position === 'support',
+      );
+      expect(row).toBeDefined();
+      // Started as primary, must remain primary even after the inferred upsert.
+      expect(row!.isPrimaryFormation).toBe(true);
+    });
+
+    it('idempotent: re-running over the same data does not create duplicates', async () => {
+      const built = await buildService({
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'ACA 13',
+            title: 'Voting thresholds',
+            electionDate: new Date(),
+          },
+        ],
+        contributions: [{ externalId: '12345:1', committeeId: 'committee-A' }],
+        cvr2Filings: [
+          {
+            filingId: '12345',
+            ballotName: 'Voting thresholds',
+            ballotNumber: 'ACA 13',
+            supportOrOppose: 'S',
+          },
+        ],
+      });
+
+      await built.service.linkAll();
+      await built.service.linkAll();
+
+      // Only one (committee, proposition, position) row exists
+      const rowsForKey = built.positionsTable.filter(
+        (p) =>
+          p.committeeId === 'committee-A' &&
+          p.propositionId === 'prop-1' &&
+          p.position === 'support',
+      );
+      expect(rowsForKey).toHaveLength(1);
+    });
+
+    it('skips CVR2 rows with unrecognized supportOrOppose codes', async () => {
+      const built = await buildService({
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'ACA 13',
+            title: 'Voting thresholds',
+            electionDate: new Date(),
+          },
+        ],
+        contributions: [{ externalId: '12345:1', committeeId: 'committee-A' }],
+        cvr2Filings: [
+          {
+            filingId: '12345',
+            ballotName: 'Voting thresholds',
+            ballotNumber: 'ACA 13',
+            supportOrOppose: '???', // garbage code
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+      expect(result.cvr2Resolved).toBe(0);
+      expect(result.cvr2Skipped).toBe(1);
+    });
+
+    it('honors FINANCE_LINKER_ELECTION_WINDOW_YEARS to exclude old propositions', async () => {
+      const ancient = new Date();
+      ancient.setFullYear(ancient.getFullYear() - 10);
+      const built = await buildService({
+        configValues: { FINANCE_LINKER_ELECTION_WINDOW_YEARS: '1' },
+        propositions: [
+          {
+            id: 'prop-old',
+            externalId: 'ACA 13',
+            title: 'Voting thresholds',
+            electionDate: ancient,
+          },
+        ],
+        contributions: [{ externalId: '12345:1', committeeId: 'committee-A' }],
+        cvr2Filings: [
+          {
+            filingId: '12345',
+            ballotName: 'Voting thresholds',
+            ballotNumber: 'ACA 13',
+            supportOrOppose: 'S',
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+      expect(result.cvr2Resolved).toBe(0);
+      expect(built.positionsTable).toHaveLength(0);
+    });
+  });
+
+  describe('fuzzy title resolution', () => {
+    it('matches via the externalId alias even when the user supplies just the bill number', async () => {
+      const built = await buildService({
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'ACA 13',
+            title: 'Voting thresholds',
+            electionDate: new Date(),
+          },
+        ],
+        expenditures: [
+          {
+            id: 'exp-1',
+            externalId: '88888:1',
+            committeeId: 'committee-X',
+            propositionTitle: 'ACA 13', // matches via externalId, not title
+            propositionId: null,
+            supportOrOppose: 'support',
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+      expect(result.expenditureLinked).toBe(1);
+      expect(built.expRows[0].propositionId).toBe('prop-1');
+    });
+
+    it('matches via leading-token prefix when title is similar but not identical', async () => {
+      const built = await buildService({
+        configValues: { FINANCE_LINKER_TITLE_MATCH_MIN_TOKENS: '2' },
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'PROP 36',
+            title: 'Drug treatment expansion act',
+            electionDate: new Date(),
+          },
+        ],
+        expenditures: [
+          {
+            id: 'exp-1',
+            externalId: '88888:1',
+            committeeId: 'committee-X',
+            propositionTitle: 'Drug treatment expansion of 2026 ballot', // first 2 tokens match
+            propositionId: null,
+            supportOrOppose: 'oppose',
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+      expect(result.expenditureLinked).toBe(1);
+    });
+
+    it('returns no match when token overlap is below the threshold', async () => {
+      const built = await buildService({
+        configValues: { FINANCE_LINKER_TITLE_MATCH_MIN_TOKENS: '3' },
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'PROP 36',
+            title: 'Drug treatment expansion act',
+            electionDate: new Date(),
+          },
+        ],
+        expenditures: [
+          {
+            id: 'exp-1',
+            externalId: '88888:1',
+            committeeId: 'committee-X',
+            propositionTitle: 'Drug pricing — totally different measure',
+            propositionId: null,
+            supportOrOppose: 'oppose',
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+      expect(result.expenditureLinked).toBe(0);
+      expect(built.expRows[0].propositionId).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
@@ -1,0 +1,463 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  CommitteeMeasurePositionType,
+  DbService,
+} from '@opuspopuli/relationaldb-provider';
+
+/**
+ * Connects campaign-finance records to propositions.
+ *
+ * Two paths populate `committee_measure_positions` and the new `proposition_id`
+ * FKs on expenditures / independent_expenditures:
+ *
+ * 1) **CVR2 (FPPC Form 410, authoritative)**: every `cvr2_filings` row gives
+ *    `(filingId, ballotName, supportOrOppose)`. We resolve `filingId →
+ *    committeeId` by reading `Contribution`/`Expenditure.externalId` (which
+ *    encodes FILING_ID per the bulk-download convention), and resolve
+ *    `ballotName → propositionId` via the title lookup. Each row that
+ *    resolves writes a `CommitteeMeasurePosition` with
+ *    `isPrimaryFormation = true` and `sourceFiling = filingId`.
+ *
+ * 2) **Inferred (from existing receipts/expenditures)**: every
+ *    `Expenditure` / `IndependentExpenditure` row that already carries a
+ *    `propositionTitle` (sourced from `BAL_NAME` on RCPT_CD/EXPN_CD/S496_CD)
+ *    gets its `propositionId` FK populated, and the owning committee gets a
+ *    `CommitteeMeasurePosition` row with `isPrimaryFormation = false`.
+ *
+ * Idempotent: every step uses upserts on stable unique keys. Re-running over
+ * the same data is a no-op.
+ *
+ * Tunables:
+ * - `FINANCE_LINKER_TITLE_MATCH_MIN_TOKENS` (default 2) — minimum number of
+ *   normalized tokens that must overlap for a fuzzy title match to count.
+ * - `FINANCE_LINKER_ELECTION_WINDOW_YEARS` (default 2) — only consider
+ *   propositions whose `electionDate` falls within this many years of "now"
+ *   when building the title lookup. Keeps the fuzzy-match space small and
+ *   avoids cross-cycle false positives.
+ */
+@Injectable()
+export class PropositionFinanceLinkerService {
+  private readonly logger = new Logger(PropositionFinanceLinkerService.name);
+  private readonly minMatchTokens: number;
+  private readonly electionWindowYears: number;
+
+  constructor(
+    @Optional() private readonly config?: ConfigService,
+    @Optional() private readonly db?: DbService,
+  ) {
+    this.minMatchTokens = this.readPositiveInt(
+      'FINANCE_LINKER_TITLE_MATCH_MIN_TOKENS',
+      2,
+    );
+    this.electionWindowYears = this.readPositiveInt(
+      'FINANCE_LINKER_ELECTION_WINDOW_YEARS',
+      2,
+    );
+  }
+
+  /**
+   * Run the full link pass. Safe to call after every campaign-finance sync
+   * batch — idempotent thanks to the unique constraint on
+   * `(committeeId, propositionId, position)`.
+   *
+   * Returns counts so callers can log progress; never throws on a single
+   * record's resolution failure (those are warned and skipped).
+   */
+  async linkAll(): Promise<{
+    cvr2Resolved: number;
+    cvr2Skipped: number;
+    expenditureLinked: number;
+    independentExpenditureLinked: number;
+    inferredPositions: number;
+  }> {
+    if (!this.db) {
+      return {
+        cvr2Resolved: 0,
+        cvr2Skipped: 0,
+        expenditureLinked: 0,
+        independentExpenditureLinked: 0,
+        inferredPositions: 0,
+      };
+    }
+
+    const titleLookup = await this.buildTitleLookup();
+    if (titleLookup.size === 0) {
+      this.logger.debug(
+        'No propositions in election window — finance linker is a no-op',
+      );
+      return {
+        cvr2Resolved: 0,
+        cvr2Skipped: 0,
+        expenditureLinked: 0,
+        independentExpenditureLinked: 0,
+        inferredPositions: 0,
+      };
+    }
+
+    const filingToCommittee = await this.buildFilingToCommitteeIndex();
+
+    const cvr2Result = await this.linkFromCvr2Filings(
+      titleLookup,
+      filingToCommittee,
+    );
+    const expenditureLinked = await this.linkExpenditures(titleLookup);
+    const independentExpenditureLinked =
+      await this.linkIndependentExpenditures(titleLookup);
+    const inferredPositions = await this.upsertInferredPositions();
+
+    this.logger.log(
+      `Finance linker pass complete: ` +
+        `cvr2=${cvr2Result.resolved}/${cvr2Result.resolved + cvr2Result.skipped}, ` +
+        `expenditures linked=${expenditureLinked}, IEs linked=${independentExpenditureLinked}, ` +
+        `inferred positions=${inferredPositions}`,
+    );
+
+    return {
+      cvr2Resolved: cvr2Result.resolved,
+      cvr2Skipped: cvr2Result.skipped,
+      expenditureLinked,
+      independentExpenditureLinked,
+      inferredPositions,
+    };
+  }
+
+  /**
+   * Build a lookup from normalized title tokens to a `Proposition.id`.
+   * Constrained to the active election window so a 2024 measure with a
+   * similar title doesn't capture 2026 contributions. Returns empty when
+   * no propositions are in window.
+   */
+  private async buildTitleLookup(): Promise<Map<string, string>> {
+    const cutoff = new Date();
+    cutoff.setFullYear(cutoff.getFullYear() - this.electionWindowYears);
+
+    const props = await this.db!.proposition.findMany({
+      where: {
+        deletedAt: null,
+        OR: [{ electionDate: null }, { electionDate: { gte: cutoff } }],
+      },
+      select: { id: true, externalId: true, title: true },
+    });
+
+    const lookup = new Map<string, string>();
+    for (const prop of props) {
+      // Index two ways so callers can match either an exact externalId hit
+      // ("ACA 13") or a fuzzy title hit ("Voting thresholds").
+      lookup.set(this.normalize(prop.externalId), prop.id);
+      lookup.set(this.normalize(prop.title), prop.id);
+    }
+    return lookup;
+  }
+
+  /**
+   * Build `filingId → committeeId` from existing Contribution / Expenditure
+   * rows. The bulk-download handler stores externalIds shaped like
+   * `<FILING_ID>:<row index>` (or similar); we extract the FILING_ID prefix
+   * and pair it with the row's `committeeId`.
+   */
+  private async buildFilingToCommitteeIndex(): Promise<Map<string, string>> {
+    const map = new Map<string, string>();
+
+    const addRows = async (
+      rows: Array<{ externalId: string; committeeId: string }>,
+    ) => {
+      for (const r of rows) {
+        const filingId = this.extractFilingId(r.externalId);
+        if (filingId && !map.has(filingId)) {
+          map.set(filingId, r.committeeId);
+        }
+      }
+    };
+
+    await addRows(
+      await this.db!.contribution.findMany({
+        select: { externalId: true, committeeId: true },
+      }),
+    );
+    await addRows(
+      await this.db!.expenditure.findMany({
+        select: { externalId: true, committeeId: true },
+      }),
+    );
+
+    return map;
+  }
+
+  /**
+   * Walk every `Cvr2Filing` row and write a `CommitteeMeasurePosition` for
+   * each one whose filingId resolves to a known committee AND whose
+   * ballotName / ballotNumber resolves to a known proposition. Sets
+   * `isPrimaryFormation = true` because CVR2 is the authoritative Form 410
+   * declaration.
+   */
+  private async linkFromCvr2Filings(
+    titleLookup: Map<string, string>,
+    filingToCommittee: Map<string, string>,
+  ): Promise<{ resolved: number; skipped: number }> {
+    const filings = await this.db!.cvr2Filing.findMany({
+      select: {
+        filingId: true,
+        ballotName: true,
+        ballotNumber: true,
+        supportOrOppose: true,
+      },
+    });
+
+    let resolved = 0;
+    let skipped = 0;
+
+    for (const f of filings) {
+      const committeeId = filingToCommittee.get(f.filingId);
+      const propositionId =
+        this.resolveProposition(f.ballotNumber, titleLookup) ??
+        this.resolveProposition(f.ballotName, titleLookup);
+      const position = this.mapPosition(f.supportOrOppose);
+
+      if (!committeeId || !propositionId || !position) {
+        skipped++;
+        continue;
+      }
+
+      await this.upsertPosition({
+        committeeId,
+        propositionId,
+        position,
+        isPrimaryFormation: true,
+        sourceFiling: f.filingId,
+      });
+      resolved++;
+    }
+
+    return { resolved, skipped };
+  }
+
+  /**
+   * Resolve `Expenditure.propositionTitle` strings to a `Proposition.id` and
+   * write the FK back. Skips rows that already have `propositionId` set.
+   */
+  private async linkExpenditures(
+    titleLookup: Map<string, string>,
+  ): Promise<number> {
+    const candidates = await this.db!.expenditure.findMany({
+      where: {
+        propositionId: null,
+        propositionTitle: { not: null },
+      },
+      select: { id: true, propositionTitle: true },
+    });
+
+    let linked = 0;
+    for (const e of candidates) {
+      const propositionId = this.resolveProposition(
+        e.propositionTitle,
+        titleLookup,
+      );
+      if (!propositionId) continue;
+      await this.db!.expenditure.update({
+        where: { id: e.id },
+        data: { propositionId },
+      });
+      linked++;
+    }
+    return linked;
+  }
+
+  /** Same idea as `linkExpenditures` but for IndependentExpenditure rows. */
+  private async linkIndependentExpenditures(
+    titleLookup: Map<string, string>,
+  ): Promise<number> {
+    const candidates = await this.db!.independentExpenditure.findMany({
+      where: {
+        propositionId: null,
+        propositionTitle: { not: null },
+      },
+      select: { id: true, propositionTitle: true },
+    });
+
+    let linked = 0;
+    for (const ie of candidates) {
+      const propositionId = this.resolveProposition(
+        ie.propositionTitle,
+        titleLookup,
+      );
+      if (!propositionId) continue;
+      await this.db!.independentExpenditure.update({
+        where: { id: ie.id },
+        data: { propositionId },
+      });
+      linked++;
+    }
+    return linked;
+  }
+
+  /**
+   * For every (committeeId, propositionId) pair that surfaces in linked
+   * Expenditure / IndependentExpenditure rows, upsert a
+   * `CommitteeMeasurePosition` with `isPrimaryFormation = false` if a row
+   * doesn't already exist. The unique constraint guarantees idempotency.
+   * The position is taken from each row's `supportOrOppose`; rows with no
+   * usable position are skipped.
+   */
+  private async upsertInferredPositions(): Promise<number> {
+    const expRows = await this.db!.expenditure.findMany({
+      where: { propositionId: { not: null } },
+      select: {
+        committeeId: true,
+        propositionId: true,
+        supportOrOppose: true,
+      },
+      distinct: ['committeeId', 'propositionId', 'supportOrOppose'],
+    });
+    const ieRows = await this.db!.independentExpenditure.findMany({
+      where: { propositionId: { not: null } },
+      select: {
+        committeeId: true,
+        propositionId: true,
+        supportOrOppose: true,
+      },
+      distinct: ['committeeId', 'propositionId', 'supportOrOppose'],
+    });
+
+    let written = 0;
+    const seen = new Set<string>();
+    for (const r of [...expRows, ...ieRows]) {
+      if (!r.propositionId) continue;
+      const position = this.mapPosition(r.supportOrOppose ?? null);
+      if (!position) continue;
+      const key = `${r.committeeId}:${r.propositionId}:${position}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const created = await this.upsertPosition({
+        committeeId: r.committeeId,
+        propositionId: r.propositionId,
+        position,
+        isPrimaryFormation: false,
+        sourceFiling: null,
+      });
+      if (created) written++;
+    }
+    return written;
+  }
+
+  /**
+   * Upsert a single `CommitteeMeasurePosition`. Returns `true` when a new
+   * row was created. The unique key is `(committeeId, propositionId,
+   * position)`. We only OVERWRITE `isPrimaryFormation` when the new value
+   * is `true` — a CVR2-sourced row should never be downgraded to inferred
+   * by a subsequent expenditure pass.
+   */
+  private async upsertPosition(input: {
+    committeeId: string;
+    propositionId: string;
+    position: 'support' | 'oppose';
+    isPrimaryFormation: boolean;
+    sourceFiling: string | null;
+  }): Promise<boolean> {
+    const positionEnum =
+      input.position === 'support'
+        ? CommitteeMeasurePositionType.support
+        : CommitteeMeasurePositionType.oppose;
+
+    const result = await this.db!.committeeMeasurePosition.upsert({
+      where: {
+        committeeId_propositionId_position: {
+          committeeId: input.committeeId,
+          propositionId: input.propositionId,
+          position: positionEnum,
+        },
+      },
+      update: input.isPrimaryFormation
+        ? {
+            isPrimaryFormation: true,
+            sourceFiling: input.sourceFiling ?? undefined,
+          }
+        : {},
+      create: {
+        committeeId: input.committeeId,
+        propositionId: input.propositionId,
+        position: positionEnum,
+        isPrimaryFormation: input.isPrimaryFormation,
+        sourceFiling: input.sourceFiling,
+      },
+      select: { createdAt: true, updatedAt: true },
+    });
+    // Newly-created rows have createdAt === updatedAt; updates differ.
+    return result.createdAt.getTime() === result.updatedAt.getTime();
+  }
+
+  /**
+   * Map CalAccess SUP_OPP_CD ('S' / 'O') and the loose 'support' / 'oppose'
+   * strings used in our schema to the enum values. Returns null for
+   * anything we can't recognize — those rows are skipped rather than
+   * guessed at.
+   */
+  private mapPosition(
+    raw: string | null | undefined,
+  ): 'support' | 'oppose' | null {
+    if (!raw) return null;
+    const v = raw.trim().toLowerCase();
+    if (v === 's' || v === 'support') return 'support';
+    if (v === 'o' || v === 'oppose') return 'oppose';
+    return null;
+  }
+
+  /**
+   * Resolve a free-text title (BAL_NAME, BAL_NUM, or propositionTitle) to a
+   * Proposition.id. Tries an exact normalized match first, then a token
+   * overlap heuristic that requires at least `minMatchTokens` normalized
+   * tokens to be a prefix of any indexed title. Returns null on no match.
+   */
+  private resolveProposition(
+    title: string | null | undefined,
+    titleLookup: Map<string, string>,
+  ): string | null {
+    if (!title) return null;
+    const normalized = this.normalize(title);
+    if (!normalized) return null;
+
+    const exact = titleLookup.get(normalized);
+    if (exact) return exact;
+
+    // Fuzzy: token-prefix match against any indexed key.
+    const tokens = normalized.split(' ').filter((t) => t.length > 1);
+    if (tokens.length < this.minMatchTokens) return null;
+
+    const probe = tokens.slice(0, this.minMatchTokens).join(' ');
+    for (const [key, propositionId] of titleLookup.entries()) {
+      if (key.startsWith(probe)) return propositionId;
+    }
+    return null;
+  }
+
+  /**
+   * Normalize a string for matching: lowercase, strip punctuation, collapse
+   * whitespace. Keeps alphanumerics + spaces only.
+   */
+  private normalize(value: string): string {
+    return value
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9\s]/g, ' ')
+      .replaceAll(/\s+/g, ' ')
+      .trim();
+  }
+
+  /**
+   * Pull the FILING_ID prefix out of an externalId. The bulk-download
+   * handler concatenates FILING_ID + a row discriminator with either ':'
+   * or '-' as the separator; we conservatively split on either. If no
+   * separator exists, the entire externalId is treated as the filing id.
+   */
+  private extractFilingId(externalId: string): string | null {
+    if (!externalId) return null;
+    const idx = externalId.search(/[:-]/);
+    return idx >= 0 ? externalId.slice(0, idx) : externalId;
+  }
+
+  private readPositiveInt(envKey: string, fallback: number): number {
+    const raw = this.config?.get<string>(envKey);
+    if (!raw) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/proposition-funding.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-funding.service.spec.ts
@@ -1,0 +1,393 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  CommitteeMeasurePositionType,
+  DbService,
+  Prisma,
+} from '@opuspopuli/relationaldb-provider';
+import type { ICache } from '@opuspopuli/common';
+
+import { PropositionFundingService } from './proposition-funding.service';
+import { REGION_CACHE } from './region.tokens';
+
+/**
+ * Wrap a JS number in a Prisma.Decimal-shaped stub so toNumber() works
+ * the same way the real Prisma client returns aggregate sums. The funding
+ * service goes through .toNumber() rather than Number() so we have to
+ * provide that method.
+ */
+function dec(n: number): Prisma.Decimal {
+  return { toNumber: () => n } as unknown as Prisma.Decimal;
+}
+
+describe('PropositionFundingService', () => {
+  async function buildService(
+    opts: {
+      positions?: Array<{
+        committeeId: string;
+        position: 'support' | 'oppose';
+      }>;
+      contributionSums?: Map<string, number>; // committeeId set → sum
+      contributionCount?: number;
+      expenditureSums?: Map<string, number>;
+      ieSums?: Array<{ position: 'support' | 'oppose'; sum: number }>;
+      topDonors?: Array<{
+        donorName: string;
+        sum: number;
+        count: number;
+      }>;
+      distinctDonors?: string[];
+      committees?: Array<{ id: string; name: string }>;
+      contributionByCommittee?: Map<string, number>;
+      cached?: string | null;
+      withDb?: boolean;
+      withCache?: boolean;
+    } = {},
+  ) {
+    const {
+      positions = [],
+      contributionSums = new Map(),
+      expenditureSums = new Map(),
+      ieSums = [],
+      topDonors = [],
+      distinctDonors = [],
+      committees = [],
+      contributionByCommittee = new Map(),
+      cached = null,
+      withDb = true,
+      withCache = true,
+    } = opts;
+
+    const cacheStore = new Map<string, string>();
+    if (cached) cacheStore.set('propositionFunding:prop-1', cached);
+
+    const mockCache: ICache<string> = {
+      get: jest.fn(async (k: string) => cacheStore.get(k) ?? null),
+      set: jest.fn(async (k: string, v: string) => {
+        cacheStore.set(k, v);
+      }),
+      delete: jest.fn(async (k: string) => {
+        cacheStore.delete(k);
+      }),
+      destroy: jest.fn(async () => {}),
+      keys: jest.fn(async () => Array.from(cacheStore.keys())),
+    } as unknown as ICache<string>;
+
+    const mockDb = {
+      committeeMeasurePosition: {
+        findMany: jest.fn(async (args: any) =>
+          positions
+            .filter((p) => p.position === args.where.position)
+            .map((p) => ({ committeeId: p.committeeId })),
+        ),
+      },
+      contribution: {
+        aggregate: jest.fn(async (args: any) => {
+          const ids = args.where.committeeId.in as string[];
+          const key = ids.slice().sort().join('|');
+          return { _sum: { amount: dec(contributionSums.get(key) ?? 0) } };
+        }),
+        groupBy: jest.fn(async (args: any) => {
+          if (args.by.includes('donorName')) {
+            return topDonors.map((d) => ({
+              donorName: d.donorName,
+              _sum: { amount: dec(d.sum) },
+              _count: { _all: d.count },
+            }));
+          }
+          if (args.by.includes('committeeId')) {
+            return Array.from(contributionByCommittee.entries()).map(
+              ([cid, total]) => ({
+                committeeId: cid,
+                _sum: { amount: dec(total) },
+              }),
+            );
+          }
+          return [];
+        }),
+        findMany: jest.fn(async () =>
+          distinctDonors.map((name) => ({ donorName: name })),
+        ),
+      },
+      expenditure: {
+        aggregate: jest.fn(async (args: any) => {
+          const ids = args.where.committeeId.in as string[];
+          const key = ids.slice().sort().join('|');
+          return { _sum: { amount: dec(expenditureSums.get(key) ?? 0) } };
+        }),
+      },
+      independentExpenditure: {
+        aggregate: jest.fn(async (args: any) => {
+          const codes: string[] = args.where.supportOrOppose.in;
+          const position: 'support' | 'oppose' = codes.includes('support')
+            ? 'support'
+            : 'oppose';
+          const match = ieSums.find((s) => s.position === position);
+          return { _sum: { amount: dec(match?.sum ?? 0) } };
+        }),
+      },
+      committee: {
+        findMany: jest.fn(async () => committees),
+      },
+    } as unknown as DbService;
+
+    const providers: unknown[] = [PropositionFundingService];
+    if (withDb) providers.push({ provide: DbService, useValue: mockDb });
+    if (withCache)
+      providers.push({ provide: REGION_CACHE, useValue: mockCache });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: providers as Parameters<
+        typeof Test.createTestingModule
+      >[0]['providers'],
+    }).compile();
+
+    return {
+      service: module.get(PropositionFundingService),
+      cacheStore,
+      mockCache,
+      mockDb,
+    };
+  }
+
+  describe('when db is unavailable', () => {
+    it('returns an empty funding shape', async () => {
+      const built = await buildService({ withDb: false, withCache: false });
+      const out = await built.service.getFunding('prop-1');
+      expect(out.propositionId).toBe('prop-1');
+      expect(out.support.totalRaised).toBe(0);
+      expect(out.oppose.totalRaised).toBe(0);
+      expect(out.support.topDonors).toEqual([]);
+    });
+  });
+
+  describe('aggregation', () => {
+    it('sums contributions + expenditures + IEs separately for each side', async () => {
+      const built = await buildService({
+        positions: [
+          { committeeId: 'c-yes', position: 'support' },
+          { committeeId: 'c-no', position: 'oppose' },
+        ],
+        contributionSums: new Map([
+          ['c-yes', 100_000],
+          ['c-no', 50_000],
+        ]),
+        expenditureSums: new Map([
+          ['c-yes', 80_000],
+          ['c-no', 40_000],
+        ]),
+        ieSums: [
+          { position: 'support', sum: 25_000 },
+          { position: 'oppose', sum: 15_000 },
+        ],
+        topDonors: [],
+        distinctDonors: [],
+        committees: [],
+      });
+
+      const out = await built.service.getFunding('prop-1');
+
+      // 100k contributions + 25k IEs = 125k raised on the support side
+      expect(out.support.totalRaised).toBe(125_000);
+      expect(out.support.totalSpent).toBe(80_000 + 25_000);
+      // 50k + 15k = 65k raised on the oppose side
+      expect(out.oppose.totalRaised).toBe(65_000);
+      expect(out.oppose.totalSpent).toBe(40_000 + 15_000);
+    });
+
+    it('returns IE-only totals when no committees are linked to either side', async () => {
+      const built = await buildService({
+        positions: [],
+        ieSums: [
+          { position: 'support', sum: 10_000 },
+          { position: 'oppose', sum: 20_000 },
+        ],
+      });
+
+      const out = await built.service.getFunding('prop-1');
+
+      expect(out.support.totalRaised).toBe(10_000);
+      expect(out.oppose.totalRaised).toBe(20_000);
+      expect(out.support.committeeCount).toBe(0);
+      expect(out.oppose.committeeCount).toBe(0);
+      expect(out.support.topDonors).toEqual([]);
+      expect(out.oppose.topDonors).toEqual([]);
+    });
+
+    it('exposes top donors aggregated by donor name', async () => {
+      const built = await buildService({
+        positions: [{ committeeId: 'c-yes', position: 'support' }],
+        contributionSums: new Map([['c-yes', 60_000]]),
+        topDonors: [
+          { donorName: 'BIG GIVER LLC', sum: 50_000, count: 3 },
+          { donorName: 'A. Donor', sum: 10_000, count: 1 },
+        ],
+        distinctDonors: ['BIG GIVER LLC', 'A. Donor', 'Quiet Donor'],
+      });
+
+      const out = await built.service.getFunding('prop-1');
+
+      expect(out.support.topDonors).toHaveLength(2);
+      expect(out.support.topDonors[0]).toEqual({
+        donorName: 'BIG GIVER LLC',
+        totalAmount: 50_000,
+        contributionCount: 3,
+      });
+      // donorCount uses the distinct list, not the top-donors slice
+      expect(out.support.donorCount).toBe(3);
+    });
+
+    it('returns primary committees sorted by total raised, capped at 3', async () => {
+      const built = await buildService({
+        positions: [
+          { committeeId: 'c-1', position: 'support' },
+          { committeeId: 'c-2', position: 'support' },
+          { committeeId: 'c-3', position: 'support' },
+          { committeeId: 'c-4', position: 'support' },
+        ],
+        contributionSums: new Map([['c-1|c-2|c-3|c-4', 1_000_000]]),
+        committees: [
+          { id: 'c-1', name: 'Small Yes Committee' },
+          { id: 'c-2', name: 'Big Yes Committee' },
+          { id: 'c-3', name: 'Mid Yes Committee' },
+          { id: 'c-4', name: 'Tiny Yes Committee' },
+        ],
+        contributionByCommittee: new Map([
+          ['c-1', 50_000],
+          ['c-2', 800_000],
+          ['c-3', 130_000],
+          ['c-4', 20_000],
+        ]),
+      });
+
+      const out = await built.service.getFunding('prop-1');
+
+      expect(out.support.primaryCommittees).toHaveLength(3);
+      expect(out.support.primaryCommittees[0].name).toBe('Big Yes Committee');
+      expect(out.support.primaryCommittees[1].name).toBe('Mid Yes Committee');
+      expect(out.support.primaryCommittees[2].name).toBe('Small Yes Committee');
+    });
+  });
+
+  describe('caching', () => {
+    it('returns the cached value without hitting the DB', async () => {
+      const cachedShape = JSON.stringify({
+        propositionId: 'prop-1',
+        asOf: new Date('2026-04-25T00:00:00Z').toISOString(),
+        support: {
+          totalRaised: 999,
+          totalSpent: 0,
+          donorCount: 0,
+          committeeCount: 0,
+          topDonors: [],
+          primaryCommittees: [],
+        },
+        oppose: {
+          totalRaised: 0,
+          totalSpent: 0,
+          donorCount: 0,
+          committeeCount: 0,
+          topDonors: [],
+          primaryCommittees: [],
+        },
+      });
+      const built = await buildService({ cached: cachedShape });
+
+      const out = await built.service.getFunding('prop-1');
+
+      expect(out.support.totalRaised).toBe(999);
+      expect(built.mockCache.get).toHaveBeenCalledWith(
+        'propositionFunding:prop-1',
+      );
+      expect(out.asOf).toBeInstanceOf(Date);
+    });
+
+    it('writes to cache after computing fresh', async () => {
+      const built = await buildService({
+        positions: [{ committeeId: 'c-yes', position: 'support' }],
+        contributionSums: new Map([['c-yes', 1_000]]),
+      });
+
+      await built.service.getFunding('prop-1');
+
+      expect(built.mockCache.set).toHaveBeenCalledWith(
+        'propositionFunding:prop-1',
+        expect.any(String),
+      );
+    });
+
+    it('invalidateCache deletes the entry', async () => {
+      const built = await buildService({
+        cached: JSON.stringify({
+          propositionId: 'prop-1',
+          asOf: new Date().toISOString(),
+          support: {
+            totalRaised: 1,
+            totalSpent: 0,
+            donorCount: 0,
+            committeeCount: 0,
+            topDonors: [],
+            primaryCommittees: [],
+          },
+          oppose: {
+            totalRaised: 0,
+            totalSpent: 0,
+            donorCount: 0,
+            committeeCount: 0,
+            topDonors: [],
+            primaryCommittees: [],
+          },
+        }),
+      });
+
+      await built.service.invalidateCache('prop-1');
+      expect(built.mockCache.delete).toHaveBeenCalledWith(
+        'propositionFunding:prop-1',
+      );
+    });
+
+    it('runs without a cache (cache is optional)', async () => {
+      const built = await buildService({
+        withCache: false,
+        positions: [],
+        ieSums: [{ position: 'support', sum: 5 }],
+      });
+
+      const out = await built.service.getFunding('prop-1');
+      expect(out.support.totalRaised).toBe(5);
+    });
+  });
+
+  describe('position code normalization', () => {
+    it('honors both long-form and CalAccess single-letter IE codes', async () => {
+      const built = await buildService({
+        positions: [],
+        ieSums: [
+          { position: 'support', sum: 1_000 },
+          { position: 'oppose', sum: 2_000 },
+        ],
+      });
+
+      const out = await built.service.getFunding('prop-1');
+
+      // Verify the aggregate was called with both codes for each side.
+      const ieCalls = (
+        built.mockDb.independentExpenditure.aggregate as jest.Mock
+      ).mock.calls;
+      expect(ieCalls).toHaveLength(2);
+      const codeSets = ieCalls.map((c) => c[0].where.supportOrOppose.in);
+      expect(codeSets).toContainEqual(['support', 'S']);
+      expect(codeSets).toContainEqual(['oppose', 'O']);
+
+      expect(out.support.totalRaised).toBe(1_000);
+      expect(out.oppose.totalRaised).toBe(2_000);
+    });
+  });
+
+  // CommitteeMeasurePositionType is referenced indirectly via the service —
+  // assert that it's an actual enum object so a future Prisma regen surfaces.
+  it('relies on the Prisma-generated CommitteeMeasurePositionType enum', () => {
+    expect(CommitteeMeasurePositionType.support).toBe('support');
+    expect(CommitteeMeasurePositionType.oppose).toBe('oppose');
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/proposition-funding.service.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-funding.service.ts
@@ -1,0 +1,278 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import {
+  CommitteeMeasurePositionType,
+  DbService,
+  Prisma,
+} from '@opuspopuli/relationaldb-provider';
+import type { ICache } from '@opuspopuli/common';
+import { REGION_CACHE } from './region.tokens';
+
+/** Output shape — mirrored by PropositionFundingModel for the GraphQL surface. */
+export interface SidedFunding {
+  totalRaised: number;
+  totalSpent: number;
+  donorCount: number;
+  committeeCount: number;
+  topDonors: {
+    donorName: string;
+    totalAmount: number;
+    contributionCount: number;
+  }[];
+  primaryCommittees: { id: string; name: string; totalRaised: number }[];
+}
+
+export interface PropositionFunding {
+  propositionId: string;
+  asOf: Date;
+  support: SidedFunding;
+  oppose: SidedFunding;
+}
+
+const TOP_DONORS_LIMIT = 5;
+const PRIMARY_COMMITTEES_LIMIT = 3;
+
+/**
+ * Aggregates campaign-finance flows for a single proposition.
+ *
+ * For each side (support / oppose), totals come from two channels:
+ *
+ * 1. Contributions to committees that have a `CommitteeMeasurePosition`
+ *    matching the proposition + side. These are the primarily-formed and
+ *    inferred ballot-measure committees.
+ * 2. Independent expenditures whose `propositionId = $1` and whose
+ *    `supportOrOppose` matches the side. These cover general-purpose
+ *    committees (Super PACs, party committees) that spend on the measure
+ *    without forming a primarily-formed committee for it.
+ *
+ * `totalSpent` follows the same dual-channel logic with `Expenditure` rows.
+ * `topDonors` aggregates by donor name across the side's committees.
+ *
+ * Cached in REGION_CACHE under `propositionFunding:{id}` for 4 hours; the
+ * linker is responsible for invalidating after each sync (this service
+ * doesn't know when the underlying data changes).
+ */
+@Injectable()
+export class PropositionFundingService {
+  private readonly logger = new Logger(PropositionFundingService.name);
+
+  constructor(
+    @Optional() private readonly db?: DbService,
+    @Optional() @Inject(REGION_CACHE) private readonly cache?: ICache<string>,
+  ) {}
+
+  /**
+   * Compute (or return cached) funding totals for a proposition. Returns
+   * an empty-shaped result when the service has no DB or no positions exist.
+   */
+  async getFunding(propositionId: string): Promise<PropositionFunding> {
+    const cacheKey = `propositionFunding:${propositionId}`;
+    const cached = await this.cache?.get(cacheKey);
+    if (cached) {
+      const parsed = JSON.parse(cached) as PropositionFunding;
+      // Revive the asOf Date which JSON serializes to a string.
+      parsed.asOf = new Date(parsed.asOf);
+      return parsed;
+    }
+
+    const fresh = await this.computeFunding(propositionId);
+    await this.cache?.set(cacheKey, JSON.stringify(fresh));
+    return fresh;
+  }
+
+  /**
+   * Compute funding from scratch. Splits the read into per-side queries
+   * because the aggregation differs by position; runs them in parallel.
+   */
+  private async computeFunding(
+    propositionId: string,
+  ): Promise<PropositionFunding> {
+    if (!this.db) {
+      return this.emptyFunding(propositionId);
+    }
+    const [support, oppose] = await Promise.all([
+      this.computeSide(propositionId, CommitteeMeasurePositionType.support),
+      this.computeSide(propositionId, CommitteeMeasurePositionType.oppose),
+    ]);
+    return {
+      propositionId,
+      asOf: new Date(),
+      support,
+      oppose,
+    };
+  }
+
+  /**
+   * Compute aggregates for one side. Reads the committees declaring this
+   * position, then sums their contributions and expenditures, plus any
+   * independent expenditures targeting the measure with the matching code.
+   */
+  private async computeSide(
+    propositionId: string,
+    position: CommitteeMeasurePositionType,
+  ): Promise<SidedFunding> {
+    const positions = await this.db!.committeeMeasurePosition.findMany({
+      where: { propositionId, position },
+      select: { committeeId: true },
+    });
+    const committeeIds = positions.map((p) => p.committeeId);
+
+    if (committeeIds.length === 0) {
+      // Even with no primarily-formed committees, IEs may target the measure.
+      const ieAggregates = await this.computeIndependentExpenditureAggregates(
+        propositionId,
+        position,
+      );
+      return {
+        totalRaised: ieAggregates.totalRaised,
+        totalSpent: ieAggregates.totalSpent,
+        donorCount: 0,
+        committeeCount: 0,
+        topDonors: [],
+        primaryCommittees: [],
+      };
+    }
+
+    const [
+      contributionAgg,
+      expenditureAgg,
+      ieAgg,
+      donorAgg,
+      uniqueDonors,
+      primaryCommittees,
+    ] = await Promise.all([
+      this.db!.contribution.aggregate({
+        where: { committeeId: { in: committeeIds } },
+        _sum: { amount: true },
+      }),
+      this.db!.expenditure.aggregate({
+        where: { committeeId: { in: committeeIds } },
+        _sum: { amount: true },
+      }),
+      this.computeIndependentExpenditureAggregates(propositionId, position),
+      this.db!.contribution.groupBy({
+        by: ['donorName'],
+        where: { committeeId: { in: committeeIds } },
+        _sum: { amount: true },
+        _count: { _all: true },
+        orderBy: { _sum: { amount: 'desc' } },
+        take: TOP_DONORS_LIMIT,
+      }),
+      this.db!.contribution.findMany({
+        where: { committeeId: { in: committeeIds } },
+        distinct: ['donorName'],
+        select: { donorName: true },
+      }),
+      this.computePrimaryCommittees(propositionId, position),
+    ]);
+
+    return {
+      totalRaised: toNumber(contributionAgg._sum.amount) + ieAgg.totalRaised,
+      totalSpent: toNumber(expenditureAgg._sum.amount) + ieAgg.totalSpent,
+      donorCount: uniqueDonors.length,
+      committeeCount: committeeIds.length,
+      topDonors: donorAgg.map((d) => ({
+        donorName: d.donorName,
+        totalAmount: toNumber(d._sum.amount),
+        contributionCount: d._count._all,
+      })),
+      primaryCommittees,
+    };
+  }
+
+  /**
+   * Sum independent expenditures targeting the measure with this position.
+   * Counts both `totalRaised` and `totalSpent` against the same number — an
+   * IE represents money spent (not raised through a committee) but for the
+   * UI's "total against this measure" view both columns include it.
+   */
+  private async computeIndependentExpenditureAggregates(
+    propositionId: string,
+    position: CommitteeMeasurePositionType,
+  ): Promise<{ totalRaised: number; totalSpent: number }> {
+    const codes =
+      position === CommitteeMeasurePositionType.support
+        ? ['support', 'S']
+        : ['oppose', 'O'];
+
+    const ieAgg = await this.db!.independentExpenditure.aggregate({
+      where: {
+        propositionId,
+        supportOrOppose: { in: codes },
+      },
+      _sum: { amount: true },
+    });
+    const total = toNumber(ieAgg._sum.amount);
+    return { totalRaised: total, totalSpent: total };
+  }
+
+  /**
+   * Top N committees by total raised for a side. Useful UI signal: lets
+   * the funding card show "Backed by: <Committee Name>" links.
+   */
+  private async computePrimaryCommittees(
+    propositionId: string,
+    position: CommitteeMeasurePositionType,
+  ): Promise<{ id: string; name: string; totalRaised: number }[]> {
+    const positions = await this.db!.committeeMeasurePosition.findMany({
+      where: { propositionId, position },
+      select: { committeeId: true },
+    });
+    if (positions.length === 0) return [];
+
+    const committeeIds = positions.map((p) => p.committeeId);
+    const committees = await this.db!.committee.findMany({
+      where: { id: { in: committeeIds } },
+      select: { id: true, name: true },
+    });
+    const totals = await this.db!.contribution.groupBy({
+      by: ['committeeId'],
+      where: { committeeId: { in: committeeIds } },
+      _sum: { amount: true },
+    });
+    const totalsMap = new Map(
+      totals.map((t) => [t.committeeId, toNumber(t._sum.amount)]),
+    );
+
+    return committees
+      .map((c) => ({
+        id: c.id,
+        name: c.name,
+        totalRaised: totalsMap.get(c.id) ?? 0,
+      }))
+      .sort((a, b) => b.totalRaised - a.totalRaised)
+      .slice(0, PRIMARY_COMMITTEES_LIMIT);
+  }
+
+  private emptyFunding(propositionId: string): PropositionFunding {
+    const empty: SidedFunding = {
+      totalRaised: 0,
+      totalSpent: 0,
+      donorCount: 0,
+      committeeCount: 0,
+      topDonors: [],
+      primaryCommittees: [],
+    };
+    return {
+      propositionId,
+      asOf: new Date(),
+      support: empty,
+      oppose: { ...empty },
+    };
+  }
+
+  /**
+   * Invalidate the cached funding entry for one proposition. Called by the
+   * linker after each sync so subsequent reads recompute from fresh data.
+   */
+  async invalidateCache(propositionId: string): Promise<void> {
+    await this.cache?.delete(`propositionFunding:${propositionId}`);
+  }
+}
+
+/** Coerce Prisma.Decimal | null | undefined to a JS number. */
+function toNumber(value: Prisma.Decimal | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  // Prisma.Decimal exposes toNumber() — preferred over Number(value) which
+  // goes through toString() first.
+  return value.toNumber();
+}

--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -19,6 +19,8 @@ import { RegionScheduler } from './region.scheduler';
 import { BioGeneratorService } from './bio-generator.service';
 import { CommitteeSummaryGeneratorService } from './committee-summary-generator.service';
 import { PropositionAnalysisService } from './proposition-analysis.service';
+import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
+import { PropositionFundingService } from './proposition-funding.service';
 import { PrismaManifestRepository } from '../infrastructure/prisma-manifest-repository';
 import { REGION_CACHE } from './region.tokens';
 
@@ -74,6 +76,8 @@ const promptClientAsyncConfig = {
     BioGeneratorService,
     CommitteeSummaryGeneratorService,
     PropositionAnalysisService,
+    PropositionFinanceLinkerService,
+    PropositionFundingService,
     // Alias for injecting the pipeline into RegionDomainService
     {
       provide: 'SCRAPING_PIPELINE',

--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -217,6 +217,54 @@ describe('RegionResolver', () => {
     });
   });
 
+  describe('propositionFunding', () => {
+    const mockFunding = {
+      propositionId: 'prop-1',
+      asOf: new Date('2026-04-25T00:00:00Z'),
+      support: {
+        totalRaised: 100_000,
+        totalSpent: 80_000,
+        donorCount: 5,
+        committeeCount: 1,
+        topDonors: [
+          { donorName: 'A. Donor', totalAmount: 50_000, contributionCount: 2 },
+        ],
+        primaryCommittees: [
+          { id: 'c-1', name: 'Yes on Prop 1', totalRaised: 100_000 },
+        ],
+      },
+      oppose: {
+        totalRaised: 0,
+        totalSpent: 0,
+        donorCount: 0,
+        committeeCount: 0,
+        topDonors: [],
+        primaryCommittees: [],
+      },
+    };
+
+    it('returns the aggregated funding shape from the service', async () => {
+      regionService.getPropositionFunding.mockResolvedValue(mockFunding as any);
+
+      const result = await resolver.propositionFunding('prop-1');
+
+      expect(result).not.toBeNull();
+      expect(result?.support.totalRaised).toBe(100_000);
+      expect(result?.support.topDonors[0].donorName).toBe('A. Donor');
+      expect(regionService.getPropositionFunding).toHaveBeenCalledWith(
+        'prop-1',
+      );
+    });
+
+    it('returns null when the service has no funding data wired', async () => {
+      regionService.getPropositionFunding.mockResolvedValue(null);
+
+      const result = await resolver.propositionFunding('prop-1');
+
+      expect(result).toBeNull();
+    });
+  });
+
   describe('regeneratePropositionAnalysis', () => {
     it('should re-fetch and return the proposition after a successful regenerate', async () => {
       regionService.regeneratePropositionAnalysis.mockResolvedValue(true);

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -23,6 +23,7 @@ import {
   PropositionModel,
   PaginatedPropositions,
 } from './models/proposition.model';
+import { PropositionFundingModel } from './models/proposition-funding.model';
 import { MeetingModel, PaginatedMeetings } from './models/meeting.model';
 import {
   BioClaimModel,
@@ -86,6 +87,26 @@ export class RegionResolver {
     const result = await this.regionService.getProposition(id);
     if (!result) return null;
     return mapPropositionRecord(result);
+  }
+
+  /**
+   * Aggregated campaign-finance totals for a single proposition. Public
+   * so the proposition detail page can render the funding section without
+   * authentication. Returns null when no funding has been linked to the
+   * proposition (the resolver uses the model's nullable mapping; the
+   * service itself returns an all-zeros shape when the proposition exists
+   * but has no positions or IEs yet).
+   */
+  @Public()
+  @Query(() => PropositionFundingModel, { nullable: true })
+  @Extensions({ complexity: 25 })
+  async propositionFunding(
+    @Args({ name: 'propositionId', type: () => ID }) propositionId: string,
+  ): Promise<PropositionFundingModel | null> {
+    const funding =
+      await this.regionService.getPropositionFunding(propositionId);
+    if (!funding) return null;
+    return funding as unknown as PropositionFundingModel;
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -85,7 +85,7 @@ export class RegionResolver {
   ): Promise<PropositionModel | null> {
     const result = await this.regionService.getProposition(id);
     if (!result) return null;
-    return mapPropositionRecord(result) as PropositionModel;
+    return mapPropositionRecord(result);
   }
 
   /**
@@ -104,7 +104,7 @@ export class RegionResolver {
     await this.regionService.regeneratePropositionAnalysis(id);
     const result = await this.regionService.getProposition(id);
     if (!result) return null;
-    return mapPropositionRecord(result) as PropositionModel;
+    return mapPropositionRecord(result);
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -6,6 +6,8 @@ import {
   RegionDomainService,
 } from './region.service';
 import { PropositionAnalysisService } from './proposition-analysis.service';
+import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
+import { PropositionFundingService } from './proposition-funding.service';
 import { REGION_CACHE } from './region.tokens';
 import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
 import {
@@ -1323,6 +1325,7 @@ describe('RegionDomainService — campaign finance sync', () => {
         sourceSystem: 'fec',
       },
     ],
+    committeeMeasureFilings: [],
   };
 
   beforeEach(async () => {
@@ -1465,6 +1468,7 @@ describe('RegionDomainService — campaign finance sync', () => {
       contributions: [],
       expenditures: [],
       independentExpenditures: [],
+      committeeMeasureFilings: [],
     });
 
     const results = await service.syncAll();
@@ -2270,6 +2274,250 @@ describe('RegionDomainService — proposition analysis wiring', () => {
       await expect(svc.regeneratePropositionAnalysis('prop-1')).resolves.toBe(
         false,
       );
+    });
+  });
+});
+
+describe('RegionDomainService — proposition finance wiring', () => {
+  /**
+   * Build a service with PropositionFinanceLinkerService + PropositionFundingService
+   * mocks injected. Mirrors the proposition-analysis-wiring helper above so
+   * the linker hook + funding getter both have a clean test surface.
+   */
+  async function buildService(
+    opts: {
+      linker?: { linkAll: jest.Mock };
+      funding?: { getFunding: jest.Mock };
+    } = {},
+  ) {
+    const mockDb = createMockDbService();
+    mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+    mockDb.regionPlugin.findUnique.mockResolvedValue(null);
+    mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
+    mockDb.proposition.findMany.mockResolvedValue([]);
+    mockDb.committee.findMany.mockResolvedValue([]);
+    mockDb.contribution.findMany.mockResolvedValue([]);
+    mockDb.expenditure.findMany.mockResolvedValue([]);
+    mockDb.independentExpenditure.findMany.mockResolvedValue([]);
+    (mockDb.$transaction as jest.Mock).mockImplementation(
+      async (operations: Promise<unknown>[]) => Promise.all(operations),
+    );
+
+    const fetchCampaignFinance = jest.fn().mockResolvedValue({
+      committees: [],
+      contributions: [],
+      expenditures: [],
+      independentExpenditures: [],
+      committeeMeasureFilings: [],
+    });
+
+    const mockPlugin = {
+      getName: jest.fn().mockReturnValue('test'),
+      getRegionInfo: jest.fn().mockReturnValue({
+        id: 'r',
+        name: 'R',
+        description: 'd',
+        timezone: 'America/Los_Angeles',
+      }),
+      getSupportedDataTypes: jest
+        .fn()
+        .mockReturnValue([DataType.CAMPAIGN_FINANCE]),
+      getProviderName: jest.fn().mockReturnValue('test'),
+      fetchPropositions: jest.fn().mockResolvedValue([]),
+      fetchMeetings: jest.fn().mockResolvedValue([]),
+      fetchRepresentatives: jest.fn().mockResolvedValue([]),
+      fetchCampaignFinance,
+    } as unknown as jest.Mocked<IRegionPlugin> & {
+      fetchCampaignFinance: jest.Mock;
+    };
+
+    const localRegistered: RegisteredPlugin = {
+      name: 'test',
+      instance: mockPlugin,
+      status: 'active',
+      loadedAt: new Date(),
+    };
+
+    const mockRegistry = {
+      register: jest.fn(),
+      unregister: jest.fn(),
+      getActive: jest.fn().mockReturnValue(mockPlugin),
+      registerLocal: jest.fn(),
+      registerFederal: jest.fn(),
+      getLocal: jest.fn().mockReturnValue(mockPlugin),
+      getFederal: jest.fn().mockReturnValue(undefined),
+      getAll: jest.fn().mockReturnValue([localRegistered]),
+      getActiveName: jest.fn().mockReturnValue('test'),
+      hasActive: jest.fn().mockReturnValue(true),
+      getHealth: jest.fn(),
+      getStatus: jest.fn(),
+      onModuleDestroy: jest.fn(),
+    };
+    const mockLoader = {
+      loadPlugin: jest.fn().mockResolvedValue(mockPlugin),
+      loadFederalPlugin: jest.fn().mockResolvedValue(mockPlugin),
+      unloadPlugin: jest.fn(),
+    };
+
+    const linker = {
+      linkAll: jest.fn().mockResolvedValue({
+        cvr2Resolved: 0,
+        cvr2Skipped: 0,
+        expenditureLinked: 0,
+        independentExpenditureLinked: 0,
+        inferredPositions: 0,
+      }),
+      ...opts.linker,
+    };
+    const funding = {
+      getFunding: jest.fn().mockResolvedValue({
+        propositionId: 'prop-1',
+        asOf: new Date(),
+        support: {
+          totalRaised: 0,
+          totalSpent: 0,
+          donorCount: 0,
+          committeeCount: 0,
+          topDonors: [],
+          primaryCommittees: [],
+        },
+        oppose: {
+          totalRaised: 0,
+          totalSpent: 0,
+          donorCount: 0,
+          committeeCount: 0,
+          topDonors: [],
+          primaryCommittees: [],
+        },
+      }),
+      ...opts.funding,
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegionDomainService,
+        { provide: PluginLoaderService, useValue: mockLoader },
+        { provide: PluginRegistryService, useValue: mockRegistry },
+        { provide: DbService, useValue: mockDb },
+        {
+          provide: REGION_CACHE,
+          useValue: {
+            get: jest.fn(),
+            set: jest.fn(),
+            delete: jest.fn(),
+            destroy: jest.fn(),
+            keys: jest.fn().mockResolvedValue([]),
+          },
+        },
+        // The new optional deps under test:
+        { provide: PropositionFinanceLinkerService, useValue: linker },
+        { provide: PropositionFundingService, useValue: funding },
+      ],
+    }).compile();
+
+    const svc = module.get<RegionDomainService>(RegionDomainService);
+    await svc.onModuleInit();
+    return { service: svc, linker, funding, fetchCampaignFinance };
+  }
+
+  describe('post-sync linker hook', () => {
+    it('runs the linker after a campaign-finance sync', async () => {
+      // syncAll uses the plugin instance directly (which has
+      // fetchCampaignFinance), unlike syncDataType which goes through the
+      // RegionProviderService wrapper that doesn't forward that method.
+      const { service, linker } = await buildService();
+      await service.syncAll([DataType.CAMPAIGN_FINANCE]);
+      expect(linker.linkAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the sync result successful when the linker throws', async () => {
+      const { service, linker } = await buildService({
+        linker: {
+          linkAll: jest.fn().mockRejectedValue(new Error('linker boom')),
+        },
+      });
+
+      const results = await service.syncAll([DataType.CAMPAIGN_FINANCE]);
+      const cf = results.find((r) => r.dataType === DataType.CAMPAIGN_FINANCE);
+      expect(cf?.errors).toEqual([]);
+      expect(linker.linkAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('getPropositionFunding', () => {
+    it('delegates to the funding service when available', async () => {
+      const { service, funding } = await buildService();
+      const out = await service.getPropositionFunding('prop-1');
+      expect(funding.getFunding).toHaveBeenCalledWith('prop-1');
+      expect(out).not.toBeNull();
+    });
+  });
+
+  describe('getPropositionFunding when funding service is absent', () => {
+    it('returns null', async () => {
+      // Build a bare-bones service without the funding provider.
+      const mockDb = createMockDbService();
+      mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+      mockDb.regionPlugin.findUnique.mockResolvedValue(null);
+      mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
+      mockDb.proposition.findMany.mockResolvedValue([]);
+      const mockPlugin = {
+        getName: jest.fn().mockReturnValue('t'),
+        getRegionInfo: jest.fn().mockReturnValue({
+          id: 'r',
+          name: 'R',
+          description: 'd',
+          timezone: 'America/Los_Angeles',
+        }),
+        getSupportedDataTypes: jest.fn().mockReturnValue([]),
+        getProviderName: jest.fn().mockReturnValue('t'),
+        fetchPropositions: jest.fn().mockResolvedValue([]),
+        fetchMeetings: jest.fn().mockResolvedValue([]),
+        fetchRepresentatives: jest.fn().mockResolvedValue([]),
+      } as unknown as jest.Mocked<IRegionPlugin>;
+      const mockRegistry = {
+        register: jest.fn(),
+        unregister: jest.fn(),
+        getActive: jest.fn().mockReturnValue(mockPlugin),
+        registerLocal: jest.fn(),
+        registerFederal: jest.fn(),
+        getLocal: jest.fn().mockReturnValue(mockPlugin),
+        getFederal: jest.fn().mockReturnValue(undefined),
+        getAll: jest.fn().mockReturnValue([]),
+        getActiveName: jest.fn().mockReturnValue('t'),
+        hasActive: jest.fn().mockReturnValue(true),
+        getHealth: jest.fn(),
+        getStatus: jest.fn(),
+        onModuleDestroy: jest.fn(),
+      };
+      const mockLoader = {
+        loadPlugin: jest.fn().mockResolvedValue(mockPlugin),
+        loadFederalPlugin: jest.fn().mockResolvedValue(mockPlugin),
+        unloadPlugin: jest.fn(),
+      };
+
+      const module: TestingModule = await Test.createTestingModule({
+        providers: [
+          RegionDomainService,
+          { provide: PluginLoaderService, useValue: mockLoader },
+          { provide: PluginRegistryService, useValue: mockRegistry },
+          { provide: DbService, useValue: mockDb },
+          {
+            provide: REGION_CACHE,
+            useValue: {
+              get: jest.fn(),
+              set: jest.fn(),
+              delete: jest.fn(),
+              destroy: jest.fn(),
+              keys: jest.fn().mockResolvedValue([]),
+            },
+          },
+        ],
+      }).compile();
+      const svc = module.get<RegionDomainService>(RegionDomainService);
+      await svc.onModuleInit();
+
+      await expect(svc.getPropositionFunding('prop-1')).resolves.toBeNull();
     });
   });
 });

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -269,8 +269,8 @@ export function mapPropositionRecord(
     existingVsProposed:
       item.existingVsProposed &&
       typeof item.existingVsProposed === 'object' &&
-      'current' in (item.existingVsProposed as object) &&
-      'proposed' in (item.existingVsProposed as object)
+      'current' in item.existingVsProposed &&
+      'proposed' in item.existingVsProposed
         ? (item.existingVsProposed as { current: string; proposed: string })
         : undefined,
     analysisSections: Array.isArray(item.analysisSections)

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -34,6 +34,11 @@ import { REGION_CACHE } from './region.tokens';
 import { BioGeneratorService } from './bio-generator.service';
 import { CommitteeSummaryGeneratorService } from './committee-summary-generator.service';
 import { PropositionAnalysisService } from './proposition-analysis.service';
+import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
+import {
+  PropositionFundingService,
+  type PropositionFunding,
+} from './proposition-funding.service';
 
 /**
  * Minimal interface for data fetching used by sync methods.
@@ -309,6 +314,10 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     private readonly committeeSummaryGenerator?: CommitteeSummaryGeneratorService,
     @Optional()
     private readonly propositionAnalysis?: PropositionAnalysisService,
+    @Optional()
+    private readonly propositionFinanceLinker?: PropositionFinanceLinkerService,
+    @Optional()
+    private readonly propositionFunding?: PropositionFundingService,
   ) {}
 
   async onModuleDestroy(): Promise<void> {
@@ -1027,13 +1036,29 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     if (
       data.contributions.length > 0 ||
       data.expenditures.length > 0 ||
-      data.independentExpenditures.length > 0
+      data.independentExpenditures.length > 0 ||
+      data.committeeMeasureFilings.length > 0
     ) {
       await this.ensureCommitteeStubs(data);
       const result = await this.upsertCampaignFinanceBatch(data);
       totalProcessed += result.processed;
       totalCreated += result.created;
       totalUpdated += result.updated;
+    }
+
+    // Resolve committee↔proposition links from CVR2 + propositionTitle
+    // strings. Fire-and-forget: the linker's own errors should not fail
+    // the sync since the raw data is already persisted and a later run
+    // can re-resolve. Mirrors the post-sync hook pattern from
+    // syncPropositions → propositionAnalysis.generateMissing().
+    if (this.propositionFinanceLinker) {
+      try {
+        await this.propositionFinanceLinker.linkAll();
+      } catch (error) {
+        this.logger.warn(
+          `Proposition finance linker failed: ${(error as Error).message}`,
+        );
+      }
     }
 
     return {
@@ -1044,7 +1069,22 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Aggregate funding for a single proposition. Delegates to the funding
+   * service (which handles caching). Returns null when the funding service
+   * isn't wired (e.g. some test contexts).
+   */
+  async getPropositionFunding(
+    propositionId: string,
+  ): Promise<PropositionFunding | null> {
+    if (!this.propositionFunding) return null;
+    return this.propositionFunding.getFunding(propositionId);
+  }
+
+  /**
    * Sort a flat array of campaign finance items into typed buckets.
+   * The CVR2 (committee↔measure filing) discriminator runs before the
+   * generic "sourceSystem + type" committee check because CVR2 records
+   * also carry a sourceSystem.
    */
   private sortCampaignFinanceItems(
     items: Record<string, unknown>[],
@@ -1053,6 +1093,8 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     const contributions: CampaignFinanceResult['contributions'] = [];
     const expenditures: CampaignFinanceResult['expenditures'] = [];
     const independentExpenditures: CampaignFinanceResult['independentExpenditures'] =
+      [];
+    const committeeMeasureFilings: CampaignFinanceResult['committeeMeasureFilings'] =
       [];
 
     for (const rec of items) {
@@ -1068,6 +1110,13 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
         independentExpenditures.push(
           rec as unknown as CampaignFinanceResult['independentExpenditures'][0],
         );
+      } else if (
+        'filingId' in rec &&
+        ('ballotName' in rec || 'ballotNumber' in rec)
+      ) {
+        committeeMeasureFilings.push(
+          rec as unknown as CampaignFinanceResult['committeeMeasureFilings'][0],
+        );
       } else if ('sourceSystem' in rec && 'type' in rec) {
         committees.push(
           rec as unknown as CampaignFinanceResult['committees'][0],
@@ -1075,7 +1124,13 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    return { committees, contributions, expenditures, independentExpenditures };
+    return {
+      committees,
+      contributions,
+      expenditures,
+      independentExpenditures,
+      committeeMeasureFilings,
+    };
   }
 
   /**
@@ -1133,6 +1188,18 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
           'date',
           'electionDate',
           'description',
+          'sourceSystem',
+        ],
+      },
+      {
+        records: data.committeeMeasureFilings,
+        model: this.db.cvr2Filing,
+        fields: [
+          'filingId',
+          'ballotName',
+          'ballotNumber',
+          'ballotJurisdiction',
+          'supportOrOppose',
           'sourceSystem',
         ],
       },

--- a/apps/backend/src/apps/region/src/scripts/run-finance-linker.ts
+++ b/apps/backend/src/apps/region/src/scripts/run-finance-linker.ts
@@ -1,0 +1,48 @@
+/**
+ * One-off: run PropositionFinanceLinkerService.linkAll() against the data
+ * already in the DB. Useful for:
+ *
+ * - Validating the inferred-position path on real CalAccess data without
+ *   re-triggering a full campaign-finance sync (which is expensive and
+ *   re-fetches federal data we don't need to re-test).
+ * - Re-resolving propositionTitle → propositionId after new propositions
+ *   are added (e.g. when an election cycle adds measures the prior sync
+ *   missed).
+ * - Re-processing cvr2_filings independently of the bulk-download cycle.
+ *
+ * Usage (after `pnpm --filter backend build:region`):
+ *   node apps/backend/dist/src/apps/region/apps/region/src/scripts/run-finance-linker.js
+ *
+ * Idempotent: re-running over the same data is a no-op thanks to the
+ * unique constraint on (committee_id, proposition_id, position).
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
+import { AppModule } from '../app.module';
+import { PropositionFinanceLinkerService } from '../domains/proposition-finance-linker.service';
+
+async function main(): Promise<void> {
+  const logger = new Logger('run-finance-linker');
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'warn', 'error'],
+  });
+  try {
+    const linker = app.get(PropositionFinanceLinkerService, { strict: false });
+    logger.log('Starting proposition finance linker pass…');
+    const result = await linker.linkAll();
+    logger.log(
+      `Done. cvr2Resolved=${result.cvr2Resolved} cvr2Skipped=${result.cvr2Skipped} ` +
+        `expenditureLinked=${result.expenditureLinked} ` +
+        `independentExpenditureLinked=${result.independentExpenditureLinked} ` +
+        `inferredPositions=${result.inferredPositions}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Linker run failed:', err);
+  process.exit(1);
+});

--- a/apps/frontend/__tests__/components/region/PropositionFundingSection.test.tsx
+++ b/apps/frontend/__tests__/components/region/PropositionFundingSection.test.tsx
@@ -1,0 +1,215 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PropositionFundingSection } from "@/components/region/PropositionFundingSection";
+import type { PropositionFunding, SidedFunding } from "@/lib/graphql/region";
+
+let mockQueryResult: {
+  data: { propositionFunding: PropositionFunding | null } | null;
+  loading: boolean;
+  error: Error | null;
+} = { data: null, loading: false, error: null };
+
+jest.mock("@apollo/client/react", () => ({
+  useQuery: jest.fn(() => mockQueryResult),
+}));
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+const emptySide: SidedFunding = {
+  totalRaised: 0,
+  totalSpent: 0,
+  donorCount: 0,
+  committeeCount: 0,
+  topDonors: [],
+  primaryCommittees: [],
+};
+
+const populatedFunding: PropositionFunding = {
+  propositionId: "prop-1",
+  asOf: "2026-04-25T00:00:00Z",
+  support: {
+    totalRaised: 1_250_000,
+    totalSpent: 980_000,
+    donorCount: 42,
+    committeeCount: 2,
+    topDonors: [
+      {
+        donorName: "BIG GIVER LLC",
+        totalAmount: 500_000,
+        contributionCount: 5,
+      },
+      {
+        donorName: "Alice Donor",
+        totalAmount: 75_000,
+        contributionCount: 1,
+      },
+    ],
+    primaryCommittees: [
+      { id: "c-1", name: "Yes on Prop 1", totalRaised: 1_200_000 },
+      { id: "c-2", name: "Coalition for Yes", totalRaised: 50_000 },
+    ],
+  },
+  oppose: {
+    totalRaised: 600_000,
+    totalSpent: 400_000,
+    donorCount: 18,
+    committeeCount: 1,
+    topDonors: [
+      {
+        donorName: "Anti-Prop Coalition",
+        totalAmount: 300_000,
+        contributionCount: 3,
+      },
+    ],
+    primaryCommittees: [
+      { id: "c-3", name: "No on Prop 1", totalRaised: 600_000 },
+    ],
+  },
+};
+
+describe("PropositionFundingSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryResult = { data: null, loading: false, error: null };
+  });
+
+  it("renders the loading skeleton while the query is in flight", () => {
+    mockQueryResult = { data: null, loading: true, error: null };
+
+    const { container } = render(
+      <PropositionFundingSection propositionId="prop-1" />,
+    );
+
+    // SectionTitle still renders + the skeleton placeholders pulse
+    expect(screen.getByText(/Who's Funding This/i)).toBeInTheDocument();
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("renders the empty state when the query errors", () => {
+    mockQueryResult = {
+      data: null,
+      loading: false,
+      error: new Error("network down"),
+    };
+
+    render(<PropositionFundingSection propositionId="prop-1" />);
+
+    expect(
+      screen.getByText(/No campaign-finance filings linked/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty state when no funding has been linked yet", () => {
+    mockQueryResult = {
+      data: { propositionFunding: null },
+      loading: false,
+      error: null,
+    };
+
+    render(<PropositionFundingSection propositionId="prop-1" />);
+
+    expect(
+      screen.getByText(/No campaign-finance filings linked/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty state when both sides report zero money", () => {
+    mockQueryResult = {
+      data: {
+        propositionFunding: {
+          propositionId: "prop-1",
+          asOf: "2026-04-25T00:00:00Z",
+          support: { ...emptySide },
+          oppose: { ...emptySide },
+        },
+      },
+      loading: false,
+      error: null,
+    };
+
+    render(<PropositionFundingSection propositionId="prop-1" />);
+
+    expect(
+      screen.getByText(/No campaign-finance filings linked/i),
+    ).toBeInTheDocument();
+  });
+
+  describe("with populated funding", () => {
+    beforeEach(() => {
+      mockQueryResult = {
+        data: { propositionFunding: populatedFunding },
+        loading: false,
+        error: null,
+      };
+    });
+
+    it("renders Supporting and Opposing column labels", () => {
+      render(<PropositionFundingSection propositionId="prop-1" />);
+
+      expect(screen.getByText("Supporting")).toBeInTheDocument();
+      expect(screen.getByText("Opposing")).toBeInTheDocument();
+    });
+
+    it("formats the totals as currency", () => {
+      render(<PropositionFundingSection propositionId="prop-1" />);
+
+      // formatCurrency uses the en-US Intl default which includes cents.
+      expect(screen.getByText("$1,250,000.00")).toBeInTheDocument();
+      expect(screen.getByText("$600,000.00")).toBeInTheDocument();
+    });
+
+    it("shows pluralized donor + committee counts", () => {
+      render(<PropositionFundingSection propositionId="prop-1" />);
+
+      expect(
+        screen.getByText("raised by 2 committees from 42 donors"),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("raised by 1 committee from 18 donors"),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the top-donor list with names and amounts", () => {
+      render(<PropositionFundingSection propositionId="prop-1" />);
+
+      expect(screen.getByText("BIG GIVER LLC")).toBeInTheDocument();
+      expect(screen.getByText("$500,000.00")).toBeInTheDocument();
+      expect(screen.getByText("Anti-Prop Coalition")).toBeInTheDocument();
+    });
+
+    it("renders primary committees as links to their detail pages", () => {
+      render(<PropositionFundingSection propositionId="prop-1" />);
+
+      const yesLink = screen.getByRole("link", { name: "Yes on Prop 1" });
+      expect(yesLink).toHaveAttribute(
+        "href",
+        "/region/campaign-finance/committees/c-1",
+      );
+      const noLink = screen.getByRole("link", { name: "No on Prop 1" });
+      expect(noLink).toHaveAttribute(
+        "href",
+        "/region/campaign-finance/committees/c-3",
+      );
+    });
+
+    it("shows the asOf timestamp footer", () => {
+      render(<PropositionFundingSection propositionId="prop-1" />);
+
+      expect(
+        screen.getByText(/Reflects CalAccess records as of/i),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/__tests__/pages/region/proposition-detail.test.tsx
+++ b/apps/frontend/__tests__/pages/region/proposition-detail.test.tsx
@@ -101,6 +101,17 @@ jest.mock("next/link", () => {
   };
 });
 
+// Stub PropositionFundingSection to avoid duplicate useQuery dispatch and
+// to keep these tests focused on the page's layer wiring (the funding
+// section has its own dedicated unit test).
+jest.mock("@/components/region/PropositionFundingSection", () => ({
+  PropositionFundingSection: ({ propositionId }: { propositionId: string }) => (
+    <div data-testid="funding-section" data-propid={propositionId}>
+      [funding section]
+    </div>
+  ),
+}));
+
 describe("PropositionDetailPage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -245,7 +256,7 @@ describe("PropositionDetailPage", () => {
       });
     });
 
-    it("should navigate to Layer 3 when See Both Sides is clicked", async () => {
+    it("should navigate to Layer 3 when See Both Sides is clicked + render the funding section there", async () => {
       const user = userEvent.setup();
       render(<PropositionDetailPage />);
 
@@ -264,6 +275,11 @@ describe("PropositionDetailPage", () => {
         expect(
           screen.getByText("Best Arguments From Each Side"),
         ).toBeInTheDocument();
+        // Funding section now lives on Layer 3 (it answers "who's behind
+        // each side", which fits "Both Sides" better than "Details").
+        const section = screen.getByTestId("funding-section");
+        expect(section).toBeInTheDocument();
+        expect(section).toHaveAttribute("data-propid", "1");
       });
     });
 
@@ -356,28 +372,6 @@ describe("PropositionDetailPage", () => {
         expect(
           screen.getByText(/All real property is taxed based on its 1978/i),
         ).toBeInTheDocument();
-      });
-    });
-
-    it("should show campaign-finance placeholder only when no analysis exists", async () => {
-      // With analysis present, the Yes/No Campaign placeholders are
-      // suppressed because the page assumes funding rendering belongs to
-      // a future iteration. With analysis absent (legacy/empty rows) the
-      // placeholders still surface so the layout doesn't collapse.
-      mockQueryResult = {
-        data: { proposition: mockPropositionNoExtras },
-        loading: false,
-        error: null,
-      };
-
-      const user = userEvent.setup();
-      render(<PropositionDetailPage />);
-
-      await user.click(screen.getByRole("button", { name: "Learn More" }));
-
-      await waitFor(() => {
-        expect(screen.getByText("Yes Campaign")).toBeInTheDocument();
-        expect(screen.getByText("No Campaign")).toBeInTheDocument();
       });
     });
 

--- a/apps/frontend/app/region/propositions/[id]/page.tsx
+++ b/apps/frontend/app/region/propositions/[id]/page.tsx
@@ -25,6 +25,7 @@ import { LayerNav } from "@/components/region/LayerNav";
 import { YesNoOutcomeCard } from "@/components/region/YesNoOutcomeCard";
 import { ClaimAttribution } from "@/components/region/ClaimAttribution";
 import { SegmentedFullText } from "@/components/region/SegmentedFullText";
+import { PropositionFundingSection } from "@/components/region/PropositionFundingSection";
 import { formatDate } from "@/lib/format";
 
 const STATUS_STYLES: Record<
@@ -75,10 +76,56 @@ function QuickView({
   readonly proposition: Proposition;
   readonly onNext: () => void;
 }) {
-  const summary = proposition.analysisSummary?.trim() || proposition.summary;
+  // Prefer the richer AI-generated paragraph. Fall back to the raw
+  // scrape `summary` only when it differs from the title — the SOS
+  // listing-page scrape often puts identical text in both, and rendering
+  // a paragraph that's just the title repeated is worse than nothing.
+  const summary =
+    proposition.analysisSummary?.trim() ||
+    (proposition.summary?.trim() &&
+    proposition.summary.trim() !== proposition.title.trim()
+      ? proposition.summary
+      : null);
+
+  // Top 3 key provisions give Quick View substantive depth without
+  // duplicating Layer 2's full bulleted list. If the analyzer hasn't
+  // populated provisions yet we just skip the section.
+  const topProvisions = (proposition.keyProvisions ?? []).slice(0, 3);
+
   return (
     <div className="animate-layer-enter">
-      <p className="text-lg text-[#475569] leading-relaxed mb-6">{summary}</p>
+      {summary ? (
+        <p className="text-lg text-[#475569] leading-relaxed mb-6">{summary}</p>
+      ) : (
+        <p className="text-base italic text-slate-400 mb-6">
+          AI analysis pending — a plain-language summary will appear here once
+          the measure text is processed.
+        </p>
+      )}
+
+      {topProvisions.length > 0 && (
+        <div className="mb-6">
+          <p className="text-xs font-bold uppercase tracking-wider text-[#595959] mb-2">
+            What this would do
+          </p>
+          <ul className="space-y-2 text-[#334155]">
+            {topProvisions.map((provision) => (
+              <li key={provision} className="flex gap-2 leading-relaxed">
+                <span aria-hidden className="text-slate-400 mt-0.5">
+                  →
+                </span>
+                <span>{provision}</span>
+              </li>
+            ))}
+          </ul>
+          {(proposition.keyProvisions?.length ?? 0) > topProvisions.length && (
+            <p className="mt-2 text-xs text-slate-500">
+              + {proposition.keyProvisions!.length - topProvisions.length} more
+              in Details.
+            </p>
+          )}
+        </div>
+      )}
 
       {proposition.fiscalImpact && (
         <div className="inline-flex items-start gap-3 px-4 py-3 bg-slate-100 rounded-lg text-sm text-[#334155] mb-6 max-w-2xl">
@@ -168,10 +215,6 @@ function Details({
   readonly onNavigateToClaim: (claim: PropositionAnalysisClaim) => void;
   readonly onNext: () => void;
 }) {
-  const hasAnalysis =
-    !!proposition.analysisSummary ||
-    (proposition.keyProvisions?.length ?? 0) > 0;
-
   return (
     <div className="animate-layer-enter">
       <div className="mb-8">
@@ -271,40 +314,24 @@ function Details({
 
       <LinkedPetitionScans propositionId={propositionId} />
 
-      {!hasAnalysis && (
-        <div className="mb-8">
-          <SectionTitle>Who&apos;s Funding This</SectionTitle>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div className="bg-slate-50 border border-dashed border-slate-300 rounded-xl p-5 text-center">
-              <p className="text-xs font-bold uppercase tracking-wider text-slate-600 mb-1">
-                Yes Campaign
-              </p>
-              <p className="text-sm text-slate-700">Funding data coming soon</p>
-            </div>
-            <div className="bg-slate-50 border border-dashed border-slate-300 rounded-xl p-5 text-center">
-              <p className="text-xs font-bold uppercase tracking-wider text-slate-600 mb-1">
-                No Campaign
-              </p>
-              <p className="text-sm text-slate-700">Funding data coming soon</p>
-            </div>
-          </div>
-        </div>
-      )}
-
       <LayerButton onClick={onNext}>See Both Sides</LayerButton>
     </div>
   );
 }
 
 function BothSides({
+  propositionId,
   onNext,
   onBack,
 }: {
+  readonly propositionId: string;
   readonly onNext: () => void;
   readonly onBack: () => void;
 }) {
   return (
     <div className="animate-layer-enter">
+      <PropositionFundingSection propositionId={propositionId} />
+
       <div className="mb-8">
         <SectionTitle>Best Arguments From Each Side</SectionTitle>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
@@ -510,7 +537,11 @@ export default function PropositionDetailPage() {
           />
         )}
         {layer === 3 && (
-          <BothSides onNext={() => setLayer(4)} onBack={() => setLayer(1)} />
+          <BothSides
+            propositionId={id}
+            onNext={() => setLayer(4)}
+            onBack={() => setLayer(1)}
+          />
         )}
         {layer === 4 && (
           <DeepDive

--- a/apps/frontend/app/region/propositions/[id]/page.tsx
+++ b/apps/frontend/app/region/propositions/[id]/page.tsx
@@ -178,8 +178,8 @@ function Details({
         <SectionTitle>Key Provisions</SectionTitle>
         {proposition.keyProvisions && proposition.keyProvisions.length > 0 ? (
           <ul className="list-disc pl-5 space-y-2 text-[#334155]">
-            {proposition.keyProvisions.map((provision, idx) => (
-              <li key={idx} className="leading-relaxed">
+            {proposition.keyProvisions.map((provision) => (
+              <li key={provision} className="leading-relaxed">
                 <span>{provision}</span>
                 <ClaimAttribution
                   claims={claimsForField(

--- a/apps/frontend/app/region/propositions/page.tsx
+++ b/apps/frontend/app/region/propositions/page.tsx
@@ -56,6 +56,28 @@ function StatusBadge({ status }: { readonly status: PropositionStatus }) {
   );
 }
 
+/**
+ * Pick the best one-line description for a proposition card.
+ *
+ * Priority:
+ *   1. analysisSummary — AI-generated plain-language one-liner. Always
+ *      better than the raw scrape when available.
+ *   2. summary, but only if it differs from title. The SOS listing-page
+ *      scrape pulls the same anchor text into both fields, so summary
+ *      often duplicates title; suppress that case rather than render a
+ *      pointless second copy.
+ *   3. null — caller renders a soft "Analysis pending" hint.
+ */
+function pickDescription(proposition: Proposition): string | null {
+  const analysis = proposition.analysisSummary?.trim();
+  if (analysis) return analysis;
+
+  const summary = proposition.summary?.trim();
+  if (summary && summary !== proposition.title.trim()) return summary;
+
+  return null;
+}
+
 function PropositionCard({
   proposition,
 }: Readonly<{ proposition: Proposition }>) {
@@ -66,6 +88,7 @@ function PropositionCard({
         day: "numeric",
       })
     : null;
+  const description = pickDescription(proposition);
 
   return (
     <Link
@@ -77,9 +100,15 @@ function PropositionCard({
           <h3 className="text-lg font-semibold text-[#222222] line-clamp-2">
             {proposition.title}
           </h3>
-          <p className="mt-2 text-sm text-[#4d4d4d] line-clamp-3">
-            {proposition.summary}
-          </p>
+          {description ? (
+            <p className="mt-2 text-sm text-[#4d4d4d] line-clamp-3">
+              {description}
+            </p>
+          ) : (
+            <p className="mt-2 text-sm italic text-slate-400">
+              Plain-language summary pending AI analysis.
+            </p>
+          )}
         </div>
         <StatusBadge status={proposition.status} />
       </div>

--- a/apps/frontend/components/region/PropositionFundingSection.tsx
+++ b/apps/frontend/components/region/PropositionFundingSection.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import Link from "next/link";
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_PROPOSITION_FUNDING,
+  type PropositionFundingData,
+  type PropositionIdVars,
+  type SidedFunding,
+} from "@/lib/graphql/region";
+import { formatCurrency, formatDate } from "@/lib/format";
+import { SectionTitle } from "@/components/region/SectionTitle";
+
+/**
+ * "Who's Funding This" section for the proposition detail page (Layer 2).
+ *
+ * Two-column Yes/No layout (`grid-cols-1 sm:grid-cols-2`) using the neutral
+ * slate palette so neither side reads as "good" or "bad" — same convention
+ * as YesNoOutcomeCard. Each column shows totals, donor/committee counts,
+ * top donors, and primary committees with links to their detail pages.
+ *
+ * Always renders (no `hasAnalysis` gating). When the analyzer has no
+ * positions for this measure, both sides show the empty state — clearer
+ * than hiding the section, since "no funding yet" is itself information
+ * for a voter looking at an early-cycle measure.
+ */
+export function PropositionFundingSection({
+  propositionId,
+}: {
+  readonly propositionId: string;
+}) {
+  const { data, loading, error } = useQuery<
+    PropositionFundingData,
+    PropositionIdVars
+  >(GET_PROPOSITION_FUNDING, {
+    variables: { propositionId },
+    fetchPolicy: "cache-and-network",
+  });
+
+  if (loading && !data) {
+    return (
+      <section className="mb-8">
+        <SectionTitle>Who&apos;s Funding This</SectionTitle>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+          <FundingSkeleton label="Supporting" />
+          <FundingSkeleton label="Opposing" />
+        </div>
+      </section>
+    );
+  }
+
+  if (error || !data?.propositionFunding) {
+    return (
+      <section className="mb-8">
+        <SectionTitle>Who&apos;s Funding This</SectionTitle>
+        <FundingEmpty />
+      </section>
+    );
+  }
+
+  const funding = data.propositionFunding;
+  const hasAnyMoney =
+    funding.support.totalRaised > 0 ||
+    funding.oppose.totalRaised > 0 ||
+    funding.support.totalSpent > 0 ||
+    funding.oppose.totalSpent > 0;
+
+  if (!hasAnyMoney) {
+    return (
+      <section className="mb-8">
+        <SectionTitle>Who&apos;s Funding This</SectionTitle>
+        <FundingEmpty />
+      </section>
+    );
+  }
+
+  return (
+    <section className="mb-8">
+      <SectionTitle>Who&apos;s Funding This</SectionTitle>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
+        <FundingSideCard label="Supporting" side={funding.support} />
+        <FundingSideCard label="Opposing" side={funding.oppose} />
+      </div>
+      <p className="mt-3 text-xs text-slate-500">
+        Reflects CalAccess records as of {formatDate(funding.asOf)}.
+      </p>
+    </section>
+  );
+}
+
+/**
+ * One column of the funding grid. Renders totals + donor/committee counts
+ * up top, then top donors, then primary committees as links.
+ */
+function FundingSideCard({
+  label,
+  side,
+}: {
+  readonly label: string;
+  readonly side: SidedFunding;
+}) {
+  return (
+    <div className="border-2 border-gray-200 rounded-xl p-5">
+      <p className="text-xs uppercase tracking-[1.5px] font-extrabold text-[#595959] mb-3">
+        {label}
+      </p>
+
+      <p className="text-2xl font-extrabold text-[#222222]">
+        {formatCurrency(side.totalRaised)}
+      </p>
+      <p className="text-xs text-slate-600 mb-4">
+        raised by {pluralize(side.committeeCount, "committee")} from{" "}
+        {pluralize(side.donorCount, "donor")}
+      </p>
+
+      {side.topDonors.length > 0 && (
+        <div className="mb-4">
+          <p className="text-xs font-bold uppercase tracking-wider text-slate-600 mb-2">
+            Top donors
+          </p>
+          <ul className="space-y-1.5">
+            {side.topDonors.map((donor) => (
+              <li
+                key={donor.donorName}
+                className="flex items-baseline justify-between gap-3 text-sm"
+              >
+                <span className="text-[#334155] truncate">
+                  {donor.donorName}
+                </span>
+                <span className="text-[#222222] font-semibold whitespace-nowrap">
+                  {formatCurrency(donor.totalAmount)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {side.primaryCommittees.length > 0 && (
+        <div>
+          <p className="text-xs font-bold uppercase tracking-wider text-slate-600 mb-2">
+            Primary committees
+          </p>
+          <ul className="space-y-1.5">
+            {side.primaryCommittees.map((committee) => (
+              <li key={committee.id} className="text-sm">
+                <Link
+                  href={`/region/campaign-finance/committees/${committee.id}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  {committee.name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FundingSkeleton({ label }: { readonly label: string }) {
+  return (
+    <div className="border-2 border-gray-200 rounded-xl p-5 animate-pulse">
+      <p className="text-xs uppercase tracking-[1.5px] font-extrabold text-[#595959] mb-3">
+        {label}
+      </p>
+      <div className="h-7 w-32 bg-slate-200 rounded mb-2" />
+      <div className="h-3 w-40 bg-slate-100 rounded mb-5" />
+      <div className="space-y-2">
+        <div className="h-3 bg-slate-100 rounded w-full" />
+        <div className="h-3 bg-slate-100 rounded w-5/6" />
+        <div className="h-3 bg-slate-100 rounded w-4/6" />
+      </div>
+    </div>
+  );
+}
+
+function FundingEmpty() {
+  return (
+    <div className="bg-slate-50 border border-dashed border-slate-300 rounded-xl p-6 text-center">
+      <p className="text-sm text-slate-700">
+        No campaign-finance filings linked to this measure yet.
+      </p>
+      <p className="text-xs text-slate-500 mt-1">
+        Funding data appears once committees file Form 410 declarations or
+        report expenditures targeting this measure.
+      </p>
+    </div>
+  );
+}
+
+function pluralize(n: number, singular: string): string {
+  return n === 1 ? `1 ${singular}` : `${n} ${singular}s`;
+}

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -396,6 +396,7 @@ export const GET_PROPOSITIONS = gql`
         externalId
         title
         summary
+        analysisSummary
         status
         electionDate
         sourceUrl
@@ -444,6 +445,87 @@ export const GET_PROPOSITION = gql`
       analysisGeneratedAt
       createdAt
       updatedAt
+    }
+  }
+`;
+
+/** A single donor's aggregated giving to one side of a measure. */
+export interface TopDonor {
+  donorName: string;
+  totalAmount: number;
+  contributionCount: number;
+}
+
+/** Compact summary of a primarily-formed committee for a measure. */
+export interface CommitteeSummaryFunding {
+  id: string;
+  name: string;
+  totalRaised: number;
+}
+
+/** Funding totals for one side (support or oppose) of a ballot measure. */
+export interface SidedFunding {
+  totalRaised: number;
+  totalSpent: number;
+  donorCount: number;
+  committeeCount: number;
+  topDonors: TopDonor[];
+  primaryCommittees: CommitteeSummaryFunding[];
+}
+
+/** Aggregated funding for a single proposition. */
+export interface PropositionFunding {
+  propositionId: string;
+  asOf: string;
+  support: SidedFunding;
+  oppose: SidedFunding;
+}
+
+export interface PropositionFundingData {
+  propositionFunding: PropositionFunding | null;
+}
+
+export interface PropositionIdVars {
+  propositionId: string;
+}
+
+export const GET_PROPOSITION_FUNDING = gql`
+  query GetPropositionFunding($propositionId: ID!) {
+    propositionFunding(propositionId: $propositionId) {
+      propositionId
+      asOf
+      support {
+        totalRaised
+        totalSpent
+        donorCount
+        committeeCount
+        topDonors {
+          donorName
+          totalAmount
+          contributionCount
+        }
+        primaryCommittees {
+          id
+          name
+          totalRaised
+        }
+      }
+      oppose {
+        totalRaised
+        totalSpent
+        donorCount
+        committeeCount
+        topDonors {
+          donorName
+          totalAmount
+          contributionCount
+        }
+        primaryCommittees {
+          id
+          name
+          totalRaised
+        }
+      }
     }
   }
 `;

--- a/docker-compose-uat.yml
+++ b/docker-compose-uat.yml
@@ -240,11 +240,16 @@ services:
     deploy:
       resources:
         limits:
+          # Bumped 2048M → 6144M for the campaign-finance bulk sync. The
+          # federal plugin's fetchCampaignFinance accumulates all FEC
+          # records (~3M) in memory before returning instead of honoring
+          # the onBatch streaming flow — separate bug worth fixing, but
+          # for now we just give the container enough headroom.
           cpus: '1.0'
-          memory: 2048M
+          memory: 6144M
         reservations:
           cpus: '0.25'
-          memory: 256M
+          memory: 512M
 
   api:
     build:

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -286,6 +286,24 @@ export interface IndependentExpenditure {
 }
 
 /**
+ * Raw CVR2_CAMPAIGN_DISCLOSURE_CD record from CalAccess. Each row represents
+ * one ballot-measure declaration on an FPPC Form 410 filing — links a filing
+ * (and therefore a committee) to a specific measure with a support/oppose
+ * code. Persisted as-is so the proposition-finance-linker can resolve to
+ * (committeeId, propositionId) at link time, decoupled from the bulk-download
+ * cycle order.
+ */
+export interface CommitteeMeasureFiling {
+  externalId: string; // FILING_ID + LINE_ITEM
+  filingId: string; // FILING_ID — joinable to Contribution.externalId / Expenditure.externalId
+  ballotName?: string; // BAL_NAME — fuzzy-matches Proposition.title
+  ballotNumber?: string; // BAL_NUM — e.g. "ACA 13"
+  ballotJurisdiction?: string; // BAL_JURIS
+  supportOrOppose?: "support" | "oppose"; // mapped from SUP_OPP_CD
+  sourceSystem: "cal_access" | "fec";
+}
+
+/**
  * Aggregated result from campaign finance data fetch
  */
 export interface CampaignFinanceResult {
@@ -293,6 +311,7 @@ export interface CampaignFinanceResult {
   contributions: Contribution[];
   expenditures: Expenditure[];
   independentExpenditures: IndependentExpenditure[];
+  committeeMeasureFilings: CommitteeMeasureFiling[];
 }
 
 /**

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.27"
+    "@opuspopuli/regions": "^1.0.28"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/src/declarative/declarative-region-plugin.ts
+++ b/packages/region-provider/src/declarative/declarative-region-plugin.ts
@@ -101,6 +101,8 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
     const expenditures: CampaignFinanceResult["expenditures"] = [];
     const independentExpenditures: CampaignFinanceResult["independentExpenditures"] =
       [];
+    const committeeMeasureFilings: CampaignFinanceResult["committeeMeasureFilings"] =
+      [];
 
     for (const item of allItems) {
       const rec = item;
@@ -116,6 +118,16 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
         independentExpenditures.push(
           rec as unknown as CampaignFinanceResult["independentExpenditures"][0],
         );
+      } else if (
+        "filingId" in rec &&
+        ("ballotName" in rec || "ballotNumber" in rec)
+      ) {
+        // CVR2 record — Form 410 ballot-measure declaration. Has filingId +
+        // a ballot identifier. Discriminate before "sourceSystem + type"
+        // because a CVR2 row also carries a sourceSystem.
+        committeeMeasureFilings.push(
+          rec as unknown as CampaignFinanceResult["committeeMeasureFilings"][0],
+        );
       } else if ("sourceSystem" in rec && "type" in rec) {
         committees.push(
           rec as unknown as CampaignFinanceResult["committees"][0],
@@ -123,7 +135,13 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
       }
     }
 
-    return { committees, contributions, expenditures, independentExpenditures };
+    return {
+      committees,
+      contributions,
+      expenditures,
+      independentExpenditures,
+      committeeMeasureFilings,
+    };
   }
 
   override async healthCheck() {

--- a/packages/relationaldb-provider/prisma/migrations/20260425010000_add_proposition_funding_links/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260425010000_add_proposition_funding_links/migration.sql
@@ -1,0 +1,82 @@
+-- Connect campaign-finance records to propositions.
+--
+-- Adds:
+--   * CommitteeMeasurePositionType enum (support / oppose)
+--   * committee_measure_positions join table — many-to-many committee↔proposition
+--     with position + isPrimaryFormation flag (true when sourced authoritatively
+--     from CVR2 Form 410 records, false when inferred from expenditures)
+--   * cvr2_filings — raw CVR2_CAMPAIGN_DISCLOSURE_CD records persisted so the
+--     proposition-finance-linker can run independently of the bulk-download cycle
+--   * proposition_id FK on expenditures + independent_expenditures so aggregation
+--     can join cleanly without string matching
+--
+-- All new columns / tables are additive. Existing rows are unaffected; the
+-- linker populates the new FKs lazily after each campaign-finance sync.
+
+-- 1. New enum --------------------------------------------------------------
+CREATE TYPE "CommitteeMeasurePositionType" AS ENUM ('support', 'oppose');
+
+-- 2. CommitteeMeasurePosition join table ----------------------------------
+CREATE TABLE "committee_measure_positions" (
+    "id" TEXT NOT NULL,
+    "committee_id" TEXT NOT NULL,
+    "proposition_id" TEXT NOT NULL,
+    "position" "CommitteeMeasurePositionType" NOT NULL,
+    "is_primary_formation" BOOLEAN NOT NULL DEFAULT false,
+    "source_filing" VARCHAR(50),
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "committee_measure_positions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "committee_measure_positions_committee_id_proposition_id_pos_key"
+    ON "committee_measure_positions" ("committee_id", "proposition_id", "position");
+CREATE INDEX "committee_measure_positions_proposition_id_position_idx"
+    ON "committee_measure_positions" ("proposition_id", "position");
+
+ALTER TABLE "committee_measure_positions"
+    ADD CONSTRAINT "committee_measure_positions_committee_id_fkey"
+    FOREIGN KEY ("committee_id") REFERENCES "committees" ("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "committee_measure_positions"
+    ADD CONSTRAINT "committee_measure_positions_proposition_id_fkey"
+    FOREIGN KEY ("proposition_id") REFERENCES "propositions" ("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- 3. Cvr2Filing raw records -----------------------------------------------
+CREATE TABLE "cvr2_filings" (
+    "id" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "filing_id" VARCHAR(50) NOT NULL,
+    "ballot_name" TEXT,
+    "ballot_number" VARCHAR(50),
+    "ballot_jurisdiction" VARCHAR(100),
+    "support_or_oppose" VARCHAR(10),
+    "source_system" VARCHAR(20) NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "cvr2_filings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "cvr2_filings_external_id_key" ON "cvr2_filings" ("external_id");
+CREATE INDEX "cvr2_filings_filing_id_idx" ON "cvr2_filings" ("filing_id");
+CREATE INDEX "cvr2_filings_ballot_name_idx" ON "cvr2_filings" ("ballot_name");
+
+-- 4. proposition_id FK on expenditures ------------------------------------
+ALTER TABLE "expenditures" ADD COLUMN "proposition_id" TEXT;
+CREATE INDEX "expenditures_proposition_id_idx" ON "expenditures" ("proposition_id");
+ALTER TABLE "expenditures"
+    ADD CONSTRAINT "expenditures_proposition_id_fkey"
+    FOREIGN KEY ("proposition_id") REFERENCES "propositions" ("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- 5. proposition_id FK on independent_expenditures ------------------------
+ALTER TABLE "independent_expenditures" ADD COLUMN "proposition_id" TEXT;
+CREATE INDEX "independent_expenditures_proposition_id_idx" ON "independent_expenditures" ("proposition_id");
+ALTER TABLE "independent_expenditures"
+    ADD CONSTRAINT "independent_expenditures_proposition_id_fkey"
+    FOREIGN KEY ("proposition_id") REFERENCES "propositions" ("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -621,7 +621,10 @@ model Proposition {
   updatedAt    DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt    DateTime? @map("deleted_at") @db.Timestamptz
 
-  linkedDocuments DocumentProposition[]
+  linkedDocuments         DocumentProposition[]
+  committeePositions      CommitteeMeasurePosition[]
+  expenditures            Expenditure[]
+  independentExpenditures IndependentExpenditure[]
 
   @@index([status])
   @@index([electionDate])
@@ -704,6 +707,12 @@ model RegionPlugin {
 // CAMPAIGN FINANCE
 // ============================================
 
+/// Position a committee takes on a ballot measure (FPPC Form 410 + inferred from expenditures).
+enum CommitteeMeasurePositionType {
+  support @map("support")
+  oppose  @map("oppose")
+}
+
 /// Campaign committee — the entity that raises and spends money.
 /// Covers candidate committees, ballot measure committees, PACs, Super PACs, and party committees.
 model Committee {
@@ -725,12 +734,58 @@ model Committee {
   contributions           Contribution[]
   expenditures            Expenditure[]
   independentExpenditures IndependentExpenditure[]
+  measurePositions        CommitteeMeasurePosition[]
 
   @@index([name])
   @@index([type])
   @@index([sourceSystem])
   @@index([propositionId])
   @@map("committees")
+}
+
+/// Many-to-many: a committee's declared positions on ballot measures.
+/// Sourced authoritatively from CVR2 (Form 410) when isPrimaryFormation = true,
+/// otherwise inferred by the proposition-finance-linker from expenditures/IEs
+/// that target a known measure. Lets us aggregate funding per measure even when
+/// a single committee takes positions on multiple measures.
+model CommitteeMeasurePosition {
+  id                 String                       @id @default(uuid())
+  committeeId        String                       @map("committee_id")
+  propositionId      String                       @map("proposition_id")
+  position           CommitteeMeasurePositionType
+  isPrimaryFormation Boolean                      @default(false) @map("is_primary_formation")
+  sourceFiling       String?                      @map("source_filing") @db.VarChar(50) /// CVR2 FILING_ID when known
+  createdAt          DateTime                     @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt          DateTime                     @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  committee   Committee   @relation(fields: [committeeId], references: [id], onDelete: Cascade)
+  proposition Proposition @relation(fields: [propositionId], references: [id], onDelete: Cascade)
+
+  @@unique([committeeId, propositionId, position])
+  @@index([propositionId, position])
+  @@map("committee_measure_positions")
+}
+
+/// Raw CVR2_CAMPAIGN_DISCLOSURE_CD records — the FPPC Form 410 ballot-measure
+/// declaration. Persisted (rather than processed transiently) so the linker can
+/// run independently of the bulk-download cycle and re-process if Proposition
+/// rows are added later. Resolution to (committeeId, propositionId) happens
+/// in PropositionFinanceLinkerService.
+model Cvr2Filing {
+  id                 String   @id @default(uuid())
+  externalId         String   @unique @map("external_id") /// FILING_ID + LINE_ITEM
+  filingId           String   @map("filing_id") @db.VarChar(50)
+  ballotName         String?  @map("ballot_name")
+  ballotNumber       String?  @map("ballot_number") @db.VarChar(50)
+  ballotJurisdiction String?  @map("ballot_jurisdiction") @db.VarChar(100)
+  supportOrOppose    String?  @map("support_or_oppose") @db.VarChar(10) /// CalAccess SUP_OPP_CD: 'S' or 'O'
+  sourceSystem       String   @map("source_system") @db.VarChar(20)
+  createdAt          DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt          DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([filingId])
+  @@index([ballotName])
+  @@map("cvr2_filings")
 }
 
 /// Campaign contribution — money received by a committee from a donor.
@@ -775,17 +830,22 @@ model Expenditure {
   expenditureCode    String?  @map("expenditure_code") @db.VarChar(10)
   candidateName      String?  @map("candidate_name")
   propositionTitle   String?  @map("proposition_title")
+  /// Resolved by the proposition-finance-linker from propositionTitle. Nullable
+  /// because resolution requires the matching Proposition row to exist.
+  propositionId      String?  @map("proposition_id")
   supportOrOppose    String?  @map("support_or_oppose") @db.VarChar(10)
   sourceSystem       String   @map("source_system") @db.VarChar(20)
   createdAt          DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt          DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
-  committee Committee @relation(fields: [committeeId], references: [id])
+  committee   Committee    @relation(fields: [committeeId], references: [id])
+  proposition Proposition? @relation(fields: [propositionId], references: [id], onDelete: SetNull)
 
   @@index([committeeId])
   @@index([payeeName])
   @@index([date])
   @@index([sourceSystem])
+  @@index([propositionId])
   @@map("expenditures")
 }
 
@@ -798,6 +858,9 @@ model IndependentExpenditure {
   committeeName    String    @map("committee_name")
   candidateName    String?   @map("candidate_name")
   propositionTitle String?   @map("proposition_title")
+  /// Resolved by the proposition-finance-linker from propositionTitle. Nullable
+  /// because resolution requires the matching Proposition row to exist.
+  propositionId    String?   @map("proposition_id")
   supportOrOppose  String    @map("support_or_oppose") @db.VarChar(10)
   amount           Decimal   @db.Decimal(12, 2)
   date             DateTime  @db.Date
@@ -807,11 +870,13 @@ model IndependentExpenditure {
   createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
-  committee Committee @relation(fields: [committeeId], references: [id])
+  committee   Committee    @relation(fields: [committeeId], references: [id])
+  proposition Proposition? @relation(fields: [propositionId], references: [id], onDelete: SetNull)
 
   @@index([committeeId])
   @@index([candidateName])
   @@index([propositionTitle])
+  @@index([propositionId])
   @@index([date])
   @@index([supportOrOppose])
   @@index([sourceSystem])

--- a/packages/relationaldb-provider/src/index.ts
+++ b/packages/relationaldb-provider/src/index.ts
@@ -68,6 +68,8 @@ export type {
   Contribution,
   Expenditure,
   IndependentExpenditure,
+  CommitteeMeasurePosition,
+  Cvr2Filing,
   PromptTemplate,
   AbuseReport,
   DocumentProposition,
@@ -93,6 +95,7 @@ export {
   AbuseReportReason,
   AbuseReportStatus,
   LinkSource,
+  CommitteeMeasurePositionType,
 } from "@prisma/client";
 
 // Test utilities are available from "@opuspopuli/relationaldb-provider/testing"

--- a/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
@@ -457,10 +457,21 @@ export class BulkDownloadHandler {
   }
 
   /**
-   * Strip surrounding double quotes and trim whitespace from a CSV cell value.
+   * Sanitize a CSV/TSV cell value: strip embedded NUL bytes (U+0000),
+   * surrounding double quotes, and surrounding whitespace.
+   *
+   * NUL bytes appear in CalAccess TSVs (notably in committee names and
+   * descriptions) and Postgres rejects them in UTF-8 text columns with
+   * SQLSTATE 22021 ("invalid byte sequence for encoding UTF8: 0x00"),
+   * which fails the entire batch transaction. We drop them here at the
+   * parse layer so every downstream consumer (mapper, upsert, linker)
+   * sees clean strings.
    */
   private static stripQuotes(val: string): string {
-    return val.trim().replaceAll(/(^"|"$)/g, "");
+    return val
+      .replaceAll("\u0000", "")
+      .trim()
+      .replaceAll(/(^"|"$)/g, "");
   }
 
   /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,7 @@ importers:
         version: 6.8.0
       '@langchain/community':
         specifier: ^1.1.22
-        version: 1.1.25(453be0cca20f224e3fbb4aa70730f2f7)
+        version: 1.1.25(6652600d9ead4b757955ce52e1590d23)
       '@langchain/core':
         specifier: ^1.1.31
         version: 1.1.36(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@6.33.0(ws@8.19.0(bufferutil@4.1.0))(zod@4.3.6))
@@ -156,8 +156,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.22
-        version: 1.0.22
+        specifier: ^1.0.28
+        version: 1.0.28
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -516,7 +516,7 @@ importers:
         version: 16.5.0
       jest:
         specifier: ^30.2.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-axe:
         specifier: ^10.0.0
         version: 10.0.0
@@ -534,7 +534,7 @@ importers:
         version: 4.2.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -574,7 +574,7 @@ importers:
         version: 7.0.11
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -583,7 +583,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -651,7 +651,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -660,7 +660,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -691,7 +691,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -700,7 +700,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -740,7 +740,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -749,7 +749,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -774,7 +774,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -783,7 +783,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -842,7 +842,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -851,7 +851,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -879,10 +879,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -891,7 +891,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -905,8 +905,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.27
-        version: 1.0.27
+        specifier: ^1.0.28
+        version: 1.0.28
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -919,7 +919,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -928,7 +928,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -956,10 +956,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       prisma:
         specifier: '5'
         version: 5.22.0
@@ -971,7 +971,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1029,7 +1029,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1038,7 +1038,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1069,7 +1069,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1078,7 +1078,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1115,7 +1115,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1124,7 +1124,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1152,13 +1152,13 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1647,8 +1647,8 @@ packages:
     resolution: {integrity: sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/core@3.974.1':
-    resolution: {integrity: sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==}
+  '@aws-sdk/core@3.974.5':
+    resolution: {integrity: sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/crc64-nvme@3.972.5':
@@ -1659,64 +1659,64 @@ packages:
     resolution: {integrity: sha512-EamaclJcCEaPHp6wiVknNMM2RlsPMjAHSsYSFLNENBM8Wz92QPc6cOn3dif6vPDQt0Oo4IEghDy3NMDCzY/IvA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-env@3.972.27':
-    resolution: {integrity: sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==}
+  '@aws-sdk/credential-provider-env@3.972.31':
+    resolution: {integrity: sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.25':
     resolution: {integrity: sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-http@3.972.29':
-    resolution: {integrity: sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==}
+  '@aws-sdk/credential-provider-http@3.972.33':
+    resolution: {integrity: sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.26':
     resolution: {integrity: sha512-xKxEAMuP6GYx2y5GET+d3aGEroax3AgGfwBE65EQAUe090lzyJ/RzxPX9s8v7Z6qAk0XwfQl+LrmH05X7YvTeg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-ini@3.972.31':
-    resolution: {integrity: sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==}
+  '@aws-sdk/credential-provider-ini@3.972.35':
+    resolution: {integrity: sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.26':
     resolution: {integrity: sha512-EFcM8RM3TUxnZOfMJo++3PnyxFu1fL/huzmn3Vh+8IWRgqZawUD3cRwwOr+/4bE9DpyHaLOWFAjY0lfK5X9ZkQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-login@3.972.31':
-    resolution: {integrity: sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==}
+  '@aws-sdk/credential-provider-login@3.972.35':
+    resolution: {integrity: sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.27':
     resolution: {integrity: sha512-jXpxSolfFnPVj6GCTtx3xIdWNoDR7hYC/0SbetGZxOC9UnNmipHeX1k6spVstf7eWJrMhXNQEgXC0pD1r5tXIg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-node@3.972.32':
-    resolution: {integrity: sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog==}
+  '@aws-sdk/credential-provider-node@3.972.36':
+    resolution: {integrity: sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.23':
     resolution: {integrity: sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-process@3.972.27':
-    resolution: {integrity: sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==}
+  '@aws-sdk/credential-provider-process@3.972.31':
+    resolution: {integrity: sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.26':
     resolution: {integrity: sha512-c6ghvRb6gTlMznWhGxn/bpVCcp0HRaz4DobGVD9kI4vwHq186nU2xN/S7QGkm0lo0H2jQU8+dgpUFLxfTcwCOg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-sso@3.972.31':
-    resolution: {integrity: sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==}
+  '@aws-sdk/credential-provider-sso@3.972.35':
+    resolution: {integrity: sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.26':
     resolution: {integrity: sha512-cXcS3+XD3iwhoXkM44AmxjmbcKueoLCINr1e+IceMmCySda5ysNIfiGBGe9qn5EMiQ9Jd7pP0AGFtcd6OV3Lvg==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/credential-provider-web-identity@3.972.31':
-    resolution: {integrity: sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==}
+  '@aws-sdk/credential-provider-web-identity@3.972.35':
+    resolution: {integrity: sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.972.12':
@@ -1775,6 +1775,10 @@ packages:
     resolution: {integrity: sha512-5q7UGSTtt7/KF0Os8wj2VZtlLxeWJVb0e2eDrDJlWot2EIxUNKDDMPFq/FowUqrwZ40rO2bu6BypxaKNvQhI+g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-s3@3.972.34':
+    resolution: {integrity: sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-sdk-sqs@3.972.8':
     resolution: {integrity: sha512-KhwktzM8+EPoOkh+92WO2Fq6Ibk9GXr9eEh0nBOd/ZO83z7i8a7BF+mTNN6k8+eKAhLerbMWRT196u5JhKe0QA==}
     engines: {node: '>=20.0.0'}
@@ -1787,24 +1791,24 @@ packages:
     resolution: {integrity: sha512-AilFIh4rI/2hKyyGN6XrB0yN96W2o7e7wyrPWCM6QjZM1mcC/pVkW3IWWRvuBWMpVP8Fg+rMpbzeLQ6dTM4gig==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-user-agent@3.972.31':
-    resolution: {integrity: sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog==}
+  '@aws-sdk/middleware-user-agent@3.972.35':
+    resolution: {integrity: sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.996.16':
     resolution: {integrity: sha512-L7Qzoj/qQU1cL5GnYLQP5LbI+wlLCLoINvcykR3htKcQ4tzrPf2DOs72x933BM7oArYj1SKrkb2lGlsJHIic3g==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/nested-clients@3.996.21':
-    resolution: {integrity: sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==}
+  '@aws-sdk/nested-clients@3.997.3':
+    resolution: {integrity: sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.10':
     resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/region-config-resolver@3.972.12':
-    resolution: {integrity: sha512-QQI43Mxd53nBij0pm8HXC+t4IOC6gnhhZfzxE0OATQyO6QfPV4e+aTIRRuAJKA6Nig/cR8eLwPryqYTX9ZrjAQ==}
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/s3-request-presigner@3.1019.0':
@@ -1819,12 +1823,16 @@ packages:
     resolution: {integrity: sha512-4nZSrBr1NO+48HCM/6BRU8mnRjuHZjcpziCvLXZk5QVftwWz5Mxqbhwdz4xf7WW88buaTB8uRO2MHklSX1m0vg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.22':
+    resolution: {integrity: sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1019.0':
     resolution: {integrity: sha512-OF+2RfRmUKyjzrRWlDcyju3RBsuqcrYDQ8TwrJg8efcOotMzuZN4U9mpVTIdATpmEc4lWNZBMSjPzrGm6JPnAQ==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1032.0':
-    resolution: {integrity: sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==}
+  '@aws-sdk/token-providers@3.1036.0':
+    resolution: {integrity: sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.6':
@@ -1847,8 +1855,8 @@ packages:
     resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/util-endpoints@3.996.7':
-    resolution: {integrity: sha512-ty4LQxN1QC+YhUP28NfEgZDEGXkyqOQy+BDriBozqHsrYO4JMgiPhfizqOGF7P+euBTZ5Ez6SKlLAMCLo8tzmw==}
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-format-url@3.972.8':
@@ -1874,8 +1882,8 @@ packages:
       aws-crt:
         optional: true
 
-  '@aws-sdk/util-user-agent-node@3.973.17':
-    resolution: {integrity: sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg==}
+  '@aws-sdk/util-user-agent-node@3.973.21':
+    resolution: {integrity: sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -1890,8 +1898,8 @@ packages:
     resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/xml-builder@3.972.18':
-    resolution: {integrity: sha512-BMDNVG1ETXRhl1tnisQiYBef3RShJ1kfZA7x7afivTFMLirfHNTb6U71K569HNXhSXbQZsweHvSDZ6euBw8hPA==}
+  '@aws-sdk/xml-builder@3.972.19':
+    resolution: {integrity: sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
@@ -4908,11 +4916,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.22':
-    resolution: {integrity: sha512-7/4WoFkaz1/Q5OTfWZT/5X8RIPN6yZaFZAp8lNxXZAep1+iZ83C3C0XPIZ36kVdLNzYNXUhGYPntcsVR87F61w==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.22/17a1666cdf708f202c2e086dbe1de1f1484d1298}
-
-  '@opuspopuli/regions@1.0.27':
-    resolution: {integrity: sha512-E+1xCESkIuwgD8KSEOIWxErCwcpGC6igH8j8zettRRpMoKLf5e+bJsOoUmeS4D4t5woHGpx7r00qgqIeoIABJQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.27/426ccfc6c316498abaa7dad87b25b6e1393b238b}
+  '@opuspopuli/regions@1.0.28':
+    resolution: {integrity: sha512-M+sWzB6ZxqA/jlaVVFrjrB60B+rR72ommMPjniJhzIlUZilWrqP3OHmkLl1tnK5cxWNi0wTmXT7lKtSoTQNIeQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.28/78b2103e2bcf20d0cb2fac35fb0224b70681eeda}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -5287,16 +5292,16 @@ packages:
     resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/config-resolver@4.4.16':
-    resolution: {integrity: sha512-GFlGPNLZKrGfqWpqVb31z7hvYCA9ZscfX1buYnvvMGcRYsQQnhH+4uN6mWWflcD5jB4OXP/LBrdpukEdjl41tg==}
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/core@3.23.12':
     resolution: {integrity: sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/core@3.23.15':
-    resolution: {integrity: sha512-E7GVCgsQttzfujEZb6Qep005wWf4xiL4x06apFEtzQMWYBPggZh/0cnOxPficw5cuK/YjjkehKoIN4YUaSh0UQ==}
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.2.12':
@@ -5387,24 +5392,24 @@ packages:
     resolution: {integrity: sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-endpoint@4.4.30':
-    resolution: {integrity: sha512-qS2XqhKeXmdZ4nEQ4cOxIczSP/Y91wPAHYuRwmWDCh975B7/57uxsm5d6sisnUThn2u2FwzMdJNM7AbO1YPsPg==}
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-retry@4.4.44':
     resolution: {integrity: sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-retry@4.5.3':
-    resolution: {integrity: sha512-TE8dJNi6JuxzGSxMCVd3i9IEWDndCl3bmluLsBNDWok8olgj65OfkndMhl9SZ7m14c+C5SQn/PcUmrDl57rSFw==}
+  '@smithy/middleware-retry@4.5.5':
+    resolution: {integrity: sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-serde@4.2.15':
     resolution: {integrity: sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/middleware-serde@4.2.18':
-    resolution: {integrity: sha512-M6CSgnp3v4tYz9ynj2JHbA60woBZcGqEwNjTKjBsNHPV26R1ZX52+0wW8WsZU18q45jD0tw2wL22S17Ze9LpEw==}
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/middleware-stack@4.2.12':
@@ -5427,8 +5432,8 @@ packages:
     resolution: {integrity: sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/node-http-handler@4.5.3':
-    resolution: {integrity: sha512-lc5jFL++x17sPhIwMWJ3YOnqmSjw/2Po6VLDlUIXvxVWRuJwRXnJ4jOBBLB0cfI5BB5ehIl02Fxr1PDvk/kxDw==}
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/property-provider@4.2.12':
@@ -5467,8 +5472,8 @@ packages:
     resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/service-error-classification@4.2.14':
-    resolution: {integrity: sha512-vVimoUnGxlx4eLLQbZImdOZFOe+Zh+5ACntv8VxZuGP72LdWu5GV3oEmCahSEReBgRJoWjypFkrehSj7BWx1HQ==}
+  '@smithy/service-error-classification@4.3.0':
+    resolution: {integrity: sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/shared-ini-file-loader@4.4.7':
@@ -5487,8 +5492,8 @@ packages:
     resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/smithy-client@4.12.11':
-    resolution: {integrity: sha512-wzz/Wa1CH/Tlhxh0s4DQPEcXSxSVfJ59AZcUh9Gu0c6JTlKuwGf4o/3P2TExv0VbtPFt8odIBG+eQGK2+vTECg==}
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/smithy-client@4.12.7':
@@ -5539,24 +5544,24 @@ packages:
     resolution: {integrity: sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-browser@4.3.47':
-    resolution: {integrity: sha512-zlIuXai3/SHjQUQ8y3g/woLvrH573SK2wNjcDaHu5e9VOcC0JwM1MI0Sq0GZJyN3BwSUneIhpjZ18nsiz5AtQw==}
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-defaults-mode-node@4.2.47':
     resolution: {integrity: sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-defaults-mode-node@4.2.52':
-    resolution: {integrity: sha512-cQBz8g68Vnw1W2meXlkb3D/hXJU+Taiyj9P8qLJtjREEV9/Td65xi4A/H1sRQ8EIgX5qbZbvdYPKygKLholZ3w==}
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-endpoints@3.3.3':
     resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-endpoints@3.4.1':
-    resolution: {integrity: sha512-wMxNDZJrgS5mQV9oxCs4TWl5767VMgOfqfZ3JHyCkMtGC2ykW9iPqMvFur695Otcc5yxLG8OKO/80tsQBxrhXg==}
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-hex-encoding@4.2.2':
@@ -5575,16 +5580,16 @@ packages:
     resolution: {integrity: sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-retry@4.3.2':
-    resolution: {integrity: sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==}
+  '@smithy/util-retry@4.3.4':
+    resolution: {integrity: sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-stream@4.5.20':
     resolution: {integrity: sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-stream@4.5.23':
-    resolution: {integrity: sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==}
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-uri-escape@4.2.2':
@@ -6470,6 +6475,9 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
@@ -6646,8 +6654,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.15.1:
-    resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
+  axios@1.15.2:
+    resolution: {integrity: sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -6780,8 +6788,8 @@ packages:
   bare-url@2.4.0:
     resolution: {integrity: sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==}
 
-  bare-url@2.4.1:
-    resolution: {integrity: sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==}
+  bare-url@2.4.2:
+    resolution: {integrity: sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -7600,6 +7608,10 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  enhanced-resolve@5.21.0:
+    resolution: {integrity: sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==}
+    engines: {node: '>=10.13.0'}
+
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
@@ -7615,6 +7627,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
@@ -7923,8 +7939,8 @@ packages:
     resolution: {integrity: sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  express-rate-limit@8.3.2:
-    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+  express-rate-limit@8.4.1:
+    resolution: {integrity: sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==}
     engines: {node: '>= 16'}
     peerDependencies:
       express: '>= 4.11'
@@ -8451,8 +8467,8 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  hono@4.12.14:
-    resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
+  hono@4.12.15:
+    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@4.0.0:
@@ -9310,8 +9326,8 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
-  langsmith@0.5.20:
-    resolution: {integrity: sha512-ULhLM8RswvQDXufLtNtvclHrWCBx8Cb5UPI6lAZC+8Dq59iHsVPz/3Ac9khWNm1VIvChRsuykixD/WrmzuuA3Q==}
+  langsmith@0.5.25:
+    resolution: {integrity: sha512-AG7NOymrDmwaWq+wus5hJHZjPFKXwsEdfqGBU3eZiF5242mme+5wuJocdBJKGyU1kgBO7TuLHiqtdyIwl4V4yQ==}
     peerDependencies:
       '@opentelemetry/api': '*'
       '@opentelemetry/exporter-trace-otlp-proto': '*'
@@ -9372,8 +9388,8 @@ packages:
   libphonenumber-js@1.12.31:
     resolution: {integrity: sha512-Z3IhgVgrqO1S5xPYM3K5XwbkDasU67/Vys4heW+lfSBALcUZjeIIzI8zCLifY+OCzSq+fpDdywMDa7z+4srJPQ==}
 
-  libphonenumber-js@1.12.41:
-    resolution: {integrity: sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==}
+  libphonenumber-js@1.12.42:
+    resolution: {integrity: sha512-oKQFPTibqQwZZkChCDVMFVJXMZdyJNqDWZWYNn8BgyAaK/6yFJEowxCY0RVFirRyWP63hMRuKlkSEd9qlvbWXg==}
 
   lighthouse-logger@2.0.2:
     resolution: {integrity: sha512-vWl2+u5jgOQuZR55Z1WM0XDdrJT6mzMP8zHUct7xTlWhuQs+eV0g+QL0RQdFjT54zVmbhLCP8vIVpy1wGn/gCg==}
@@ -9477,6 +9493,10 @@ packages:
 
   loader-runner@4.3.1:
     resolution: {integrity: sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==}
+    engines: {node: '>=6.11.5'}
+
+  loader-runner@4.3.2:
+    resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
 
   locate-path@5.0.0:
@@ -9967,8 +9987,8 @@ packages:
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
-  nypm@0.6.5:
-    resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
+  nypm@0.6.6:
+    resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -10190,8 +10210,8 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
-  parse5@8.0.0:
-    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
@@ -11290,6 +11310,10 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
 
@@ -11332,8 +11356,8 @@ packages:
       uglify-js:
         optional: true
 
-  terser-webpack-plugin@5.4.0:
-    resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
+  terser-webpack-plugin@5.5.0:
+    resolution: {integrity: sha512-UYhptBwhWvfIjKd/UuFo6D8uq9xpGLDK+z8EDsj/zWhrTaH34cKEbrkMKfV5YWqGBvAYA3tlzZbs2R+qYrbQJA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -11358,8 +11382,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  terser@5.46.1:
-    resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
+  terser@5.46.2:
+    resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -11874,6 +11898,10 @@ packages:
 
   webpack-sources@3.3.4:
     resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
+    engines: {node: '>=10.13.0'}
+
+  webpack-sources@3.4.0:
+    resolution: {integrity: sha512-gHwIe1cgBvvfLeu1Yz/dcFpmHfKDVxxyqI+kzqmuxZED81z2ChxpyqPaWcNqigPywhaEke7AjSGga+kxY55gjQ==}
     engines: {node: '>=10.13.0'}
 
   webpack@5.104.1:
@@ -12877,41 +12905,41 @@ snapshots:
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.1
-      '@aws-sdk/credential-provider-node': 3.972.32(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/credential-provider-node': 3.972.36(aws-crt@1.30.0(bufferutil@4.1.0))
       '@aws-sdk/middleware-host-header': 3.972.10
       '@aws-sdk/middleware-logger': 3.972.10
       '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.31
-      '@aws-sdk/region-config-resolver': 3.972.12
+      '@aws-sdk/middleware-user-agent': 3.972.35
+      '@aws-sdk/region-config-resolver': 3.972.13
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.7
+      '@aws-sdk/util-endpoints': 3.996.8
       '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.17(aws-crt@1.30.0(bufferutil@4.1.0))
-      '@smithy/config-resolver': 4.4.16
-      '@smithy/core': 3.23.15
+      '@aws-sdk/util-user-agent-node': 3.973.21(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
       '@smithy/fetch-http-handler': 5.3.17
       '@smithy/hash-node': 4.2.14
       '@smithy/invalid-dependency': 4.2.14
       '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.30
-      '@smithy/middleware-retry': 4.5.3
-      '@smithy/middleware-serde': 4.2.18
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.5
+      '@smithy/middleware-serde': 4.2.20
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.5.3
+      '@smithy/node-http-handler': 4.6.1
       '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.47
-      '@smithy/util-defaults-mode-node': 4.2.52
-      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.2
+      '@smithy/util-retry': 4.3.4
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -13100,19 +13128,20 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@aws-sdk/core@3.974.1':
+  '@aws-sdk/core@3.974.5':
     dependencies:
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/xml-builder': 3.972.18
-      '@smithy/core': 3.23.15
+      '@aws-sdk/xml-builder': 3.972.19
+      '@smithy/core': 3.23.17
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/signature-v4': 5.3.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.4
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     optional: true
@@ -13130,9 +13159,9 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-env@3.972.27':
+  '@aws-sdk/credential-provider-env@3.972.31':
     dependencies:
-      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/core': 3.974.5
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/types': 4.14.1
@@ -13152,17 +13181,17 @@ snapshots:
       '@smithy/util-stream': 4.5.20
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-http@3.972.29':
+  '@aws-sdk/credential-provider-http@3.972.33':
     dependencies:
-      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/core': 3.974.5
       '@aws-sdk/types': 3.973.8
       '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.5.3
+      '@smithy/node-http-handler': 4.6.1
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
-      '@smithy/util-stream': 4.5.23
+      '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
     optional: true
 
@@ -13185,16 +13214,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))':
+  '@aws-sdk/credential-provider-ini@3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))':
     dependencies:
-      '@aws-sdk/core': 3.974.1
-      '@aws-sdk/credential-provider-env': 3.972.27
-      '@aws-sdk/credential-provider-http': 3.972.29
-      '@aws-sdk/credential-provider-login': 3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))
-      '@aws-sdk/credential-provider-process': 3.972.27
-      '@aws-sdk/credential-provider-sso': 3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))
-      '@aws-sdk/credential-provider-web-identity': 3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))
-      '@aws-sdk/nested-clients': 3.996.21(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/credential-provider-env': 3.972.31
+      '@aws-sdk/credential-provider-http': 3.972.33
+      '@aws-sdk/credential-provider-login': 3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/credential-provider-process': 3.972.31
+      '@aws-sdk/credential-provider-sso': 3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/credential-provider-web-identity': 3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/nested-clients': 3.997.3(aws-crt@1.30.0(bufferutil@4.1.0))
       '@aws-sdk/types': 3.973.8
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/property-provider': 4.2.14
@@ -13218,10 +13247,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-login@3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))':
+  '@aws-sdk/credential-provider-login@3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))':
     dependencies:
-      '@aws-sdk/core': 3.974.1
-      '@aws-sdk/nested-clients': 3.996.21(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/nested-clients': 3.997.3(aws-crt@1.30.0(bufferutil@4.1.0))
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/protocol-http': 5.3.14
@@ -13249,14 +13278,14 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.972.32(aws-crt@1.30.0(bufferutil@4.1.0))':
+  '@aws-sdk/credential-provider-node@3.972.36(aws-crt@1.30.0(bufferutil@4.1.0))':
     dependencies:
-      '@aws-sdk/credential-provider-env': 3.972.27
-      '@aws-sdk/credential-provider-http': 3.972.29
-      '@aws-sdk/credential-provider-ini': 3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))
-      '@aws-sdk/credential-provider-process': 3.972.27
-      '@aws-sdk/credential-provider-sso': 3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))
-      '@aws-sdk/credential-provider-web-identity': 3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/credential-provider-env': 3.972.31
+      '@aws-sdk/credential-provider-http': 3.972.33
+      '@aws-sdk/credential-provider-ini': 3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/credential-provider-process': 3.972.31
+      '@aws-sdk/credential-provider-sso': 3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/credential-provider-web-identity': 3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))
       '@aws-sdk/types': 3.973.8
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/property-provider': 4.2.14
@@ -13276,9 +13305,9 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/credential-provider-process@3.972.27':
+  '@aws-sdk/credential-provider-process@3.972.31':
     dependencies:
-      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/core': 3.974.5
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -13299,11 +13328,11 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-sso@3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))':
+  '@aws-sdk/credential-provider-sso@3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))':
     dependencies:
-      '@aws-sdk/core': 3.974.1
-      '@aws-sdk/nested-clients': 3.996.21(aws-crt@1.30.0(bufferutil@4.1.0))
-      '@aws-sdk/token-providers': 3.1032.0(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/nested-clients': 3.997.3(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/token-providers': 3.1036.0(aws-crt@1.30.0(bufferutil@4.1.0))
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -13325,10 +13354,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/credential-provider-web-identity@3.972.31(aws-crt@1.30.0(bufferutil@4.1.0))':
+  '@aws-sdk/credential-provider-web-identity@3.972.35(aws-crt@1.30.0(bufferutil@4.1.0))':
     dependencies:
-      '@aws-sdk/core': 3.974.1
-      '@aws-sdk/nested-clients': 3.996.21(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/nested-clients': 3.997.3(aws-crt@1.30.0(bufferutil@4.1.0))
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -13463,6 +13492,24 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-s3@3.972.34':
+    dependencies:
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@aws-sdk/middleware-sdk-sqs@3.972.8':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -13489,15 +13536,15 @@ snapshots:
       '@smithy/util-retry': 4.2.12
       tslib: 2.8.1
 
-  '@aws-sdk/middleware-user-agent@3.972.31':
+  '@aws-sdk/middleware-user-agent@3.972.35':
     dependencies:
-      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/core': 3.974.5
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.7
-      '@smithy/core': 3.23.15
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
-      '@smithy/util-retry': 4.3.2
+      '@smithy/util-retry': 4.3.4
       tslib: 2.8.1
     optional: true
 
@@ -13544,44 +13591,45 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/nested-clients@3.996.21(aws-crt@1.30.0(bufferutil@4.1.0))':
+  '@aws-sdk/nested-clients@3.997.3(aws-crt@1.30.0(bufferutil@4.1.0))':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/core': 3.974.5
       '@aws-sdk/middleware-host-header': 3.972.10
       '@aws-sdk/middleware-logger': 3.972.10
       '@aws-sdk/middleware-recursion-detection': 3.972.11
-      '@aws-sdk/middleware-user-agent': 3.972.31
-      '@aws-sdk/region-config-resolver': 3.972.12
+      '@aws-sdk/middleware-user-agent': 3.972.35
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.22
       '@aws-sdk/types': 3.973.8
-      '@aws-sdk/util-endpoints': 3.996.7
+      '@aws-sdk/util-endpoints': 3.996.8
       '@aws-sdk/util-user-agent-browser': 3.972.10
-      '@aws-sdk/util-user-agent-node': 3.973.17(aws-crt@1.30.0(bufferutil@4.1.0))
-      '@smithy/config-resolver': 4.4.16
-      '@smithy/core': 3.23.15
+      '@aws-sdk/util-user-agent-node': 3.973.21(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
       '@smithy/fetch-http-handler': 5.3.17
       '@smithy/hash-node': 4.2.14
       '@smithy/invalid-dependency': 4.2.14
       '@smithy/middleware-content-length': 4.2.14
-      '@smithy/middleware-endpoint': 4.4.30
-      '@smithy/middleware-retry': 4.5.3
-      '@smithy/middleware-serde': 4.2.18
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.5
+      '@smithy/middleware-serde': 4.2.20
       '@smithy/middleware-stack': 4.2.14
       '@smithy/node-config-provider': 4.3.14
-      '@smithy/node-http-handler': 4.5.3
+      '@smithy/node-http-handler': 4.6.1
       '@smithy/protocol-http': 5.3.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.47
-      '@smithy/util-defaults-mode-node': 4.2.52
-      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.2
+      '@smithy/util-retry': 4.3.4
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -13596,10 +13644,10 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@aws-sdk/region-config-resolver@3.972.12':
+  '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
       '@aws-sdk/types': 3.973.8
-      '@smithy/config-resolver': 4.4.16
+      '@smithy/config-resolver': 4.4.17
       '@smithy/node-config-provider': 4.3.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
@@ -13634,6 +13682,16 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
+  '@aws-sdk/signature-v4-multi-region@3.996.22':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.34
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    optional: true
+
   '@aws-sdk/token-providers@3.1019.0(aws-crt@1.30.0(bufferutil@4.1.0))':
     dependencies:
       '@aws-sdk/core': 3.973.25
@@ -13646,10 +13704,10 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/token-providers@3.1032.0(aws-crt@1.30.0(bufferutil@4.1.0))':
+  '@aws-sdk/token-providers@3.1036.0(aws-crt@1.30.0(bufferutil@4.1.0))':
     dependencies:
-      '@aws-sdk/core': 3.974.1
-      '@aws-sdk/nested-clients': 3.996.21(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/core': 3.974.5
+      '@aws-sdk/nested-clients': 3.997.3(aws-crt@1.30.0(bufferutil@4.1.0))
       '@aws-sdk/types': 3.973.8
       '@smithy/property-provider': 4.2.14
       '@smithy/shared-ini-file-loader': 4.4.9
@@ -13690,12 +13748,12 @@ snapshots:
       '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
 
-  '@aws-sdk/util-endpoints@3.996.7':
+  '@aws-sdk/util-endpoints@3.996.8':
     dependencies:
       '@aws-sdk/types': 3.973.8
       '@smithy/types': 4.14.1
       '@smithy/url-parser': 4.2.14
-      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-endpoints': 3.4.2
       tslib: 2.8.1
     optional: true
 
@@ -13736,9 +13794,9 @@ snapshots:
     optionalDependencies:
       aws-crt: 1.30.0(bufferutil@4.1.0)
 
-  '@aws-sdk/util-user-agent-node@3.973.17(aws-crt@1.30.0(bufferutil@4.1.0))':
+  '@aws-sdk/util-user-agent-node@3.973.21(aws-crt@1.30.0(bufferutil@4.1.0))':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.31
+      '@aws-sdk/middleware-user-agent': 3.972.35
       '@aws-sdk/types': 3.973.8
       '@smithy/node-config-provider': 4.3.14
       '@smithy/types': 4.14.1
@@ -13759,7 +13817,7 @@ snapshots:
       fast-xml-parser: 5.5.9
       tslib: 2.8.1
 
-  '@aws-sdk/xml-builder@3.972.18':
+  '@aws-sdk/xml-builder@3.972.19':
     dependencies:
       '@smithy/types': 4.14.1
       fast-xml-parser: 5.5.11
@@ -14608,14 +14666,14 @@ snapshots:
 
   '@hexagon/base64@1.1.28': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.14)':
+  '@hono/node-server@1.19.11(hono@4.12.15)':
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.15
     optional: true
 
-  '@hono/node-server@1.19.14(hono@4.12.14)':
+  '@hono/node-server@1.19.14(hono@4.12.15)':
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.15
 
   '@httptoolkit/websocket-stream@6.0.1(bufferutil@4.1.0)':
     dependencies:
@@ -15049,41 +15107,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 25.5.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.3.0
@@ -15100,41 +15123,6 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
       jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 25.5.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -15491,7 +15479,7 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/community@1.1.25(453be0cca20f224e3fbb4aa70730f2f7)':
+  '@langchain/community@1.1.25(6652600d9ead4b757955ce52e1590d23)':
     dependencies:
       '@browserbasehq/stagehand': 3.2.0(@cfworker/json-schema@4.1.1)(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(deepmerge@4.3.1)(encoding@0.1.13)(zod@4.3.6)
       '@ibm-cloud/watsonx-ai': 1.7.10(typescript@5.9.3)
@@ -15510,7 +15498,7 @@ snapshots:
     optionalDependencies:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-sdk/client-s3': 3.1019.0(aws-crt@1.30.0(bufferutil@4.1.0))
-      '@aws-sdk/credential-provider-node': 3.972.32(aws-crt@1.30.0(bufferutil@4.1.0))
+      '@aws-sdk/credential-provider-node': 3.972.36(aws-crt@1.30.0(bufferutil@4.1.0))
       '@browserbasehq/sdk': 2.10.0(encoding@0.1.13)
       '@smithy/eventstream-codec': 4.2.14
       '@smithy/protocol-http': 5.3.14
@@ -15549,7 +15537,7 @@ snapshots:
       camelcase: 6.3.0
       decamelize: 1.2.0
       js-tiktoken: 1.0.21
-      langsmith: 0.5.20(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.20.0(bufferutil@4.1.0))
+      langsmith: 0.5.25(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.20.0(bufferutil@4.1.0))
       mustache: 4.2.0
       p-queue: 6.6.2
       p-retry: 4.6.2
@@ -15772,17 +15760,17 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.14)
-      ajv: 8.18.0
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      '@hono/node-server': 1.19.14(hono@4.12.15)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.0.8
       express: 5.2.1
-      express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.14
+      express-rate-limit: 8.4.1(express@5.2.1)
+      hono: 4.12.15
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -16980,9 +16968,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.22': {}
-
-  '@opuspopuli/regions@1.0.27': {}
+  '@opuspopuli/regions@1.0.28': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -17145,13 +17131,13 @@ snapshots:
       '@electric-sql/pglite': 0.4.1
       '@electric-sql/pglite-socket': 0.1.1(@electric-sql/pglite@0.4.1)
       '@electric-sql/pglite-tools': 0.3.1(@electric-sql/pglite@0.4.1)
-      '@hono/node-server': 1.19.11(hono@4.12.14)
+      '@hono/node-server': 1.19.11(hono@4.12.15)
       '@prisma/get-platform': 7.2.0
       '@prisma/query-plan-executor': 7.2.0
       '@prisma/streams-local': 0.1.2
       foreground-child: 3.3.1
       get-port-please: 3.2.0
-      hono: 4.12.14
+      hono: 4.12.15
       http-status-codes: 2.3.0
       pathe: 2.0.3
       proper-lockfile: 4.1.2
@@ -17215,7 +17201,7 @@ snapshots:
 
   '@prisma/streams-local@0.1.2':
     dependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
       better-result: 2.8.2
       env-paths: 3.0.0
       proper-lockfile: 4.1.2
@@ -17472,12 +17458,12 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
-  '@smithy/config-resolver@4.4.16':
+  '@smithy/config-resolver@4.4.17':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-endpoints': 3.4.2
       '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
     optional: true
@@ -17495,7 +17481,7 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/core@3.23.15':
+  '@smithy/core@3.23.17':
     dependencies:
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
@@ -17503,7 +17489,7 @@ snapshots:
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-stream': 4.5.23
+      '@smithy/util-stream': 4.5.25
       '@smithy/util-utf8': 4.2.2
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
@@ -17658,10 +17644,10 @@ snapshots:
       '@smithy/util-middleware': 4.2.12
       tslib: 2.8.1
 
-  '@smithy/middleware-endpoint@4.4.30':
+  '@smithy/middleware-endpoint@4.4.32':
     dependencies:
-      '@smithy/core': 3.23.15
-      '@smithy/middleware-serde': 4.2.18
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
       '@smithy/node-config-provider': 4.3.14
       '@smithy/shared-ini-file-loader': 4.4.9
       '@smithy/types': 4.14.1
@@ -17682,16 +17668,16 @@ snapshots:
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
-  '@smithy/middleware-retry@4.5.3':
+  '@smithy/middleware-retry@4.5.5':
     dependencies:
-      '@smithy/core': 3.23.15
+      '@smithy/core': 3.23.17
       '@smithy/node-config-provider': 4.3.14
       '@smithy/protocol-http': 5.3.14
-      '@smithy/service-error-classification': 4.2.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/service-error-classification': 4.3.0
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       '@smithy/util-middleware': 4.2.14
-      '@smithy/util-retry': 4.3.2
+      '@smithy/util-retry': 4.3.4
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
     optional: true
@@ -17703,9 +17689,9 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/middleware-serde@4.2.18':
+  '@smithy/middleware-serde@4.2.20':
     dependencies:
-      '@smithy/core': 3.23.15
+      '@smithy/core': 3.23.17
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
       tslib: 2.8.1
@@ -17745,7 +17731,7 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/node-http-handler@4.5.3':
+  '@smithy/node-http-handler@4.6.1':
     dependencies:
       '@smithy/protocol-http': 5.3.14
       '@smithy/querystring-builder': 4.2.14
@@ -17803,7 +17789,7 @@ snapshots:
     dependencies:
       '@smithy/types': 4.13.1
 
-  '@smithy/service-error-classification@4.2.14':
+  '@smithy/service-error-classification@4.3.0':
     dependencies:
       '@smithy/types': 4.14.1
     optional: true
@@ -17842,14 +17828,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@smithy/smithy-client@4.12.11':
+  '@smithy/smithy-client@4.12.13':
     dependencies:
-      '@smithy/core': 3.23.15
-      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
       '@smithy/middleware-stack': 4.2.14
       '@smithy/protocol-http': 5.3.14
       '@smithy/types': 4.14.1
-      '@smithy/util-stream': 4.5.23
+      '@smithy/util-stream': 4.5.25
       tslib: 2.8.1
     optional: true
 
@@ -17920,10 +17906,10 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-browser@4.3.47':
+  '@smithy/util-defaults-mode-browser@4.3.49':
     dependencies:
       '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     optional: true
@@ -17938,13 +17924,13 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-defaults-mode-node@4.2.52':
+  '@smithy/util-defaults-mode-node@4.2.54':
     dependencies:
-      '@smithy/config-resolver': 4.4.16
+      '@smithy/config-resolver': 4.4.17
       '@smithy/credential-provider-imds': 4.2.14
       '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.14
-      '@smithy/smithy-client': 4.12.11
+      '@smithy/smithy-client': 4.12.13
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     optional: true
@@ -17955,7 +17941,7 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-endpoints@3.4.1':
+  '@smithy/util-endpoints@3.4.2':
     dependencies:
       '@smithy/node-config-provider': 4.3.14
       '@smithy/types': 4.14.1
@@ -17983,9 +17969,9 @@ snapshots:
       '@smithy/types': 4.13.1
       tslib: 2.8.1
 
-  '@smithy/util-retry@4.3.2':
+  '@smithy/util-retry@4.3.4':
     dependencies:
-      '@smithy/service-error-classification': 4.2.14
+      '@smithy/service-error-classification': 4.3.0
       '@smithy/types': 4.14.1
       tslib: 2.8.1
     optional: true
@@ -18001,10 +17987,10 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
-  '@smithy/util-stream@4.5.23':
+  '@smithy/util-stream@4.5.25':
     dependencies:
       '@smithy/fetch-http-handler': 5.3.17
-      '@smithy/node-http-handler': 4.5.3
+      '@smithy/node-http-handler': 4.6.1
       '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       '@smithy/util-buffer-from': 4.2.2
@@ -18957,9 +18943,9 @@ snapshots:
     optionalDependencies:
       ajv: 8.17.1
 
-  ajv-formats@3.0.1(ajv@8.18.0):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-keywords@3.5.2(ajv@6.14.0):
     dependencies:
@@ -18985,6 +18971,13 @@ snapshots:
       require-from-string: 2.0.2
 
   ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0
@@ -19155,7 +19148,7 @@ snapshots:
     dependencies:
       '@aws-sdk/util-utf8-browser': 3.259.0
       '@httptoolkit/websocket-stream': 6.0.1(bufferutil@4.1.0)
-      axios: 1.15.1(debug@4.4.3)
+      axios: 1.15.2(debug@4.4.3)
       buffer: 6.0.3
       crypto-js: 4.2.0
       mqtt: 4.3.8(bufferutil@4.1.0)
@@ -19180,7 +19173,7 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.15.1(debug@4.4.3):
+  axios@1.15.2(debug@4.4.3):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
@@ -19304,7 +19297,7 @@ snapshots:
       bare-events: 2.8.2
       bare-path: 3.0.0
       bare-stream: 2.13.0(bare-events@2.8.2)
-      bare-url: 2.4.1
+      bare-url: 2.4.2
       fast-fifo: 1.3.2
     transitivePeerDependencies:
       - bare-abort-controller
@@ -19340,7 +19333,7 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
-  bare-url@2.4.1:
+  bare-url@2.4.2:
     dependencies:
       bare-path: 3.0.0
     optional: true
@@ -19672,7 +19665,7 @@ snapshots:
   class-validator@0.15.1:
     dependencies:
       '@types/validator': 13.15.10
-      libphonenumber-js: 1.12.41
+      libphonenumber-js: 1.12.42
       validator: 13.15.35
     optional: true
 
@@ -20215,6 +20208,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
+  enhanced-resolve@5.21.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   enquirer@2.4.1:
     dependencies:
       ansi-colors: 4.1.3
@@ -20225,6 +20223,9 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0:
+    optional: true
 
   env-paths@3.0.0:
     optional: true
@@ -20740,7 +20741,7 @@ snapshots:
       jest-mock: 30.3.0
       jest-util: 30.3.0
 
-  express-rate-limit@8.3.2(express@5.2.1):
+  express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
       ip-address: 10.1.0
@@ -21140,7 +21141,7 @@ snapshots:
       consola: 3.4.2
       defu: 6.1.7
       node-fetch-native: 1.6.7
-      nypm: 0.6.5
+      nypm: 0.6.6
       pathe: 2.0.3
     optional: true
 
@@ -21349,7 +21350,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  hono@4.12.14: {}
+  hono@4.12.15: {}
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -21453,7 +21454,7 @@ snapshots:
       '@types/debug': 4.1.13
       '@types/node': 18.19.130
       '@types/tough-cookie': 4.0.5
-      axios: 1.15.1(debug@4.4.3)
+      axios: 1.15.2(debug@4.4.3)
       camelcase: 6.3.0
       debug: 4.4.3
       dotenv: 16.6.1
@@ -21464,7 +21465,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.15.1(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.15.2(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -21893,15 +21894,34 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@22.19.15):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.15)
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.3.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -21921,25 +21941,6 @@ snapshots:
       exit-x: 0.2.2
       import-local: 3.2.0
       jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest-cli@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -21981,7 +21982,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@22.19.15):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -22008,39 +22009,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.15
-      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.5.0
-      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -22073,70 +22041,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.5.0
-      ts-node: 10.9.2(@types/node@25.6.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.6.0
-      ts-node: 10.9.2(@types/node@25.6.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -22329,10 +22233,10 @@ snapshots:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
-  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3):
+  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3):
     dependencies:
       '@jest/globals': 30.3.0
-      jest: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+      jest: 30.3.0
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -22661,12 +22565,38 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest@30.3.0:
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@25.5.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@22.19.15):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22680,19 +22610,6 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22778,7 +22695,7 @@ snapshots:
       html-encoding-sniffer: 6.0.0(@noble/hashes@2.0.1)
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.3.5
-      parse5: 8.0.0
+      parse5: 8.0.1
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
@@ -22887,10 +22804,9 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  langsmith@0.5.20(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.20.0(bufferutil@4.1.0)):
+  langsmith@0.5.25(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.6.1(@opentelemetry/api@1.9.1))(openai@4.104.0(encoding@0.1.13)(ws@8.20.0(bufferutil@4.1.0))(zod@4.3.6))(ws@8.20.0(bufferutil@4.1.0)):
     dependencies:
       p-queue: 6.6.2
-      uuid: 10.0.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/exporter-trace-otlp-proto': 0.214.0(@opentelemetry/api@1.9.1)
@@ -22946,7 +22862,7 @@ snapshots:
 
   libphonenumber-js@1.12.31: {}
 
-  libphonenumber-js@1.12.41:
+  libphonenumber-js@1.12.42:
     optional: true
 
   lighthouse-logger@2.0.2:
@@ -23039,6 +22955,8 @@ snapshots:
   load-esm@1.0.3: {}
 
   loader-runner@4.3.1: {}
+
+  loader-runner@4.3.2: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -23528,7 +23446,7 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
-  nypm@0.6.5:
+  nypm@0.6.6:
     dependencies:
       citty: 0.2.2
       pathe: 2.0.3
@@ -23808,9 +23726,9 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
-  parse5@8.0.0:
+  parse5@8.0.1:
     dependencies:
-      entities: 6.0.1
+      entities: 8.0.0
     optional: true
 
   parseley@0.12.1:
@@ -24462,9 +24380,9 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.15.1(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.15.2(debug@4.4.3)):
     dependencies:
-      axios: 1.15.1(debug@4.4.3)
+      axios: 1.15.2(debug@4.4.3)
 
   retry@0.12.0: {}
 
@@ -25101,6 +25019,8 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  tapable@2.3.3: {}
+
   tar-fs@2.1.4:
     dependencies:
       chownr: 1.1.4
@@ -25179,12 +25099,12 @@ snapshots:
       terser: 5.46.0
       webpack: 5.104.1
 
-  terser-webpack-plugin@5.4.0(webpack@5.105.4):
+  terser-webpack-plugin@5.5.0(webpack@5.105.4):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.46.1
+      terser: 5.46.2
       webpack: 5.105.4
 
   terser@5.16.9:
@@ -25201,7 +25121,7 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  terser@5.46.1:
+  terser@5.46.2:
     dependencies:
       '@jridgewell/source-map': 0.3.11
       acorn: 8.16.0
@@ -25348,12 +25268,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@22.19.15)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -25388,12 +25308,32 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@25.5.0)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.3
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      jest-util: 30.3.0
+
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 30.3.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -25472,25 +25412,6 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@25.6.0)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.6.0
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-tqdm@0.8.6: {}
 
@@ -25827,6 +25748,8 @@ snapshots:
 
   webpack-sources@3.3.4: {}
 
+  webpack-sources@3.4.0: {}
+
   webpack@5.104.1:
     dependencies:
       '@types/eslint-scope': 3.7.7
@@ -25871,21 +25794,21 @@ snapshots:
       acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.1
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.20.1
+      enhanced-resolve: 5.21.0
       es-module-lexer: 2.0.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
+      loader-runner: 4.3.2
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.2
-      terser-webpack-plugin: 5.4.0(webpack@5.105.4)
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.5.0(webpack@5.105.4)
       watchpack: 2.5.1
-      webpack-sources: 3.3.4
+      webpack-sources: 3.4.0
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild


### PR DESCRIPTION
## Summary

Wires CalAccess campaign-finance records to specific propositions so the proposition detail page can show real funding flowing for and against each measure. Replaces the Layer 3 *Who's Funding This* placeholder with a live two-sided breakdown — total raised, donor count, top donors, primary committees — sourced from the existing CalAccess sync plus a new CVR2 source.

Also bundles 3 separable changes called out in their own commits:
- `chore(infra)`: bumps the region container memory ceiling to 6 GB as a workaround for the federal plugin OOM (#630)
- `fix(scraping-pipeline)`: strips NUL bytes from TSV cell values — long-latent CalAccess bug surfaced during validation
- The original `fix:` commit picks up the Sonar smells from the prior #627 follow-up

## What changed

**Schema** — additive migration `20260425010000_add_proposition_funding_links`
- `CommitteeMeasurePositionType` enum + `committee_measure_positions` join table (committee↔proposition many-to-many with `is_primary_formation` flag)
- `cvr2_filings` raw-record table for FPPC Form 410 declarations
- `proposition_id` FKs on `expenditures` + `independent_expenditures`

**Backend**
- `PropositionFinanceLinkerService` — runs after every campaign-finance sync. Two paths:
  - **CVR2 (authoritative)**: resolves `FILING_ID → committeeId` via existing `Contribution`/`Expenditure.externalId` and `BAL_NAME → propositionId` via fuzzy title match. Sets `isPrimaryFormation = true`.
  - **Inferred**: existing `Expenditure`/`IndependentExpenditure.propositionTitle` fuzzy-matched against `Proposition.title` → sets the FK + upserts position with `isPrimaryFormation = false`.
- `PropositionFundingService` — aggregation. Per-side totals, top 5 donors by name, top 3 primary committees by total raised. Cached in `REGION_CACHE`.
- New `propositionFunding(propositionId: ID!)` public GraphQL query.
- One-off `run-finance-linker.ts` bootstrap script (mirrors `backfill-proposition-analysis.ts`).

**Ingestion**
- Common types: `CampaignFinanceResult.committeeMeasureFilings` + `CommitteeMeasureFiling` interface.
- `declarative-region-plugin.ts` + `region.service.ts` discriminate CVR2 records before the generic committee check.
- `@opuspopuli/regions` bumped to `^1.0.28` consumer + region-provider — brings in the published [CVR2 source](https://github.com/OpusPopuli/opuspopuli-regions/pull/7) for California.

**Frontend**
- New `PropositionFundingSection` on Layer 3 *Both Sides* (Yes/No two-column, neutral palette, totals + top donors + primary committees).
- Layer 1 *Quick View* gains a *What this would do* compact bullet list (top 3 key provisions) and an honest empty state when AI analysis hasn't run yet.
- List-page card now prefers `analysisSummary`, only falls back to `summary` when it differs from `title` — fixes the title-duplication on the SOS-scraped data.

## Validation

| | Done | Status |
|---|---|---|
| Unit tests | ~36 new tests across linker, funding, wiring, frontend | ✅ 1430+ backend, 1170+ frontend |
| Linker against real-shaped synthetic data on UAT | Inserted one expenditure with `propositionTitle = "ACA 13"`, ran linker | ✅ FK resolved, new `is_primary_formation = false` row, idempotent re-run |
| Browser pass | Walked Layer 1→2→3→4 on SCA 1 detail + list page | ✅ |
| Migration | `prisma migrate deploy` clean against UAT DB | ✅ |
| **CVR2 ingestion against real CalAccess data** | Sync got partway then hit federal OOM (#630), recovered with 6 GB ceiling. **Not exercised end-to-end.** | ⚠️ blocked on #630 |
| **Real-data inferred linkage** | Ran linker against existing CalAccess data — 0 expenditures linked because of upstream data-quality issues | ⚠️ blocked on #632, #633 |

## Follow-ups filed during validation

- #630 federal plugin OOMs — `api` sources accumulate in memory instead of streaming via `onBatch`
- #631 FEC `api` sources silently truncate at `MAX_PAGES=10`
- #632 `Proposition.title` polluted with full SOS anchor-link text
- #633 CalAccess `BAL_NAME` ingestion overloaded with non-measure values
- #634 `ensureCommitteeStubs` hardcodes `sourceSystem='fec'`

The 6 GB memory bump in `docker-compose-uat.yml` is explicitly a stop-gap pinned to #630 and should revert once that fix lands.

## Out of scope (explicit)

- Layer 4 *Campaign Finance Details* — still placeholder
- Layer 3 *Best Arguments From Each Side* + *Economic & Policy Analysis* — still placeholders
- Committee detail page — funding-card links currently 404, deliberately deferred
- Fractional attribution for multi-measure committees — current implementation overcounts; transparent (committee count surfaced so readers can see concentration)
- FIPS / composite-key proposition model
- Old-cycle propositions — linker uses a 2-year election window by default

## Test plan for reviewers

- [ ] `pnpm install` brings in `@opuspopuli/regions@^1.0.28` (CVR2 source visible in `regions/california.json` — 9 sources total)
- [ ] `pnpm --filter @opuspopuli/relationaldb-provider db:migrate` applies the new migration cleanly (purely additive, safe to run on a UAT-class DB)
- [ ] `pnpm --filter backend test` and `pnpm --filter frontend test` both pass
- [ ] (optional) Trigger `syncRegionData(dataTypes: [CAMPAIGN_FINANCE])` mutation and watch for the `Finance linker pass complete:` log line — note this currently needs the 6 GB ceiling and will be blocked at scale until #630 lands
- [ ] (optional) Hand-seed a `Committee` + `CommitteeMeasurePosition` for one of the existing propositions and visit `/region/propositions/<id>` → Layer 3 should render the funding section against the seeded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)