### PR TITLE
release: campaign-finance gating, scrape resilience, healthcheck

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,7 +76,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.28",
+    "@opuspopuli/regions": "^1.0.29",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,7 +76,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.29",
+    "@opuspopuli/regions": "^1.0.31",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/app.module.ts
+++ b/apps/backend/src/apps/region/src/app.module.ts
@@ -39,6 +39,20 @@ import { MetricsModule } from 'src/common/metrics';
 import { SecretsModule } from '@opuspopuli/secrets-provider';
 
 /**
+ * Parse a positive integer byte count from an env var; fall back to
+ * `defaultBytes` if absent or invalid. Used by the HealthModule config
+ * below to override the in-process default RSS threshold per deployment.
+ */
+function parseRssThreshold(
+  raw: string | undefined,
+  defaultBytes: number,
+): number {
+  if (!raw) return defaultBytes;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultBytes;
+}
+
+/**
  * Region App Module
  *
  * Handles civic data management for the region.
@@ -71,7 +85,23 @@ import { SecretsModule } from '@opuspopuli/secrets-provider';
     CaslModule.forRoot(),
     SecretsModule,
     RegionDomainModule,
-    HealthModule.forRoot({ serviceName: 'region-service', hasDatabase: true }),
+    // Region's RSS legitimately spikes to ~1.7GB during CalAccess bulk
+    // download (~3M contributions, ~70K committee stubs accumulated in
+    // memory before flush). Container memory limit is 6GB; the healthcheck
+    // threshold needs to be well above the observed spike but well below
+    // the container limit. 3GB lands in the right zone — masks no real
+    // OOM risk and stops the false-alarm spam during legitimate sync.
+    // Other services (users, documents, knowledge, api) keep the 1GB
+    // default — they don't do bulk-download work, so a lower threshold
+    // there still catches real memory leaks. See #642.
+    HealthModule.forRoot({
+      serviceName: 'region-service',
+      hasDatabase: true,
+      memoryRssThreshold: parseRssThreshold(
+        process.env.MEMORY_RSS_THRESHOLD_BYTES,
+        3 * 1024 * 1024 * 1024,
+      ),
+    }),
     MetricsModule.forRoot({ serviceName: 'region-service' }),
   ],
   providers: SHARED_PROVIDERS,

--- a/apps/frontend/__tests__/accessibility/settings.a11y.test.tsx
+++ b/apps/frontend/__tests__/accessibility/settings.a11y.test.tsx
@@ -43,7 +43,7 @@ const mockAddresses = [
   {
     id: "addr-1",
     userId: "user-1",
-    addressType: "residential",
+    addressType: "RESIDENTIAL",
     isPrimary: true,
     label: "Home",
     addressLine1: "123 Main St",

--- a/apps/frontend/__tests__/pages/settings/addresses.test.tsx
+++ b/apps/frontend/__tests__/pages/settings/addresses.test.tsx
@@ -48,7 +48,7 @@ const mockAddresses = [
   {
     id: "addr-1",
     userId: "user-1",
-    addressType: "residential",
+    addressType: "RESIDENTIAL",
     isPrimary: true,
     label: "Home",
     addressLine1: "123 Main St",
@@ -65,7 +65,7 @@ const mockAddresses = [
   {
     id: "addr-2",
     userId: "user-1",
-    addressType: "mailing",
+    addressType: "MAILING",
     isPrimary: false,
     label: "Work",
     addressLine1: "456 Office Blvd",

--- a/apps/frontend/app/settings/addresses/page.tsx
+++ b/apps/frontend/app/settings/addresses/page.tsx
@@ -19,11 +19,15 @@ import {
   AddressType,
 } from "@/lib/graphql/profile";
 
+// Values are uppercase to match the GraphQL `AddressType` enum's wire format.
+// labelKeys stay lowercase since the i18n translation files key by the
+// lowercase value (`addresses.types.residential` etc.) — no need to migrate
+// every locale's translation key when only the wire format changed.
 const ADDRESS_TYPES: { value: AddressType; labelKey: string }[] = [
-  { value: "residential", labelKey: "addresses.types.residential" },
-  { value: "mailing", labelKey: "addresses.types.mailing" },
-  { value: "business", labelKey: "addresses.types.business" },
-  { value: "voting", labelKey: "addresses.types.voting" },
+  { value: "RESIDENTIAL", labelKey: "addresses.types.residential" },
+  { value: "MAILING", labelKey: "addresses.types.mailing" },
+  { value: "BUSINESS", labelKey: "addresses.types.business" },
+  { value: "VOTING", labelKey: "addresses.types.voting" },
 ];
 
 const US_STATES = [
@@ -81,7 +85,7 @@ const US_STATES = [
 ];
 
 const emptyAddress: CreateAddressInput = {
-  addressType: "residential",
+  addressType: "RESIDENTIAL",
   isPrimary: false,
   label: "",
   addressLine1: "",
@@ -413,7 +417,9 @@ export default function AddressesPage() {
                   <div className="flex items-center gap-3 mb-2">
                     <span className="text-sm font-medium text-[#222222] capitalize">
                       {address.label ||
-                        t(`addresses.types.${address.addressType}`)}
+                        t(
+                          `addresses.types.${address.addressType.toLowerCase()}`,
+                        )}
                     </span>
                     {address.isPrimary && (
                       <span className="px-2 py-0.5 text-xs font-medium bg-green-100 text-green-700 rounded">

--- a/apps/frontend/lib/graphql/profile.ts
+++ b/apps/frontend/lib/graphql/profile.ts
@@ -128,7 +128,18 @@ export interface UpdateProfileInput {
   homeownerStatus?: HomeownerStatus;
 }
 
-export type AddressType = "residential" | "mailing" | "business" | "voting";
+/**
+ * GraphQL `AddressType` enum — wire-format names are uppercase.
+ *
+ * NestJS's `registerEnumType` (apps/backend/src/common/enums/address.enum.ts)
+ * exposes the enum KEYS to GraphQL, not the VALUES. The TS-side enum
+ * has uppercase keys (`RESIDENTIAL`, `MAILING`, ...) and lowercase
+ * string values (`'residential'`, ...) — the backend stores lowercase
+ * in the DB but mutations + responses on the wire carry the uppercase
+ * name. Sending the lowercase value over GraphQL fails validation:
+ * `Value "residential" does not exist in "AddressType" enum.`
+ */
+export type AddressType = "RESIDENTIAL" | "MAILING" | "BUSINESS" | "VOTING";
 
 export interface UserAddress {
   id: string;

--- a/docker-compose-uat.yml
+++ b/docker-compose-uat.yml
@@ -202,6 +202,12 @@ services:
       # LLM for AI-powered structural analysis during data scraping
       LLM_URL: http://host.docker.internal:11434
       LLM_MODEL: qwen3.5:9b
+      # Bump default Ollama request timeout (60s) — proposition-analysis,
+      # bio, and structural-analysis prompts are 7-18KB and routinely
+      # take 60-150s on qwen3.5:9b on a Mac, especially after a sleep
+      # cycle when the model has to reload into memory. 180s gives
+      # headroom without masking actual hangs. See #646.
+      OLLAMA_REQUEST_TIMEOUT_MS: "180000"
       # AI Prompt Service for proprietary prompt templates
       PROMPT_SERVICE_URL: http://opuspopuli-prompts:3210
       # FEC API key for federal campaign finance data

--- a/packages/extraction-provider/__tests__/extraction.provider.spec.ts
+++ b/packages/extraction-provider/__tests__/extraction.provider.spec.ts
@@ -288,6 +288,134 @@ describe("ExtractionProvider", () => {
     });
   });
 
