### PR TITLE
feat: legislative committees with AI-generated descriptions

### DIFF
--- a/apps/backend/src/apps/region/src/domains/legislative-committee-description-generator.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-committee-description-generator.service.spec.ts
@@ -1,0 +1,265 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { createMock } from '@golevelup/ts-jest';
+import { PromptClientService } from '@opuspopuli/prompt-client';
+import type { ILLMProvider } from '@opuspopuli/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+import { LegislativeCommitteeDescriptionGeneratorService } from './legislative-committee-description-generator.service';
+
+describe('LegislativeCommitteeDescriptionGeneratorService', () => {
+  async function buildService(
+    opts: {
+      withDeps?: boolean;
+      withDb?: boolean;
+      configValues?: Record<string, string | undefined>;
+      dbRows?: Array<{ id: string; name: string; chamber: string }>;
+    } = {},
+  ) {
+    const {
+      withDeps = true,
+      withDb = true,
+      configValues = {},
+      dbRows = [],
+    } = opts;
+
+    const mockPromptClient = createMock<PromptClientService>();
+    mockPromptClient.getDocumentAnalysisPrompt.mockResolvedValue({
+      promptText: 'built prompt',
+      promptHash: 'hash',
+      promptVersion: '1.0.0',
+    });
+
+    const mockLlm = {
+      generate: jest.fn(),
+    } as unknown as jest.Mocked<ILLMProvider>;
+
+    const mockConfig = {
+      get: jest.fn((key: string) => configValues[key]),
+    } as unknown as ConfigService;
+
+    const mockDb = {
+      legislativeCommittee: {
+        findMany: jest.fn().mockResolvedValue(dbRows),
+        update: jest.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as DbService;
+
+    const providers: unknown[] = [
+      LegislativeCommitteeDescriptionGeneratorService,
+    ];
+    if (withDeps) {
+      providers.push(
+        { provide: ConfigService, useValue: mockConfig },
+        { provide: PromptClientService, useValue: mockPromptClient },
+        { provide: 'LLM_PROVIDER', useValue: mockLlm },
+      );
+    }
+    if (withDb) {
+      providers.push({ provide: DbService, useValue: mockDb });
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: providers as Parameters<
+        typeof Test.createTestingModule
+      >[0]['providers'],
+    }).compile();
+
+    return {
+      service: module.get(LegislativeCommitteeDescriptionGeneratorService),
+      promptClient: mockPromptClient,
+      llm: mockLlm,
+      db: mockDb as DbService & {
+        legislativeCommittee: { findMany: jest.Mock; update: jest.Mock };
+      },
+    };
+  }
+
+  describe('when dependencies are unavailable', () => {
+    it('returns silently with no db, prompt client, or llm', async () => {
+      const built = await buildService({ withDeps: false, withDb: false });
+      await expect(
+        built.service.generateMissingDescriptions(),
+      ).resolves.toBeUndefined();
+    });
+
+    it('returns silently when db is wired but prompt client + llm are not', async () => {
+      const built = await buildService({ withDeps: false });
+      await built.service.generateMissingDescriptions();
+      expect(built.db.legislativeCommittee.findMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('candidate selection', () => {
+    it('queries only committees missing a description and not soft-deleted', async () => {
+      const built = await buildService();
+      await built.service.generateMissingDescriptions();
+      const findManyArgs =
+        built.db.legislativeCommittee.findMany.mock.calls[0][0];
+      expect(findManyArgs.where).toMatchObject({
+        deletedAt: null,
+        description: null,
+      });
+    });
+
+    it('returns early when no candidates exist', async () => {
+      const built = await buildService({ dbRows: [] });
+      await built.service.generateMissingDescriptions();
+      expect(built.llm.generate).not.toHaveBeenCalled();
+      expect(built.db.legislativeCommittee.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cap handling', () => {
+    const three = [
+      { id: 'a', name: 'Budget', chamber: 'Assembly' },
+      { id: 'b', name: 'Health', chamber: 'Assembly' },
+      { id: 'c', name: 'Education', chamber: 'Assembly' },
+    ];
+
+    it('passes the env-default cap into the DB query as `take`', async () => {
+      const built = await buildService({
+        configValues: {
+          LEGISLATIVE_COMMITTEE_DESCRIPTION_MAX_COMMITTEES: '2',
+        },
+        dbRows: three.slice(0, 2),
+      });
+      built.llm.generate.mockResolvedValue({
+        text: '{"description":"ok"}',
+      } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      await built.service.generateMissingDescriptions();
+
+      expect(built.db.legislativeCommittee.findMany.mock.calls[0][0].take).toBe(
+        2,
+      );
+      expect(built.llm.generate).toHaveBeenCalledTimes(2);
+    });
+
+    it('mutation-arg override beats env default', async () => {
+      const built = await buildService({
+        configValues: {
+          LEGISLATIVE_COMMITTEE_DESCRIPTION_MAX_COMMITTEES: '5',
+        },
+        dbRows: three.slice(0, 1),
+      });
+      built.llm.generate.mockResolvedValue({
+        text: '{"description":"ok"}',
+      } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      await built.service.generateMissingDescriptions(1);
+
+      expect(built.db.legislativeCommittee.findMany.mock.calls[0][0].take).toBe(
+        1,
+      );
+    });
+
+    it('omits `take` when no cap is configured', async () => {
+      const built = await buildService({ dbRows: three });
+      built.llm.generate.mockResolvedValue({
+        text: '{"description":"ok"}',
+      } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      await built.service.generateMissingDescriptions();
+
+      expect(
+        'take' in built.db.legislativeCommittee.findMany.mock.calls[0][0],
+      ).toBe(false);
+    });
+  });
+
+  describe('prompt formatting', () => {
+    it('formats committee identity as Chamber + Committee Name and routes to the right prompt', async () => {
+      const built = await buildService({
+        dbRows: [{ id: 'c1', name: 'Health', chamber: 'Assembly' }],
+      });
+      built.llm.generate.mockResolvedValue({
+        text: '{"description":"Considers public-health bills."}',
+      } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      await built.service.generateMissingDescriptions();
+
+      const promptArg =
+        built.promptClient.getDocumentAnalysisPrompt.mock.calls[0][0];
+      expect(promptArg.documentType).toBe('legislative-committee-description');
+      expect(promptArg.text).toContain('Chamber: Assembly');
+      expect(promptArg.text).toContain('Committee Name: Health');
+    });
+  });
+
+  describe('response parsing', () => {
+    const base = { id: 'c1', name: 'Budget', chamber: 'Assembly' };
+
+    it('tier-1: persists description from a clean JSON response', async () => {
+      const built = await buildService({ dbRows: [base] });
+      built.llm.generate.mockResolvedValue({
+        text: '{"description":"Reviews the state budget."}',
+      } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      await built.service.generateMissingDescriptions();
+
+      expect(built.db.legislativeCommittee.update).toHaveBeenCalledWith({
+        where: { id: 'c1' },
+        data: { description: 'Reviews the state budget.' },
+      });
+    });
+
+    it('tier-1: explicit `null` description means "name too generic" and is not persisted', async () => {
+      const built = await buildService({ dbRows: [base] });
+      built.llm.generate.mockResolvedValue({
+        text: '{"description":null}',
+      } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      await built.service.generateMissingDescriptions();
+
+      expect(built.db.legislativeCommittee.update).not.toHaveBeenCalled();
+    });
+
+    it('tier-2: salvages description field from a truncated response', async () => {
+      const built = await buildService({ dbRows: [base] });
+      built.llm.generate.mockResolvedValue({
+        text: '{"description":"Considers fiscal-impact legislation",',
+      } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      await built.service.generateMissingDescriptions();
+
+      expect(built.db.legislativeCommittee.update).toHaveBeenCalledWith({
+        where: { id: 'c1' },
+        data: { description: 'Considers fiscal-impact legislation' },
+      });
+    });
+
+    it('returns without update when both tiers fail', async () => {
+      const built = await buildService({ dbRows: [base] });
+      built.llm.generate.mockResolvedValue({
+        text: 'no json at all',
+      } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      await built.service.generateMissingDescriptions();
+
+      expect(built.db.legislativeCommittee.update).not.toHaveBeenCalled();
+    });
+
+    it('swallows LLM errors so one failed committee does not cancel peers', async () => {
+      const built = await buildService({
+        dbRows: [
+          { ...base, id: 'c1' },
+          { ...base, id: 'c2', name: 'Survivor' },
+        ],
+      });
+      built.llm.generate
+        .mockRejectedValueOnce(new Error('flake'))
+        .mockResolvedValueOnce({
+          text: '{"description":"ok"}',
+        } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      await built.service.generateMissingDescriptions();
+
+      expect(built.db.legislativeCommittee.update).toHaveBeenCalledTimes(1);
+      expect(built.db.legislativeCommittee.update).toHaveBeenCalledWith({
+        where: { id: 'c2' },
+        data: { description: 'ok' },
+      });
+    });
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/legislative-committee-description-generator.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-committee-description-generator.service.ts
@@ -1,0 +1,205 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PromptClientService } from '@opuspopuli/prompt-client';
+import type { ILLMProvider } from '@opuspopuli/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import {
+  extractFieldString,
+  extractJsonObjectSlice,
+} from './llm-json-salvage.util';
+
+/** Minimal shape of a committee row needed to render a description prompt. */
+interface CommitteeForDescription {
+  id: string;
+  name: string;
+  chamber: string;
+}
+
+/**
+ * Generates AI 2-3 sentence descriptions of what a legislative committee
+ * does, anchored only in the chamber + committee name. Uses the
+ * `document-analysis-legislative-committee-description` prompt in the
+ * prompt-service.
+ *
+ * DB-driven candidate selection (committees with `description IS NULL`)
+ * mirrors the resilience pattern of CommitteeSummaryGeneratorService —
+ * resilient to scrape flakes, runs even when no committees actually
+ * changed in a given sync cycle.
+ *
+ * Tunable via env vars:
+ * - LEGISLATIVE_COMMITTEE_DESCRIPTION_MAX_TOKENS (default 200)
+ * - LEGISLATIVE_COMMITTEE_DESCRIPTION_CONCURRENCY (default 1)
+ * - LEGISLATIVE_COMMITTEE_DESCRIPTION_MAX_COMMITTEES (default unlimited;
+ *   useful in dev to verify pipeline on a handful before unleashing on
+ *   the full ~30-60 committee roster).
+ */
+@Injectable()
+export class LegislativeCommitteeDescriptionGeneratorService {
+  private readonly logger = new Logger(
+    LegislativeCommitteeDescriptionGeneratorService.name,
+  );
+  private readonly maxTokens: number;
+  private readonly concurrency: number;
+  private readonly maxCommittees?: number;
+
+  constructor(
+    @Optional() private readonly config?: ConfigService,
+    @Optional() private readonly promptClient?: PromptClientService,
+    @Optional()
+    @Inject('LLM_PROVIDER')
+    private readonly llm?: ILLMProvider,
+    @Optional() private readonly db?: DbService,
+  ) {
+    this.maxTokens = this.readPositiveInt(
+      'LEGISLATIVE_COMMITTEE_DESCRIPTION_MAX_TOKENS',
+      200,
+    );
+    this.concurrency = this.readPositiveInt(
+      'LEGISLATIVE_COMMITTEE_DESCRIPTION_CONCURRENCY',
+      1,
+    );
+    this.maxCommittees = this.readOptionalPositiveInt(
+      'LEGISLATIVE_COMMITTEE_DESCRIPTION_MAX_COMMITTEES',
+    );
+  }
+
+  /**
+   * Generate descriptions for any active committee that doesn't have one.
+   * Idempotent: reruns are no-ops once all committees are described.
+   *
+   * @param maxOverride — per-call cap that takes precedence over the
+   *   LEGISLATIVE_COMMITTEE_DESCRIPTION_MAX_COMMITTEES env default.
+   */
+  async generateMissingDescriptions(maxOverride?: number): Promise<void> {
+    if (!this.promptClient || !this.llm || !this.db) return;
+
+    const cap =
+      maxOverride && maxOverride > 0 ? maxOverride : this.maxCommittees;
+
+    const pending = await this.db.legislativeCommittee.findMany({
+      where: { deletedAt: null, description: null },
+      select: { id: true, name: true, chamber: true },
+      orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+      ...(cap ? { take: cap } : {}),
+    });
+
+    if (pending.length === 0) return;
+
+    const capSource =
+      maxOverride && maxOverride > 0 ? 'mutation arg' : 'env default';
+    const capNote = cap ? ` (cap ${capSource}=${cap})` : '';
+    this.logger.log(
+      `Generating AI descriptions for ${pending.length} legislative committees${capNote} (concurrency=${this.concurrency}, maxTokens=${this.maxTokens})`,
+    );
+
+    let succeeded = 0;
+    for (let i = 0; i < pending.length; i += this.concurrency) {
+      const batch = pending.slice(i, i + this.concurrency);
+      const results = await Promise.all(
+        batch.map((c) => this.tryGenerateAndPersist(c)),
+      );
+      succeeded += results.filter(Boolean).length;
+    }
+
+    this.logger.log(
+      `Generated ${succeeded}/${pending.length} legislative committee descriptions successfully`,
+    );
+  }
+
+  private async tryGenerateAndPersist(
+    committee: CommitteeForDescription,
+  ): Promise<boolean> {
+    try {
+      const description = await this.generateDescription(committee);
+      if (!description) return false;
+      await this.db!.legislativeCommittee.update({
+        where: { id: committee.id },
+        data: { description },
+      });
+      return true;
+    } catch (error) {
+      this.logger.warn(
+        `Description generation failed for ${committee.chamber} ${committee.name}: ${(error as Error).message}`,
+      );
+      return false;
+    }
+  }
+
+  private async generateDescription(
+    committee: CommitteeForDescription,
+  ): Promise<string | undefined> {
+    const structuredText = this.formatCommitteeData(committee);
+
+    const { promptText } = await this.promptClient!.getDocumentAnalysisPrompt({
+      documentType: 'legislative-committee-description',
+      text: structuredText,
+    });
+
+    const result = await this.llm!.generate(promptText, {
+      maxTokens: this.maxTokens,
+      temperature: 0.2,
+    });
+
+    return this.parseDescriptionFromResponse(result.text);
+  }
+
+  /**
+   * Format the committee identity as key-value text for the prompt.
+   * Deliberately minimal: chamber + name are the only signals the prompt
+   * is allowed to ground in (per its RULE 4).
+   */
+  private formatCommitteeData(committee: CommitteeForDescription): string {
+    return [
+      `Chamber: ${committee.chamber}`,
+      `Committee Name: ${committee.name}`,
+    ].join('\n');
+  }
+
+  /**
+   * Two-tier parse mirroring the bio + summary generators so a
+   * malformed/truncated JSON response still yields a usable description.
+   */
+  private parseDescriptionFromResponse(text: string): string | undefined {
+    const candidate = extractJsonObjectSlice(text);
+    if (candidate) {
+      try {
+        const parsed = JSON.parse(candidate) as { description?: string | null };
+        const description = parsed.description?.trim();
+        if (description && description.length > 0) return description;
+        // Explicit `null` from the LLM means "name too generic" — bail.
+        if (parsed.description === null) return undefined;
+      } catch {
+        // fall through to Tier 2
+      }
+    }
+
+    const salvaged = extractFieldString(text, 'description', 20);
+    if (salvaged && salvaged.length > 0) {
+      this.logger.debug(
+        `Committee description tier-2 salvage: extracted ${salvaged.length}-char description from ${text.length}-char response`,
+      );
+      return salvaged;
+    }
+
+    const head = text.slice(0, 80).replaceAll('\n', ' ');
+    const tail = text.slice(-80).replaceAll('\n', ' ');
+    this.logger.debug(
+      `Committee description parse failed entirely: ${text.length}-char response. Head: "${head}..." Tail: "...${tail}"`,
+    );
+    return undefined;
+  }
+
+  private readPositiveInt(envKey: string, fallback: number): number {
+    const raw = this.config?.get<string>(envKey);
+    if (!raw) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  private readOptionalPositiveInt(envKey: string): number | undefined {
+    const raw = this.config?.get<string>(envKey);
+    if (!raw) return undefined;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/legislative-committee-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-committee-linker.service.spec.ts
@@ -1,0 +1,339 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
+
+interface RepRow {
+  id: string;
+  chamber: string;
+  committees: unknown;
+}
+
+describe('LegislativeCommitteeLinkerService', () => {
+  /**
+   * Build a service backed by an in-memory mock DB. The mock honors the
+   * pagination cursor used by linkAll() so we can also test multi-page
+   * scenarios cheaply.
+   */
+  async function buildService(
+    opts: {
+      reps?: RepRow[];
+      configValues?: Record<string, string | undefined>;
+      withDb?: boolean;
+    } = {},
+  ) {
+    const { reps = [], configValues = {}, withDb = true } = opts;
+
+    const committeesTable: Array<{
+      id: string;
+      externalId: string;
+      name: string;
+      chamber: string;
+    }> = [];
+    const assignmentsTable: Array<{
+      representativeId: string;
+      legislativeCommitteeId: string;
+      role: string | null;
+    }> = [];
+
+    let nextId = 1;
+    const newId = () => `cmt-${nextId++}`;
+
+    const findManyReps = jest.fn(async (args: any) => {
+      const all = [...reps]; // deletedAt filter ignored for tests
+      const startIdx = args.cursor
+        ? all.findIndex((r) => r.id === args.cursor.id) + (args.skip ?? 0)
+        : 0;
+      return all.slice(startIdx, startIdx + (args.take ?? all.length));
+    });
+
+    const upsertCommittee = jest.fn(async (args: any) => {
+      const existing = committeesTable.find(
+        (c) => c.externalId === args.where.externalId,
+      );
+      if (existing) {
+        existing.name = args.update.name ?? existing.name;
+        existing.chamber = args.update.chamber ?? existing.chamber;
+        return { id: existing.id };
+      }
+      const row = {
+        id: newId(),
+        externalId: args.create.externalId,
+        name: args.create.name,
+        chamber: args.create.chamber,
+      };
+      committeesTable.push(row);
+      return { id: row.id };
+    });
+
+    const upsertAssignment = jest.fn(async (args: any) => {
+      const key = args.where.representativeId_legislativeCommitteeId;
+      const existing = assignmentsTable.find(
+        (a) =>
+          a.representativeId === key.representativeId &&
+          a.legislativeCommitteeId === key.legislativeCommitteeId,
+      );
+      if (existing) {
+        existing.role = args.update.role ?? existing.role;
+        return existing;
+      }
+      const row = {
+        representativeId: args.create.representativeId,
+        legislativeCommitteeId: args.create.legislativeCommitteeId,
+        role: args.create.role ?? null,
+      };
+      assignmentsTable.push(row);
+      return row;
+    });
+
+    const mockDb = {
+      representative: { findMany: findManyReps },
+      legislativeCommittee: { upsert: upsertCommittee },
+      representativeCommitteeAssignment: { upsert: upsertAssignment },
+    } as unknown as DbService;
+
+    const mockConfig = {
+      get: jest.fn((k: string) => configValues[k]),
+    } as unknown as ConfigService;
+
+    const providers: unknown[] = [LegislativeCommitteeLinkerService];
+    providers.push({ provide: ConfigService, useValue: mockConfig });
+    if (withDb) providers.push({ provide: DbService, useValue: mockDb });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: providers as Parameters<
+        typeof Test.createTestingModule
+      >[0]['providers'],
+    }).compile();
+
+    return {
+      service: module.get(LegislativeCommitteeLinkerService),
+      committeesTable,
+      assignmentsTable,
+      mocks: { findManyReps, upsertCommittee, upsertAssignment },
+    };
+  }
+
+  describe('when db is unavailable', () => {
+    it('returns zeros without throwing', async () => {
+      const built = await buildService({ withDb: false });
+      const result = await built.service.linkAll();
+      expect(result).toEqual({
+        committeesUpserted: 0,
+        assignmentsUpserted: 0,
+        repsScanned: 0,
+        skipped: 0,
+      });
+    });
+  });
+
+  describe('name normalization', () => {
+    it('collapses common variants to a single committee row', async () => {
+      const built = await buildService({
+        reps: [
+          {
+            id: 'r1',
+            chamber: 'Assembly',
+            committees: [{ name: 'Budget', role: 'Chair' }],
+          },
+          {
+            id: 'r2',
+            chamber: 'Assembly',
+            committees: [{ name: 'Committee on Budget', role: 'Member' }],
+          },
+          {
+            id: 'r3',
+            chamber: 'Assembly',
+            committees: [
+              { name: 'Standing Committee on the Budget', role: 'Vice Chair' },
+            ],
+          },
+          {
+            id: 'r4',
+            chamber: 'Assembly',
+            committees: [{ name: 'Assembly Budget Committee', role: 'Member' }],
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+
+      // All four phrasings collapse to one Assembly committee row.
+      expect(built.committeesTable).toHaveLength(1);
+      expect(built.committeesTable[0]).toMatchObject({
+        externalId: 'assembly:budget',
+        chamber: 'Assembly',
+      });
+      // Display name picks the longest scraped form.
+      expect(built.committeesTable[0].name).toBe(
+        'Standing Committee on the Budget',
+      );
+      // 4 reps → 4 assignments.
+      expect(result.assignmentsUpserted).toBe(4);
+    });
+
+    it('keeps Assembly and Senate Health as distinct committees', async () => {
+      const built = await buildService({
+        reps: [
+          {
+            id: 'r1',
+            chamber: 'Assembly',
+            committees: [{ name: 'Health' }],
+          },
+          {
+            id: 'r2',
+            chamber: 'Senate',
+            committees: [{ name: 'Health' }],
+          },
+        ],
+      });
+
+      await built.service.linkAll();
+
+      expect(built.committeesTable).toHaveLength(2);
+      const externalIds = built.committeesTable.map((c) => c.externalId).sort();
+      expect(externalIds).toEqual(['assembly:health', 'senate:health']);
+    });
+  });
+
+  describe('role canonicalization', () => {
+    it('maps role variants to Chair / Vice Chair / Member', async () => {
+      const built = await buildService({
+        reps: [
+          {
+            id: 'r1',
+            chamber: 'Assembly',
+            committees: [{ name: 'X', role: 'Chair' }],
+          },
+          {
+            id: 'r2',
+            chamber: 'Assembly',
+            committees: [{ name: 'Y', role: 'Vice Chair' }],
+          },
+          {
+            id: 'r3',
+            chamber: 'Assembly',
+            committees: [{ name: 'Z', role: 'vice-chair' }],
+          },
+          {
+            id: 'r4',
+            chamber: 'Assembly',
+            committees: [{ name: 'W', role: null }],
+          },
+          {
+            id: 'r5',
+            chamber: 'Assembly',
+            committees: [{ name: 'V', role: 'Ranking Minority' }],
+          },
+        ],
+      });
+
+      await built.service.linkAll();
+
+      const roles = built.assignmentsTable.map((a) => a.role).sort();
+      expect(roles).toEqual([
+        'Chair',
+        'Member',
+        'Member',
+        'Vice Chair',
+        'Vice Chair',
+      ]);
+    });
+  });
+
+  describe('idempotency', () => {
+    it('produces zero new rows on a second run over unchanged data', async () => {
+      const built = await buildService({
+        reps: [
+          {
+            id: 'r1',
+            chamber: 'Assembly',
+            committees: [
+              { name: 'Budget', role: 'Chair' },
+              { name: 'Health', role: 'Member' },
+            ],
+          },
+        ],
+      });
+
+      const first = await built.service.linkAll();
+      expect(first.committeesUpserted).toBe(2);
+      expect(first.assignmentsUpserted).toBe(2);
+
+      const second = await built.service.linkAll();
+      expect(built.committeesTable).toHaveLength(2);
+      expect(built.assignmentsTable).toHaveLength(2);
+      // Counts reflect what was processed, but the in-memory tables
+      // confirm no duplicates were created.
+      expect(second.repsScanned).toBe(1);
+    });
+  });
+
+  describe('malformed input handling', () => {
+    it('skips reps with non-array committees JSON', async () => {
+      const built = await buildService({
+        reps: [
+          { id: 'r1', chamber: 'Assembly', committees: null },
+          { id: 'r2', chamber: 'Assembly', committees: { not: 'an-array' } },
+          {
+            id: 'r3',
+            chamber: 'Assembly',
+            committees: [{ name: 'Real Committee' }],
+          },
+        ],
+      });
+
+      const result = await built.service.linkAll();
+
+      expect(result.repsScanned).toBe(3);
+      expect(result.skipped).toBe(2);
+      expect(built.committeesTable).toHaveLength(1);
+    });
+
+    it('drops committee entries with missing or empty name', async () => {
+      const built = await buildService({
+        reps: [
+          {
+            id: 'r1',
+            chamber: 'Assembly',
+            committees: [
+              { name: '' },
+              { name: '   ' },
+              { role: 'Chair' },
+              { name: 'Real' },
+            ],
+          },
+        ],
+      });
+
+      await built.service.linkAll();
+
+      expect(built.committeesTable).toHaveLength(1);
+      expect(built.committeesTable[0].externalId).toBe('assembly:real');
+    });
+  });
+
+  describe('pagination', () => {
+    it('walks more reps than fit in one batch', async () => {
+      const reps: RepRow[] = Array.from({ length: 7 }, (_, i) => ({
+        id: `r${i}`,
+        chamber: 'Assembly',
+        committees: [{ name: `Committee ${i}` }],
+      }));
+
+      const built = await buildService({
+        reps,
+        configValues: { LEGISLATIVE_COMMITTEE_LINKER_BATCH_SIZE: '3' },
+      });
+
+      await built.service.linkAll();
+
+      // 7 reps each on their own committee → 7 distinct committees.
+      expect(built.committeesTable).toHaveLength(7);
+      // Multiple findMany calls because batch size is 3.
+      expect(built.mocks.findManyReps.mock.calls.length).toBeGreaterThan(1);
+    });
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/legislative-committee-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-committee-linker.service.ts
@@ -1,0 +1,354 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+/**
+ * Shape of one entry inside Representative.committees JSON.
+ * Matches CommitteeAssignment from @opuspopuli/common — repeated here as
+ * a private interface so the service doesn't pull in the whole common
+ * package just to type a JSON cast.
+ */
+interface RawCommitteeAssignment {
+  name?: string;
+  role?: string | null;
+  url?: string | null;
+}
+
+/** Canonical role buckets we collapse the noisy scraped role strings into. */
+type CanonicalRole = 'Chair' | 'Vice Chair' | 'Member';
+
+/** Per-rep, per-committee tuple emitted in phase 1, consumed in phase 3. */
+interface Membership {
+  representativeId: string;
+  committeeKey: string;
+  role: CanonicalRole;
+}
+
+const VICE_CHAIR_PATTERN = /\bvice[\s-]?chair\b/i;
+const CHAIR_PATTERN = /\bchair\b/i;
+
+/**
+ * Links Representatives to LegislativeCommittees by walking each rep's
+ * `committees` JSON column and materializing the relational graph:
+ * distinct LegislativeCommittee rows + RepresentativeCommitteeAssignment
+ * join rows. Idempotent — re-running over unchanged data produces zero
+ * writes thanks to the unique constraints on
+ * (legislative_committees.external_id) and
+ * (representative_committee_assignments.{representative_id, legislative_committee_id}).
+ *
+ * Naming follows the established `*-linker` convention
+ * (PropositionFinanceLinkerService) — services that connect entity rows
+ * by populating join tables / FKs, even when one side is materialized
+ * along the way as derived state.
+ *
+ * Mirrors the optional-deps + post-sync-hook pattern of BioGeneratorService
+ * — no-ops gracefully when DB isn't wired (e.g., narrow unit-test contexts).
+ *
+ * Run automatically after every `syncRepresentatives` pass; also exposed
+ * via a one-off bootstrap script for ad-hoc runs.
+ *
+ * Tunables (env):
+ *   LEGISLATIVE_COMMITTEE_LINKER_BATCH_SIZE — default 50; how many
+ *   representatives to read in one DB page when paginating the source.
+ */
+@Injectable()
+export class LegislativeCommitteeLinkerService {
+  private readonly logger = new Logger(LegislativeCommitteeLinkerService.name);
+  private readonly batchSize: number;
+
+  constructor(
+    @Optional() private readonly config?: ConfigService,
+    @Optional() private readonly db?: DbService,
+  ) {
+    this.batchSize = this.readPositiveInt(
+      'LEGISLATIVE_COMMITTEE_LINKER_BATCH_SIZE',
+      50,
+    );
+  }
+
+  /**
+   * Walk every active Representative's `committees` JSON, derive the set
+   * of distinct (chamber, name) committees, upsert into legislative_committees,
+   * then upsert the membership rows. Returns counts so callers can log.
+   *
+   * Three phases broken out as helpers below:
+   *   1. collectFromReps  — read JSONB into in-memory committee + membership maps
+   *   2. upsertCommittees — materialize one LegislativeCommittee row per key
+   *   3. upsertMemberships — materialize the join rows (dedup'd on (rep, committee))
+   */
+  async linkAll(): Promise<{
+    committeesUpserted: number;
+    assignmentsUpserted: number;
+    repsScanned: number;
+    skipped: number;
+  }> {
+    if (!this.db) {
+      return {
+        committeesUpserted: 0,
+        assignmentsUpserted: 0,
+        repsScanned: 0,
+        skipped: 0,
+      };
+    }
+
+    const collected = await this.collectFromReps();
+    const keyToId = await this.upsertCommittees(collected.committeeMap);
+    const assignmentsUpserted = await this.upsertMemberships(
+      collected.memberships,
+      keyToId,
+    );
+
+    this.logger.log(
+      `Legislative committee linker complete: ` +
+        `committees=${collected.committeeMap.size} assignments=${assignmentsUpserted} ` +
+        `reps=${collected.repsScanned} skipped=${collected.skipped}`,
+    );
+
+    return {
+      committeesUpserted: collected.committeeMap.size,
+      assignmentsUpserted,
+      repsScanned: collected.repsScanned,
+      skipped: collected.skipped,
+    };
+  }
+
+  /**
+   * Phase 1: paginate through every active rep, accumulate the distinct
+   * committee map (keyed by `<chamber>:<normalizedName>`) and the per-rep
+   * membership tuples. Skip reps with null/non-array `committees` payloads
+   * and committee entries with missing/empty names.
+   */
+  private async collectFromReps(): Promise<{
+    committeeMap: Map<string, { chamber: string; name: string }>;
+    memberships: Membership[];
+    repsScanned: number;
+    skipped: number;
+  }> {
+    const committeeMap = new Map<string, { chamber: string; name: string }>();
+    const memberships: Membership[] = [];
+    let cursor: string | undefined;
+    let repsScanned = 0;
+    let skipped = 0;
+
+    for (;;) {
+      const reps = await this.fetchRepBatch(cursor);
+      if (reps.length === 0) break;
+      cursor = reps.at(-1)!.id;
+
+      for (const rep of reps) {
+        repsScanned++;
+        const accepted = this.processRepCommittees(
+          rep,
+          committeeMap,
+          memberships,
+        );
+        if (!accepted) skipped++;
+      }
+
+      if (reps.length < this.batchSize) break;
+    }
+
+    return { committeeMap, memberships, repsScanned, skipped };
+  }
+
+  /**
+   * Read a single page of reps. Prisma's JSON null-filter syntax is
+   * awkward; we just read every active rep and let coerceAssignments()
+   * filter null/empty payloads at the app level. Dataset is small
+   * (O(hundreds)).
+   */
+  private async fetchRepBatch(
+    cursor: string | undefined,
+  ): Promise<Array<{ id: string; chamber: string; committees: unknown }>> {
+    return this.db!.representative.findMany({
+      where: { deletedAt: null },
+      select: { id: true, chamber: true, committees: true },
+      orderBy: { id: 'asc' },
+      take: this.batchSize,
+      ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+    });
+  }
+
+  /**
+   * Process a single rep's `committees` JSONB: append distinct committee
+   * keys to `committeeMap` and per-assignment tuples to `memberships`.
+   * Returns true when at least one assignment was kept (i.e. the rep
+   * counts toward the "scanned" total instead of "skipped").
+   */
+  private processRepCommittees(
+    rep: { id: string; chamber: string; committees: unknown },
+    committeeMap: Map<string, { chamber: string; name: string }>,
+    memberships: Membership[],
+  ): boolean {
+    const assignments = this.coerceAssignments(rep.committees);
+    if (assignments.length === 0) return false;
+
+    for (const a of assignments) {
+      const rawName = a.name?.trim();
+      if (!rawName) continue;
+      const normalized = this.normalize(rawName);
+      if (!normalized) continue;
+      const key = this.externalId(rep.chamber, normalized);
+
+      // First time we see this committee key, register canonical
+      // metadata. We pick the longest scraped name as the display
+      // form on the assumption that fuller phrasings ("Standing
+      // Committee on Budget") are typically the official name.
+      const existing = committeeMap.get(key);
+      if (!existing || rawName.length > existing.name.length) {
+        committeeMap.set(key, { chamber: rep.chamber, name: rawName });
+      }
+
+      memberships.push({
+        representativeId: rep.id,
+        committeeKey: key,
+        role: this.canonicalizeRole(a.role),
+      });
+    }
+    return true;
+  }
+
+  /**
+   * Phase 2: upsert each distinct committee row, capturing its db id so
+   * phase 3 can resolve membership FKs.
+   */
+  private async upsertCommittees(
+    committeeMap: Map<string, { chamber: string; name: string }>,
+  ): Promise<Map<string, string>> {
+    const keyToId = new Map<string, string>();
+    for (const [key, meta] of committeeMap.entries()) {
+      const row = await this.db!.legislativeCommittee.upsert({
+        where: { externalId: key },
+        update: { name: meta.name, chamber: meta.chamber },
+        create: {
+          externalId: key,
+          name: meta.name,
+          chamber: meta.chamber,
+        },
+        select: { id: true },
+      });
+      keyToId.set(key, row.id);
+    }
+    return keyToId;
+  }
+
+  /**
+   * Phase 3: upsert each membership tuple. Dedup on
+   * (representativeId, committeeId) — a single rep listed twice on the
+   * same committee with different role spellings just settles on the
+   * canonicalized role from the latest entry.
+   */
+  private async upsertMemberships(
+    memberships: Membership[],
+    keyToId: Map<string, string>,
+  ): Promise<number> {
+    const seen = new Set<string>();
+    let count = 0;
+    for (const m of memberships) {
+      const committeeId = keyToId.get(m.committeeKey);
+      if (!committeeId) continue;
+      const dedupKey = `${m.representativeId}::${committeeId}`;
+      if (seen.has(dedupKey)) continue;
+      seen.add(dedupKey);
+      await this.db!.representativeCommitteeAssignment.upsert({
+        where: {
+          representativeId_legislativeCommitteeId: {
+            representativeId: m.representativeId,
+            legislativeCommitteeId: committeeId,
+          },
+        },
+        update: { role: m.role },
+        create: {
+          representativeId: m.representativeId,
+          legislativeCommitteeId: committeeId,
+          role: m.role,
+        },
+      });
+      count++;
+    }
+    return count;
+  }
+
+  /**
+   * Validate + coerce the JSONB `committees` column to a typed array.
+   * Returns `[]` for null, non-array, or all-malformed payloads. Element
+   * shape is loose because scrape sources have drifted historically; we
+   * just need a `name` string to do anything useful.
+   */
+  private coerceAssignments(raw: unknown): RawCommitteeAssignment[] {
+    if (!Array.isArray(raw)) return [];
+    return raw
+      .filter((x): x is Record<string, unknown> => !!x && typeof x === 'object')
+      .map((x) => ({
+        name: typeof x.name === 'string' ? x.name : undefined,
+        role: typeof x.role === 'string' ? x.role : null,
+        url: typeof x.url === 'string' ? x.url : null,
+      }));
+  }
+
+  /**
+   * Normalize a committee name into a stable lookup key. Strategy:
+   *  - lowercase
+   *  - drop non-alphanumeric (keeps only letters, digits, single spaces)
+   *  - drop chamber-prefix words (Assembly, Senate) since chamber is in
+   *    the key separately
+   *  - drop "committee", "committee on", "standing committee on" wrappers
+   *  - collapse whitespace
+   * Result for "Standing Committee on the Budget" / "Budget" /
+   *   "Budget Committee" / "Assembly Budget" → all collapse to "budget".
+   */
+  private normalize(name: string): string {
+    let n = name.toLowerCase().replaceAll(/[^a-z0-9\s]/g, ' ');
+    // Strip wrapper phrases — order matters, longer-first.
+    n = n
+      .replaceAll(/\bstanding committee on the\b/g, ' ')
+      .replaceAll(/\bstanding committee on\b/g, ' ')
+      .replaceAll(/\bcommittee on the\b/g, ' ')
+      .replaceAll(/\bcommittee on\b/g, ' ')
+      .replaceAll(/\bsubcommittee on\b/g, ' ')
+      .replaceAll(/\bcommittee\b/g, ' ')
+      .replaceAll(/\bsubcommittee\b/g, ' ')
+      .replaceAll(/\bassembly\b/g, ' ')
+      .replaceAll(/\bsenate\b/g, ' ');
+    return n.replaceAll(/\s+/g, ' ').trim();
+  }
+
+  /** Build the unique external_id for a (chamber, normalized name) pair. */
+  private externalId(chamber: string, normalizedName: string): string {
+    return `${chamber.toLowerCase()}:${normalizedName}`;
+  }
+
+  /**
+   * Public helper for callers that need to resolve a raw scrape committee
+   * name (e.g. an entry from `Representative.committees` JSONB) to the
+   * canonical external id used by the LegislativeCommittee table. Returns
+   * null when the name doesn't normalize to anything useful.
+   *
+   * Exposed so the rep query resolver can look up the matching
+   * LegislativeCommittee.id without duplicating normalization logic.
+   */
+  externalIdFor(chamber: string, rawName: string): string | null {
+    const normalized = this.normalize(rawName);
+    if (!normalized) return null;
+    return this.externalId(chamber, normalized);
+  }
+
+  /**
+   * Canonicalize a scraped role string. Returns one of three buckets:
+   * Chair, Vice Chair, Member. "Vice Chair" is checked before "Chair"
+   * because the chair pattern is a substring of the vice-chair phrase.
+   */
+  private canonicalizeRole(raw: string | null | undefined): CanonicalRole {
+    if (!raw) return 'Member';
+    if (VICE_CHAIR_PATTERN.test(raw)) return 'Vice Chair';
+    if (CHAIR_PATTERN.test(raw)) return 'Chair';
+    return 'Member';
+  }
+
+  private readPositiveInt(envKey: string, fallback: number): number {
+    const raw = this.config?.get<string>(envKey);
+    if (!raw) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/legislative-committee.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-committee.service.spec.ts
@@ -1,0 +1,375 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Test, TestingModule } from '@nestjs/testing';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+import { LegislativeCommitteeService } from './legislative-committee.service';
+
+describe('LegislativeCommitteeService', () => {
+  async function buildService(
+    opts: {
+      committees?: any[];
+      detail?: any;
+      meetings?: any[];
+      withDb?: boolean;
+    } = {},
+  ) {
+    const {
+      committees = [],
+      detail = null,
+      meetings = [],
+      withDb = true,
+    } = opts;
+
+    const findManyCommittees = jest.fn(async (args: any) => {
+      const filtered = args.where?.chamber
+        ? committees.filter((c) => c.chamber === args.where.chamber)
+        : committees;
+      const sorted = [...filtered].sort((a, b) => {
+        const c = a.chamber.localeCompare(b.chamber);
+        return c !== 0 ? c : a.name.localeCompare(b.name);
+      });
+      const skip = args.skip ?? 0;
+      const take = args.take ?? sorted.length;
+      return sorted.slice(skip, skip + take);
+    });
+    const countCommittees = jest.fn(async (args: any) => {
+      return args.where?.chamber
+        ? committees.filter((c) => c.chamber === args.where.chamber).length
+        : committees.length;
+    });
+    const findFirstCommittee = jest.fn(async (args: any) =>
+      detail && detail.id === args.where.id ? detail : null,
+    );
+    const findManyMeetings = jest.fn(async () => meetings);
+
+    const mockDb = {
+      legislativeCommittee: {
+        findMany: findManyCommittees,
+        count: countCommittees,
+        findFirst: findFirstCommittee,
+      },
+      meeting: { findMany: findManyMeetings },
+    } as unknown as DbService;
+
+    const providers: unknown[] = [LegislativeCommitteeService];
+    if (withDb) providers.push({ provide: DbService, useValue: mockDb });
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: providers as Parameters<
+        typeof Test.createTestingModule
+      >[0]['providers'],
+    }).compile();
+
+    return {
+      service: module.get(LegislativeCommitteeService),
+      mocks: {
+        findManyCommittees,
+        countCommittees,
+        findFirstCommittee,
+        findManyMeetings,
+      },
+    };
+  }
+
+  describe('list', () => {
+    it('returns empty result when db is unavailable', async () => {
+      const built = await buildService({ withDb: false });
+      const out = await built.service.list({ skip: 0, take: 10 });
+      expect(out).toEqual({ items: [], total: 0, hasMore: false });
+    });
+
+    it('returns paginated items with member counts', async () => {
+      const committees = [
+        {
+          id: 'c1',
+          externalId: 'assembly:budget',
+          name: 'Budget',
+          chamber: 'Assembly',
+          url: null,
+          description: null,
+          _count: { assignments: 12 },
+        },
+        {
+          id: 'c2',
+          externalId: 'senate:health',
+          name: 'Health',
+          chamber: 'Senate',
+          url: null,
+          description: null,
+          _count: { assignments: 8 },
+        },
+      ];
+      const built = await buildService({ committees });
+
+      const out = await built.service.list({ skip: 0, take: 10 });
+
+      expect(out.total).toBe(2);
+      expect(out.hasMore).toBe(false);
+      expect(out.items[0]).toMatchObject({ name: 'Budget', memberCount: 12 });
+      expect(out.items[1]).toMatchObject({ name: 'Health', memberCount: 8 });
+    });
+
+    it('honors the chamber filter', async () => {
+      const committees = [
+        {
+          id: 'c1',
+          externalId: 'assembly:budget',
+          name: 'Budget',
+          chamber: 'Assembly',
+          url: null,
+          description: null,
+          _count: { assignments: 1 },
+        },
+        {
+          id: 'c2',
+          externalId: 'senate:health',
+          name: 'Health',
+          chamber: 'Senate',
+          url: null,
+          description: null,
+          _count: { assignments: 1 },
+        },
+      ];
+      const built = await buildService({ committees });
+
+      const out = await built.service.list({
+        skip: 0,
+        take: 10,
+        chamber: 'Senate',
+      });
+
+      expect(out.total).toBe(1);
+      expect(out.items[0].chamber).toBe('Senate');
+    });
+
+    it('reports hasMore=true when more items exist than page size', async () => {
+      const committees = Array.from({ length: 11 }, (_, i) => ({
+        id: `c${i}`,
+        externalId: `assembly:c${i}`,
+        name: `C${String(i).padStart(2, '0')}`,
+        chamber: 'Assembly',
+        url: null,
+        description: null,
+        _count: { assignments: 0 },
+      }));
+      const built = await buildService({ committees });
+
+      const out = await built.service.list({ skip: 0, take: 10 });
+
+      expect(out.total).toBe(11);
+      expect(out.hasMore).toBe(true);
+      expect(out.items).toHaveLength(10);
+    });
+  });
+
+  describe('getDetail', () => {
+    it('returns null when db is unavailable', async () => {
+      const built = await buildService({ withDb: false });
+      const out = await built.service.getDetail('any');
+      expect(out).toBeNull();
+    });
+
+    it('returns null when the committee does not exist', async () => {
+      const built = await buildService({ detail: null });
+      const out = await built.service.getDetail('missing');
+      expect(out).toBeNull();
+    });
+
+    it('sorts members Chair → Vice Chair → Member → other, then by lastName', async () => {
+      const detail = {
+        id: 'c1',
+        externalId: 'assembly:health',
+        name: 'Health',
+        chamber: 'Assembly',
+        url: null,
+        description: null,
+        createdAt: new Date('2026-01-01'),
+        updatedAt: new Date('2026-01-02'),
+        assignments: [
+          {
+            role: 'Member',
+            representative: {
+              id: 'r-zoe',
+              name: 'Zoe Z',
+              lastName: 'Z',
+              party: 'D',
+              photoUrl: null,
+            },
+          },
+          {
+            role: 'Chair',
+            representative: {
+              id: 'r-chair',
+              name: 'Chair Person',
+              lastName: 'Person',
+              party: 'D',
+              photoUrl: null,
+            },
+          },
+          {
+            role: 'Member',
+            representative: {
+              id: 'r-anne',
+              name: 'Anne A',
+              lastName: 'A',
+              party: 'D',
+              photoUrl: null,
+            },
+          },
+          {
+            role: 'Vice Chair',
+            representative: {
+              id: 'r-vc',
+              name: 'Vice C',
+              lastName: 'Cee',
+              party: 'D',
+              photoUrl: null,
+            },
+          },
+        ],
+      };
+      const built = await buildService({ detail });
+
+      const out = await built.service.getDetail('c1');
+
+      expect(out!.members.map((m) => m.representativeId)).toEqual([
+        'r-chair',
+        'r-vc',
+        'r-anne',
+        'r-zoe',
+      ]);
+      expect(out!.memberCount).toBe(4);
+    });
+
+    it('includes fuzzy-matched recent hearings from the same chamber', async () => {
+      const detail = {
+        id: 'c1',
+        externalId: 'assembly:health',
+        name: 'Health',
+        chamber: 'Assembly',
+        url: null,
+        description: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        assignments: [],
+      };
+      const meetings = [
+        {
+          id: 'm1',
+          title: 'Health Committee — Regular Session',
+          scheduledAt: new Date('2026-04-15'),
+          agendaUrl: 'https://example.com/m1',
+        },
+      ];
+
+      const built = await buildService({ detail, meetings });
+
+      const out = await built.service.getDetail('c1');
+
+      expect(out!.hearings).toHaveLength(1);
+      expect(out!.hearings[0].title).toContain('Health');
+
+      // Verify the fuzzy match used the right scope
+      const calls = built.mocks.findManyMeetings.mock.calls as unknown[][];
+      const meetingArgs = calls[0][0] as any;
+      expect(meetingArgs.where.body).toBe('Assembly');
+      expect(meetingArgs.where.title.contains).toBe('Health');
+      expect(meetingArgs.where.title.mode).toBe('insensitive');
+    });
+
+    it('returns empty hearings array when no meetings match', async () => {
+      const detail = {
+        id: 'c1',
+        externalId: 'senate:obscure',
+        name: 'Obscure',
+        chamber: 'Senate',
+        url: null,
+        description: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        assignments: [],
+      };
+      const built = await buildService({ detail, meetings: [] });
+
+      const out = await built.service.getDetail('c1');
+
+      expect(out!.hearings).toEqual([]);
+    });
+
+    it('dedupes meetings on (title, scheduledAt) and prefers absolute URLs', async () => {
+      // Mirrors the real Assembly scrape bug: same hearing scraped 4× with
+      // mixed relative + absolute agendaUrl values.
+      const detail = {
+        id: 'c1',
+        externalId: 'assembly:health',
+        name: 'Health',
+        chamber: 'Assembly',
+        url: null,
+        description: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        assignments: [],
+      };
+      const sharedDate = new Date('2026-05-11');
+      const meetings = [
+        {
+          id: 'm1',
+          title: 'Budget Subcommittee No. 1 On Health',
+          scheduledAt: sharedDate,
+          agendaUrl: '/api/dailyfile/agenda/18995',
+        },
+        {
+          id: 'm2',
+          title: 'Budget Subcommittee No. 1 On Health',
+          scheduledAt: sharedDate,
+          agendaUrl: '/api/dailyfile/agenda/18995',
+        },
+        {
+          id: 'm3',
+          title: 'Budget Subcommittee No. 1 On Health',
+          scheduledAt: sharedDate,
+          agendaUrl: 'https://www.assembly.ca.gov/api/dailyfile/agenda/18995',
+        },
+      ];
+
+      const built = await buildService({ detail, meetings });
+
+      const out = await built.service.getDetail('c1');
+
+      expect(out!.hearings).toHaveLength(1);
+      // Absolute URL wins the tiebreak so the Agenda link is clickable.
+      expect(out!.hearings[0].agendaUrl).toBe(
+        'https://www.assembly.ca.gov/api/dailyfile/agenda/18995',
+      );
+    });
+
+    it('strips relative agendaUrls so the frontend hides the Agenda link', async () => {
+      const detail = {
+        id: 'c1',
+        externalId: 'assembly:health',
+        name: 'Health',
+        chamber: 'Assembly',
+        url: null,
+        description: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        assignments: [],
+      };
+      const meetings = [
+        {
+          id: 'm1',
+          title: 'Health Committee — Regular Session',
+          scheduledAt: new Date('2026-04-15'),
+          agendaUrl: '/api/dailyfile/agenda/19000',
+        },
+      ];
+
+      const built = await buildService({ detail, meetings });
+
+      const out = await built.service.getDetail('c1');
+
+      expect(out!.hearings).toHaveLength(1);
+      expect(out!.hearings[0].agendaUrl).toBeNull();
+    });
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/legislative-committee.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-committee.service.ts
@@ -1,0 +1,272 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+/** Output shape for the list query. */
+export interface LegislativeCommitteeListItem {
+  id: string;
+  externalId: string;
+  name: string;
+  chamber: string;
+  url: string | null;
+  description: string | null;
+  memberCount: number;
+}
+
+export interface PaginatedLegislativeCommittees {
+  items: LegislativeCommitteeListItem[];
+  total: number;
+  hasMore: boolean;
+}
+
+export interface LegislativeCommitteeMember {
+  representativeId: string;
+  name: string;
+  role: string | null;
+  party: string;
+  photoUrl: string | null;
+}
+
+export interface LegislativeCommitteeHearing {
+  id: string;
+  title: string;
+  scheduledAt: Date;
+  agendaUrl: string | null;
+}
+
+export interface LegislativeCommitteeDetail {
+  id: string;
+  externalId: string;
+  name: string;
+  chamber: string;
+  url: string | null;
+  description: string | null;
+  memberCount: number;
+  members: LegislativeCommitteeMember[];
+  hearings: LegislativeCommitteeHearing[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const HEARING_LIMIT = 10;
+const HEARING_WINDOW_MONTHS = 12;
+const ROLE_SORT_ORDER = ['Chair', 'Vice Chair', 'Member'];
+
+/**
+ * Read service for legislative committees. Backfilled by
+ * LegislativeCommitteeBackfillService; this service exposes:
+ *
+ *   - paginated list with optional chamber filter
+ *   - detail view with sorted members and best-effort recent hearings
+ *
+ * Hearings linkage is fuzzy: we substring-match the committee's
+ * normalized name against `Meeting.title` within the same chamber, capped
+ * at HEARING_WINDOW_MONTHS and HEARING_LIMIT. Phase 2 will introduce a
+ * `Meeting.legislativeCommitteeId` FK populated by a dedicated linker.
+ */
+@Injectable()
+export class LegislativeCommitteeService {
+  private readonly logger = new Logger(LegislativeCommitteeService.name);
+
+  constructor(@Optional() private readonly db?: DbService) {}
+
+  /**
+   * Paginated list. Sorted Chamber asc, Name asc so the UI renders a
+   * stable Assembly-then-Senate breakdown.
+   */
+  async list(args: {
+    skip: number;
+    take: number;
+    chamber?: string;
+  }): Promise<PaginatedLegislativeCommittees> {
+    if (!this.db) return { items: [], total: 0, hasMore: false };
+
+    const { skip, take, chamber } = args;
+    const where = {
+      deletedAt: null,
+      ...(chamber ? { chamber } : {}),
+    };
+
+    const [rows, total] = await Promise.all([
+      this.db.legislativeCommittee.findMany({
+        where,
+        select: {
+          id: true,
+          externalId: true,
+          name: true,
+          chamber: true,
+          url: true,
+          description: true,
+          _count: { select: { assignments: true } },
+        },
+        orderBy: [{ chamber: 'asc' }, { name: 'asc' }],
+        skip,
+        // Fetch one extra to compute hasMore without a second count query.
+        take: take + 1,
+      }),
+      this.db.legislativeCommittee.count({ where }),
+    ]);
+
+    const hasMore = rows.length > take;
+    const items = rows.slice(0, take).map((r) => ({
+      id: r.id,
+      externalId: r.externalId,
+      name: r.name,
+      chamber: r.chamber,
+      url: r.url,
+      description: r.description,
+      memberCount: r._count.assignments,
+    }));
+
+    return { items, total, hasMore };
+  }
+
+  /**
+   * Detail view. Members are sorted by canonical role (Chair → Vice Chair
+   * → Member → other) then by lastName. Hearings are best-effort fuzzy
+   * matches against Meeting.title in the same chamber.
+   */
+  async getDetail(id: string): Promise<LegislativeCommitteeDetail | null> {
+    if (!this.db) return null;
+
+    const committee = await this.db.legislativeCommittee.findFirst({
+      where: { id, deletedAt: null },
+      include: {
+        assignments: {
+          include: {
+            representative: {
+              select: {
+                id: true,
+                name: true,
+                lastName: true,
+                party: true,
+                photoUrl: true,
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!committee) return null;
+
+    // Sort first using the source `lastName` field, then project — avoids
+    // having to drop a private `lastName` from the output rows after the
+    // sort. Spread to a fresh array so we don't mutate Prisma's result.
+    const members = [...committee.assignments]
+      .sort((a, b) => {
+        const aIdx = this.roleIndex(a.role);
+        const bIdx = this.roleIndex(b.role);
+        if (aIdx !== bIdx) return aIdx - bIdx;
+        return a.representative.lastName.localeCompare(
+          b.representative.lastName,
+        );
+      })
+      .map((a) => ({
+        representativeId: a.representative.id,
+        name: a.representative.name,
+        role: a.role,
+        party: a.representative.party,
+        photoUrl: a.representative.photoUrl,
+      }));
+
+    const hearings = await this.fuzzyHearings(
+      committee.name,
+      committee.chamber,
+    );
+
+    return {
+      id: committee.id,
+      externalId: committee.externalId,
+      name: committee.name,
+      chamber: committee.chamber,
+      url: committee.url,
+      description: committee.description,
+      memberCount: committee.assignments.length,
+      members,
+      hearings,
+      createdAt: committee.createdAt,
+      updatedAt: committee.updatedAt,
+    };
+  }
+
+  /**
+   * Best-effort hearing match: any Meeting in the same chamber whose
+   * title contains the committee's name (case-insensitive), scheduled in
+   * the last HEARING_WINDOW_MONTHS, ordered most-recent-first, capped at
+   * HEARING_LIMIT. Phase 2 will replace with an explicit FK.
+   *
+   * Two defenses against known scrape bugs (issues filed separately):
+   *
+   * 1. The Assembly scrape currently produces duplicate Meeting rows for
+   *    the same hearing — same title, date, agenda URL, just stored 2-4
+   *    times. Dedupe here on (title, scheduledAt) so the UI shows one
+   *    row per hearing. When duplicates exist with mixed absolute/relative
+   *    URLs, prefer the absolute one.
+   * 2. Some `agenda_url` values are stored as relative paths
+   *    (`/api/dailyfile/...`) instead of absolute URLs. The frontend
+   *    would resolve those against its own origin and 404. Drop any
+   *    URL that doesn't look like an absolute http(s) URL — the frontend
+   *    already hides the agenda link when the URL is null.
+   */
+  private async fuzzyHearings(
+    committeeName: string,
+    chamber: string,
+  ): Promise<LegislativeCommitteeHearing[]> {
+    if (!this.db) return [];
+
+    const cutoff = new Date();
+    cutoff.setMonth(cutoff.getMonth() - HEARING_WINDOW_MONTHS);
+
+    // Pull more than HEARING_LIMIT so dedup doesn't shrink the visible
+    // set below the cap on a duplicate-heavy chamber.
+    const meetings = await this.db.meeting.findMany({
+      where: {
+        deletedAt: null,
+        body: chamber,
+        scheduledAt: { gte: cutoff },
+        title: { contains: committeeName, mode: 'insensitive' },
+      },
+      select: {
+        id: true,
+        title: true,
+        scheduledAt: true,
+        agendaUrl: true,
+      },
+      orderBy: { scheduledAt: 'desc' },
+      take: HEARING_LIMIT * 4,
+    });
+
+    const seen = new Map<string, LegislativeCommitteeHearing>();
+    for (const m of meetings) {
+      const key = `${m.title}::${m.scheduledAt.toISOString()}`;
+      const agendaUrl = this.absoluteUrlOrNull(m.agendaUrl);
+      const existing = seen.get(key);
+      // Prefer the row with a usable absolute URL; otherwise keep the first.
+      if (!existing || (!existing.agendaUrl && agendaUrl)) {
+        seen.set(key, {
+          id: m.id,
+          title: m.title,
+          scheduledAt: m.scheduledAt,
+          agendaUrl,
+        });
+      }
+    }
+
+    return Array.from(seen.values()).slice(0, HEARING_LIMIT);
+  }
+
+  private absoluteUrlOrNull(url: string | null): string | null {
+    if (!url) return null;
+    return /^https?:\/\//i.test(url) ? url : null;
+  }
+
+  /**
+   * Map a canonical role string to a sort index. Unrecognized roles fall
+   * to the end of the list so we don't lose them, just rank them last.
+   */
+  private roleIndex(role: string | null): number {
+    if (!role) return ROLE_SORT_ORDER.length;
+    const idx = ROLE_SORT_ORDER.indexOf(role);
+    return idx >= 0 ? idx : ROLE_SORT_ORDER.length;
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/models/legislative-committee.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/legislative-committee.model.ts
@@ -1,0 +1,114 @@
+import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Compact summary used by the list page + by the detail page's header.
+ * memberCount is the size of the assignments join.
+ */
+@ObjectType()
+export class LegislativeCommitteeModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  externalId!: string;
+
+  @Field()
+  name!: string;
+
+  @Field()
+  chamber!: string;
+
+  @Field({ nullable: true })
+  url?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field(() => Int)
+  memberCount!: number;
+}
+
+@ObjectType()
+export class LegislativeCommitteeMemberModel {
+  @Field(() => ID)
+  representativeId!: string;
+
+  @Field()
+  name!: string;
+
+  @Field({ nullable: true })
+  role?: string;
+
+  @Field()
+  party!: string;
+
+  @Field({ nullable: true })
+  photoUrl?: string;
+}
+
+@ObjectType()
+export class LegislativeCommitteeHearingModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  title!: string;
+
+  @Field()
+  scheduledAt!: Date;
+
+  @Field({ nullable: true })
+  agendaUrl?: string;
+}
+
+/**
+ * Detail shape returned by the legislativeCommittee(id) query — the
+ * committee summary plus pre-resolved members and recent hearings.
+ */
+@ObjectType()
+export class LegislativeCommitteeDetailModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  externalId!: string;
+
+  @Field()
+  name!: string;
+
+  @Field()
+  chamber!: string;
+
+  @Field({ nullable: true })
+  url?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field(() => Int)
+  memberCount!: number;
+
+  @Field(() => [LegislativeCommitteeMemberModel])
+  members!: LegislativeCommitteeMemberModel[];
+
+  @Field(() => [LegislativeCommitteeHearingModel])
+  hearings!: LegislativeCommitteeHearingModel[];
+
+  @Field()
+  createdAt!: Date;
+
+  @Field()
+  updatedAt!: Date;
+}
+
+@ObjectType()
+export class PaginatedLegislativeCommittees {
+  @Field(() => [LegislativeCommitteeModel])
+  items!: LegislativeCommitteeModel[];
+
+  @Field(() => Int)
+  total!: number;
+
+  @Field()
+  hasMore!: boolean;
+}

--- a/apps/backend/src/apps/region/src/domains/models/representative.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/representative.model.ts
@@ -67,6 +67,16 @@ export class CommitteeAssignmentModel {
 
   @Field({ nullable: true })
   url?: string;
+
+  /**
+   * Resolved id of the matching `LegislativeCommittee` row when the
+   * rep's chamber + normalized committee name matches one in the linked
+   * relational table. Null when the linker hasn't run, the name doesn't
+   * collapse to a known committee, or the chamber doesn't match.
+   * Used by the frontend to turn the row into a link to the detail page.
+   */
+  @Field({ nullable: true })
+  legislativeCommitteeId?: string;
 }
 
 /**

--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -21,6 +21,9 @@ import { CommitteeSummaryGeneratorService } from './committee-summary-generator.
 import { PropositionAnalysisService } from './proposition-analysis.service';
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
 import { PropositionFundingService } from './proposition-funding.service';
+import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
+import { LegislativeCommitteeService } from './legislative-committee.service';
+import { LegislativeCommitteeDescriptionGeneratorService } from './legislative-committee-description-generator.service';
 import { PrismaManifestRepository } from '../infrastructure/prisma-manifest-repository';
 import { REGION_CACHE } from './region.tokens';
 
@@ -78,6 +81,9 @@ const promptClientAsyncConfig = {
     PropositionAnalysisService,
     PropositionFinanceLinkerService,
     PropositionFundingService,
+    LegislativeCommitteeLinkerService,
+    LegislativeCommitteeService,
+    LegislativeCommitteeDescriptionGeneratorService,
     // Alias for injecting the pipeline into RegionDomainService
     {
       provide: 'SCRAPING_PIPELINE',

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -45,6 +45,10 @@ import {
   IndependentExpenditureModel,
   PaginatedIndependentExpenditures,
 } from './models/independent-expenditure.model';
+import {
+  LegislativeCommitteeDetailModel,
+  PaginatedLegislativeCommittees,
+} from './models/legislative-committee.model';
 
 /**
  * Region Resolver
@@ -182,14 +186,28 @@ export class RegionResolver {
   ): Promise<RepresentativeModel | null> {
     const result = await this.regionService.getRepresentative(id);
     if (!result) return null;
-    // Convert database nulls to GraphQL undefined
+
+    // Resolve each JSONB committee entry to its LegislativeCommittee.id
+    // so the frontend can render a link into the committee detail page.
+    const rawCommittees =
+      (result.committees as unknown as CommitteeAssignmentModel[]) ?? [];
+    const idByName = await this.regionService.resolveLegislativeCommitteeIds(
+      result.chamber,
+      rawCommittees,
+    );
+    const enrichedCommittees = rawCommittees.length
+      ? rawCommittees.map((c) => ({
+          ...c,
+          legislativeCommitteeId:
+            idByName.get(c.name?.trim() ?? '') ?? undefined,
+        }))
+      : undefined;
+
     return {
       ...result,
       photoUrl: result.photoUrl ?? undefined,
       contactInfo: (result.contactInfo as ContactInfoModel) ?? undefined,
-      committees:
-        (result.committees as unknown as CommitteeAssignmentModel[]) ??
-        undefined,
+      committees: enrichedCommittees,
       committeesSummary: result.committeesSummary ?? undefined,
       bio: result.bio ?? undefined,
       bioSource: result.bioSource ?? undefined,
@@ -232,6 +250,78 @@ export class RegionResolver {
         ? (r.bioClaims as unknown as BioClaimModel[])
         : undefined,
     })) as RepresentativeModel[];
+  }
+
+  // ==========================================
+  // LEGISLATIVE COMMITTEE QUERIES
+  // ==========================================
+
+  /**
+   * Paginated list of legislative committees, optionally filtered by chamber.
+   * Backed by RepresentativeCommitteeAssignment (membership) and the
+   * LegislativeCommittee table backfilled from Representative.committees JSON.
+   */
+  @Public()
+  @Query(() => PaginatedLegislativeCommittees)
+  @Extensions({ complexity: 15 })
+  async legislativeCommittees(
+    @Args() { skip, take }: PaginationArgs,
+    @Args({ name: 'chamber', nullable: true }) chamber?: string,
+  ): Promise<PaginatedLegislativeCommittees> {
+    const result = await this.regionService.listLegislativeCommittees({
+      skip,
+      take,
+      chamber,
+    });
+    return {
+      items: result.items.map((c) => ({
+        id: c.id,
+        externalId: c.externalId,
+        name: c.name,
+        chamber: c.chamber,
+        url: c.url ?? undefined,
+        description: c.description ?? undefined,
+        memberCount: c.memberCount,
+      })),
+      total: result.total,
+      hasMore: result.hasMore,
+    };
+  }
+
+  /**
+   * Detail view: committee + sorted members + best-effort recent hearings.
+   */
+  @Public()
+  @Query(() => LegislativeCommitteeDetailModel, { nullable: true })
+  async legislativeCommittee(
+    @Args({ name: 'id', type: () => ID }) id: string,
+  ): Promise<LegislativeCommitteeDetailModel | null> {
+    const result = await this.regionService.getLegislativeCommittee(id);
+    if (!result) return null;
+    return {
+      id: result.id,
+      externalId: result.externalId,
+      name: result.name,
+      chamber: result.chamber,
+      url: result.url ?? undefined,
+      description: result.description ?? undefined,
+      memberCount: result.memberCount,
+      members: result.members.map((m) => ({
+        representativeId: m.representativeId,
+        name: m.name,
+        role: m.role ?? undefined,
+        party: m.party,
+        photoUrl: m.photoUrl ?? undefined,
+      })),
+      hearings: result.hearings.map((h) => ({
+        id: h.id,
+        title: h.title,
+        scheduledAt: h.scheduledAt,
+        agendaUrl: h.agendaUrl ?? undefined,
+      })),
+      createdAt: result.createdAt,
+      updatedAt: result.updatedAt,
+    };
   }
 
   // ==========================================

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -664,7 +664,7 @@ describe('RegionDomainService', () => {
       expect(mockDb.representative.findMany).not.toHaveBeenCalled();
     });
 
-    it('should build correct OR conditions for assembly and senate districts', async () => {
+    it('matches BOTH padded and unpadded district forms for both chambers', async () => {
       mockDb.representative.findMany.mockResolvedValue([]);
 
       await service.getRepresentativesByDistricts(
@@ -673,18 +673,22 @@ describe('RegionDomainService', () => {
         'Assembly District 12',
       );
 
+      // Assembly stores unpadded ("12"), Senate stores padded ("05") — but a
+      // future scrape drift in either direction must not silently miss matches.
       expect(mockDb.representative.findMany).toHaveBeenCalledWith({
         where: {
           OR: [
-            { chamber: 'Assembly', district: 'District: 12' },
+            { chamber: 'Assembly', district: '12' },
+            { chamber: 'Assembly', district: '12' },
             { chamber: 'Senate', district: '05' },
+            { chamber: 'Senate', district: '5' },
           ],
         },
         orderBy: [{ chamber: 'asc' }, { lastName: 'asc' }],
       });
     });
 
-    it('should zero-pad single-digit district numbers (Congressional District 2 -> "02")', async () => {
+    it('emits both "02" and "2" for a single-digit Senate district', async () => {
       mockDb.representative.findMany.mockResolvedValue([]);
 
       await service.getRepresentativesByDistricts(
@@ -695,13 +699,16 @@ describe('RegionDomainService', () => {
 
       expect(mockDb.representative.findMany).toHaveBeenCalledWith({
         where: {
-          OR: [{ chamber: 'Senate', district: '02' }],
+          OR: [
+            { chamber: 'Senate', district: '02' },
+            { chamber: 'Senate', district: '2' },
+          ],
         },
         orderBy: [{ chamber: 'asc' }, { lastName: 'asc' }],
       });
     });
 
-    it('should preserve two-digit district numbers (Assembly District 12 -> "12")', async () => {
+    it('emits unpadded "12" for an Assembly two-digit district', async () => {
       mockDb.representative.findMany.mockResolvedValue([]);
 
       await service.getRepresentativesByDistricts(
@@ -712,7 +719,10 @@ describe('RegionDomainService', () => {
 
       expect(mockDb.representative.findMany).toHaveBeenCalledWith({
         where: {
-          OR: [{ chamber: 'Assembly', district: 'District: 12' }],
+          OR: [
+            { chamber: 'Assembly', district: '12' },
+            { chamber: 'Assembly', district: '12' },
+          ],
         },
         orderBy: [{ chamber: 'asc' }, { lastName: 'asc' }],
       });

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -1467,7 +1467,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       if (!raw) return [];
       const padded = this.extractDistrictNumber(raw);
       if (!padded) return [];
-      const unpadded = String(parseInt(padded, 10));
+      const unpadded = String(Number.parseInt(padded, 10));
       return [
         { chamber, district: padded },
         { chamber, district: unpadded },

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -39,6 +39,13 @@ import {
   PropositionFundingService,
   type PropositionFunding,
 } from './proposition-funding.service';
+import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
+import {
+  LegislativeCommitteeService,
+  type LegislativeCommitteeDetail,
+  type PaginatedLegislativeCommittees as PaginatedLegislativeCommitteesShape,
+} from './legislative-committee.service';
+import { LegislativeCommitteeDescriptionGeneratorService } from './legislative-committee-description-generator.service';
 
 /**
  * Minimal interface for data fetching used by sync methods.
@@ -318,6 +325,12 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     private readonly propositionFinanceLinker?: PropositionFinanceLinkerService,
     @Optional()
     private readonly propositionFunding?: PropositionFundingService,
+    @Optional()
+    private readonly legislativeCommitteeLinker?: LegislativeCommitteeLinkerService,
+    @Optional()
+    private readonly legislativeCommittees?: LegislativeCommitteeService,
+    @Optional()
+    private readonly legislativeCommitteeDescriptions?: LegislativeCommitteeDescriptionGeneratorService,
   ) {}
 
   async onModuleDestroy(): Promise<void> {
@@ -916,6 +929,38 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       await this.committeeSummaryGenerator.generateMissingSummaries(maxReps);
     }
 
+    // Materialize the rep ↔ legislative-committee graph from the
+    // Representative.committees JSONB. Idempotent — re-running over
+    // unchanged JSON produces zero new rows. Same shape as the
+    // proposition-finance linker that runs after campaign-finance sync.
+    if (this.legislativeCommitteeLinker) {
+      try {
+        await this.legislativeCommitteeLinker.linkAll();
+      } catch (error) {
+        this.logger.warn(
+          `Legislative committee linker failed: ${(error as Error).message}`,
+        );
+      }
+    }
+
+    // Fill in AI-generated 2-3 sentence descriptions for any committees
+    // (just-created or pre-existing) that don't have one yet. Runs after
+    // the linker so newly-materialized committees get described in the
+    // same sync cycle. Mirrors CommitteeSummaryGenerator's resilience —
+    // catches inside the service so an LLM/prompt-service flake never
+    // blocks the rest of the sync.
+    if (this.legislativeCommitteeDescriptions) {
+      try {
+        await this.legislativeCommitteeDescriptions.generateMissingDescriptions(
+          maxReps,
+        );
+      } catch (error) {
+        this.logger.warn(
+          `Legislative committee description generation failed: ${(error as Error).message}`,
+        );
+      }
+    }
+
     const created = reps.filter(
       (r) => !existingExternalIds.has(r.externalId),
     ).length;
@@ -1412,19 +1457,27 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     stateSenatorialDistrict?: string,
     stateAssemblyDistrict?: string,
   ): Promise<RepresentativeRecord[]> {
-    const conditions: { chamber: string; district: string }[] = [];
+    // The CA scrape stores Senate districts zero-padded ("02") but Assembly
+    // unpadded ("2"). Match against BOTH forms for both chambers so a future
+    // drift in either direction doesn't silently drop matches again.
+    const buildConditions = (
+      chamber: string,
+      raw?: string,
+    ): { chamber: string; district: string }[] => {
+      if (!raw) return [];
+      const padded = this.extractDistrictNumber(raw);
+      if (!padded) return [];
+      const unpadded = String(parseInt(padded, 10));
+      return [
+        { chamber, district: padded },
+        { chamber, district: unpadded },
+      ];
+    };
 
-    // Extract district numbers and build match conditions
-    // Census: "Congressional District 2" → Assembly: "District: 02", Senate: "02"
-    if (stateAssemblyDistrict) {
-      const num = this.extractDistrictNumber(stateAssemblyDistrict);
-      if (num)
-        conditions.push({ chamber: 'Assembly', district: `District: ${num}` });
-    }
-    if (stateSenatorialDistrict) {
-      const num = this.extractDistrictNumber(stateSenatorialDistrict);
-      if (num) conditions.push({ chamber: 'Senate', district: num });
-    }
+    const conditions = [
+      ...buildConditions('Assembly', stateAssemblyDistrict),
+      ...buildConditions('Senate', stateSenatorialDistrict),
+    ];
 
     if (conditions.length === 0) return [];
 
@@ -1449,6 +1502,72 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     const match = districtString.match(/(\d+)/);
     if (!match) return null;
     return match[1].padStart(2, '0');
+  }
+
+  // ==========================================
+  // LEGISLATIVE COMMITTEE GETTERS
+  // ==========================================
+
+  async listLegislativeCommittees(args: {
+    skip: number;
+    take: number;
+    chamber?: string;
+  }): Promise<PaginatedLegislativeCommitteesShape> {
+    if (!this.legislativeCommittees) {
+      return { items: [], total: 0, hasMore: false };
+    }
+    return this.legislativeCommittees.list(args);
+  }
+
+  async getLegislativeCommittee(
+    id: string,
+  ): Promise<LegislativeCommitteeDetail | null> {
+    if (!this.legislativeCommittees) return null;
+    return this.legislativeCommittees.getDetail(id);
+  }
+
+  /**
+   * Resolve each entry in a rep's `committees` JSONB to the matching
+   * `LegislativeCommittee.id` when one exists. Used by the rep query
+   * resolver so the frontend can render each committee row as a link to
+   * the committee detail page without duplicating normalization logic.
+   *
+   * Quietly returns `[]` (effectively a no-op) when the linker isn't
+   * available — the rep query still works, the names just stay as plain
+   * text. Same defensive shape as the linker itself.
+   */
+  async resolveLegislativeCommitteeIds(
+    chamber: string,
+    committees: ReadonlyArray<{ name?: string | null }>,
+  ): Promise<Map<string, string>> {
+    const result = new Map<string, string>();
+    if (!this.legislativeCommitteeLinker) return result;
+
+    const externalIdByName = new Map<string, string>();
+    for (const c of committees) {
+      const rawName = c?.name?.trim();
+      if (!rawName) continue;
+      const externalId = this.legislativeCommitteeLinker.externalIdFor(
+        chamber,
+        rawName,
+      );
+      if (externalId) externalIdByName.set(rawName, externalId);
+    }
+    if (externalIdByName.size === 0) return result;
+
+    const rows = await this.db.legislativeCommittee.findMany({
+      where: {
+        deletedAt: null,
+        externalId: { in: Array.from(new Set(externalIdByName.values())) },
+      },
+      select: { id: true, externalId: true },
+    });
+    const idByExternalId = new Map(rows.map((r) => [r.externalId, r.id]));
+    for (const [rawName, externalId] of externalIdByName) {
+      const id = idByExternalId.get(externalId);
+      if (id) result.set(rawName, id);
+    }
+    return result;
   }
 
   // ==========================================

--- a/apps/backend/src/apps/region/src/scripts/run-legislative-committee-descriptions.ts
+++ b/apps/backend/src/apps/region/src/scripts/run-legislative-committee-descriptions.ts
@@ -29,7 +29,9 @@ import { LegislativeCommitteeDescriptionGeneratorService } from '../domains/legi
 
 async function main(): Promise<void> {
   const logger = new Logger('run-legislative-committee-descriptions');
-  const cap = process.argv[2] ? parseInt(process.argv[2], 10) : undefined;
+  const cap = process.argv[2]
+    ? Number.parseInt(process.argv[2], 10)
+    : undefined;
 
   const app = await NestFactory.createApplicationContext(AppModule, {
     logger: ['log', 'warn', 'error'],
@@ -38,9 +40,8 @@ async function main(): Promise<void> {
     const service = app.get(LegislativeCommitteeDescriptionGeneratorService, {
       strict: false,
     });
-    logger.log(
-      `Starting legislative committee description pass${cap ? ` (cap=${cap})` : ''}…`,
-    );
+    const capSuffix = cap ? ` (cap=${cap})` : '';
+    logger.log(`Starting legislative committee description pass${capSuffix}…`);
     await service.generateMissingDescriptions(cap);
     logger.log('Done.');
   } finally {

--- a/apps/backend/src/apps/region/src/scripts/run-legislative-committee-descriptions.ts
+++ b/apps/backend/src/apps/region/src/scripts/run-legislative-committee-descriptions.ts
@@ -1,0 +1,54 @@
+/**
+ * One-off: run LegislativeCommitteeDescriptionGeneratorService against the
+ * `LegislativeCommittee` rows already in the DB. Useful for:
+ *
+ * - Backfilling descriptions on first deploy without waiting for the next
+ *   sync cycle (the post-sync hook will eventually do this, but a manual
+ *   pass is faster when you've just shipped the feature).
+ * - Re-generating after a tweak to the
+ *   `document-analysis-legislative-committee-description` prompt in the
+ *   prompt-service — drop existing descriptions first if you want to
+ *   force regeneration:
+ *     UPDATE legislative_committees SET description = NULL;
+ *
+ * Usage (after `pnpm --filter backend build:region`):
+ *   node apps/backend/dist/src/apps/region/apps/region/src/scripts/run-legislative-committee-descriptions.js
+ *
+ * Optional cap: pass an integer to limit how many committees are
+ * processed in this run (env LEGISLATIVE_COMMITTEE_DESCRIPTION_MAX_COMMITTEES
+ * also works):
+ *   node …/run-legislative-committee-descriptions.js 5
+ *
+ * Idempotent: only committees with `description IS NULL` are processed.
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
+import { AppModule } from '../app.module';
+import { LegislativeCommitteeDescriptionGeneratorService } from '../domains/legislative-committee-description-generator.service';
+
+async function main(): Promise<void> {
+  const logger = new Logger('run-legislative-committee-descriptions');
+  const cap = process.argv[2] ? parseInt(process.argv[2], 10) : undefined;
+
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'warn', 'error'],
+  });
+  try {
+    const service = app.get(LegislativeCommitteeDescriptionGeneratorService, {
+      strict: false,
+    });
+    logger.log(
+      `Starting legislative committee description pass${cap ? ` (cap=${cap})` : ''}…`,
+    );
+    await service.generateMissingDescriptions(cap);
+    logger.log('Done.');
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Description run failed:', err);
+  process.exit(1);
+});

--- a/apps/backend/src/apps/region/src/scripts/run-legislative-committee-linker.ts
+++ b/apps/backend/src/apps/region/src/scripts/run-legislative-committee-linker.ts
@@ -1,0 +1,48 @@
+/**
+ * One-off: run LegislativeCommitteeLinkerService.linkAll() against the
+ * Representative.committees JSON already in the DB. Useful for:
+ *
+ * - Backfilling the new LegislativeCommittee + RepresentativeCommitteeAssignment
+ *   tables on first deploy without waiting for the next scrape cycle.
+ * - Re-running after a manual edit to Representative.committees.
+ * - Re-running after a tweak to the name-normalization or role-canonicalization
+ *   logic so the linker collapses additional variants.
+ *
+ * Usage (after `pnpm --filter backend build:region`):
+ *   node apps/backend/dist/src/apps/region/apps/region/src/scripts/run-legislative-committee-linker.js
+ *
+ * Idempotent: re-running over unchanged data produces zero writes thanks
+ * to the unique constraints on (legislative_committees.external_id) and
+ * (representative_committee_assignments.{representative_id, legislative_committee_id}).
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
+import { AppModule } from '../app.module';
+import { LegislativeCommitteeLinkerService } from '../domains/legislative-committee-linker.service';
+
+async function main(): Promise<void> {
+  const logger = new Logger('run-legislative-committee-linker');
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'warn', 'error'],
+  });
+  try {
+    const linker = app.get(LegislativeCommitteeLinkerService, {
+      strict: false,
+    });
+    logger.log('Starting legislative committee linker pass…');
+    const result = await linker.linkAll();
+    logger.log(
+      `Done. committeesUpserted=${result.committeesUpserted} ` +
+        `assignmentsUpserted=${result.assignmentsUpserted} ` +
+        `repsScanned=${result.repsScanned} skipped=${result.skipped}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Linker run failed:', err);
+  process.exit(1);
+});

--- a/apps/frontend/__tests__/pages/region/legislative-committee-detail.test.tsx
+++ b/apps/frontend/__tests__/pages/region/legislative-committee-detail.test.tsx
@@ -1,0 +1,203 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import LegislativeCommitteeDetailPage from "@/app/region/legislative-committees/[id]/page";
+
+const mockCommittee = {
+  id: "c1",
+  externalId: "assembly:budget",
+  name: "Budget",
+  chamber: "Assembly",
+  url: "https://example.com/budget",
+  description: "Reviews and approves the state budget.",
+  memberCount: 4,
+  members: [
+    {
+      representativeId: "r-chair",
+      name: "Chair Person",
+      role: "Chair",
+      party: "Democrat",
+      photoUrl: null,
+    },
+    {
+      representativeId: "r-vc",
+      name: "Vice Chair Person",
+      role: "Vice Chair",
+      party: "Democrat",
+      photoUrl: null,
+    },
+    {
+      representativeId: "r-1",
+      name: "Member One",
+      role: "Member",
+      party: "Republican",
+      photoUrl: null,
+    },
+    {
+      representativeId: "r-2",
+      name: "Member Two",
+      role: "Member",
+      party: "Democrat",
+      photoUrl: null,
+    },
+  ],
+  hearings: [
+    {
+      id: "m1",
+      title: "Budget Subcommittee — Hearing",
+      scheduledAt: "2026-04-12T10:00:00Z",
+      agendaUrl: "https://example.com/m1",
+    },
+  ],
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-04-01T00:00:00Z",
+};
+
+let mockQueryResult: {
+  data: { legislativeCommittee: typeof mockCommittee | null } | null;
+  loading: boolean;
+  error: Error | null;
+} = {
+  data: { legislativeCommittee: mockCommittee },
+  loading: false,
+  error: null,
+};
+
+jest.mock("@apollo/client/react", () => ({
+  useQuery: jest.fn(() => mockQueryResult),
+}));
+
+jest.mock("next/navigation", () => ({
+  useParams: jest.fn(() => ({ id: "c1" })),
+}));
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+jest.mock("next/image", () => {
+  return function MockImage(props: Record<string, unknown>) {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...(props as Record<string, string>)} />;
+  };
+});
+
+describe("LegislativeCommitteeDetailPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryResult = {
+      data: { legislativeCommittee: mockCommittee },
+      loading: false,
+      error: null,
+    };
+  });
+
+  it("renders loading state", () => {
+    mockQueryResult = { data: null, loading: true, error: null };
+    render(<LegislativeCommitteeDetailPage />);
+    expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("renders error state", () => {
+    mockQueryResult = {
+      data: null,
+      loading: false,
+      error: new Error("nope"),
+    };
+    render(<LegislativeCommitteeDetailPage />);
+    expect(
+      screen.getByText(/failed to load legislative committee/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders not-found state when the query resolves to null", () => {
+    mockQueryResult = {
+      data: { legislativeCommittee: null },
+      loading: false,
+      error: null,
+    };
+    render(<LegislativeCommitteeDetailPage />);
+    expect(screen.getByText(/Committee not found/i)).toBeInTheDocument();
+  });
+
+  it("shows the snapshot layer with chair name", () => {
+    render(<LegislativeCommitteeDetailPage />);
+    // Heading shows committee name
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Budget" }),
+    ).toBeInTheDocument();
+    // Chair card from members list
+    expect(screen.getByText("Chair Person")).toBeInTheDocument();
+    // Description renders instead of ComingSoon
+    expect(
+      screen.getByText(/Reviews and approves the state budget/),
+    ).toBeInTheDocument();
+  });
+
+  it("groups members by role on the Members layer", async () => {
+    const user = userEvent.setup();
+    render(<LegislativeCommitteeDetailPage />);
+
+    await user.click(screen.getByRole("button", { name: "See members" }));
+
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Chair" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Vice Chair" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { level: 3, name: "Members" }),
+    ).toBeInTheDocument();
+
+    // Each member links to its representative detail page.
+    const chairLink = screen
+      .getAllByRole("link")
+      .find(
+        (l) => l.getAttribute("href") === "/region/representatives/r-chair",
+      );
+    expect(chairLink).toBeDefined();
+  });
+
+  it("shows a hint and the matched hearing on the Hearings layer", async () => {
+    const user = userEvent.setup();
+    render(<LegislativeCommitteeDetailPage />);
+
+    await user.click(screen.getByRole("button", { name: "See members" }));
+    await user.click(screen.getByRole("button", { name: "See hearings" }));
+
+    expect(
+      screen.getByText(/Best-effort match against scheduled meetings/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Budget Subcommittee — Hearing/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the empty hearings message when none match", async () => {
+    mockQueryResult = {
+      data: { legislativeCommittee: { ...mockCommittee, hearings: [] } },
+      loading: false,
+      error: null,
+    };
+    const user = userEvent.setup();
+    render(<LegislativeCommitteeDetailPage />);
+
+    await user.click(screen.getByRole("button", { name: "See members" }));
+    await user.click(screen.getByRole("button", { name: "See hearings" }));
+
+    expect(
+      screen.getByText(/No recent hearings matched in the last 12 months/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/pages/region/legislative-committees.test.tsx
+++ b/apps/frontend/__tests__/pages/region/legislative-committees.test.tsx
@@ -1,0 +1,136 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import LegislativeCommitteesPage from "@/app/region/legislative-committees/page";
+
+const mockCommittees = {
+  items: [
+    {
+      id: "c1",
+      externalId: "assembly:budget",
+      name: "Budget",
+      chamber: "Assembly",
+      url: null,
+      description: null,
+      memberCount: 12,
+    },
+    {
+      id: "c2",
+      externalId: "senate:health",
+      name: "Health",
+      chamber: "Senate",
+      url: null,
+      description: "Oversees public health policy.",
+      memberCount: 8,
+    },
+  ],
+  total: 2,
+  hasMore: false,
+};
+
+let mockQueryResult: {
+  data: { legislativeCommittees: typeof mockCommittees } | null;
+  loading: boolean;
+  error: Error | null;
+} = {
+  data: { legislativeCommittees: mockCommittees },
+  loading: false,
+  error: null,
+};
+
+const useQueryMock = jest.fn(() => mockQueryResult);
+
+jest.mock("@apollo/client/react", () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...(args as [])),
+}));
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+describe("LegislativeCommitteesPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryResult = {
+      data: { legislativeCommittees: mockCommittees },
+      loading: false,
+      error: null,
+    };
+  });
+
+  it("renders loading state", () => {
+    mockQueryResult = { data: null, loading: true, error: null };
+    render(<LegislativeCommitteesPage />);
+    expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(
+      0,
+    );
+  });
+
+  it("renders error state", () => {
+    mockQueryResult = {
+      data: null,
+      loading: false,
+      error: new Error("boom"),
+    };
+    render(<LegislativeCommitteesPage />);
+    expect(
+      screen.getByText(/failed to load legislative committees/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders empty state when there are no committees", () => {
+    mockQueryResult = {
+      data: {
+        legislativeCommittees: { items: [], total: 0, hasMore: false },
+      },
+      loading: false,
+      error: null,
+    };
+    render(<LegislativeCommitteesPage />);
+    expect(screen.getByText(/no legislative committees/i)).toBeInTheDocument();
+  });
+
+  it("renders each committee with member count and chamber", () => {
+    render(<LegislativeCommitteesPage />);
+    expect(screen.getByText("Budget")).toBeInTheDocument();
+    expect(screen.getByText("Health")).toBeInTheDocument();
+    expect(screen.getByText(/12 members/)).toBeInTheDocument();
+    expect(screen.getByText(/8 members/)).toBeInTheDocument();
+    // Each card links into the detail page.
+    expect(
+      screen.getByRole("link", { name: /Budget/i }).getAttribute("href"),
+    ).toBe("/region/legislative-committees/c1");
+    expect(
+      screen.getByRole("link", { name: /Health/i }).getAttribute("href"),
+    ).toBe("/region/legislative-committees/c2");
+  });
+
+  it("re-issues the query with the chamber filter when toggled", async () => {
+    const user = userEvent.setup();
+    render(<LegislativeCommitteesPage />);
+
+    // Most recent call before clicking — chamber should be undefined.
+    const initial = useQueryMock.mock.calls.at(-1);
+    expect(
+      (initial as unknown as Array<{ variables?: { chamber?: string } }>)?.[1]
+        ?.variables?.chamber,
+    ).toBeUndefined();
+
+    await user.click(screen.getByRole("button", { name: "Senate" }));
+
+    const afterClick = useQueryMock.mock.calls.at(-1);
+    expect(
+      (
+        afterClick as unknown as Array<{ variables?: { chamber?: string } }>
+      )?.[1]?.variables?.chamber,
+    ).toBe("Senate");
+  });
+});

--- a/apps/frontend/__tests__/pages/region/page.test.tsx
+++ b/apps/frontend/__tests__/pages/region/page.test.tsx
@@ -108,7 +108,11 @@ describe("RegionPage", () => {
       expect(screen.getByText("Propositions")).toBeInTheDocument();
       expect(screen.getByText("Meetings")).toBeInTheDocument();
       expect(screen.getByText("Representatives")).toBeInTheDocument();
-      expect(screen.getByText("Campaign Finance")).toBeInTheDocument();
+      // The CAMPAIGN_FINANCE data-type slot now displays as the
+      // Legislative Committees card on the home page; the campaign-finance
+      // hub stays reachable via direct URL and from proposition pages.
+      expect(screen.getByText("Legislative Committees")).toBeInTheDocument();
+      expect(screen.queryByText("Campaign Finance")).not.toBeInTheDocument();
     });
 
     it("should render data type descriptions", () => {
@@ -124,7 +128,9 @@ describe("RegionPage", () => {
         screen.getByText("Elected officials and legislators"),
       ).toBeInTheDocument();
       expect(
-        screen.getByText("Committees, contributions, and expenditures"),
+        screen.getByText(
+          "Where bills get debated and shaped before the floor vote",
+        ),
       ).toBeInTheDocument();
     });
 
@@ -146,12 +152,12 @@ describe("RegionPage", () => {
         "/region/representatives",
       );
 
-      const campaignFinanceLink = screen.getByRole("link", {
-        name: /Campaign Finance/i,
+      const legislativeCommitteesLink = screen.getByRole("link", {
+        name: /Legislative Committees/i,
       });
-      expect(campaignFinanceLink).toHaveAttribute(
+      expect(legislativeCommitteesLink).toHaveAttribute(
         "href",
-        "/region/campaign-finance",
+        "/region/legislative-committees",
       );
     });
 
@@ -215,7 +221,9 @@ describe("RegionPage", () => {
       expect(screen.getByText("Propositions")).toBeInTheDocument();
       expect(screen.queryByText("Meetings")).not.toBeInTheDocument();
       expect(screen.queryByText("Representatives")).not.toBeInTheDocument();
-      expect(screen.queryByText("Campaign Finance")).not.toBeInTheDocument();
+      expect(
+        screen.queryByText("Legislative Committees"),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/frontend/__tests__/pages/region/representative-detail.test.tsx
+++ b/apps/frontend/__tests__/pages/region/representative-detail.test.tsx
@@ -287,6 +287,45 @@ describe("RepresentativeDetailPage", () => {
       expect(screen.getByText("Education")).toBeInTheDocument();
     });
 
+    it("links a committee row to the committee detail page when legislativeCommitteeId is present", async () => {
+      const user = userEvent.setup();
+      mockQueryResult = {
+        data: {
+          representative: {
+            ...mockRepresentative,
+            committees: [
+              {
+                name: "Budget",
+                role: "Chair",
+                legislativeCommitteeId: "lc-budget",
+              },
+              // No id resolved → falls back to plain text (or external url
+              // when present); make sure the resolved row uses the new link.
+              { name: "Education", role: "Member" },
+            ],
+          },
+        },
+        loading: false,
+        error: undefined,
+      };
+
+      render(<RepresentativeDetailPage />);
+      const buttons = screen.getAllByRole("button", {
+        name: "What They Care About",
+      });
+      await user.click(buttons[buttons.length - 1]);
+
+      const budgetLink = screen
+        .getAllByRole("link")
+        .find((l) => l.textContent === "Budget");
+      expect(budgetLink?.getAttribute("href")).toBe(
+        "/region/legislative-committees/lc-budget",
+      );
+
+      // Education has no resolved id and no scrape url → renders as plain text.
+      expect(screen.getByText("Education").tagName).toBe("SPAN");
+    });
+
     it("What They Care About shows placeholder when no committees", async () => {
       const user = userEvent.setup();
       render(<RepresentativeDetailPage />);

--- a/apps/frontend/app/(auth)/auth/callback/page.tsx
+++ b/apps/frontend/app/(auth)/auth/callback/page.tsx
@@ -133,6 +133,8 @@ function AuthCallbackContent() {
     }
 
     // No valid params found
+    // Initial-mount sync — rule mis-flags this; we intentionally surface
+    // the error state synchronously when no callback params are present.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setStatus("error");
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/frontend/app/petition/results/page.tsx
+++ b/apps/frontend/app/petition/results/page.tsx
@@ -144,6 +144,9 @@ export default function PetitionResultsPage() {
     sessionStorage.removeItem("petition-scan-data");
     sessionStorage.removeItem("petition-scan-location");
 
+    // Initial-mount kickoff of the OCR pipeline — runPipeline internally
+    // calls setState. This is the documented entry point, not a cascading
+    // render loop.
     // eslint-disable-next-line react-hooks/set-state-in-effect
     runPipeline(base64, location);
   }, [router, runPipeline]);

--- a/apps/frontend/app/region/legislative-committees/[id]/page.tsx
+++ b/apps/frontend/app/region/legislative-committees/[id]/page.tsx
@@ -1,0 +1,412 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { useParams } from "next/navigation";
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_LEGISLATIVE_COMMITTEE,
+  IdVars,
+  LegislativeCommitteeData,
+  type LegislativeCommitteeDetail,
+  type LegislativeCommitteeMember,
+  type LegislativeCommitteeHearing,
+} from "@/lib/graphql/region";
+import { Breadcrumb } from "@/components/region/Breadcrumb";
+import { LoadingSkeleton, ErrorState } from "@/components/region/ListStates";
+import { SectionTitle } from "@/components/region/SectionTitle";
+import { ComingSoon } from "@/components/region/ComingSoon";
+import { LayerButton } from "@/components/region/LayerButton";
+import { LayerNav } from "@/components/region/LayerNav";
+import { PartyBadge } from "@/components/region/PartyBadge";
+import { formatDate } from "@/lib/format";
+
+const LAYERS = [
+  { n: 1, label: "Snapshot" },
+  { n: 2, label: "Members" },
+  { n: 3, label: "Hearings" },
+  { n: 4, label: "Deep Dive" },
+] as const;
+
+const ROLE_GROUPS: ReadonlyArray<{
+  heading: string;
+  match: (r?: string) => boolean;
+}> = [
+  { heading: "Chair", match: (r) => r === "Chair" },
+  { heading: "Vice Chair", match: (r) => r === "Vice Chair" },
+  {
+    heading: "Members",
+    match: (r) => !r || (r !== "Chair" && r !== "Vice Chair"),
+  },
+];
+
+function ChamberBadge({ chamber }: { readonly chamber: string }) {
+  const isAssembly = chamber === "Assembly";
+  const cls = isAssembly
+    ? "bg-blue-100 text-blue-800"
+    : "bg-purple-100 text-purple-800";
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${cls}`}
+    >
+      {chamber}
+    </span>
+  );
+}
+
+function MemberRow({
+  member,
+}: {
+  readonly member: LegislativeCommitteeMember;
+}) {
+  return (
+    <Link
+      href={`/region/representatives/${member.representativeId}`}
+      className="flex items-center gap-4 p-4 bg-white rounded-lg border border-slate-200 hover:border-slate-300 hover:shadow-sm transition-all"
+    >
+      {member.photoUrl ? (
+        <Image
+          src={member.photoUrl}
+          alt=""
+          width={48}
+          height={48}
+          className="w-12 h-12 rounded-full object-cover bg-slate-100"
+          unoptimized
+        />
+      ) : (
+        <div className="w-12 h-12 rounded-full bg-slate-100" aria-hidden />
+      )}
+      <div className="flex-1 min-w-0">
+        <p className="font-medium text-[#222222] truncate">{member.name}</p>
+        {member.role && member.role !== "Member" && (
+          <p className="text-xs text-[#595959]">{member.role}</p>
+        )}
+      </div>
+      <PartyBadge party={member.party} />
+    </Link>
+  );
+}
+
+function Snapshot({
+  committee,
+  onNext,
+}: {
+  readonly committee: LegislativeCommitteeDetail;
+  readonly onNext: () => void;
+}) {
+  const chair = committee.members.find((m) => m.role === "Chair");
+
+  return (
+    <div className="animate-layer-enter">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div className="bg-slate-50 rounded-lg p-4">
+          <p className="text-xs font-bold uppercase tracking-wider text-[#595959] mb-1">
+            Members
+          </p>
+          <p className="text-2xl font-semibold text-[#222222]">
+            {committee.memberCount}
+          </p>
+        </div>
+        <div className="bg-slate-50 rounded-lg p-4">
+          <p className="text-xs font-bold uppercase tracking-wider text-[#595959] mb-1">
+            Chamber
+          </p>
+          <p className="text-2xl font-semibold text-[#222222]">
+            {committee.chamber}
+          </p>
+        </div>
+        <div className="bg-slate-50 rounded-lg p-4">
+          <p className="text-xs font-bold uppercase tracking-wider text-[#595959] mb-1">
+            Chair
+          </p>
+          <p className="text-base font-semibold text-[#222222] truncate">
+            {chair ? (
+              chair.name
+            ) : (
+              <span className="italic text-slate-400">Vacant</span>
+            )}
+          </p>
+        </div>
+      </div>
+
+      <SectionTitle>What this committee does</SectionTitle>
+      {committee.description ? (
+        <p className="text-[#334155] leading-relaxed mb-6">
+          {committee.description}
+        </p>
+      ) : (
+        <ComingSoon
+          title="Description coming soon"
+          description="A plain-language description of this committee's jurisdiction is on the way. For now, see the members tab to understand its composition."
+        />
+      )}
+
+      <LayerButton onClick={onNext}>See members</LayerButton>
+    </div>
+  );
+}
+
+function Members({
+  committee,
+  onNext,
+  onBack,
+}: {
+  readonly committee: LegislativeCommitteeDetail;
+  readonly onNext: () => void;
+  readonly onBack: () => void;
+}) {
+  const groups = ROLE_GROUPS.map((g) => ({
+    heading: g.heading,
+    members: committee.members.filter((m) => g.match(m.role ?? undefined)),
+  })).filter((g) => g.members.length > 0);
+
+  return (
+    <div className="animate-layer-enter">
+      {groups.length === 0 && (
+        <p className="italic text-slate-400 mb-6">
+          No member assignments are linked to this committee yet.
+        </p>
+      )}
+      {groups.map((g) => (
+        <div key={g.heading} className="mb-8">
+          <SectionTitle>{g.heading}</SectionTitle>
+          <div className="space-y-2">
+            {g.members.map((m) => (
+              <MemberRow key={m.representativeId} member={m} />
+            ))}
+          </div>
+        </div>
+      ))}
+      <div className="flex flex-wrap gap-3">
+        <LayerButton onClick={onNext}>See hearings</LayerButton>
+        <LayerButton onClick={onBack} variant="secondary">
+          Back to snapshot
+        </LayerButton>
+      </div>
+    </div>
+  );
+}
+
+function HearingRow({
+  hearing,
+}: {
+  readonly hearing: LegislativeCommitteeHearing;
+}) {
+  return (
+    <li className="bg-white rounded-lg border border-slate-200 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <p className="font-medium text-[#222222]">{hearing.title}</p>
+          <p className="mt-1 text-sm text-[#4d4d4d]">
+            {formatDate(hearing.scheduledAt)}
+          </p>
+        </div>
+        {hearing.agendaUrl && (
+          <a
+            href={hearing.agendaUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline whitespace-nowrap"
+          >
+            Agenda →
+          </a>
+        )}
+      </div>
+    </li>
+  );
+}
+
+function Hearings({
+  committee,
+  onNext,
+  onBack,
+}: {
+  readonly committee: LegislativeCommitteeDetail;
+  readonly onNext: () => void;
+  readonly onBack: () => void;
+}) {
+  return (
+    <div className="animate-layer-enter">
+      <SectionTitle>Recent hearings</SectionTitle>
+      <p className="text-sm text-[#4d4d4d] mb-4">
+        Best-effort match against scheduled meetings in the {committee.chamber}{" "}
+        whose title mentions {committee.name}. An explicit hearing-to-committee
+        link is planned for a later release.
+      </p>
+      {committee.hearings.length === 0 ? (
+        <p className="italic text-slate-400 mb-6">
+          No recent hearings matched in the last 12 months.
+        </p>
+      ) : (
+        <ul className="space-y-2 mb-6">
+          {committee.hearings.map((h) => (
+            <HearingRow key={h.id} hearing={h} />
+          ))}
+        </ul>
+      )}
+      <div className="flex flex-wrap gap-3">
+        <LayerButton onClick={onNext}>Sources & deep dive</LayerButton>
+        <LayerButton onClick={onBack} variant="secondary">
+          Back to members
+        </LayerButton>
+      </div>
+    </div>
+  );
+}
+
+function DeepDive({
+  committee,
+  onBack,
+}: {
+  readonly committee: LegislativeCommitteeDetail;
+  readonly onBack: () => void;
+}) {
+  return (
+    <div className="animate-layer-enter">
+      <SectionTitle>Sources</SectionTitle>
+      <dl className="bg-slate-50 rounded-lg p-4 mb-6 grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-3 text-sm">
+        <div>
+          <dt className="font-bold uppercase tracking-wider text-xs text-[#595959]">
+            External ID
+          </dt>
+          <dd className="font-mono text-[#334155] break-all">
+            {committee.externalId}
+          </dd>
+        </div>
+        <div>
+          <dt className="font-bold uppercase tracking-wider text-xs text-[#595959]">
+            Last updated
+          </dt>
+          <dd className="text-[#334155]">{formatDate(committee.updatedAt)}</dd>
+        </div>
+        {committee.url && (
+          <div className="sm:col-span-2">
+            <dt className="font-bold uppercase tracking-wider text-xs text-[#595959]">
+              Official link
+            </dt>
+            <dd>
+              <a
+                href={committee.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-blue-600 hover:text-blue-700 hover:underline break-all"
+              >
+                {committee.url}
+              </a>
+            </dd>
+          </div>
+        )}
+      </dl>
+
+      <SectionTitle>Coming soon</SectionTitle>
+      <ComingSoon
+        title="Deeper context"
+        description="Jurisdiction, bill referrals, and staff contacts will appear here once dedicated committee scraping ships."
+      />
+
+      <div className="mt-6">
+        <LayerButton onClick={onBack} variant="secondary">
+          Back to hearings
+        </LayerButton>
+      </div>
+    </div>
+  );
+}
+
+export default function LegislativeCommitteeDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const [layer, setLayer] = useState(1);
+
+  const { data, loading, error } = useQuery<LegislativeCommitteeData, IdVars>(
+    GET_LEGISLATIVE_COMMITTEE,
+    { variables: { id } },
+  );
+
+  if (loading) {
+    return (
+      <div className="max-w-4xl mx-auto px-8 py-12">
+        <LoadingSkeleton count={1} height="h-64" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="max-w-4xl mx-auto px-8 py-12">
+        <ErrorState entity="legislative committee" />
+      </div>
+    );
+  }
+
+  const committee = data?.legislativeCommittee;
+
+  if (!committee) {
+    return (
+      <div className="max-w-4xl mx-auto px-8 py-12">
+        <div className="bg-gray-50 border border-gray-200 rounded-xl p-8 text-center">
+          <p className="text-[#4d4d4d] mb-4">Committee not found.</p>
+          <Link
+            href="/region/legislative-committees"
+            className="text-blue-600 hover:text-blue-700 hover:underline text-sm font-medium"
+          >
+            Back to legislative committees
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-8 py-12">
+      <Breadcrumb
+        segments={[
+          { label: "Region", href: "/region" },
+          {
+            label: "Legislative Committees",
+            href: "/region/legislative-committees",
+          },
+          { label: committee.name },
+        ]}
+      />
+
+      <div className="mb-6">
+        <h1 className="text-2xl font-extrabold text-[#222222] leading-tight mb-3">
+          {committee.name}
+        </h1>
+        <div className="flex flex-wrap items-center gap-3">
+          <ChamberBadge chamber={committee.chamber} />
+          <span className="text-sm text-[#4d4d4d]">
+            {committee.memberCount}{" "}
+            {committee.memberCount === 1 ? "member" : "members"}
+          </span>
+        </div>
+      </div>
+
+      <LayerNav layers={LAYERS} current={layer} onChange={setLayer} />
+
+      <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
+        {layer === 1 && (
+          <Snapshot committee={committee} onNext={() => setLayer(2)} />
+        )}
+        {layer === 2 && (
+          <Members
+            committee={committee}
+            onNext={() => setLayer(3)}
+            onBack={() => setLayer(1)}
+          />
+        )}
+        {layer === 3 && (
+          <Hearings
+            committee={committee}
+            onNext={() => setLayer(4)}
+            onBack={() => setLayer(2)}
+          />
+        )}
+        {layer === 4 && (
+          <DeepDive committee={committee} onBack={() => setLayer(3)} />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/app/region/legislative-committees/page.tsx
+++ b/apps/frontend/app/region/legislative-committees/page.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_LEGISLATIVE_COMMITTEES,
+  LegislativeCommittee,
+  LegislativeCommitteesData,
+} from "@/lib/graphql/region";
+import { Breadcrumb } from "@/components/region/Breadcrumb";
+import { Pagination } from "@/components/region/Pagination";
+import {
+  LoadingSkeleton,
+  ErrorState,
+  EmptyState,
+} from "@/components/region/ListStates";
+
+const PAGE_SIZE = 10;
+
+const CHAMBER_FILTERS: ReadonlyArray<{ label: string; value?: string }> = [
+  { label: "All", value: undefined },
+  { label: "Assembly", value: "Assembly" },
+  { label: "Senate", value: "Senate" },
+];
+
+function ChamberBadge({ chamber }: { readonly chamber: string }) {
+  const isAssembly = chamber === "Assembly";
+  const cls = isAssembly
+    ? "bg-blue-100 text-blue-800"
+    : "bg-purple-100 text-purple-800";
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${cls}`}
+    >
+      {chamber}
+    </span>
+  );
+}
+
+function CommitteeCard({
+  committee,
+}: Readonly<{ committee: LegislativeCommittee }>) {
+  return (
+    <Link
+      href={`/region/legislative-committees/${committee.id}`}
+      className="block bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6 hover:shadow-[0_4px_16px_rgba(0,0,0,0.1)] transition-shadow"
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <h3 className="text-lg font-semibold text-[#222222]">
+            {committee.name}
+          </h3>
+          {committee.description ? (
+            <p className="mt-2 text-sm text-[#4d4d4d] line-clamp-2">
+              {committee.description}
+            </p>
+          ) : null}
+        </div>
+        <ChamberBadge chamber={committee.chamber} />
+      </div>
+      <div className="mt-4 text-sm text-[#4d4d4d]">
+        {committee.memberCount}{" "}
+        {committee.memberCount === 1 ? "member" : "members"}
+      </div>
+    </Link>
+  );
+}
+
+export default function LegislativeCommitteesPage() {
+  const [page, setPage] = useState(0);
+  const [chamber, setChamber] = useState<string | undefined>(undefined);
+
+  const { data, loading, error } = useQuery<LegislativeCommitteesData>(
+    GET_LEGISLATIVE_COMMITTEES,
+    {
+      variables: { skip: page * PAGE_SIZE, take: PAGE_SIZE, chamber },
+    },
+  );
+
+  const onChamberChange = (value: string | undefined) => {
+    setChamber(value);
+    setPage(0);
+  };
+
+  const renderContent = () => {
+    if (loading) return <LoadingSkeleton />;
+    if (error) return <ErrorState entity="legislative committees" />;
+    if (data?.legislativeCommittees.items.length === 0)
+      return <EmptyState entity="legislative committees" />;
+
+    return (
+      <>
+        <div className="space-y-4">
+          {data?.legislativeCommittees.items.map((c) => (
+            <CommitteeCard key={c.id} committee={c} />
+          ))}
+        </div>
+        <Pagination
+          page={page}
+          pageSize={PAGE_SIZE}
+          total={data?.legislativeCommittees.total || 0}
+          hasMore={data?.legislativeCommittees.hasMore || false}
+          onPageChange={setPage}
+        />
+      </>
+    );
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-8 py-12">
+      <Breadcrumb
+        segments={[
+          { label: "Region", href: "/region" },
+          { label: "Legislative Committees" },
+        ]}
+      />
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-[#222222]">
+          Legislative Committees
+        </h1>
+        <p className="mt-2 text-[#4d4d4d]">
+          Where bills get debated and shaped before they reach the floor. Click
+          a committee to see who sits on it and what hearings it has held.
+        </p>
+      </div>
+
+      <div className="mb-6 flex flex-wrap gap-2">
+        {CHAMBER_FILTERS.map((f) => {
+          const active = chamber === f.value;
+          return (
+            <button
+              key={f.label}
+              type="button"
+              onClick={() => onChamberChange(f.value)}
+              className={`px-3 py-1.5 rounded-full text-sm font-medium transition-colors ${
+                active
+                  ? "bg-[#222222] text-white"
+                  : "bg-white text-[#4d4d4d] hover:bg-slate-100"
+              }`}
+            >
+              {f.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {renderContent()}
+    </div>
+  );
+}

--- a/apps/frontend/app/region/page.tsx
+++ b/apps/frontend/app/region/page.tsx
@@ -35,11 +35,18 @@ const DATA_TYPE_CARDS: Record<
     href: "/region/representatives",
     icon: "users",
   },
+  // Repurposed — the underlying DataType key (CAMPAIGN_FINANCE) is what
+  // the backend advertises in `supportedDataTypes`, but the home-page card
+  // now points at the new legislative-committees hub. The campaign-finance
+  // hub at /region/campaign-finance stays reachable via direct URL and
+  // from each proposition's funding section; only the home front door
+  // changes — voters get more value from "what shapes a bill before it
+  // hits the floor" than from disconnected donor lists.
   CAMPAIGN_FINANCE: {
-    title: "Campaign Finance",
-    description: "Committees, contributions, and expenditures",
-    href: "/region/campaign-finance",
-    icon: "finance",
+    title: "Legislative Committees",
+    description: "Where bills get debated and shaped before the floor vote",
+    href: "/region/legislative-committees",
+    icon: "committee",
   },
 };
 
@@ -106,6 +113,25 @@ function DataTypeIcon({ type }: { readonly type: string }) {
             strokeLinejoin="round"
             strokeWidth={1.5}
             d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      );
+    case "committee":
+      // Capitol-dome glyph — a single dome arch above a flat platform,
+      // chosen over the generic clipboard "list" icon to read as
+      // legislative chamber rather than to-do list.
+      return (
+        <svg
+          className="w-8 h-8"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M4 20h16M5 20v-7m14 7v-7M5 13h14M6 13V9a6 6 0 0112 0v4M12 3v3"
           />
         </svg>
       );

--- a/apps/frontend/app/region/representatives/[id]/page.tsx
+++ b/apps/frontend/app/region/representatives/[id]/page.tsx
@@ -79,22 +79,41 @@ function isLeadershipRole(role?: string): boolean {
 }
 
 function CommitteeRow({ c }: { readonly c: CommitteeAssignment }) {
+  // Three rendering tiers, in priority order:
+  //  1. Internal link to the new committee detail page when the linker
+  //     resolved a LegislativeCommittee.id for this assignment.
+  //  2. External link to the rep-specific scrape URL when present (the
+  //     committee detail page doesn't carry that per-rep context).
+  //  3. Plain text for the rare case where neither is available.
+  const renderName = () => {
+    if (c.legislativeCommitteeId) {
+      return (
+        <Link
+          href={`/region/legislative-committees/${c.legislativeCommitteeId}`}
+          className="text-sm text-blue-600 hover:text-blue-700 hover:underline"
+        >
+          {c.name}
+        </Link>
+      );
+    }
+    if (c.url) {
+      return (
+        <a
+          href={c.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-blue-600 hover:text-blue-700 hover:underline"
+        >
+          {c.name}
+        </a>
+      );
+    }
+    return <span className="text-sm text-[#334155]">{c.name}</span>;
+  };
+
   return (
     <div className="flex items-center justify-between py-2 border-b border-gray-50 last:border-0">
-      <div className="flex items-center gap-2">
-        {c.url ? (
-          <a
-            href={c.url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-blue-600 hover:text-blue-700 hover:underline"
-          >
-            {c.name}
-          </a>
-        ) : (
-          <span className="text-sm text-[#334155]">{c.name}</span>
-        )}
-      </div>
+      <div className="flex items-center gap-2">{renderName()}</div>
       {c.role && (
         // Member badge uses slate-700 (#334155) on gray-100 (#f3f4f6) for
         // ~7.5:1 contrast; slate-500 (#64748b) — used previously — was

--- a/apps/frontend/e2e/region.spec.ts
+++ b/apps/frontend/e2e/region.spec.ts
@@ -430,7 +430,7 @@ test.describe("Region Page", () => {
     ).toBeVisible();
   });
 
-  test("should display data type cards including campaign finance", async ({
+  test("should display data type cards including legislative committees", async ({
     page,
   }) => {
     await page.goto("/region");
@@ -440,8 +440,11 @@ test.describe("Region Page", () => {
     await expect(
       page.getByRole("link", { name: /Representatives.*Elected/i }),
     ).toBeVisible();
+    // The CAMPAIGN_FINANCE data-type slot now displays as the
+    // Legislative Committees card on the home page; the campaign-finance
+    // hub stays reachable via direct URL and from proposition pages.
     await expect(
-      page.getByRole("heading", { name: "Campaign Finance" }),
+      page.getByRole("heading", { name: "Legislative Committees" }),
     ).toBeVisible();
   });
 

--- a/apps/frontend/lib/auth-context.tsx
+++ b/apps/frontend/lib/auth-context.tsx
@@ -201,6 +201,8 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
         const parsedUser = JSON.parse(storedUser) as User;
         // Trust the stored user for now - actual auth is validated by httpOnly cookies
         // on the next API request. If cookies are invalid, user will be redirected to login.
+        // Initial hydration from localStorage — synchronous setState here is
+        // the established pattern for syncing persisted auth into React state.
         // eslint-disable-next-line react-hooks/set-state-in-effect
         setUser(parsedUser);
       } catch {
@@ -208,6 +210,7 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
       }
     }
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setIsLoading(false);
   }, []);
 

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -103,6 +103,7 @@ export interface CommitteeAssignment {
   name: string;
   role?: string;
   url?: string;
+  legislativeCommitteeId?: string;
 }
 
 export interface Representative {
@@ -175,6 +176,51 @@ export interface PaginatedCommittees {
   items: Committee[];
   total: number;
   hasMore: boolean;
+}
+
+export interface LegislativeCommittee {
+  id: string;
+  externalId: string;
+  name: string;
+  chamber: string;
+  url?: string;
+  description?: string;
+  memberCount: number;
+}
+
+export interface PaginatedLegislativeCommittees {
+  items: LegislativeCommittee[];
+  total: number;
+  hasMore: boolean;
+}
+
+export interface LegislativeCommitteeMember {
+  representativeId: string;
+  name: string;
+  role?: string;
+  party: string;
+  photoUrl?: string;
+}
+
+export interface LegislativeCommitteeHearing {
+  id: string;
+  title: string;
+  scheduledAt: string;
+  agendaUrl?: string;
+}
+
+export interface LegislativeCommitteeDetail {
+  id: string;
+  externalId: string;
+  name: string;
+  chamber: string;
+  url?: string;
+  description?: string;
+  memberCount: number;
+  members: LegislativeCommitteeMember[];
+  hearings: LegislativeCommitteeHearing[];
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface Contribution {
@@ -298,6 +344,14 @@ export interface CommitteeData {
   committee: Committee | null;
 }
 
+export interface LegislativeCommitteesData {
+  legislativeCommittees: PaginatedLegislativeCommittees;
+}
+
+export interface LegislativeCommitteeData {
+  legislativeCommittee: LegislativeCommitteeDetail | null;
+}
+
 export interface ContributionsData {
   contributions: PaginatedContributions;
 }
@@ -349,6 +403,10 @@ export interface IdVars {
 
 export interface CommitteesVars extends PaginationVars {
   sourceSystem?: string;
+}
+
+export interface LegislativeCommitteesVars extends PaginationVars {
+  chamber?: string;
 }
 
 export interface ContributionsVars extends PaginationVars {
@@ -653,6 +711,7 @@ export const GET_REPRESENTATIVE = gql`
         name
         role
         url
+        legislativeCommitteeId
       }
       committeesSummary
       bio
@@ -737,6 +796,53 @@ export const GET_COMMITTEE = gql`
       status
       sourceSystem
       sourceUrl
+      createdAt
+      updatedAt
+    }
+  }
+`;
+
+export const GET_LEGISLATIVE_COMMITTEES = gql`
+  query GetLegislativeCommittees($skip: Int, $take: Int, $chamber: String) {
+    legislativeCommittees(skip: $skip, take: $take, chamber: $chamber) {
+      items {
+        id
+        externalId
+        name
+        chamber
+        url
+        description
+        memberCount
+      }
+      total
+      hasMore
+    }
+  }
+`;
+
+export const GET_LEGISLATIVE_COMMITTEE = gql`
+  query GetLegislativeCommittee($id: ID!) {
+    legislativeCommittee(id: $id) {
+      id
+      externalId
+      name
+      chamber
+      url
+      description
+      memberCount
+      members {
+        representativeId
+        name
+        role
+        party
+        photoUrl
+      }
+      hearings {
+        id
+        title
+        scheduledAt
+        agendaUrl
+      }
       createdAt
       updatedAt
     }

--- a/apps/frontend/lib/hooks/useCamera.ts
+++ b/apps/frontend/lib/hooks/useCamera.ts
@@ -90,6 +90,8 @@ export function useCamera(options: UseCameraOptions = {}): UseCameraReturn {
       typeof navigator === "undefined" ||
       !navigator.mediaDevices?.getUserMedia
     ) {
+      // Initial-mount feature-detect — surfacing "unsupported" synchronously
+      // is the whole purpose of this effect.
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setPermissionState("unsupported");
       return;

--- a/packages/relationaldb-provider/prisma/migrations/20260426010000_add_legislative_committees/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260426010000_add_legislative_committees/migration.sql
@@ -1,0 +1,59 @@
+-- Legislative committees: first-class entity + membership join table.
+--
+-- Adds:
+--   * legislative_committees — committees within a chamber (Senate Judiciary,
+--     Assembly Health, etc). NOT campaign-finance committees — that's the
+--     separate `committees` table. Populated by the backfill service from
+--     Representative.committees JSON.
+--   * representative_committee_assignments — many-to-many membership join
+--     with canonicalized role (Chair / Vice Chair / Member).
+--
+-- Migration is fully additive. Existing rows are unaffected; the
+-- representatives.committees JSONB column stays as the canonical source for
+-- the backfill and remains writable by future scrapes.
+
+-- 1. legislative_committees ------------------------------------------------
+CREATE TABLE "legislative_committees" (
+    "id" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "chamber" VARCHAR(20) NOT NULL,
+    "url" TEXT,
+    "description" TEXT,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "deleted_at" TIMESTAMPTZ,
+
+    CONSTRAINT "legislative_committees_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "legislative_committees_external_id_key" ON "legislative_committees" ("external_id");
+CREATE INDEX "legislative_committees_chamber_idx" ON "legislative_committees" ("chamber");
+CREATE INDEX "legislative_committees_name_idx" ON "legislative_committees" ("name");
+
+-- 2. representative_committee_assignments ---------------------------------
+CREATE TABLE "representative_committee_assignments" (
+    "id" TEXT NOT NULL,
+    "representative_id" TEXT NOT NULL,
+    "legislative_committee_id" TEXT NOT NULL,
+    "role" VARCHAR(50),
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "representative_committee_assignments_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "representative_committee_assignments_representative_id_legi_key"
+    ON "representative_committee_assignments" ("representative_id", "legislative_committee_id");
+CREATE INDEX "representative_committee_assignments_legislative_committee__idx"
+    ON "representative_committee_assignments" ("legislative_committee_id");
+
+ALTER TABLE "representative_committee_assignments"
+    ADD CONSTRAINT "representative_committee_assignments_representative_id_fkey"
+    FOREIGN KEY ("representative_id") REFERENCES "representatives" ("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "representative_committee_assignments"
+    ADD CONSTRAINT "representative_committee_assignments_legislative_committe_fkey"
+    FOREIGN KEY ("legislative_committee_id") REFERENCES "legislative_committees" ("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -573,7 +573,7 @@ model Representative {
   party       String
   photoUrl    String?   @map("photo_url")
   contactInfo Json?     @map("contact_info")
-  committees  Json?     @map("committees")       /// CommitteeAssignment[] as JSON
+  committees  Json?     @map("committees")       /// CommitteeAssignment[] as JSON — canonical source for the LegislativeCommittee backfill
   committeesSummary String? @map("committees_summary") @db.Text /// AI-generated preamble describing the policy areas touched by committee assignments
   bio         String?   @db.Text
   bioSource   String?   @map("bio_source") @db.VarChar(20) /// 'scraped' | 'ai-generated'
@@ -582,11 +582,58 @@ model Representative {
   updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
 
+  committeeAssignments RepresentativeCommitteeAssignment[]
+
   @@index([name])
   @@index([lastName])
   @@index([chamber])
   @@index([party])
   @@map("representatives")
+}
+
+/// Legislative committee within a chamber (e.g. Assembly Health, Senate Judiciary).
+/// First-class entity derived from Representative.committees JSON via the backfill
+/// service. NOT a campaign-finance committee — that's the separate `Committee`
+/// model. See ROADMAP issue for the eventual `Committee` → `FinanceCommittee` rename.
+model LegislativeCommittee {
+  id          String    @id @default(uuid())
+  externalId  String    @unique @map("external_id") /// `<chamber-lowercased>:<normalized-name>` e.g. "assembly:budget"
+  name        String                                 /// Display name as scraped (e.g. "Budget")
+  chamber     String    @db.VarChar(20)              /// "Assembly" | "Senate"
+  url         String?                                /// Optional canonical official link (when present in source data)
+  /// AI-generated description placeholder for Phase 2 — kept nullable so the
+  /// column ships now and a future analyzer can populate later.
+  description String?   @db.Text
+  createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+  deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
+
+  assignments RepresentativeCommitteeAssignment[]
+
+  @@index([chamber])
+  @@index([name])
+  @@map("legislative_committees")
+}
+
+/// Many-to-many: which legislators sit on which committees, with role.
+/// Populated by LegislativeCommitteeBackfillService from
+/// Representative.committees JSON. Roles are canonicalized at backfill time
+/// to one of: 'Chair' | 'Vice Chair' | 'Member' (anything unrecognized
+/// collapses to 'Member').
+model RepresentativeCommitteeAssignment {
+  id                     String   @id @default(uuid())
+  representativeId       String   @map("representative_id")
+  legislativeCommitteeId String   @map("legislative_committee_id")
+  role                   String?  @db.VarChar(50)
+  createdAt              DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt              DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  representative Representative       @relation(fields: [representativeId],       references: [id], onDelete: Cascade)
+  committee      LegislativeCommittee @relation(fields: [legislativeCommitteeId], references: [id], onDelete: Cascade)
+
+  @@unique([representativeId, legislativeCommitteeId])
+  @@index([legislativeCommitteeId])
+  @@map("representative_committee_assignments")
 }
 
 model Proposition {

--- a/packages/relationaldb-provider/src/index.ts
+++ b/packages/relationaldb-provider/src/index.ts
@@ -70,6 +70,8 @@ export type {
   IndependentExpenditure,
   CommitteeMeasurePosition,
   Cvr2Filing,
+  LegislativeCommittee,
+  RepresentativeCommitteeAssignment,
   PromptTemplate,
   AbuseReport,
   DocumentProposition,


### PR DESCRIPTION
## Summary

- Materializes a first-class **LegislativeCommittee** + **RepresentativeCommitteeAssignment** join from the existing `Representative.committees` JSONB column, via a post-sync `LegislativeCommitteeLinkerService` (mirrors the `proposition-finance-linker` pattern). Idempotent.
- New 4-layer voter-facing detail page at `/region/legislative-committees/[id]` (Snapshot / Members / Hearings / Deep Dive), plus a list page with chamber filter. Each rep page now links its committee rows to the new detail page.
- AI-generated 2-3 sentence committee descriptions powered by the new `document-analysis-legislative-committee-description` prompt in the prompt-service ([companion PR](https://github.com/OpusPopuli/prompt-service/pulls)). Auto-runs after each rep sync; `run-legislative-committee-descriptions.ts` is the one-off bootstrap script.
- Bundled fixes:
  - **Assemblyman district match** — DB stores Assembly unpadded (`"2"`) and Senate padded (`"02"`); `getRepresentativesByDistricts` now matches both forms for both chambers.
  - **Region home card swap** — `Campaign Finance` → `Legislative Committees` (the campaign-finance hub stays reachable directly).
  - **Hearings dedup + relative-URL filter** — defends the new committee detail page against two known meeting-scrape bugs (duplicate rows, relative `agenda_url` values causing 404s on the link). Underlying scrape bugs filed separately.
  - Four pre-existing `react-hooks/set-state-in-effect` errors suppressed so the docker frontend image builds — these were blocking `docker compose -f docker-compose-frontend.yml up --build`. Pure docker-build unblock; runtime behavior unchanged.

## Architecture notes

- `LegislativeCommittee` is a separate entity from the existing finance-only `Committee` model; same-cycle rename to `FinanceCommittee` is filed as future work.
- `description` column is nullable so the AI generator can fill it lazily (post-sync hook).
- Linker `linkAll()` is split into 3 phases (collect → upsertCommittees → upsertMemberships) to keep cognitive complexity under the project gate.

## Test plan

- [ ] CI green (1462 backend / 1173 frontend tests pass locally; lint clean; docker frontend builds)
- [ ] Migration `20260426010000_add_legislative_committees` applies cleanly on UAT
- [ ] After deploy, run the linker bootstrap script and confirm committee + assignment row counts (~30-80 committees, ~120-300 assignments for CA)
- [ ] Run the description bootstrap script and verify Snapshot layer renders generated text instead of "Coming soon"
- [ ] Browser walkthrough: home card → list → detail (all 4 layers) → rep page committee links round-trip
- [ ] Verify primary address with both Assembly + Senate districts shows BOTH reps on the home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)