### PR TITLE
fix: regions 1.0.32 → directive externalId for Assembly + Senate (#645)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,7 +76,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.31",
+    "@opuspopuli/regions": "^1.0.32",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -4,6 +4,7 @@ import {
   extractLastName,
   mapPropositionRecord,
   RegionDomainService,
+  stripLeadingZerosFromExternalId,
 } from './region.service';
 import { PropositionAnalysisService } from './proposition-analysis.service';
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
@@ -159,6 +160,65 @@ describe('extractLastName', () => {
   it('returns empty for empty input', () => {
     expect(extractLastName('')).toBe('');
     expect(extractLastName('   ')).toBe('');
+  });
+});
+
+describe('stripLeadingZerosFromExternalId', () => {
+  it('strips leading zeros from a single-digit zero-padded suffix', () => {
+    expect(stripLeadingZerosFromExternalId('ca-assembly-01')).toBe(
+      'ca-assembly-1',
+    );
+    expect(stripLeadingZerosFromExternalId('ca-assembly-09')).toBe(
+      'ca-assembly-9',
+    );
+    expect(stripLeadingZerosFromExternalId('ca-senate-01')).toBe('ca-senate-1');
+  });
+
+  it('strips multiple leading zeros (e.g. "001")', () => {
+    expect(stripLeadingZerosFromExternalId('rep-assembly-001')).toBe(
+      'rep-assembly-1',
+    );
+  });
+
+  it('returns IDs without leading zeros unchanged', () => {
+    expect(stripLeadingZerosFromExternalId('ca-assembly-30')).toBe(
+      'ca-assembly-30',
+    );
+    expect(stripLeadingZerosFromExternalId('ca-assembly-80')).toBe(
+      'ca-assembly-80',
+    );
+    expect(stripLeadingZerosFromExternalId('ca-senate-40')).toBe(
+      'ca-senate-40',
+    );
+  });
+
+  it('does not collapse non-padded numeric suffixes (e.g. "100" stays "100")', () => {
+    // Important: "ca-assembly-100" is the prefix-one bug from #645 — it's
+    // wrong-but-not-zero-padded, so it must NOT be silently rewritten to
+    // "ca-assembly-100". (SQL cleanup soft-deletes it instead.)
+    expect(stripLeadingZerosFromExternalId('ca-assembly-100')).toBe(
+      'ca-assembly-100',
+    );
+  });
+
+  it('returns IDs whose final segment is not all-digits unchanged', () => {
+    expect(stripLeadingZerosFromExternalId('ca-assembly-foo')).toBe(
+      'ca-assembly-foo',
+    );
+    expect(stripLeadingZerosFromExternalId('us-house-AL01')).toBe(
+      'us-house-AL01',
+    );
+  });
+
+  it('returns the input unchanged when there is no hyphen', () => {
+    expect(stripLeadingZerosFromExternalId('singleword')).toBe('singleword');
+    expect(stripLeadingZerosFromExternalId('123')).toBe('123');
+  });
+
+  it('handles "0" as the suffix without stripping it to empty', () => {
+    expect(stripLeadingZerosFromExternalId('ca-assembly-0')).toBe(
+      'ca-assembly-0',
+    );
   });
 });
 

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -244,6 +244,30 @@ function deriveDistrictFromExternalId(externalId: string): string | undefined {
   return String(Number.parseInt(last, 10));
 }
 
+/**
+ * Strip leading zeros from a representative externalId's trailing numeric
+ * segment (e.g., `ca-assembly-01` → `ca-assembly-1`). IDs whose final
+ * segment is not all digits, or whose digits already have no leading
+ * zeros, are returned unchanged.
+ *
+ * Defensive against LLM-generated extraction manifests that produce
+ * `regex_replace` patterns with `(\d+)` instead of stripping the leading
+ * zero in zero-padded URL/text inputs (e.g., href `/assemblymembers/01`).
+ * Two iterations of regions-package hint tightening (#10, #11) failed to
+ * stop the LLM from "simplifying" `0?([1-9][0-9]*)` back to `(\d+)`,
+ * so canonicalization is enforced at the consumer boundary instead —
+ * mirroring how `extractLastName` and `sanitizeDistrict` already
+ * normalize other inconsistent extractor outputs in this same path.
+ */
+export function stripLeadingZerosFromExternalId(externalId: string): string {
+  const parts = externalId.split('-');
+  const last = parts.at(-1);
+  if (!last || !/^\d+$/.test(last)) return externalId;
+  const normalized = String(Number.parseInt(last, 10));
+  if (normalized === last) return externalId;
+  return [...parts.slice(0, -1), normalized].join('-');
+}
+
 export function extractLastName(fullName: string): string {
   const trimmed = fullName.trim();
   if (!trimmed) return '';
@@ -853,6 +877,10 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     const reps = await provider.fetchRepresentatives();
     if (reps.length === 0) {
       return { processed: 0, created: 0, updated: 0 };
+    }
+
+    for (const r of reps) {
+      r.externalId = stripLeadingZerosFromExternalId(r.externalId);
     }
 
     // Enrich with AI-generated bios where missing (scraped bios are preserved)

--- a/apps/backend/src/apps/region/src/scripts/run-rep-sync.ts
+++ b/apps/backend/src/apps/region/src/scripts/run-rep-sync.ts
@@ -1,0 +1,47 @@
+/**
+ * One-off: trigger representatives-only sync from the local declarative
+ * region plugin. Useful when you need clean rep data without waiting
+ * for the 2 AM scheduled `syncAll()` and without paying the cost of
+ * the full multi-hour CalAccess + propositions + meetings cycle.
+ *
+ * Usage (assumes the region container is running and dist is built):
+ *   docker compose -f docker-compose-uat.yml exec region \
+ *     node dist/src/apps/region/apps/region/src/scripts/run-rep-sync.js
+ *
+ * Idempotent: representatives are upserted by externalId, so re-running
+ * is safe — repeated runs just refresh existing rows. Sync time is
+ * dominated by the LLM-driven detail-page enrichment, ~5 minutes when
+ * manifests are cached, ~12 minutes on a fresh manifest regeneration.
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
+import { AppModule } from '../app.module';
+import { RegionDomainService } from '../domains/region.service';
+import { DataType } from '@opuspopuli/region-provider';
+
+async function main(): Promise<void> {
+  const logger = new Logger('run-rep-sync');
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'warn', 'error'],
+  });
+  try {
+    const regionService = app.get(RegionDomainService, { strict: false });
+    logger.log('Starting representatives-only sync…');
+    const result = await regionService.syncDataType(DataType.REPRESENTATIVES);
+    logger.log(
+      `Done. processed=${result.itemsProcessed} created=${result.itemsCreated} ` +
+        `updated=${result.itemsUpdated} errors=${result.errors.length}`,
+    );
+    if (result.errors.length > 0) {
+      logger.warn(`Errors: ${result.errors.join(' | ')}`);
+    }
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Rep sync run failed:', err);
+  process.exit(1);
+});

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.31"
+    "@opuspopuli/regions": "^1.0.32"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.31
-        version: 1.0.31
+        specifier: ^1.0.32
+        version: 1.0.32
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -905,8 +905,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.31
-        version: 1.0.31
+        specifier: ^1.0.32
+        version: 1.0.32
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4854,8 +4854,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.31':
-    resolution: {integrity: sha512-LAqECHQDTx+KeP9DhFAO+dMwaJIknhOlc7wO7G/EsohzQ7PUsrht8o4BOAhntFbLv/PqNTJnnkHvNEdiaticQw==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.31/288c11b5971389fa891dbd0d22f03caa96085095}
+  '@opuspopuli/regions@1.0.32':
+    resolution: {integrity: sha512-nr2A7BEbR7LmVBF5fx8SlDzYy8Uh0Wvham9nfNXhHxwYaP+Urs1FIdj9tQyLE+22oqsaJ9bKWyzadGVYEX9ehQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.32/050e8fcfc2e9904c7a8e848eb2a52ae424d7730a}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -16560,7 +16560,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.31': {}
+  '@opuspopuli/regions@1.0.32': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:


### PR DESCRIPTION
## Summary

Fixes #645 — Assembly + Senate representatives' `external_id`s were being produced in malformed formats by LLM-generated manifests. Two compounding bugs:

1. **`ca-assembly-101`...`ca-assembly-180`** (the issue title): LLM read the soft hint `('ca-assembly-{N}')` as if `1` were a literal prefix
2. **`ca-assembly-01`...`ca-assembly-09`** (discovered during validation): LLM's `regex_replace` pattern uses `(\d+)` and captures the leading zero from zero-padded hrefs (`/assemblymembers/01`)

Both fixed end-to-end on UAT.

## What's in this PR

### 1. Bump `@opuspopuli/regions` 1.0.31 → 1.0.32

Brings in [opuspopuli-regions#11](https://github.com/OpusPopuli/opuspopuli-regions/pull/11) — directive fieldMapping hints for Assembly + Senate that prevent the prefix-one (`ca-assembly-101`) bug. Same playbook as the proposition fix in [#10](https://github.com/OpusPopuli/opuspopuli-regions/pull/10).

### 2. `stripLeadingZerosFromExternalId` consumer normalization

Empirically, the LLM still produces `regex_replace` patterns with `(\d+)` instead of stripping zero-padding — the LLM "simplifies" `0?([1-9][0-9]*)` back to `(\d+)` regardless of how emphatic the directive is (validated through two iterations of hint tightening). The framework shouldn't depend on LLM regex correctness for ID canonicalization.

New helper applied post-fetch in `syncRepresentatives` strips leading zeros from numeric-suffix `external_id`s. Defensive design:
- Only normalizes IDs whose final hyphen-segment is all-digits with at least one leading zero
- IDs like `ca-assembly-100` (prefix-one bug class) are left unchanged so they remain visible for SQL cleanup rather than silently merged
- Mirrors existing `extractLastName` + `sanitizeDistrict` helpers in the same path

7 new test cases covering: single + multi-zero strip, no-op on canonical IDs, no-op on prefix-one bug, no-op on non-numeric suffixes, no-op on hyphenless inputs, `0` boundary preserved.

## Verification on UAT

Sync result: `processed=120 created=18 updated=102 errors=0` — the 18 created are the 9 single-digit Assembly + 9 single-digit Senate districts in their newly-canonical bare form.

After resync (4th iteration):
- Assembly `bare (correct)`: 80 (`ca-assembly-1` .. `ca-assembly-80`)
- Senate `bare (correct)`: 40 (`ca-senate-1` .. `ca-senate-40`)
- Plus legacy rows still in DB awaiting SQL cleanup (zero-padded singles, prefix-one bug rows, ancient `rep-*` prefix rows)

## Test plan

- [x] backend: 1470/1470 (full suite via husky pre-commit, includes 7 new tests for the helper)
- [x] region-provider: 131/131
- [x] Verified on real UAT data — Assembly external_ids exactly `ca-assembly-1`...`ca-assembly-80`
- [x] Verified on real UAT data — Senate external_ids exactly `ca-senate-1`...`ca-senate-40`
- [x] Verified `ca-assembly-100` (prefix-one) is NOT silently rewritten

## SQL cleanup of legacy rows

To soft-delete the malformed legacy + bug rows after this lands:

```sql
UPDATE representatives SET deleted_at = NOW()
WHERE
  external_id ~ '^ca-(assembly|senate)-0[0-9]$'
  OR external_id ~ '^ca-assembly-1[0-9]{2}$'
  OR external_id ~ '^rep-(assembly|senate)-[0-9]+$';
```

Closes #645