+  describe("fetchBytes / fetchPdfText", () => {
+    /**
+     * Build a buffer containing the PDF magic bytes plus a few bytes
+     * outside the ASCII range. A UTF-8 round-trip via response.text()
+     * would replace 0x80-0xFF bytes with the U+FFFD replacement
+     * character (a 3-byte UTF-8 sequence), so a Buffer reconstructed
+     * from such a string would have a different length AND different
+     * contents — exactly the failure mode that breaks PDFParse.
+     */
+    function pdfishBuffer(): Buffer {
+      return Buffer.concat([
+        Buffer.from("%PDF-1.6\n"),
+        Buffer.from([0xe2, 0xe3, 0xcf, 0xd3, 0x0d, 0x0a]), // binary marker
+        Buffer.from("1 0 obj\n<< /Type /Catalog >>\nendobj\n"),
+        Buffer.from([0x80, 0x81, 0x82, 0xff]), // arbitrary non-ASCII bytes
+      ]);
+    }
+
+    /**
+     * Build a fresh standalone ArrayBuffer with exactly the source
+     * bytes — `Buffer#buffer` returns the underlying pool's full
+     * ArrayBuffer (often 8KB), not the slice the Buffer represents.
+     */
+    function asArrayBuffer(buf: Buffer): ArrayBuffer {
+      const ab = new ArrayBuffer(buf.byteLength);
+      new Uint8Array(ab).set(buf);
+      return ab;
+    }
+
+    it("returns the response body as a Buffer with bytes preserved exactly", async () => {
+      const original = pdfishBuffer();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "https://example.com/test.pdf",
+        arrayBuffer: () => Promise.resolve(asArrayBuffer(original)),
+        headers: new Map([["content-type", "application/pdf"]]),
+      });
+
+      const result = await provider.fetchBytes("https://example.com/test.pdf");
+
+      expect(result.content).toBeInstanceOf(Buffer);
+      expect(result.content.length).toBe(original.length);
+      // Critical: every byte preserved (not UTF-8-mangled)
+      expect(result.content.equals(original)).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(result.contentType).toBe("application/pdf");
+    });
+
+    it("fetchPdfText pipes binary-safe bytes into extractPdfText", async () => {
+      const original = pdfishBuffer();
+      let bufferGivenToParser: Buffer | undefined;
+
+      // Replace the global pdf-parse mock to capture what extractPdfText
+      // received, so we can assert it wasn't UTF-8-mangled by the fetch path.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const pdfParse = require("pdf-parse");
+      pdfParse.PDFParse.mockImplementationOnce(({ data }: { data: Buffer }) => {
+        bufferGivenToParser = data;
+        return {
+          getText: jest.fn().mockResolvedValue({ text: "ok" }),
+          destroy: jest.fn().mockResolvedValue(undefined),
+        };
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        url: "https://example.com/test.pdf",
+        arrayBuffer: () => Promise.resolve(asArrayBuffer(original)),
+        headers: new Map([["content-type", "application/pdf"]]),
+      });
+
+      const text = await provider.fetchPdfText("https://example.com/test.pdf");
+
+      expect(text).toBe("ok");
+      expect(bufferGivenToParser).toBeInstanceOf(Buffer);
+      expect(bufferGivenToParser!.equals(original)).toBe(true);
+    });
+
+    it("fetchBytesWithRetry retries on transient error then succeeds", async () => {
+      const original = pdfishBuffer();
+      mockFetch
+        .mockRejectedValueOnce(new Error("Network error"))
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          url: "https://example.com/x.pdf",
+          arrayBuffer: () => Promise.resolve(asArrayBuffer(original)),
+          headers: new Map([["content-type", "application/pdf"]]),
+        });
+
+      const promise = provider.fetchBytesWithRetry(
+        "https://example.com/x.pdf",
+        {
+          bypassCache: true,
+        } as never,
+      );
+
+      // Drain the retry backoff timer (mirrors the existing
+      // fetchWithRetry retry test's shape — single advance, not
+      // runAllTimersAsync, to avoid the cache-cleanup interval loop)
+      await jest.advanceTimersByTimeAsync(5000);
+      const result = await promise;
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(result.content.equals(original)).toBe(true);
+    });
+
+    it("throws FetchError on non-2xx response", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        url: "https://example.com/missing.pdf",
+        arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+        headers: new Map(),
+      });
+
+      await expect(
+        provider.fetchBytes("https://example.com/missing.pdf"),
+      ).rejects.toThrow(FetchError);
+    });
+  });
+
   describe("selectElements", () => {
     const html = `
       <html>

--- a/packages/extraction-provider/src/extraction.provider.ts
+++ b/packages/extraction-provider/src/extraction.provider.ts
@@ -251,6 +251,115 @@ export class ExtractionProvider {
   }
 
   /**
+   * Fetch a URL and return its body as a Buffer (binary-safe).
+   *
+   * Use this for PDFs and other binary content. The text-mode
+   * fetchUrl/fetchWithRetry decode the body as UTF-8 via
+   * `response.text()`, which mangles non-UTF-8 bytes (every byte > 0x7F
+   * gets replaced with U+FFFD) and cannot be reversed via
+   * `Buffer.from(string, 'binary')`. PDFs round-tripped through that
+   * path arrive at PDFParse with a corrupted cross-reference table and
+   * fail with "Invalid Root reference".
+   *
+   * Bypasses the text cache (binary content shouldn't share a cache
+   * key with text fetches of the same URL) but still goes through the
+   * rate limiter and circuit breaker.
+   */
+  async fetchBytes(
+    url: string,
+    options: FetchOptions = {},
+  ): Promise<{
+    content: Buffer;
+    statusCode: number;
+    contentType: string;
+    finalUrl?: string;
+    redirectedFrom?: string;
+  }> {
+    await this.rateLimiter.acquire();
+    this.logger.debug(`Fetching bytes from ${url}`);
+
+    return this.circuitBreaker.execute(async () => {
+      const timeout = options.timeout ?? this.config.defaultTimeout;
+      const response = await this.fetchFn(url, {
+        headers: options.headers,
+        signal: AbortSignal.timeout(timeout),
+      });
+
+      if (!response.ok) {
+        throw new FetchError(
+          url,
+          response.status,
+          `HTTP ${response.status}: ${response.statusText}`,
+        );
+      }
+
+      const arrayBuffer = await response.arrayBuffer();
+      const content = Buffer.from(arrayBuffer);
+      const contentType = response.headers.get("content-type") || "unknown";
+      const finalUrl = response.url;
+      const wasRedirected = finalUrl && finalUrl !== url;
+
+      if (wasRedirected) {
+        this.logger.warn(
+          `URL redirect detected: ${url} → ${finalUrl}. Consider updating the data source config.`,
+        );
+      }
+
+      return {
+        content,
+        statusCode: response.status,
+        contentType,
+        ...(wasRedirected && { redirectedFrom: url, finalUrl }),
+      };
+    });
+  }
+
+  /**
+   * Fetch a URL as bytes with exponential-backoff retry. Same retry
+   * shape as fetchWithRetry, but the body is preserved binary-safe
+   * for PDF/image/zip downloads.
+   */
+  async fetchBytesWithRetry(
+    url: string,
+    options: RetryOptions = {},
+  ): Promise<{
+    content: Buffer;
+    statusCode: number;
+    contentType: string;
+    finalUrl?: string;
+    redirectedFrom?: string;
+  }> {
+    return withRetry(() => this.fetchBytes(url, options), {
+      maxAttempts: options.maxRetries ?? this.config.retry.maxAttempts,
+      baseDelayMs: options.baseDelayMs ?? this.config.retry.baseDelayMs,
+      maxDelayMs: options.maxDelayMs ?? this.config.retry.maxDelayMs,
+      isRetryable: RetryPredicates.any(
+        RetryPredicates.isNetworkError,
+        RetryPredicates.isServerError,
+        RetryPredicates.isRateLimitError,
+      ),
+      onRetry: (error, attempt, delayMs) => {
+        this.logger.warn(
+          `Retry attempt ${attempt} for ${url} after ${delayMs}ms: ${error.message}`,
+        );
+      },
+    });
+  }
+
+  /**
+   * Convenience: fetch a PDF URL as bytes (binary-safe) and extract
+   * its text in one call. The previous pattern
+   * `fetchWithRetry(url) → Buffer.from(content, "binary") → extractPdfText`
+   * was broken for any PDF whose bytes weren't pure ASCII — which is
+   * essentially every real PDF — because fetchWithRetry's
+   * `response.text()` UTF-8-decodes the body and cannot be reversed.
+   */
+  async fetchPdfText(url: string, options: RetryOptions = {}): Promise<string> {
+    const result = await this.fetchBytesWithRetry(url, options);
+    return this.extractPdfText(result.content);
+  }
+
+  /**
    * Parse HTML and select elements via CSS selector
    *
    * @param html - HTML content to parse

--- a/packages/extraction-provider/src/extraction.provider.ts
+++ b/packages/extraction-provider/src/extraction.provider.ts
@@ -157,54 +157,14 @@ export class ExtractionProvider {
       }
     }
 
-    // Wait for rate limiter
     await this.rateLimiter.acquire();
-
     this.logger.debug(`Fetching ${url}`);
 
-    // Wrap the fetch call with circuit breaker protection
-    return this.circuitBreaker.execute(async () => {
-      const timeout = options.timeout ?? this.config.defaultTimeout;
+    const fetched = await this.fetchAndDecode(url, options, (r) => r.text());
+    const result: CachedFetchResult = { ...fetched, fromCache: false };
 
-      const response = await this.fetchFn(url, {
-        headers: options.headers,
-        signal: AbortSignal.timeout(timeout),
-      });
-
-      if (!response.ok) {
-        throw new FetchError(
-          url,
-          response.status,
-          `HTTP ${response.status}: ${response.statusText}`,
-        );
-      }
-
-      const content = await response.text();
-      const contentType = response.headers.get("content-type") || "unknown";
-
-      // Detect permanent redirects (fetch follows them automatically)
-      const finalUrl = response.url;
-      const wasRedirected = finalUrl && finalUrl !== url;
-
-      if (wasRedirected) {
-        this.logger.warn(
-          `URL redirect detected: ${url} → ${finalUrl}. Consider updating the data source config.`,
-        );
-      }
-
-      const result: CachedFetchResult = {
-        content,
-        fromCache: false,
-        statusCode: response.status,
-        contentType,
-        ...(wasRedirected && { redirectedFrom: url, finalUrl }),
-      };
-
-      // Cache the result
-      await this.cache.set(cacheKey, result);
-
-      return result;
-    });
+    await this.cache.set(cacheKey, result);
+    return result;
   }
 
   /**
@@ -218,21 +178,7 @@ export class ExtractionProvider {
     url: string,
     options: RetryOptions = {},
   ): Promise<CachedFetchResult> {
-    return withRetry(() => this.fetchUrl(url, options), {
-      maxAttempts: options.maxRetries ?? this.config.retry.maxAttempts,
-      baseDelayMs: options.baseDelayMs ?? this.config.retry.baseDelayMs,
-      maxDelayMs: options.maxDelayMs ?? this.config.retry.maxDelayMs,
-      isRetryable: RetryPredicates.any(
-        RetryPredicates.isNetworkError,
-        RetryPredicates.isServerError,
-        RetryPredicates.isRateLimitError,
-      ),
-      onRetry: (error, attempt, delayMs) => {
-        this.logger.warn(
-          `Retry attempt ${attempt} for ${url} after ${delayMs}ms: ${error.message}`,
-        );
-      },
-    });
+    return this.retryStandard(url, options, () => this.fetchUrl(url, options));
   }
 
   /**
@@ -278,40 +224,9 @@ export class ExtractionProvider {
     await this.rateLimiter.acquire();
     this.logger.debug(`Fetching bytes from ${url}`);
 
-    return this.circuitBreaker.execute(async () => {
-      const timeout = options.timeout ?? this.config.defaultTimeout;
-      const response = await this.fetchFn(url, {
-        headers: options.headers,
-        signal: AbortSignal.timeout(timeout),
-      });
-
-      if (!response.ok) {
-        throw new FetchError(
-          url,
-          response.status,
-          `HTTP ${response.status}: ${response.statusText}`,
-        );
-      }
-
-      const arrayBuffer = await response.arrayBuffer();
-      const content = Buffer.from(arrayBuffer);
-      const contentType = response.headers.get("content-type") || "unknown";
-      const finalUrl = response.url;
-      const wasRedirected = finalUrl && finalUrl !== url;
-
-      if (wasRedirected) {
-        this.logger.warn(
-          `URL redirect detected: ${url} → ${finalUrl}. Consider updating the data source config.`,
-        );
-      }
-
-      return {
-        content,
-        statusCode: response.status,
-        contentType,
-        ...(wasRedirected && { redirectedFrom: url, finalUrl }),
-      };
-    });
+    return this.fetchAndDecode(url, options, async (r) =>
+      Buffer.from(await r.arrayBuffer()),
+    );
   }
 
   /**
@@ -329,21 +244,9 @@ export class ExtractionProvider {
     finalUrl?: string;
     redirectedFrom?: string;
   }> {
-    return withRetry(() => this.fetchBytes(url, options), {
-      maxAttempts: options.maxRetries ?? this.config.retry.maxAttempts,
-      baseDelayMs: options.baseDelayMs ?? this.config.retry.baseDelayMs,
-      maxDelayMs: options.maxDelayMs ?? this.config.retry.maxDelayMs,
-      isRetryable: RetryPredicates.any(
-        RetryPredicates.isNetworkError,
-        RetryPredicates.isServerError,
-        RetryPredicates.isRateLimitError,
-      ),
-      onRetry: (error, attempt, delayMs) => {
-        this.logger.warn(
-          `Retry attempt ${attempt} for ${url} after ${delayMs}ms: ${error.message}`,
-        );
-      },
-    });
+    return this.retryStandard(url, options, () =>
+      this.fetchBytes(url, options),
+    );
   }
 
   /**
@@ -425,6 +328,82 @@ export class ExtractionProvider {
    */
   getCacheProvider(): string {
     return this.cacheProvider;
+  }
+
+  /**
+   * Shared HTTP path: rate-limited callers go through circuit breaker,
+   * we throw FetchError on non-2xx, decode the body via the caller's
+   * `decodeBody` (text vs bytes), and detect/log permanent redirects.
+   * Returning a `content` of generic type `T` lets fetchUrl produce
+   * `string` and fetchBytes produce `Buffer` from the same scaffolding.
+   */
+  private async fetchAndDecode<T>(
+    url: string,
+    options: FetchOptions,
+    decodeBody: (response: Response) => Promise<T>,
+  ): Promise<{
+    content: T;
+    statusCode: number;
+    contentType: string;
+    finalUrl?: string;
+    redirectedFrom?: string;
+  }> {
+    return this.circuitBreaker.execute(async () => {
+      const timeout = options.timeout ?? this.config.defaultTimeout;
+      const response = await this.fetchFn(url, {
+        headers: options.headers,
+        signal: AbortSignal.timeout(timeout),
+      });
+
+      if (!response.ok) {
+        throw new FetchError(
+          url,
+          response.status,
+          `HTTP ${response.status}: ${response.statusText}`,
+        );
+      }
+
+      const content = await decodeBody(response);
+      const contentType = response.headers.get("content-type") || "unknown";
+      const finalUrl = response.url;
+      const wasRedirected = finalUrl && finalUrl !== url;
+
+      if (wasRedirected) {
+        this.logger.warn(
+          `URL redirect detected: ${url} → ${finalUrl}. Consider updating the data source config.`,
+        );
+      }
+
+      return {
+        content,
+        statusCode: response.status,
+        contentType,
+        ...(wasRedirected && { redirectedFrom: url, finalUrl }),
+      };
+    });
+  }
+
+  /** Standard retry wrapper used by fetchWithRetry and fetchBytesWithRetry. */
+  private retryStandard<T>(
+    url: string,
+    options: RetryOptions,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    return withRetry(fn, {
+      maxAttempts: options.maxRetries ?? this.config.retry.maxAttempts,
+      baseDelayMs: options.baseDelayMs ?? this.config.retry.baseDelayMs,
+      maxDelayMs: options.maxDelayMs ?? this.config.retry.maxDelayMs,
+      isRetryable: RetryPredicates.any(
+        RetryPredicates.isNetworkError,
+        RetryPredicates.isServerError,
+        RetryPredicates.isRateLimitError,
+      ),
+      onRetry: (error, attempt, delayMs) => {
+        this.logger.warn(
+          `Retry attempt ${attempt} for ${url} after ${delayMs}ms: ${error.message}`,
+        );
+      },
+    });
   }
 
   /**

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.29"
+    "@opuspopuli/regions": "^1.0.31"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.28"
+    "@opuspopuli/regions": "^1.0.29"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/scraping-pipeline/__tests__/detail-crawler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/detail-crawler.spec.ts
@@ -275,15 +275,12 @@ describe("DetailCrawlerService", () => {
       expect(repResult.items[0].bio).toBeDefined();
     });
 
-    it("should detect PDF detail pages and extract text content", async () => {
-      // Mock extraction with PDF detection support
-      mockExtraction.fetchWithRetry.mockResolvedValue({
-        content: "%PDF-1.4 simulated pdf content about water policy",
-        fromCache: false,
-      } as any);
-
-      // Add extractPdfText to mock
-      (mockExtraction as any).extractPdfText = jest
+    it("should detect PDF detail pages by .pdf extension and use the binary-safe fetchPdfText path", async () => {
+      // The .pdf extension shortcuts to fetchPdfText — the old
+      // `fetchWithRetry → Buffer.from(content, "binary")` path
+      // silently mangled real PDFs (UTF-8 decode is irreversible
+      // for non-ASCII bytes). See ExtractionProvider.fetchPdfText.
+      (mockExtraction as any).fetchPdfText = jest
         .fn()
         .mockResolvedValue("Full text of the water policy reform bill.");
 
@@ -305,16 +302,22 @@ describe("DetailCrawlerService", () => {
       expect(result.items[0].fullText).toBe(
         "Full text of the water policy reform bill.",
       );
-      expect((mockExtraction as any).extractPdfText).toHaveBeenCalled();
+      expect((mockExtraction as any).fetchPdfText).toHaveBeenCalledWith(
+        "https://elections.cdn.sos.ca.gov/ballot-measures/pdf/sb-42.pdf",
+      );
+      // Should NOT have used the broken text-fetch path
+      expect(mockExtraction.fetchWithRetry).not.toHaveBeenCalled();
     });
 
-    it("should detect PDF by content prefix even without .pdf extension", async () => {
+    it("should detect PDF by content prefix on non-.pdf URLs and refetch as bytes", async () => {
+      // For URLs that don't advertise .pdf but turn out to serve a PDF
+      // (content-sniffed): the first fetchWithRetry's text body is already
+      // mangled, so we re-fetch via fetchPdfText to get clean bytes.
       mockExtraction.fetchWithRetry.mockResolvedValue({
         content: "%PDF-1.7 some binary pdf data",
         fromCache: false,
       } as any);
-
-      (mockExtraction as any).extractPdfText = jest
+      (mockExtraction as any).fetchPdfText = jest
         .fn()
         .mockResolvedValue("Extracted PDF text content.");
 
@@ -329,6 +332,10 @@ describe("DetailCrawlerService", () => {
       await crawler.enrichItems(rawResult, createSource(), mockLlm);
 
       expect(rawResult.items[0].fullText).toBe("Extracted PDF text content.");
+      // Sniffed PDFs trigger a second fetch as bytes
+      expect((mockExtraction as any).fetchPdfText).toHaveBeenCalledWith(
+        "https://example.com/document/12345",
+      );
     });
   });
 

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -605,6 +605,71 @@ describe("DomainMapperService", () => {
       expect(result.items[0]).toMatchObject({ supportOrOppose: "support" });
       expect(result.items[1]).toMatchObject({ supportOrOppose: "oppose" });
     });
+
+    // #633: CalAccess BAL_NAME is misused by filers for committee names,
+    // party names, city names, etc. on non-ballot-measure expenditures.
+    // Real ballot-measure rows always carry BAL_NUM too — gate
+    // propositionTitle on its presence.
+    describe("propositionTitle gating on ballotNumber (#633)", () => {
+      const buildExpenditure = (overrides: Record<string, unknown>) => ({
+        externalId: "EXP-GATE",
+        committeeId: "C001",
+        payeeName: "Vendor",
+        amount: "100",
+        date: "2026-01-01",
+        propositionTitle: "California Republican Party",
+        sourceSystem: "cal_access",
+        ...overrides,
+      });
+
+      const mapOne = (raw: Record<string, unknown>) =>
+        mapper.map(
+          createRawResult({ items: [raw] }),
+          createSource({
+            dataType: DataType.CAMPAIGN_FINANCE,
+            category: "expenditure",
+          }),
+        );
+
+      it("drops propositionTitle when ballotNumber is absent (filer noise)", () => {
+        const result = mapOne(buildExpenditure({}));
+        expect(result.items[0]).toMatchObject({ payeeName: "Vendor" });
+        expect(
+          (result.items[0] as { propositionTitle?: string }).propositionTitle,
+        ).toBeUndefined();
+      });
+
+      it("drops propositionTitle when ballotNumber is null", () => {
+        const result = mapOne(buildExpenditure({ ballotNumber: null }));
+        expect(
+          (result.items[0] as { propositionTitle?: string }).propositionTitle,
+        ).toBeUndefined();
+      });
+
+      it("drops propositionTitle when ballotNumber is an empty string", () => {
+        const result = mapOne(buildExpenditure({ ballotNumber: "   " }));
+        expect(
+          (result.items[0] as { propositionTitle?: string }).propositionTitle,
+        ).toBeUndefined();
+      });
+
+      it("keeps propositionTitle when ballotNumber is populated (real measure)", () => {
+        const result = mapOne(
+          buildExpenditure({
+            ballotNumber: "10",
+            propositionTitle: "Medi-Cal Funding and Accountability Act",
+          }),
+        );
+        expect(
+          (result.items[0] as { propositionTitle?: string }).propositionTitle,
+        ).toBe("Medi-Cal Funding and Accountability Act");
+      });
+
+      it("never leaks the transient ballotNumber field into the output", () => {
+        const result = mapOne(buildExpenditure({ ballotNumber: "10" }));
+        expect(result.items[0]).not.toHaveProperty("ballotNumber");
+      });
+    });
   });
 
   describe("campaign finance — independent expenditures", () => {

--- a/packages/scraping-pipeline/__tests__/field-transformer.spec.ts
+++ b/packages/scraping-pipeline/__tests__/field-transformer.spec.ts
@@ -177,4 +177,62 @@ describe("FieldTransformer", () => {
       expect(result).toBe("not a date");
     });
   });
+
+  describe("unknown transform type", () => {
+    // Per-process dedup means we need a fresh module per test to
+    // consistently observe the first-warning path.
+    let warnSpy: jest.SpyInstance;
+    let Fresh: typeof FieldTransformer;
+
+    beforeEach(() => {
+      jest.resetModules();
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const NestCommon = require("@nestjs/common");
+      warnSpy = jest
+        .spyOn(NestCommon.Logger.prototype, "warn")
+        .mockImplementation();
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      Fresh = require("../src/extraction/field-transformer").FieldTransformer;
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('warns when transform.type is unknown (e.g. "regex" instead of "regex_replace")', () => {
+      // Cast through unknown — TS literal-union forbids "regex" at compile
+      // time, but DB-loaded manifests bypass that check at runtime.
+      const result = Fresh.apply(
+        "ACA 13 (Ward) Voting thresholds. (Res. Ch. 176, 2023) (PDF)",
+        {
+          type: "regex" as unknown as "regex_replace",
+          params: { pattern: "^([A-Z]+\\s*\\d+)" },
+        },
+      );
+
+      // Value passes through unchanged — we don't break callers with bad data,
+      // but the warning surfaces the bug instead of failing silently.
+      expect(result).toBe(
+        "ACA 13 (Ward) Voting thresholds. (Res. Ch. 176, 2023) (PDF)",
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = warnSpy.mock.calls[0][0] as string;
+      expect(message).toContain('Unknown transform type "regex"');
+      expect(message).toContain("regex_replace");
+      expect(message).toContain('extractionMethod: "regex"');
+    });
+
+    it("dedupes warnings — same unknown type repeated does not spam the log", () => {
+      Fresh.apply("a", { type: "bogus" as unknown as "regex_replace" });
+      Fresh.apply("b", { type: "bogus" as unknown as "regex_replace" });
+      Fresh.apply("c", { type: "bogus" as unknown as "regex_replace" });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("warns separately for distinct unknown types", () => {
+      Fresh.apply("a", { type: "regex" as unknown as "regex_replace" });
+      Fresh.apply("b", { type: "extract" as unknown as "regex_replace" });
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/packages/scraping-pipeline/src/crawling/detail-crawler.service.ts
+++ b/packages/scraping-pipeline/src/crawling/detail-crawler.service.ts
@@ -263,24 +263,37 @@ export class DetailCrawlerService {
 
   /**
    * Fetch detail page content, handling PDF extraction if needed.
+   *
+   * URLs ending in .pdf are fetched binary-safe via fetchPdfText; the
+   * old pattern of `fetchWithRetry → Buffer.from(content, "binary")`
+   * silently mangled real PDF bytes (the response.text() UTF-8 decode
+   * is irreversible for non-ASCII bytes, leaving the parser to fail
+   * with "Invalid Root reference"). For pages that don't end in .pdf
+   * but turn out to be PDF responses, we re-fetch as bytes since the
+   * first fetch's content is already corrupted.
    */
   private async fetchDetailContent(detailUrl: string): Promise<string> {
-    const fetchResult = await this.extraction.fetchWithRetry(detailUrl);
-    let content = fetchResult.content;
-
-    const isPdf =
-      detailUrl.toLowerCase().endsWith(".pdf") || content.startsWith("%PDF");
-
-    if (isPdf) {
-      content = await this.extraction.extractPdfText(
-        Buffer.from(content, "binary"),
-      );
+    if (detailUrl.toLowerCase().endsWith(".pdf")) {
+      const text = await this.extraction.fetchPdfText(detailUrl);
       this.logger.debug(
-        `Extracted ${content.length} chars from PDF: ${detailUrl}`,
+        `Extracted ${text.length} chars from PDF: ${detailUrl}`,
       );
+      return text;
     }
 
-    return content;
+    const fetchResult = await this.extraction.fetchWithRetry(detailUrl);
+    if (fetchResult.content.startsWith("%PDF")) {
+      // URL didn't advertise .pdf but the response body is one — refetch
+      // as bytes. The text-mode body is already corrupted; we can't
+      // recover it via Buffer.from(content, "binary").
+      const text = await this.extraction.fetchPdfText(detailUrl);
+      this.logger.debug(
+        `Extracted ${text.length} chars from PDF: ${detailUrl} (content-sniffed)`,
+      );
+      return text;
+    }
+
+    return fetchResult.content;
   }
 
   /**

--- a/packages/scraping-pipeline/src/extraction/field-transformer.ts
+++ b/packages/scraping-pipeline/src/extraction/field-transformer.ts
@@ -6,12 +6,22 @@
  * regex replacement, and basic string transforms.
  */
 
+import { Logger } from "@nestjs/common";
 import type { FieldTransform } from "@opuspopuli/common";
 
 /**
  * Applies a FieldTransform to an extracted string value.
  */
 export class FieldTransformer {
+  private static readonly logger = new Logger(FieldTransformer.name);
+
+  /**
+   * Set of transform types we've already warned about, so unknown types
+   * encountered repeatedly during a sync don't spam the log. The set is
+   * lifetime-of-process; restart clears it.
+   */
+  private static readonly warnedUnknownTypes = new Set<string>();
+
   /**
    * Apply a transform to a raw extracted value.
    *
@@ -51,8 +61,30 @@ export class FieldTransformer {
         return FieldTransformer.parseDate(value, transform.params);
 
       default:
+        // Unknown transform type — log once per type per process so a
+        // typo or LLM hallucination ("regex" instead of "regex_replace")
+        // surfaces instead of silently passing the value through. The
+        // FieldTransformType union enforces this at compile time, but
+        // manifests loaded from the DB are typed `unknown` at runtime
+        // and bypass the check. See scraping-pipeline #604 / region #632
+        // — debugging this took hours because the symptom was "extraction
+        // returns 0 items" with no error pointing at the cause.
+        FieldTransformer.warnUnknownType(transform.type);
         return value;
     }
+  }
+
+  private static warnUnknownType(type: string): void {
+    if (FieldTransformer.warnedUnknownTypes.has(type)) return;
+    FieldTransformer.warnedUnknownTypes.add(type);
+    FieldTransformer.logger.warn(
+      `Unknown transform type "${type}" — value passed through unchanged. ` +
+        `Valid types: trim, lowercase, uppercase, strip_html, url_resolve, ` +
+        `regex_replace, name_format, date_parse. ` +
+        `If you need substring extraction via regex, use ` +
+        `extractionMethod: "regex" with regexPattern + regexGroup on the ` +
+        `field mapping itself, NOT a transform.`,
+    );
   }
 
   /**

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -497,39 +497,60 @@ const ContributionSchema = z.object({
   sourceSystem: z.enum(["cal_access", "fec"]),
 });
 
-const ExpenditureSchema = z.object({
-  externalId: z.string().min(1),
-  committeeId: z.string().min(1),
-  payeeName: z.string().min(1),
-  amount: z.coerce.number(),
-  date: coerceFlexibleDate,
-  purposeDescription: z
-    .string()
-    .nullable()
-    .transform((v) => v ?? undefined)
-    .optional(),
-  expenditureCode: z
-    .string()
-    .nullable()
-    .transform((v) => v ?? undefined)
-    .optional(),
-  candidateName: z
-    .string()
-    .nullable()
-    .transform((v) => v ?? undefined)
-    .optional(),
-  propositionTitle: z
-    .string()
-    .nullable()
-    .transform((v) => v ?? undefined)
-    .optional(),
-  supportOrOppose: z
-    .string()
-    .nullable()
-    .optional()
-    .transform((val) => (val ? supportOpposeTransform(val) : undefined)),
-  sourceSystem: z.enum(["cal_access", "fec"]),
-});
+const ExpenditureSchema = z
+  .object({
+    externalId: z.string().min(1),
+    committeeId: z.string().min(1),
+    payeeName: z.string().min(1),
+    amount: z.coerce.number(),
+    date: coerceFlexibleDate,
+    purposeDescription: z
+      .string()
+      .nullable()
+      .transform((v) => v ?? undefined)
+      .optional(),
+    expenditureCode: z
+      .string()
+      .nullable()
+      .transform((v) => v ?? undefined)
+      .optional(),
+    candidateName: z
+      .string()
+      .nullable()
+      .transform((v) => v ?? undefined)
+      .optional(),
+    propositionTitle: z
+      .string()
+      .nullable()
+      .transform((v) => v ?? undefined)
+      .optional(),
+    // Transient gating field — extracted from CalAccess BAL_NUM, used to
+    // decide whether `propositionTitle` is real or filer noise (#633),
+    // then dropped from the output below. The DB has no `ballotNumber`
+    // column on Expenditure; don't add one without a separate plan.
+    ballotNumber: z
+      .string()
+      .nullable()
+      .transform((v) => (v ? v.trim() : undefined))
+      .optional(),
+    supportOrOppose: z
+      .string()
+      .nullable()
+      .optional()
+      .transform((val) => (val ? supportOpposeTransform(val) : undefined)),
+    sourceSystem: z.enum(["cal_access", "fec"]),
+  })
+  // Drop `propositionTitle` when the row carries no `BAL_NUM`. CalAccess
+  // filers misuse the BAL_NAME field to stuff committee names, party
+  // names, city names, etc. on non-ballot-measure expenditures; real
+  // ballot-measure rows always carry both. This is the same gate the
+  // proposition-finance-linker already applies to CVR2 rows ("ballotName/
+  // ballotNumber being non-empty"). Strip `ballotNumber` itself so it
+  // doesn't leak into downstream consumers expecting the persisted shape.
+  .transform(({ ballotNumber, ...rest }) => ({
+    ...rest,
+    propositionTitle: ballotNumber ? rest.propositionTitle : undefined,
+  }));
 
 const IndependentExpenditureSchema = z.object({
   externalId: z.string().min(1),

--- a/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
+++ b/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
@@ -314,16 +314,16 @@ export class ScrapingPipelineService {
       `Pipeline started [pdf]: ${regionId}/${source.dataType} from ${source.url}`,
     );
 
-    // Provide LLM and PDF text extraction as callbacks
+    // Provide LLM and PDF text extraction as callbacks. Use the
+    // binary-safe fetchPdfText path — the old `fetchWithRetry +
+    // Buffer.from(content, "binary")` pattern silently mangled real
+    // PDF bytes via response.text()'s UTF-8 decode, leaving PDFParse
+    // to fail with "Invalid Root reference".
     return this.pdfExtract.execute<T>(
       source,
       regionId,
       this.llm,
-      async (url: string) => {
-        const fetchResult = await this.extraction.fetchWithRetry(url);
-        const buffer = Buffer.from(fetchResult.content, "binary");
-        return this.extraction.extractPdfText(buffer);
-      },
+      (url: string) => this.extraction.fetchPdfText(url),
     );
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.28
-        version: 1.0.28
+        specifier: ^1.0.29
+        version: 1.0.29
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -905,8 +905,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.28
-        version: 1.0.28
+        specifier: ^1.0.29
+        version: 1.0.29
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4854,8 +4854,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.28':
-    resolution: {integrity: sha512-M+sWzB6ZxqA/jlaVVFrjrB60B+rR72ommMPjniJhzIlUZilWrqP3OHmkLl1tnK5cxWNi0wTmXT7lKtSoTQNIeQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.28/78b2103e2bcf20d0cb2fac35fb0224b70681eeda}
+  '@opuspopuli/regions@1.0.29':
+    resolution: {integrity: sha512-gKUgJls4E1arsiMUpMEJgfdvwiWoPpt+dSNM99tmDXMqEwnlIBSFYiT/og54lW/Kqp+H1nnZbrd6cCcCsP3isg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.29/b73f8763b48103a6d37c1013af2180cb8dba83b3}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -16560,7 +16560,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.28': {}
+  '@opuspopuli/regions@1.0.29': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.29
-        version: 1.0.29
+        specifier: ^1.0.31
+        version: 1.0.31
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -905,8 +905,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.29
-        version: 1.0.29
+        specifier: ^1.0.31
+        version: 1.0.31
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4854,8 +4854,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.29':
-    resolution: {integrity: sha512-gKUgJls4E1arsiMUpMEJgfdvwiWoPpt+dSNM99tmDXMqEwnlIBSFYiT/og54lW/Kqp+H1nnZbrd6cCcCsP3isg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.29/b73f8763b48103a6d37c1013af2180cb8dba83b3}
+  '@opuspopuli/regions@1.0.31':
+    resolution: {integrity: sha512-LAqECHQDTx+KeP9DhFAO+dMwaJIknhOlc7wO7G/EsohzQ7PUsrht8o4BOAhntFbLv/PqNTJnnkHvNEdiaticQw==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.31/288c11b5971389fa891dbd0d22f03caa96085095}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -16560,7 +16560,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.29': {}
+  '@opuspopuli/regions@1.0.31': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:


### PR DESCRIPTION
## Summary

Release of [#643](https://github.com/OpusPopuli/opuspopuli/pull/643) — three fixes shipped together because they share the same redeploy + sync test cycle, all validated end-to-end on UAT against real California civic data.

## What's in this release

### Closes #633 — gate `Expenditure.propositionTitle` on `BAL_NUM`

CalAccess filers misuse the `BAL_NAME` field to stuff committee names, party names, and city names on non-ballot-measure expenditures. `ExpenditureSchema` now reads a transient `ballotNumber` from `BAL_NUM` (via `@opuspopuli/regions` 1.0.29+) and post-parse drops `propositionTitle` whenever `ballotNumber` is empty/absent. Filters out the ~17K filer-noise rows without affecting real ballot-measure expenditures.

### Closes #632 — propositions extraction hint cleanup

CA SOS propositions scrape was stuffing the entire anchor-link text into `Proposition.title`. Fixed via cleaner extraction directives in `@opuspopuli/regions` (`opuspopuli-regions`#8, #9, #10 → published as 1.0.29 / 1.0.30 / 1.0.31).

### Closes #642 — region rssThreshold env-configurable, defaults to 3GB

Region's RSS legitimately spikes to ~1.7GB during CalAccess bulk download. Threshold is now `MEMORY_RSS_THRESHOLD_BYTES` env-configurable; region-only override defaults to 3GB.

### Bonus fixes (caught + fixed during validation)

- **PDF binary-mangling** — `ExtractionProvider.fetchPdfText` (new) round-trips PDFs through `arrayBuffer`/`Buffer.from` instead of UTF-8-decoding via `response.text()`. Prior path corrupted any PDF with bytes > 0x7F.
- **Unknown `FieldTransformer.transform.type` was silently dropped** — switch default now logs `WARN` once per type per process. Caught the LLM-hallucinated `type: "regex"` that broke propositions sync after 1.0.30.
- **`OLLAMA_REQUEST_TIMEOUT_MS` 60s → 180s** — proposition-analysis prompts legitimately exceed the prior default.
- **`AddressType` GraphQL wire-format** — frontend was sending lowercase but the schema uses uppercase enum values.
- **Real-data validation of [#634](https://github.com/OpusPopuli/opuspopuli/issues/634)** (already shipped in #640) — confirmed `committees` table now correctly tags ~68K cal_access stubs (was 0) and ~4K fec stubs (was 68K mislabeled).

## Test plan

- [x] All checks green on PR #643 — Build, Test, E2E, Lint, Security Scan, Trivy, Build Packages, SonarCloud (incl. duplication quality gate)
- [x] Backend: 1463/1463
- [x] Scraping-pipeline: 254/254 (incl. 5 new for #633 gate, 3 new for unknown-transform warning)
- [x] Extraction-provider: 110/110 (incl. 4 new for fetchBytes/fetchPdfText)
- [x] #633 verified on real CalAccess data — filer-noise dropped, top values clean
- [x] #642 verified — no false-alarm healthcheck failures during multi-hour sync
- [x] FieldTransformer warning verified — propositions sync produced no warnings (LLM followed directive hints)
- [x] Senate scrape end-to-end (40 reps + detail enrichment)
- [x] Linker materialized 83 committees + 874 assignments

## Known follow-ups (filed separately, not in this release)

- [#645](https://github.com/OpusPopuli/opuspopuli/issues/645) — Assembly external_ids regenerated as `ca-assembly-101` instead of `ca-assembly-1`
- [#646](https://github.com/OpusPopuli/opuspopuli/issues/646) — Post-sync AI generators silently fail under degraded Ollama state
- [#647](https://github.com/OpusPopuli/opuspopuli/issues/647) — Magic-link sign-in fires two emails per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)