### PR TITLE
fix: California rep sync data quality + structured-extractor object children

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,7 +76,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.32",
+    "@opuspopuli/regions": "^1.0.34",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import {
   extractLastName,
+  isLikelyValidBio,
   mapPropositionRecord,
   RegionDomainService,
   stripLeadingZerosFromExternalId,
@@ -153,6 +154,30 @@ describe('extractLastName', () => {
     expect(extractLastName('Frank Smith III')).toBe('Smith');
   });
 
+  it('takes the part before the comma when input is "Last, First"', () => {
+    expect(extractLastName('Hadwick, Heather')).toBe('Hadwick');
+    expect(extractLastName('Aguiar-Curry, Cecilia M.')).toBe('Aguiar-Curry');
+    expect(extractLastName('Tangipa, David J.')).toBe('Tangipa');
+    expect(extractLastName('Smith, John Jr.')).toBe('Smith');
+  });
+
+  it('handles whitespace around the comma', () => {
+    expect(extractLastName('Hadwick ,  Heather')).toBe('Hadwick');
+  });
+
+  it('strips suffixes that precede the comma in "Last Suffix, First"', () => {
+    expect(extractLastName('Solache Jr., José Luis')).toBe('Solache');
+    expect(extractLastName('Smith Sr., John')).toBe('Smith');
+    expect(extractLastName('Doe III, Jane')).toBe('Doe');
+  });
+
+  it('preserves multi-word surnames before the comma', () => {
+    // Spanish double surnames are common — "Ávila Farías" is one
+    // surname, not surname + suffix. Suffix stripping only touches
+    // the recognized Jr/Sr/II/III/IV/Esq tokens.
+    expect(extractLastName('Ávila Farías, Anamarie')).toBe('Ávila Farías');
+  });
+
   it('falls back to trimmed input when no spaces', () => {
     expect(extractLastName('Madonna')).toBe('Madonna');
   });
@@ -160,6 +185,57 @@ describe('extractLastName', () => {
   it('returns empty for empty input', () => {
     expect(extractLastName('')).toBe('');
     expect(extractLastName('   ')).toBe('');
+  });
+});
+
+describe('isLikelyValidBio', () => {
+  it('rejects empty / null / undefined', () => {
+    expect(isLikelyValidBio(null)).toBe(false);
+    expect(isLikelyValidBio(undefined)).toBe(false);
+    expect(isLikelyValidBio('')).toBe(false);
+    expect(isLikelyValidBio('   ')).toBe(false);
+  });
+
+  it('rejects bios under 100 chars', () => {
+    expect(isLikelyValidBio('Home')).toBe(false);
+    expect(isLikelyValidBio('Senator Smith represents District 4.')).toBe(
+      false,
+    );
+  });
+
+  it('rejects "Home" nav-link junk', () => {
+    expect(
+      isLikelyValidBio(
+        'Home page content with a lot of filler text padded out to over a hundred characters total length here',
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects "Latest News" headline blocks', () => {
+    expect(
+      isLikelyValidBio(
+        'Latest News Senator Smith Takes on New Leadership Role with Senate Rules Committee When Is It Enough?',
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects bios where "Latest News" appears after a short biographical-looking header', () => {
+    // Real case from CA Senate sync: a per-senator page emits
+    // "Senator X Representing District N Latest News [headlines]..."
+    // The leading clause looks bio-like but the rest is news content.
+    expect(
+      isLikelyValidBio(
+        'Senator Kelly Seyarto Representing District 32 Latest News Senator Seyarto Proclaims Crime Victims Rights Week California Senate Republicans Introduce Legislation',
+      ),
+    ).toBe(false);
+  });
+
+  it('accepts a real bio with biographical content', () => {
+    expect(
+      isLikelyValidBio(
+        'Senator Smith was elected to represent California Senate District 4 in 2022. Prior to her election she served as a county supervisor for eight years and worked as a public-interest attorney focused on consumer protection.',
+      ),
+    ).toBe(true);
   });
 });
 

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -268,10 +268,51 @@ export function stripLeadingZerosFromExternalId(externalId: string): string {
   return [...parts.slice(0, -1), normalized].join('-');
 }
 
+/**
+ * Decide whether a scraped bio string is real content vs junk extracted
+ * from the wrong DOM (nav links, news headline blocks, single-word labels).
+ *
+ * Background: the LLM-generated structural manifest for the CA Senate
+ * picks up bio content from per-senator detail sites despite the regions
+ * config explicitly discouraging it ("Individual senator sites use
+ * different Drupal themes per-senator"). The result is a mix of literal
+ * "Home" (the nav link), "Latest News ..." headline blocks, and other
+ * non-biographical strings landing in the bio column. When that happens,
+ * the BioGenerator's `!r.bio || r.bio.trim() === ''` filter sees the
+ * junk as a valid bio and skips AI generation, locking the rep into the
+ * junk forever.
+ *
+ * This function returns true only for bios that look biographical:
+ * length ≥ 100 chars and no obvious junk-prefix patterns. Borderline
+ * but real bios pass; obvious junk does not.
+ */
+export function isLikelyValidBio(bio: string | null | undefined): boolean {
+  if (!bio) return false;
+  const trimmed = bio.trim();
+  if (trimmed.length < 100) return false;
+  if (/^Home\b/i.test(trimmed)) return false;
+  // "Latest News..." headline blocks from per-senator detail sites are
+  // junk even when prefixed by a short biographical-looking header
+  // ("Senator X Representing District N Latest News ..."). If the
+  // phrase appears in the first 100 chars, the rest is news content,
+  // not a bio.
+  if (/Latest News/i.test(trimmed.slice(0, 100))) return false;
+  return true;
+}
+
 export function extractLastName(fullName: string): string {
   const trimmed = fullName.trim();
   if (!trimmed) return '';
   const suffixPattern = /\b(Jr|Sr|II|III|IV|Esq)\.?$/i;
+  // Legislative directories often emit "LastName, FirstName [MiddleInitial]"
+  // (e.g. "Hadwick, Heather", "Aguiar-Curry, Cecilia M."). Comma form is
+  // unambiguous: surname is everything before the first comma — but the
+  // suffix can appear before the comma too ("Solache Jr., José Luis"),
+  // so strip it from that side as well.
+  if (trimmed.includes(',')) {
+    const beforeComma = trimmed.slice(0, trimmed.indexOf(',')).trim();
+    return beforeComma.replace(suffixPattern, '').trim();
+  }
   const withoutSuffix = trimmed.replace(suffixPattern, '').trim();
   const tokens = withoutSuffix.split(/\s+/);
   return tokens.at(-1) ?? trimmed;
@@ -850,7 +891,11 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
    */
   private sanitizeDistrict(rep: Representative): string {
     const raw = (rep.district ?? '').trim();
-    if (/^\d+$/.test(raw)) return raw;
+    // Numeric district: canonicalize by stripping leading zeros so the
+    // stored district matches the externalId form (`ca-assembly-1`, not
+    // `ca-assembly-01`). The CA Assembly listing emits `01`, `02`, ... in
+    // the district field and we strip the same way externalId does.
+    if (/^\d+$/.test(raw)) return String(Number.parseInt(raw, 10));
     const derived = deriveDistrictFromExternalId(rep.externalId);
     if (derived !== undefined) {
       this.logger.warn(
@@ -881,6 +926,26 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
 
     for (const r of reps) {
       r.externalId = stripLeadingZerosFromExternalId(r.externalId);
+      // Drop bios that look like extraction junk (e.g. "Home" nav link,
+      // "Latest News..." headline blocks from per-senator detail sites
+      // with mismatched Drupal themes). Nulling here makes the bio-
+      // generator's `!r.bio || r.bio.trim() === ''` filter pick them up
+      // and replace with an AI-generated bio on this same run.
+      if (r.bio && !isLikelyValidBio(r.bio)) {
+        this.logger.warn(
+          `Discarding junk bio for ${r.externalId} (${r.bio.length} chars): ${r.bio.slice(0, 60)}…`,
+        );
+        r.bio = undefined;
+        r.bioSource = undefined;
+      }
+      // Mark provenance for bios that arrived from the scrape. Done here
+      // (not only in BioGenerator) because BioGenerator returns early
+      // when LLM/prompt deps are unwired, leaving scraped bios with a
+      // null bioSource. This loop is idempotent with the BioGenerator's
+      // own marking pass.
+      if (r.bio && !r.bioSource) {
+        r.bioSource = 'scraped';
+      }
     }
 
     // Enrich with AI-generated bios where missing (scraped bios are preserved)

--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -108,10 +108,57 @@ export interface FieldMapping {
   /** Search scope: 'item' (default) searches within the item element,
    *  'container' searches from the container element (for sibling data like headings) */
   scope?: "item" | "container";
-  /** For 'structured' method: child field selectors to extract from each matched
-   *  element (e.g., { name: "h3", phone: ".phone" }). Produces an array of objects. */
-  children?: Record<string, string>;
+  /** For 'structured' method: per-child extraction config. Each value is
+   *  either a string selector (legacy DSL with `_text` / `_regex:` / `|attr:`
+   *  shortcuts) or a full ChildFieldConfig object that supports
+   *  extractionMethod + transform. Produces an array of objects. */
+  children?: Record<string, ChildFieldConfig>;
 }
+
+/**
+ * Per-child extraction config inside a `structured` FieldMapping.
+ *
+ * Two equivalent forms:
+ *
+ * 1. **String shortcut** — terse DSL parsed by the structured extractor:
+ *    - `"css-selector"` — text from descendant
+ *    - `"css-selector|attr:name"` — attribute from descendant
+ *    - `"_text"` — full text of the parent element
+ *    - `"_regex:PATTERN"` — capture group 1 from full element text
+ *
+ * 2. **Object form** — when you need an extraction method that doesn't fit
+ *    the shortcut (e.g., regex with non-default capture group, attribute on
+ *    a specific selector with a transform applied after, etc.):
+ *
+ *    ```ts
+ *    { selector: "p.member__address", extractionMethod: "text",
+ *      transform: { type: "regex_replace", params: {...} } }
+ *    ```
+ *
+ *    Object form supports the same shape as the top-level FieldMapping
+ *    (selector + extractionMethod + attribute / regexPattern+regexGroup +
+ *    transform), minus the fieldName/scope/required/defaultValue parts
+ *    that don't apply at child scope.
+ */
+export type ChildFieldConfig =
+  | string
+  | {
+      /** CSS selector relative to the matched element. Required for text /
+       *  attribute / html. Optional for regex (defaults to the full
+       *  element text). */
+      selector?: string;
+      /** Extraction method. Defaults to 'text' when a selector is given,
+       *  'regex' when only a regexPattern is given. */
+      extractionMethod?: ExtractionMethod;
+      /** For extractionMethod='attribute': which attribute to read. */
+      attribute?: string;
+      /** For extractionMethod='regex': the pattern. */
+      regexPattern?: string;
+      /** For extractionMethod='regex': capture group (default: 1). */
+      regexGroup?: number;
+      /** Optional transform applied after extraction. */
+      transform?: FieldTransform;
+    };
 
 export type ExtractionMethod =
   | "text"

--- a/packages/extraction-provider/__tests__/extraction.provider.spec.ts
+++ b/packages/extraction-provider/__tests__/extraction.provider.spec.ts
@@ -60,7 +60,7 @@ describe("ExtractionProvider", () => {
       expect(result.fromCache).toBe(false);
       expect(result.statusCode).toBe(200);
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://example.com",
+        "https://example.com/",
         expect.objectContaining({
           signal: expect.any(AbortSignal),
         }),
@@ -166,7 +166,7 @@ describe("ExtractionProvider", () => {
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://example.com",
+        "https://example.com/",
         expect.objectContaining({
           headers: { Authorization: "Bearer token" },
         }),

--- a/packages/extraction-provider/__tests__/url-normalize.spec.ts
+++ b/packages/extraction-provider/__tests__/url-normalize.spec.ts
@@ -1,0 +1,52 @@
+import { normalizeUrl } from "../src/utils/url-normalize.js";
+
+describe("normalizeUrl", () => {
+  it("appends a trailing slash to bare-domain URLs", () => {
+    expect(normalizeUrl("https://sr04.senate.ca.gov")).toBe(
+      "https://sr04.senate.ca.gov/",
+    );
+    expect(normalizeUrl("http://example.com")).toBe("http://example.com/");
+  });
+
+  it("leaves URLs with paths unchanged", () => {
+    expect(normalizeUrl("https://example.com/foo")).toBe(
+      "https://example.com/foo",
+    );
+    expect(normalizeUrl("https://example.com/foo/bar")).toBe(
+      "https://example.com/foo/bar",
+    );
+  });
+
+  it("treats bare-domain and trailing-slash inputs as equivalent", () => {
+    expect(normalizeUrl("https://example.com")).toBe(
+      normalizeUrl("https://example.com/"),
+    );
+  });
+
+  it("lowercases hostnames", () => {
+    expect(normalizeUrl("https://EXAMPLE.com/path")).toBe(
+      "https://example.com/path",
+    );
+  });
+
+  it("elides default ports", () => {
+    expect(normalizeUrl("https://example.com:443/path")).toBe(
+      "https://example.com/path",
+    );
+    expect(normalizeUrl("http://example.com:80/")).toBe("http://example.com/");
+  });
+
+  it("preserves query strings and fragments", () => {
+    expect(normalizeUrl("https://example.com?q=1")).toBe(
+      "https://example.com/?q=1",
+    );
+    expect(normalizeUrl("https://example.com/x#frag")).toBe(
+      "https://example.com/x#frag",
+    );
+  });
+
+  it("returns the input unchanged when it can't be parsed", () => {
+    expect(normalizeUrl("not a url")).toBe("not a url");
+    expect(normalizeUrl("")).toBe("");
+  });
+});

--- a/packages/extraction-provider/src/extraction.provider.ts
+++ b/packages/extraction-provider/src/extraction.provider.ts
@@ -34,6 +34,7 @@ import {
   FetchError,
   FetchFunction,
 } from "./types.js";
+import { normalizeUrl } from "./utils/url-normalize.js";
 
 /**
  * Selected element from HTML parsing
@@ -146,6 +147,7 @@ export class ExtractionProvider {
     url: string,
     options: FetchOptions = {},
   ): Promise<CachedFetchResult> {
+    url = normalizeUrl(url);
     const cacheKey = this.getCacheKey(url, options);
 
     // Check cache first (unless bypassed)
@@ -221,6 +223,7 @@ export class ExtractionProvider {
     finalUrl?: string;
     redirectedFrom?: string;
   }> {
+    url = normalizeUrl(url);
     await this.rateLimiter.acquire();
     this.logger.debug(`Fetching bytes from ${url}`);
 
@@ -366,12 +369,19 @@ export class ExtractionProvider {
       const content = await decodeBody(response);
       const contentType = response.headers.get("content-type") || "unknown";
       const finalUrl = response.url;
-      const wasRedirected = finalUrl && finalUrl !== url;
+      const wasRedirected =
+        !!finalUrl && normalizeUrl(finalUrl) !== normalizeUrl(url);
 
       if (wasRedirected) {
-        this.logger.warn(
-          `URL redirect detected: ${url} → ${finalUrl}. Consider updating the data source config.`,
-        );
+        if (options.fromConfig) {
+          this.logger.warn(
+            `URL redirect detected: ${url} → ${finalUrl}. Consider updating the data source config.`,
+          );
+        } else {
+          this.logger.debug(
+            `URL redirect detected (harvested URL): ${url} → ${finalUrl}`,
+          );
+        }
       }
 
       return {

--- a/packages/extraction-provider/src/types.ts
+++ b/packages/extraction-provider/src/types.ts
@@ -30,6 +30,14 @@ export interface FetchOptions {
   timeout?: number;
   /** Skip cache and fetch fresh content */
   bypassCache?: boolean;
+  /**
+   * True when this URL came from a region's data source config (so a
+   * redirect is actionable: update the config). False/unset when the URL
+   * was harvested at runtime (e.g., detail links extracted from a listing
+   * page) — redirects on those aren't fixable by editing config and are
+   * logged at debug instead of warn.
+   */
+  fromConfig?: boolean;
 }
 
 /**

--- a/packages/extraction-provider/src/utils/index.ts
+++ b/packages/extraction-provider/src/utils/index.ts
@@ -24,3 +24,4 @@ export type { WithRetryOptions } from "@opuspopuli/common";
 
 // Local implementations (Redis-specific, stays in extraction-provider)
 export * from "./redis-rate-limiter.js";
+export * from "./url-normalize.js";

--- a/packages/extraction-provider/src/utils/url-normalize.ts
+++ b/packages/extraction-provider/src/utils/url-normalize.ts
@@ -1,0 +1,18 @@
+/**
+ * Canonicalize a URL via the WHATWG URL parser. Notable effects:
+ * - bare-domain inputs gain a trailing slash (`https://x.com` → `https://x.com/`)
+ * - default ports are elided
+ * - hostname is lowercased
+ *
+ * Used at fetch entry points so we (a) request the canonical form and avoid
+ * the 301 round-trip, and (b) compare apples-to-apples when detecting
+ * redirects against `Response.url`. Falls through unchanged if the input
+ * isn't a parseable URL — callers downstream will surface the failure.
+ */
+export function normalizeUrl(url: string): string {
+  try {
+    return new URL(url).toString();
+  } catch {
+    return url;
+  }
+}

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.32"
+    "@opuspopuli/regions": "^1.0.34"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/scraping-pipeline/__tests__/structured-extractor.spec.ts
+++ b/packages/scraping-pipeline/__tests__/structured-extractor.spec.ts
@@ -1,0 +1,236 @@
+import * as cheerio from "cheerio";
+import { extractStructuredArray } from "../src/extraction/structured-extractor.js";
+
+const officeHtml = `
+<div>
+  <div class="office">
+    <h4 class="office-title">Capitol Office</h4>
+    <p class="address">1021 O Street, Suite 6510, Sacramento, CA 95814; (916) 651-4016</p>
+  </div>
+  <div class="office">
+    <h4 class="office-title">District Office</h4>
+    <p class="address">5201 California Avenue, Suite 220, Bakersfield, CA 93309; (661) 395-2620</p>
+  </div>
+  <div class="office">
+    <h4 class="office-title">Field Office</h4>
+    <p class="address">100 Main Street, Anywhere, CA 90210</p>
+  </div>
+</div>
+`;
+
+describe("extractStructuredArray", () => {
+  describe("string-shortcut child selectors (legacy)", () => {
+    it("extracts text from descendant via plain selector", () => {
+      const $ = cheerio.load(officeHtml);
+      const result = extractStructuredArray($, $("body"), ".office", {
+        name: "h4.office-title",
+        address: "p.address",
+      });
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({
+        name: "Capitol Office",
+        address:
+          "1021 O Street, Suite 6510, Sacramento, CA 95814; (916) 651-4016",
+      });
+    });
+
+    it("extracts via _regex: shortcut (capture group 1)", () => {
+      const $ = cheerio.load(officeHtml);
+      const result = extractStructuredArray($, $("body"), ".office", {
+        phone: "_regex:(\\(\\d{3}\\)\\s*\\d{3}-\\d{4})",
+      });
+      // The third office has no phone — gets dropped because no fields extracted
+      expect(result).toHaveLength(2);
+      expect(result[0].phone).toBe("(916) 651-4016");
+      expect(result[1].phone).toBe("(661) 395-2620");
+    });
+
+    it("extracts attribute via |attr: shortcut", () => {
+      const $ = cheerio.load(`
+        <div>
+          <div class="row"><a href="https://a.example/">A</a></div>
+          <div class="row"><a href="https://b.example/">B</a></div>
+        </div>
+      `);
+      const result = extractStructuredArray($, $("body"), ".row", {
+        href: "a|attr:href",
+      });
+      expect(result).toEqual([
+        { href: "https://a.example/" },
+        { href: "https://b.example/" },
+      ]);
+    });
+  });
+
+  describe("object-form ChildFieldConfig", () => {
+    it("extracts text from selector with regex_replace transform stripping phone from address", () => {
+      const $ = cheerio.load(officeHtml);
+      const result = extractStructuredArray($, $("body"), ".office", {
+        address: {
+          selector: "p.address",
+          extractionMethod: "text",
+          transform: {
+            type: "regex_replace",
+            params: {
+              pattern: "\\s*;\\s*\\(\\d{3}\\)\\s*\\d{3}-\\d{4}.*$",
+              replacement: "",
+            },
+          },
+        },
+      });
+      expect(result).toHaveLength(3);
+      expect(result[0].address).toBe(
+        "1021 O Street, Suite 6510, Sacramento, CA 95814",
+      );
+      expect(result[1].address).toBe(
+        "5201 California Avenue, Suite 220, Bakersfield, CA 93309",
+      );
+      // Office without phone passes through unchanged
+      expect(result[2].address).toBe("100 Main Street, Anywhere, CA 90210");
+    });
+
+    it("extracts via regex with explicit regexGroup", () => {
+      const $ = cheerio.load(officeHtml);
+      const result = extractStructuredArray($, $("body"), ".office", {
+        phone: {
+          extractionMethod: "regex",
+          regexPattern: "\\((\\d{3})\\)\\s*(\\d{3})-(\\d{4})",
+          regexGroup: 0, // full match
+        },
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].phone).toBe("(916) 651-4016");
+    });
+
+    it("regexGroup defaults to 1 when omitted", () => {
+      const $ = cheerio.load(officeHtml);
+      const result = extractStructuredArray($, $("body"), ".office", {
+        areaCode: {
+          extractionMethod: "regex",
+          regexPattern: "\\((\\d{3})\\)",
+          // regexGroup omitted → defaults to 1
+        },
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0].areaCode).toBe("916");
+      expect(result[1].areaCode).toBe("661");
+    });
+
+    it("extracts attribute via object form", () => {
+      const $ = cheerio.load(`
+        <div>
+          <div class="row"><a href="/path-a">A</a></div>
+          <div class="row"><a href="/path-b">B</a></div>
+        </div>
+      `);
+      const result = extractStructuredArray($, $("body"), ".row", {
+        href: {
+          selector: "a",
+          extractionMethod: "attribute",
+          attribute: "href",
+        },
+      });
+      expect(result).toEqual([{ href: "/path-a" }, { href: "/path-b" }]);
+    });
+
+    it("applies url_resolve transform with baseUrl", () => {
+      const $ = cheerio.load(`
+        <div>
+          <div class="row"><a href="/a">A</a></div>
+        </div>
+      `);
+      const result = extractStructuredArray(
+        $,
+        $("body"),
+        ".row",
+        {
+          link: {
+            selector: "a",
+            extractionMethod: "attribute",
+            attribute: "href",
+            transform: { type: "url_resolve" },
+          },
+        },
+        "https://example.com/base/",
+      );
+      expect(result[0].link).toBe("https://example.com/a");
+    });
+
+    it("regex against a narrowed sub-selector", () => {
+      const $ = cheerio.load(officeHtml);
+      const result = extractStructuredArray($, $("body"), ".office", {
+        phone: {
+          selector: "p.address",
+          extractionMethod: "regex",
+          regexPattern: "\\(\\d{3}\\)\\s*\\d{3}-\\d{4}",
+          regexGroup: 0,
+        },
+      });
+      expect(result[0].phone).toBe("(916) 651-4016");
+    });
+  });
+
+  describe("mixed string + object children (the real CA Senate manifest shape)", () => {
+    it("extracts name, address-with-phone-stripped, and phone all in one pass", () => {
+      const $ = cheerio.load(officeHtml);
+      const result = extractStructuredArray($, $("body"), ".office", {
+        name: "h4.office-title", // string shortcut
+        address: {
+          selector: "p.address",
+          extractionMethod: "text",
+          transform: {
+            type: "regex_replace",
+            params: {
+              pattern: "\\s*;\\s*\\(\\d{3}\\)\\s*\\d{3}-\\d{4}.*$",
+              replacement: "",
+            },
+          },
+        },
+        phone: {
+          selector: "p.address",
+          extractionMethod: "regex",
+          regexPattern: "\\(\\d{3}\\)\\s*\\d{3}-\\d{4}",
+          regexGroup: 0,
+        },
+      });
+      expect(result).toHaveLength(3);
+      expect(result[0]).toEqual({
+        name: "Capitol Office",
+        address: "1021 O Street, Suite 6510, Sacramento, CA 95814",
+        phone: "(916) 651-4016",
+      });
+      expect(result[1]).toEqual({
+        name: "District Office",
+        address: "5201 California Avenue, Suite 220, Bakersfield, CA 93309",
+        phone: "(661) 395-2620",
+      });
+      // Office without phone: name + address present, phone absent (regex didn't match)
+      expect(result[2]).toEqual({
+        name: "Field Office",
+        address: "100 Main Street, Anywhere, CA 90210",
+      });
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty array when selector matches nothing", () => {
+      const $ = cheerio.load(officeHtml);
+      expect(
+        extractStructuredArray($, $("body"), ".nope", { name: "h4" }),
+      ).toEqual([]);
+    });
+
+    it("returns empty array when children are empty", () => {
+      const $ = cheerio.load(officeHtml);
+      expect(extractStructuredArray($, $("body"), ".office", {})).toEqual([]);
+    });
+
+    it("invalid regex pattern returns no value (does not throw)", () => {
+      const $ = cheerio.load(officeHtml);
+      const result = extractStructuredArray($, $("body"), ".office", {
+        phone: { extractionMethod: "regex", regexPattern: "(unclosed" },
+      });
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/packages/scraping-pipeline/src/extraction/manifest-extractor.service.ts
+++ b/packages/scraping-pipeline/src/extraction/manifest-extractor.service.ts
@@ -194,7 +194,7 @@ export class ManifestExtractorService {
   ): unknown {
     // Structured extraction produces an array — transforms/defaults don't apply
     if (mapping.extractionMethod === "structured") {
-      return this.extractStructuredArray($, element, mapping);
+      return this.extractStructuredArray($, element, mapping, baseUrl);
     }
 
     let value = this.extractFieldValue($, element, mapping);
@@ -218,6 +218,7 @@ export class ManifestExtractorService {
     $: CheerioAPI,
     element: Cheerio<Element>,
     mapping: FieldMapping,
+    baseUrl?: string,
   ): Record<string, string>[] {
     if (!mapping.selector || !mapping.children) return [];
     return extractStructuredArray(
@@ -225,6 +226,7 @@ export class ManifestExtractorService {
       element,
       mapping.selector,
       mapping.children,
+      baseUrl,
     );
   }
 

--- a/packages/scraping-pipeline/src/extraction/structured-extractor.ts
+++ b/packages/scraping-pipeline/src/extraction/structured-extractor.ts
@@ -1,29 +1,38 @@
 import type { CheerioAPI, Cheerio } from "cheerio";
 import type { Element, AnyNode } from "domhandler";
+import type { ChildFieldConfig } from "@opuspopuli/common";
+import { FieldTransformer } from "./field-transformer.js";
 
 /**
  * Extracts an array of structured objects from repeating elements matched by a CSS selector.
  *
  * Each matched element becomes one object; the `children` record maps child field names
- * to selectors that extract values from the element.
+ * to either a string-shortcut selector or a full ChildFieldConfig object.
  *
- * Supported child selector formats:
+ * **String shortcut forms:**
  * - `"_text"` — the full text content of the element
- * - `"_regex:PATTERN"` — extract via regex capture group 1 from element text
+ * - `"_regex:PATTERN"` — capture group 1 from element text
  * - `"css-selector|attr:name"` — extract an attribute from a descendant
  * - `"css-selector"` — extract text content from a descendant (default)
+ *
+ * **Object form:** `{ selector, extractionMethod, attribute, regexPattern,
+ * regexGroup, transform }`. Supports the same shape as the top-level
+ * FieldMapping at child scope, including post-extraction transforms via
+ * the shared `FieldTransformer`.
  *
  * @param $ Cheerio API for DOM traversal
  * @param scope The element to search within (for .find())
  * @param selector CSS selector for the repeating items
- * @param children Map of field name → selector for per-item extraction
+ * @param children Map of field name → child config (string or object)
+ * @param baseUrl Optional base URL for `url_resolve` transforms in object children
  * @returns Array of objects with extracted fields (empty if no matches or no values)
  */
 export function extractStructuredArray(
   $: CheerioAPI,
   scope: Cheerio<Element> | Cheerio<AnyNode>,
   selector: string,
-  children: Record<string, string>,
+  children: Record<string, ChildFieldConfig>,
+  baseUrl?: string,
 ): Record<string, string>[] {
   if (!selector || !children) return [];
 
@@ -31,7 +40,7 @@ export function extractStructuredArray(
   const items: Record<string, string>[] = [];
 
   matches.each((_i, el) => {
-    const item = extractChildFields($, el, children);
+    const item = extractChildFields($, el, children, baseUrl);
     if (Object.keys(item).length > 0) items.push(item);
   });
 
@@ -39,18 +48,24 @@ export function extractStructuredArray(
 }
 
 /**
- * Extract a record of child fields from a single element using child selector syntax.
+ * Extract a record of child fields from a single element, dispatching to
+ * the right extractor based on whether each child config is a string
+ * shortcut or a full object config.
  */
 function extractChildFields(
   $: CheerioAPI,
   el: AnyNode,
-  children: Record<string, string>,
+  children: Record<string, ChildFieldConfig>,
+  baseUrl?: string,
 ): Record<string, string> {
   const item: Record<string, string> = {};
   const elementText = $(el).text().replaceAll(/\s+/g, " ").trim();
 
-  for (const [childField, childSelector] of Object.entries(children)) {
-    const value = extractChildValue($, el, childSelector, elementText);
+  for (const [childField, childConfig] of Object.entries(children)) {
+    const value =
+      typeof childConfig === "string"
+        ? extractFromShortcut($, el, childConfig, elementText)
+        : extractFromObjectConfig($, el, childConfig, elementText, baseUrl);
     if (value) item[childField] = value;
   }
 
@@ -58,9 +73,10 @@ function extractChildFields(
 }
 
 /**
- * Extract a single child field value using the appropriate strategy for its selector.
+ * String-shortcut DSL — preserved for backward compat with manifests that
+ * use the terse form.
  */
-function extractChildValue(
+function extractFromShortcut(
   $: CheerioAPI,
   el: AnyNode,
   childSelector: string,
@@ -71,14 +87,13 @@ function extractChildValue(
     return elementText || undefined;
   }
 
-  // _regex:pattern: extract via regex from element text
+  // _regex:pattern: extract via regex from element text (capture group 1)
   if (childSelector.startsWith("_regex:")) {
     const pattern = childSelector.slice(7);
     try {
       const match = new RegExp(pattern).exec(elementText);
       return match?.[1]?.trim() || undefined;
     } catch {
-      // Invalid regex — skip this field
       return undefined;
     }
   }
@@ -91,4 +106,69 @@ function extractChildValue(
   return attrSpec
     ? child.first().attr(attrSpec)
     : child.first().text().replaceAll(/\s+/g, " ").trim() || undefined;
+}
+
+/**
+ * Object-form ChildFieldConfig — full extraction method + optional
+ * transform. Mirrors the semantics of top-level FieldMapping but at
+ * child scope (no fieldName/scope/required/defaultValue).
+ */
+function extractFromObjectConfig(
+  $: CheerioAPI,
+  el: AnyNode,
+  config: Exclude<ChildFieldConfig, string>,
+  elementText: string,
+  baseUrl?: string,
+): string | undefined {
+  // Default extraction method: regex if only a pattern is given, else text
+  const method =
+    config.extractionMethod ?? (config.regexPattern ? "regex" : "text");
+
+  let value: string | undefined;
+
+  switch (method) {
+    case "regex": {
+      if (!config.regexPattern) return undefined;
+      // For regex method: optionally narrow to a sub-element first via
+      // selector, otherwise run against the parent element's full text.
+      const haystack = config.selector
+        ? ($(el).find(config.selector).first().text() ?? "")
+            .replaceAll(/\s+/g, " ")
+            .trim()
+        : elementText;
+      try {
+        const match = new RegExp(config.regexPattern).exec(haystack);
+        const group = config.regexGroup ?? 1;
+        value = match?.[group]?.trim();
+      } catch {
+        return undefined;
+      }
+      break;
+    }
+    case "attribute": {
+      if (!config.selector || !config.attribute) return undefined;
+      const child = $(el).find(config.selector);
+      if (child.length === 0) return undefined;
+      value = child.first().attr(config.attribute);
+      break;
+    }
+    case "text":
+    default: {
+      // Text from selector, or whole element if no selector given
+      if (!config.selector) {
+        value = elementText || undefined;
+        break;
+      }
+      const child = $(el).find(config.selector);
+      if (child.length === 0) return undefined;
+      value = child.first().text().replaceAll(/\s+/g, " ").trim() || undefined;
+      break;
+    }
+  }
+
+  if (value && config.transform) {
+    value = FieldTransformer.apply(value, config.transform, baseUrl);
+  }
+
+  return value || undefined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.32
-        version: 1.0.32
+        specifier: ^1.0.34
+        version: 1.0.34
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -905,8 +905,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.32
-        version: 1.0.32
+        specifier: ^1.0.34
+        version: 1.0.34
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4854,8 +4854,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.32':
-    resolution: {integrity: sha512-nr2A7BEbR7LmVBF5fx8SlDzYy8Uh0Wvham9nfNXhHxwYaP+Urs1FIdj9tQyLE+22oqsaJ9bKWyzadGVYEX9ehQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.32/050e8fcfc2e9904c7a8e848eb2a52ae424d7730a}
+  '@opuspopuli/regions@1.0.34':
+    resolution: {integrity: sha512-nuOK63fHYaCqn4Oe8M8603kGogm2VbFAzfGWsTIt9A6BXbz8dhDzWok5Ljw5dXGTymb330uX6sN64DEeIE/DYA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.34/7205028767457f3b189ffa010fe0cfb4608ac1aa}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -16560,7 +16560,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.32': {}
+  '@opuspopuli/regions@1.0.34': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:


### PR DESCRIPTION
## Summary

Closes the gap on California rep sync after the 2026-05-03 QA pass. Live-verified against a clean rep sync (120 reps, 80 Assembly + 40 Senate) — every Senate-side issue from #658 is now addressed except #657 (Senate committees, structural).

## Changes

### `region.service.ts` — rep data quality
- **`extractLastName`**: handles `"Last, First"` comma form (`Hadwick, Heather` → `Hadwick`) and suffix-before-comma (`Solache Jr., José Luis` → `Solache`). Previous behavior took the last whitespace token and produced wrong surnames for every comma-formatted name.
- **`sanitizeDistrict`**: strips leading zeros from numeric districts so the stored value matches the externalId form (`1`, not `01`).
- **`isLikelyValidBio`**: new validator. Drops bios <100 chars, `Home` nav-link text, and `Latest News...` headline blocks (incl. the embedded case where a brief biographical-looking header precedes the news content). Junk bios are nulled in `syncRepresentatives` so the bio-generator picks them up and writes AI bios.
- Defensive bio-source marking in `syncRepresentatives` (since BioGenerator returns early when LLM/prompt deps are unwired).

### `extraction-provider/` — URL normalization + redirect-warning hygiene
- New `normalizeUrl` helper (WHATWG URL canonicalization: bare-domain trailing slash, default-port elision, hostname lowercasing) at `fetchUrl` + `fetchBytes` entry. Eliminates the 80+40 trailing-slash redirects per rep sync against CA per-senator/assembly hosts.
- Redirect-comparison normalizes both sides so cosmetic differences don't false-flag.
- New `FetchOptions.fromConfig`: distinguishes config-sourced URLs (where \"update your data source config\" advice is actionable) from harvested URLs (where it isn't). Warning fires at `warn` only when caller flags `fromConfig: true`; harvested URLs go to `debug`.

### `structured-extractor.ts` — object-form children with transforms (the Path B fix)
- `ChildFieldConfig` union: legacy string shortcut (`_text` / `_regex:` / `|attr:` / plain selector) **OR** full object form with `selector + extractionMethod + attribute + regexPattern + regexGroup + transform`.
- Object form mirrors top-level `FieldMapping` at child scope, sans `fieldName/scope/required/defaultValue`.
- Reuses `FieldTransformer.apply` for transforms — no new transform code, just plumbing.
- `baseUrl` threaded from `manifest-extractor.service.ts` so `url_resolve` transforms work in child configs.
- **Why this exists:** the @opuspopuli/regions 1.0.34 hint directs the LLM to produce object-shape children for CA Senate offices (so `phone` can be a separate field via regex while `address` gets `regex_replace` stripping the trailing phone segment). The extractor previously only accepted `Record<string, string>`, so the LLM-generated manifest crashed at runtime with `\"childSelector.startsWith is not a function\"`.

### Dep bump
- `@opuspopuli/regions` `^1.0.32` → `^1.0.34` in `apps/backend` and `packages/region-provider`. 1.0.34 contains the Senate hint changes for `contactInfo.website` (was `detailUrl`), phone-split via regex, and explicit \"do not extract bio\" instruction.

## Live verification (post-sync DB state, 40 Senate reps)

| Metric | Before | After |
|---|---|---|
| `contact_info.website` populated | 0/40 | **40/40** |
| Office records with `phone` field | 0/80 | **80/80** |
| Addresses with phone glued in | 80/80 | **0/80** |
| AI-generated bios | 17/40 | **40/40** |
| Junk scraped bios surviving | 23/40 | **0/40** |

Assembly unchanged: 80 reps, all committees + summaries intact.

## Test plan

- [x] `pnpm test` across all workspace projects — 1480/1480 backend, 280 scraping-pipeline (incl. 13 new `structured-extractor` cases), 117 extraction-provider, 103 region.service. All green.
- [x] Live California rep sync — 120 reps clean, all Senate fields populated, junk-bio validator fired 23 times and BioGenerator filled 23 AI bios. Logs zero errors.
- [ ] Reviewer: spot-check a Senate `contact_info.offices[]` shape (should have separate `phone` field, address without phone glued)
- [ ] Reviewer: confirm `@opuspopuli/regions@1.0.34` resolves correctly in CI

## Related issues

- Closes #658 (California Senate region-config gaps: missing website, phone-in-address, junk bios)
- Partially addresses #645 (rep sync correctness — comma-format last names + leading-zero districts)
- #657 (Senate committees) remains — structural, needs new source

🤖 Generated with [Claude Code](https://claude.com/claude-code)