### PR TITLE
release: proposition title cleanup + tiered PDF extractor with OCR fallback

### DIFF
--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -9,9 +9,11 @@ import {
   ExtractionModule,
   CacheFactory,
   FallbackCache,
+  OCR_SERVICE,
 } from '@opuspopuli/extraction-provider';
 import { MemoryCache } from '@opuspopuli/common';
 import { LLMModule } from '@opuspopuli/llm-provider';
+import { OcrModule, OcrService } from '@opuspopuli/ocr-provider';
 import { PromptClientModule } from '@opuspopuli/prompt-client';
 import { RegionDomainService } from './region.service';
 import { RegionResolver } from './region.resolver';
@@ -60,7 +62,19 @@ const promptClientAsyncConfig = {
     ScrapingPipelineModule.forRoot({
       imports: [
         LLMModule,
-        ExtractionModule,
+        // ExtractionModule.forRoot is configured below to import OcrModule
+        // and bind the OCR_SERVICE token inside ExtractionModule's own DI
+        // scope — that's what ExtractionProvider injects, and providers
+        // declared at ScrapingPipelineModule's scope are NOT visible to it.
+        ExtractionModule.forRoot({
+          extraImports: [OcrModule],
+          extraProviders: [
+            {
+              provide: OCR_SERVICE,
+              useExisting: OcrService,
+            },
+          ],
+        }),
         PromptClientModule.forRootAsync(promptClientAsyncConfig),
       ],
       providers: [

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -911,6 +911,33 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     return raw;
   }
 
+  /**
+   * Pre-upsert normalization for a single Representative record:
+   *   - canonicalize externalId (strip zero-padding from the trailing digit run)
+   *   - drop bios that look like extraction junk (nav-link "Home" text,
+   *     "Latest News" headline blocks from mismatched-theme senator sites);
+   *     nulling here makes the BioGenerator's `!r.bio || r.bio.trim() === ''`
+   *     filter pick them up and replace with an AI-generated bio
+   *   - mark provenance for bios that arrived from the scrape (covers the
+   *     case where BioGenerator returns early because LLM/prompt deps are
+   *     unwired and would otherwise leave scraped bios with a null bioSource)
+   *
+   * Idempotent with BioGenerator's own scraped-bio marking pass.
+   */
+  private normalizeRep(r: Representative): void {
+    r.externalId = stripLeadingZerosFromExternalId(r.externalId);
+    if (r.bio && !isLikelyValidBio(r.bio)) {
+      this.logger.warn(
+        `Discarding junk bio for ${r.externalId} (${r.bio.length} chars): ${r.bio.slice(0, 60)}…`,
+      );
+      r.bio = undefined;
+      r.bioSource = undefined;
+    }
+    if (r.bio && !r.bioSource) {
+      r.bioSource = 'scraped';
+    }
+  }
+
   private async syncRepresentatives(
     provider: DataFetcher = this.regionService,
     maxReps?: number,
@@ -925,27 +952,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     }
 
     for (const r of reps) {
-      r.externalId = stripLeadingZerosFromExternalId(r.externalId);
-      // Drop bios that look like extraction junk (e.g. "Home" nav link,
-      // "Latest News..." headline blocks from per-senator detail sites
-      // with mismatched Drupal themes). Nulling here makes the bio-
-      // generator's `!r.bio || r.bio.trim() === ''` filter pick them up
-      // and replace with an AI-generated bio on this same run.
-      if (r.bio && !isLikelyValidBio(r.bio)) {
-        this.logger.warn(
-          `Discarding junk bio for ${r.externalId} (${r.bio.length} chars): ${r.bio.slice(0, 60)}…`,
-        );
-        r.bio = undefined;
-        r.bioSource = undefined;
-      }
-      // Mark provenance for bios that arrived from the scrape. Done here
-      // (not only in BioGenerator) because BioGenerator returns early
-      // when LLM/prompt deps are unwired, leaving scraped bios with a
-      // null bioSource. This loop is idempotent with the BioGenerator's
-      // own marking pass.
-      if (r.bio && !r.bioSource) {
-        r.bioSource = 'scraped';
-      }
+      this.normalizeRep(r);
     }
 
     // Enrich with AI-generated bios where missing (scraped bios are preserved)

--- a/packages/extraction-provider/__tests__/pdf-extractor.spec.ts
+++ b/packages/extraction-provider/__tests__/pdf-extractor.spec.ts
@@ -1,0 +1,176 @@
+import { PdfExtractor, looksMeaningful } from "../src/utils/pdf-extractor.js";
+
+// Mock pdf-parse and mupdf at module level so we can drive every tier of
+// the cascade independently. The PdfExtractor uses dynamic `await import("mupdf")`
+// for tiers 2/3, so we mock the module here.
+
+const pdfParseGetText = jest.fn();
+jest.mock("pdf-parse", () => ({
+  PDFParse: jest.fn().mockImplementation(() => ({
+    getText: pdfParseGetText,
+    destroy: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+const mupdfPageText = jest.fn();
+const mupdfPageRender = jest.fn();
+const buildMupdfPage = (i: number) => ({
+  toStructuredText: () => ({ asText: () => mupdfPageText(i) }),
+  toPixmap: () => ({ asPNG: () => mupdfPageRender(i) }),
+});
+const buildMupdfDocument = () => ({
+  countPages: () => 2,
+  loadPage: buildMupdfPage,
+});
+jest.mock("mupdf", () => ({
+  Document: {
+    openDocument: jest.fn().mockImplementation(buildMupdfDocument),
+  },
+  Matrix: { scale: jest.fn().mockReturnValue({}) },
+  ColorSpace: { DeviceRGB: {} },
+}));
+
+const REAL_PROSE =
+  "Senator Smith introduces this measure to amend Section 10 of Article II of the California Constitution. " +
+  "It establishes new requirements for ballot measure approval thresholds. " +
+  "The amendment specifies that any subsequent measure proposing to raise voter approval thresholds " +
+  "must itself meet the same heightened threshold to take effect.";
+
+const buf = Buffer.from("dummy-pdf-bytes");
+
+describe("looksMeaningful", () => {
+  it("rejects null / undefined / empty", () => {
+    expect(looksMeaningful(null)).toBe(false);
+    expect(looksMeaningful(undefined)).toBe(false);
+    expect(looksMeaningful("")).toBe(false);
+  });
+
+  it("rejects text shorter than 200 chars", () => {
+    expect(looksMeaningful("a".repeat(199))).toBe(false);
+    expect(looksMeaningful("short bio")).toBe(false);
+  });
+
+  it("rejects pure page-marker boilerplate even at length", () => {
+    // Real SCA 1 case: 80 chars of "-- N of M --" page markers. Pad with
+    // newlines to push past the 200-char gate but still no real content.
+    const junk =
+      "\n".repeat(150) +
+      "-- 1 of 5 --\n-- 2 of 5 --\n-- 3 of 5 --\n-- 4 of 5 --\n-- 5 of 5 --\n";
+    expect(junk.length).toBeGreaterThan(200);
+    expect(looksMeaningful(junk)).toBe(false);
+  });
+
+  it("accepts real prose", () => {
+    expect(looksMeaningful(REAL_PROSE)).toBe(true);
+  });
+
+  it("accepts text with embedded page markers when there's substantive content", () => {
+    expect(looksMeaningful(REAL_PROSE + "\n-- 1 of 5 --\n")).toBe(true);
+  });
+});
+
+describe("PdfExtractor.extract — tier cascade", () => {
+  beforeEach(() => {
+    pdfParseGetText.mockReset();
+    mupdfPageText.mockReset();
+    mupdfPageRender.mockReset();
+  });
+
+  it("tier 1: returns pdf-parse output when meaningful", async () => {
+    pdfParseGetText.mockResolvedValue({ text: REAL_PROSE });
+    const result = await PdfExtractor.extract(buf);
+    expect(result).toBe(REAL_PROSE);
+    expect(mupdfPageText).not.toHaveBeenCalled();
+  });
+
+  it("tier 1 → tier 2: falls through to mupdf when pdf-parse returns junk", async () => {
+    pdfParseGetText.mockResolvedValue({
+      text: "\n".repeat(150) + "-- 1 of 5 --\n-- 2 of 5 --\n",
+    });
+    mupdfPageText.mockReturnValueOnce(REAL_PROSE).mockReturnValueOnce("");
+    const result = await PdfExtractor.extract(buf);
+    expect(result).toContain(REAL_PROSE);
+    expect(mupdfPageText).toHaveBeenCalledTimes(2);
+  });
+
+  it("tier 1 → tier 2: falls through when pdf-parse throws", async () => {
+    pdfParseGetText.mockRejectedValue(new Error("malformed pdf"));
+    mupdfPageText.mockReturnValueOnce(REAL_PROSE).mockReturnValueOnce("");
+    const result = await PdfExtractor.extract(buf);
+    expect(result).toContain(REAL_PROSE);
+  });
+
+  it("tier 2 → tier 3: falls through when mupdf text extraction throws", async () => {
+    pdfParseGetText.mockResolvedValue({ text: "" });
+    mupdfPageText.mockImplementation(() => {
+      throw new Error("mupdf font decode error");
+    });
+    mupdfPageRender.mockReturnValue(Buffer.from("png-bytes"));
+    const ocrService = {
+      extractFromBuffer: jest.fn().mockResolvedValue({ text: REAL_PROSE }),
+    } as never;
+
+    const result = await PdfExtractor.extract(buf, ocrService);
+    expect(result).toContain(REAL_PROSE);
+  });
+
+  it("tier 1 → tier 2 → tier 3 (OCR): rasterizes + OCRs each page when both text tiers fail", async () => {
+    pdfParseGetText.mockResolvedValue({ text: "" });
+    mupdfPageText.mockReturnValue("");
+    mupdfPageRender
+      .mockReturnValueOnce(Buffer.from("page1-png-bytes"))
+      .mockReturnValueOnce(Buffer.from("page2-png-bytes"));
+
+    const ocrService = {
+      extractFromBuffer: jest
+        .fn()
+        .mockResolvedValueOnce({ text: REAL_PROSE })
+        .mockResolvedValueOnce({ text: "" }),
+    } as never;
+
+    const result = await PdfExtractor.extract(buf, ocrService);
+    expect(result).toContain(REAL_PROSE);
+    // OCR was called once per page
+    expect(
+      (ocrService as { extractFromBuffer: jest.Mock }).extractFromBuffer,
+    ).toHaveBeenCalledTimes(2);
+    // Each call got a PNG buffer + image/png MIME
+    expect(
+      (ocrService as { extractFromBuffer: jest.Mock }).extractFromBuffer,
+    ).toHaveBeenNthCalledWith(1, expect.any(Buffer), "image/png");
+  });
+
+  it("tier 3 missing (no OcrService injected): returns best-effort tier-2 text", async () => {
+    pdfParseGetText.mockResolvedValue({ text: "" });
+    mupdfPageText.mockReturnValue("\n");
+    const result = await PdfExtractor.extract(buf);
+    // Whatever tier 2 produced (junk), returned rather than throwing
+    expect(typeof result).toBe("string");
+  });
+
+  it("tier 3 throws: returns best-effort tier-2 text instead of bubbling up", async () => {
+    pdfParseGetText.mockResolvedValue({ text: "" });
+    mupdfPageText.mockReturnValue("");
+    mupdfPageRender.mockReturnValue(Buffer.from("png-bytes"));
+    const ocrService = {
+      extractFromBuffer: jest
+        .fn()
+        .mockRejectedValue(new Error("tesseract crashed")),
+    } as never;
+
+    const result = await PdfExtractor.extract(buf, ocrService);
+    expect(typeof result).toBe("string"); // does not throw
+  });
+
+  it("tier 3 returns junk: degrades gracefully", async () => {
+    pdfParseGetText.mockResolvedValue({ text: "" });
+    mupdfPageText.mockReturnValue("");
+    mupdfPageRender.mockReturnValue(Buffer.from("png-bytes"));
+    const ocrService = {
+      extractFromBuffer: jest.fn().mockResolvedValue({ text: "" }),
+    } as never;
+
+    const result = await PdfExtractor.extract(buf, ocrService);
+    expect(typeof result).toBe("string");
+  });
+});

--- a/packages/extraction-provider/package.json
+++ b/packages/extraction-provider/package.json
@@ -30,6 +30,7 @@
     "@opuspopuli/common": "workspace:*",
     "cheerio": "^1.1.2",
     "ioredis": "^5.9.2",
+    "mupdf": "^1.27.0",
     "pdf-parse": "^2.4.5"
   },
   "peerDependencies": {

--- a/packages/extraction-provider/src/extraction.module.ts
+++ b/packages/extraction-provider/src/extraction.module.ts
@@ -14,6 +14,30 @@ import {
  */
 export interface ExtractionModuleOptions {
   config?: Partial<ExtractionConfig>;
+  /**
+   * Additional modules to import into ExtractionModule's scope. Useful when
+   * binding providers (via `extraProviders`) that depend on services from
+   * external modules — e.g. wiring `OCR_SERVICE` to `@opuspopuli/ocr-provider`'s
+   * `OcrService` requires importing `OcrModule` here so its exports resolve.
+   */
+  extraImports?: NonNullable<DynamicModule["imports"]>;
+  /**
+   * Additional providers to register in ExtractionModule's scope, made
+   * visible to all components declared in this module. The canonical use
+   * is binding the optional `OCR_SERVICE` token used by the tiered PDF
+   * extractor:
+   *
+   * ```ts
+   * ExtractionModule.forRoot({
+   *   extraImports: [OcrModule],
+   *   extraProviders: [{ provide: OCR_SERVICE, useExisting: OcrService }],
+   * })
+   * ```
+   *
+   * Without binding here, ExtractionProvider's `@Optional() @Inject(OCR_SERVICE)`
+   * resolves to `undefined` and image-based PDFs skip the OCR fallback.
+   */
+  extraProviders?: Provider[];
 }
 
 /**
@@ -104,6 +128,7 @@ export class ExtractionModule {
 
     return {
       module: ExtractionModule,
+      imports: options.extraImports ?? [],
       providers: [
         {
           provide: EXTRACTION_CONFIG,
@@ -111,6 +136,7 @@ export class ExtractionModule {
         },
         ExtractionProvider,
         URLExtractor,
+        ...(options.extraProviders ?? []),
         {
           provide: "TEXT_EXTRACTORS",
           useFactory: (urlExtractor: URLExtractor): ITextExtractor[] => {

--- a/packages/extraction-provider/src/extraction.provider.ts
+++ b/packages/extraction-provider/src/extraction.provider.ts
@@ -12,7 +12,17 @@ import { Inject, Injectable, Logger, Optional } from "@nestjs/common";
 import * as cheerio from "cheerio";
 import type { CheerioAPI, Cheerio } from "cheerio";
 import type { Element } from "domhandler";
-import { PDFParse } from "pdf-parse";
+import {
+  PdfExtractor,
+  type IOcrProviderForPdf,
+} from "./utils/pdf-extractor.js";
+
+/**
+ * DI token for the optional OCR fallback used by `extractPdfText`. Wire
+ * up `{ provide: OCR_SERVICE, useExisting: OcrService }` in a parent
+ * module to enable image-based PDF support; leave unwired to skip OCR.
+ */
+export const OCR_SERVICE = "OCR_SERVICE";
 import {
   type ICache,
   type IRateLimiter,
@@ -71,6 +81,19 @@ export class ExtractionProvider {
     @Optional()
     @Inject(EXTRACTION_CONFIG)
     config?: Partial<ExtractionConfig>,
+    /**
+     * Optional. When present, PDF extraction falls back to OCR for
+     * image-based PDFs (where pdf-parse and mupdf both produce no
+     * meaningful text). When absent, those PDFs return empty text and
+     * the consumer is responsible for handling no-content gracefully.
+     *
+     * Resolved via the OCR_SERVICE token + structural typing so this
+     * package stays runtime-decoupled from `@opuspopuli/ocr-provider`'s
+     * dep tree.
+     */
+    @Optional()
+    @Inject(OCR_SERVICE)
+    private readonly ocrService?: IOcrProviderForPdf,
   ) {
     this.config = {
       ...DEFAULT_EXTRACTION_CONFIG,
@@ -184,18 +207,17 @@ export class ExtractionProvider {
   }
 
   /**
-   * Extract text from PDF buffer
+   * Extract text from a PDF buffer using a tiered cascade:
+   * pdf-parse → mupdf text → mupdf rasterize + OCR. See
+   * {@link PdfExtractor} for the rationale and quality-threshold logic.
    *
-   * @param buffer - PDF file buffer
-   * @returns Extracted text content
+   * If `OcrService` was not injected, the third tier is skipped and the
+   * best-effort text from the earlier tiers is returned (which may be
+   * empty for image-based PDFs).
    */
   async extractPdfText(buffer: Buffer): Promise<string> {
     this.logger.debug("Extracting text from PDF");
-
-    const parser = new PDFParse({ data: buffer });
-    const result = await parser.getText();
-    await parser.destroy();
-    return result.text;
+    return PdfExtractor.extract(buffer, this.ocrService);
   }
 
   /**

--- a/packages/extraction-provider/src/utils/pdf-extractor.ts
+++ b/packages/extraction-provider/src/utils/pdf-extractor.ts
@@ -1,0 +1,189 @@
+import { Logger } from "@nestjs/common";
+import { PDFParse } from "pdf-parse";
+
+/**
+ * Structural type for the OCR dependency. Defined here rather than imported
+ * from `@opuspopuli/ocr-provider` so this package stays runtime-decoupled
+ * from OCR's transitive dep tree (`@nestjs/config`, etc.). Any service that
+ * exposes an `extractFromBuffer(buffer, mimeType)` method satisfies the
+ * contract — `OcrService` from `@opuspopuli/ocr-provider` does, but this
+ * type doesn't require importing it.
+ */
+export interface IOcrProviderForPdf {
+  extractFromBuffer(
+    buffer: Buffer,
+    mimeType: string,
+  ): Promise<{ text: string }>;
+}
+
+/**
+ * Tiered PDF text extractor.
+ *
+ * Many government PDFs (especially older scanned legislative archives) defeat
+ * pure text-extraction libraries. The CA SOS qualified-ballot-measures page
+ * for instance links to PDFs where pdf-parse returns only page-marker
+ * boilerplate (~80 chars) and mupdf returns ~4 chars (just newlines) — the
+ * actual measure body is a scanned image with no text layer.
+ *
+ * Strategy:
+ *   1. **pdf-parse** (fast, ~95% of well-formed PDFs)
+ *   2. **mupdf** text extraction (handles malformed/unusual encodings; same
+ *      library is reused in tier 3 for rasterization, so adding it as the
+ *      tier-2 fallback costs nothing extra)
+ *   3. **mupdf rasterization → OCR per page** (image-based PDFs; slow —
+ *      ~1-5s per page on Tesseract — and only invoked when the cheaper
+ *      tiers fail to produce meaningful text)
+ *
+ * Each tier is gated by `looksMeaningful`, not just exception-catching:
+ * pdf-parse for the SCA 1 case returns successfully with junk, so a pure
+ * try/catch fallback would never fire.
+ */
+export class PdfExtractor {
+  private static readonly logger = new Logger(PdfExtractor.name);
+
+  /**
+   * Tier-1 → tier-3 cascade. Returns the first meaningful result. If all
+   * tiers fail and OCR is unavailable, returns the best-effort tier-2
+   * output (which may be empty / junk) — callers should treat short
+   * results as "no analyzable content."
+   */
+  static async extract(
+    buffer: Buffer,
+    ocrService?: IOcrProviderForPdf,
+  ): Promise<string> {
+    // Tier 1: pdf-parse
+    const t1 = await PdfExtractor.tryPdfParse(buffer);
+    if (looksMeaningful(t1)) {
+      return t1;
+    }
+    PdfExtractor.logger.debug(
+      `pdf-parse returned ${t1?.length ?? 0} chars (insufficient); trying mupdf text`,
+    );
+
+    // Tier 2: mupdf text extraction
+    const t2 = await PdfExtractor.tryMupdfText(buffer);
+    if (looksMeaningful(t2)) {
+      PdfExtractor.logger.debug(
+        `mupdf text recovered ${t2.length} chars where pdf-parse failed`,
+      );
+      return t2;
+    }
+    PdfExtractor.logger.debug(
+      `mupdf text returned ${t2?.length ?? 0} chars (insufficient); trying OCR`,
+    );
+
+    // Tier 3: mupdf rasterize → OCR
+    if (!ocrService) {
+      PdfExtractor.logger.warn(
+        "PDF needs OCR but no OcrService injected — returning best-effort text",
+      );
+      return t2 || t1 || "";
+    }
+    const startMs = Date.now();
+    try {
+      const ocrText = await PdfExtractor.tryMupdfOcr(buffer, ocrService);
+      const elapsedSec = ((Date.now() - startMs) / 1000).toFixed(1);
+      if (looksMeaningful(ocrText)) {
+        PdfExtractor.logger.warn(
+          `OCR recovered ${ocrText.length} chars from PDF in ${elapsedSec}s — image-based PDF`,
+        );
+        return ocrText;
+      }
+      PdfExtractor.logger.warn(
+        `OCR returned ${ocrText?.length ?? 0} chars (insufficient) after ${elapsedSec}s`,
+      );
+      return ocrText || t2 || t1 || "";
+    } catch (err) {
+      PdfExtractor.logger.warn(
+        `OCR failed: ${(err as Error).message} — returning best-effort text`,
+      );
+      return t2 || t1 || "";
+    }
+  }
+
+  private static async tryPdfParse(buffer: Buffer): Promise<string> {
+    try {
+      const parser = new PDFParse({ data: buffer });
+      const result = await parser.getText();
+      await parser.destroy();
+      return result.text ?? "";
+    } catch (err) {
+      PdfExtractor.logger.debug(`pdf-parse threw: ${(err as Error).message}`);
+      return "";
+    }
+  }
+
+  private static async tryMupdfText(buffer: Buffer): Promise<string> {
+    try {
+      const mupdf = await import("mupdf");
+      const doc = mupdf.Document.openDocument(buffer, "application/pdf");
+      const pageCount = doc.countPages();
+      const pages: string[] = [];
+      for (let i = 0; i < pageCount; i++) {
+        const page = doc.loadPage(i);
+        pages.push(page.toStructuredText("preserve-whitespace").asText());
+      }
+      return pages.join("\n");
+    } catch (err) {
+      PdfExtractor.logger.debug(
+        `mupdf text extraction threw: ${(err as Error).message}`,
+      );
+      return "";
+    }
+  }
+
+  /**
+   * Rasterize each page to PNG via mupdf, then OCR each PNG via the
+   * injected OcrService. Tesseract supports image MIME types only, so the
+   * rasterization step is mandatory for image-based PDFs.
+   *
+   * 200 DPI is the OCR quality / speed sweet spot — higher gives marginal
+   * accuracy gains at meaningful runtime cost.
+   */
+  private static async tryMupdfOcr(
+    buffer: Buffer,
+    ocrService: IOcrProviderForPdf,
+  ): Promise<string> {
+    const mupdf = await import("mupdf");
+    const doc = mupdf.Document.openDocument(buffer, "application/pdf");
+    const pageCount = doc.countPages();
+    const dpi = 200;
+    const matrix = mupdf.Matrix.scale(dpi / 72, dpi / 72);
+    const pageTexts: string[] = [];
+
+    for (let i = 0; i < pageCount; i++) {
+      const page = doc.loadPage(i);
+      const pixmap = page.toPixmap(matrix, mupdf.ColorSpace.DeviceRGB);
+      const png = pixmap.asPNG();
+      const result = await ocrService.extractFromBuffer(
+        Buffer.from(png),
+        "image/png",
+      );
+      pageTexts.push(result.text);
+    }
+
+    return pageTexts.join("\n");
+  }
+}
+
+/**
+ * Heuristic for "this looks like real PDF text content, not extraction junk."
+ *
+ * Real bills are thousands of characters with substantive prose. Junk
+ * extractions (page-marker boilerplate, blank pages, unparseable fonts) tend
+ * to produce either very short output OR output that's mostly whitespace +
+ * page numbers.
+ *
+ * The threshold is deliberately conservative — we'd rather invoke a slower
+ * tier on a borderline case than persist a useless extraction.
+ */
+export function looksMeaningful(text: string | undefined | null): boolean {
+  if (!text) return false;
+  if (text.length < 200) return false;
+  // Strip "-- N of M --" page markers and any whitespace; require at least
+  // 100 chars of substantive content remaining.
+  const substantive = text
+    .replaceAll(/--\s*\d+\s*of\s*\d+\s*--/g, "")
+    .replaceAll(/\s+/g, "");
+  return substantive.length >= 100;
+}

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1,4 +1,7 @@
-import { DomainMapperService } from "../src/mapping/domain-mapper.service";
+import {
+  DomainMapperService,
+  cleanPropositionTitle,
+} from "../src/mapping/domain-mapper.service";
 import {
   DataType,
   type RawExtractionResult,
@@ -27,6 +30,75 @@ function createRawResult(
     ...overrides,
   };
 }
+
+describe("cleanPropositionTitle", () => {
+  it("strips measure-id + author + chapter-info + (PDF) from real SOS anchor text", () => {
+    expect(
+      cleanPropositionTitle(
+        "ACA 13 (Ward) Voting thresholds. (Res. Ch. 176, 2023) (PDF)",
+      ),
+    ).toBe("Voting thresholds");
+    expect(
+      cleanPropositionTitle(
+        "SB 42 (Umberg) Political Reform Act of 1974: public campaign financing: California Fair Elections Act of 2026. (Ch. 245, 2025) (PDF)",
+      ),
+    ).toBe(
+      "Political Reform Act of 1974: public campaign financing: California Fair Elections Act of 2026",
+    );
+    expect(
+      cleanPropositionTitle(
+        "SCA 1 (Newman) Elections: recall of state officers. (Res. Ch. 204, 2024) (PDF)",
+      ),
+    ).toBe("Elections: recall of state officers");
+  });
+
+  it("handles multi-letter and single-digit measure prefixes", () => {
+    expect(cleanPropositionTitle("AB 1 (Doe) Short title. (PDF)")).toBe(
+      "Short title",
+    );
+    expect(
+      cleanPropositionTitle(
+        "SCA 21 (Smith) Long title here. (Res. Ch. 99, 2025) (PDF)",
+      ),
+    ).toBe("Long title here");
+  });
+
+  it("strips only one trailing parenthetical group cleanly when there is one", () => {
+    expect(cleanPropositionTitle("AB 5 (Doe) Title. (PDF)")).toBe("Title");
+  });
+
+  it("handles colons and punctuation inside the title", () => {
+    expect(
+      cleanPropositionTitle(
+        "AB 1 (Doe) Education: K-12 funding: cost-of-living adjustments. (PDF)",
+      ),
+    ).toBe("Education: K-12 funding: cost-of-living adjustments");
+  });
+
+  it("trims whitespace", () => {
+    expect(cleanPropositionTitle("  ACA 13 (Ward)  Title.   (PDF)  ")).toBe(
+      "Title",
+    );
+  });
+
+  it("returns empty for empty input, trimmed input for whitespace-only", () => {
+    expect(cleanPropositionTitle("")).toBe("");
+    expect(cleanPropositionTitle("   ")).toBe("");
+  });
+
+  it("falls back to the trimmed input when stripping empties the string", () => {
+    // Pathological: anchor with measure id + author parenthetical but no
+    // descriptive title body. We must not return "" — the schema's
+    // min(1) validator would reject the row.
+    expect(cleanPropositionTitle("AB 1 (Doe) (PDF)")).toBe("AB 1 (Doe) (PDF)");
+  });
+
+  it("leaves an already-clean title unchanged", () => {
+    expect(cleanPropositionTitle("Voting thresholds")).toBe(
+      "Voting thresholds",
+    );
+  });
+});
 
 describe("DomainMapperService", () => {
   let mapper: DomainMapperService;
@@ -68,6 +140,52 @@ describe("DomainMapperService", () => {
 
       expect(result.success).toBe(false);
       expect(result.items).toHaveLength(0);
+    });
+
+    it("cleans the title from raw SOS anchor text and routes detailUrl → sourceUrl", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "ACA 13",
+              title:
+                "ACA 13 (Ward) Voting thresholds. (Res. Ch. 176, 2023) (PDF)",
+              detailUrl:
+                "https://www.sos.ca.gov/elections/ballot-measures/pdf/aca-13.pdf",
+            },
+          ],
+        }),
+        createSource({ dataType: DataType.PROPOSITIONS }),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        externalId: "ACA 13",
+        title: "Voting thresholds",
+        // summary defaults to cleaned title until AI analysis populates analysis_summary
+        summary: "Voting thresholds",
+        sourceUrl:
+          "https://www.sos.ca.gov/elections/ballot-measures/pdf/aca-13.pdf",
+      });
+    });
+
+    it("prefers an explicit sourceUrl over detailUrl when both present", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "PROP-X",
+              title: "X",
+              sourceUrl: "https://example.com/explicit",
+              detailUrl: "https://example.com/harvest",
+            },
+          ],
+        }),
+        createSource({ dataType: DataType.PROPOSITIONS }),
+      );
+      expect(result.items[0]).toMatchObject({
+        sourceUrl: "https://example.com/explicit",
+      });
     });
 
     it("should use title as summary when summary is empty", () => {

--- a/packages/scraping-pipeline/package.json
+++ b/packages/scraping-pipeline/package.json
@@ -50,6 +50,7 @@
     "@types/node": "^22.0.0",
     "@types/yauzl": "^2.10.3",
     "domhandler": "^5.0.3",
+    "mupdf": "^1.27.0",
     "jest": "^30.0.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",

--- a/packages/scraping-pipeline/src/extraction/structured-extractor.ts
+++ b/packages/scraping-pipeline/src/extraction/structured-extractor.ts
@@ -108,6 +108,74 @@ function extractFromShortcut(
     : child.first().text().replaceAll(/\s+/g, " ").trim() || undefined;
 }
 
+type ObjectChildConfig = Exclude<ChildFieldConfig, string>;
+
+/**
+ * Default extraction method when not explicitly set:
+ *   - 'regex' when a pattern is present (the only piece of config that
+ *     uniquely identifies a regex extraction)
+ *   - 'text' otherwise (selector-driven text extraction is the common case)
+ */
+function resolveExtractionMethod(config: ObjectChildConfig): string {
+  return config.extractionMethod ?? (config.regexPattern ? "regex" : "text");
+}
+
+/**
+ * Run a regex pattern against either the parent element's full text or a
+ * narrower child element's text. Returns the configured capture group
+ * (default 1). Invalid regexes return undefined rather than throwing.
+ */
+function extractByRegex(
+  $: CheerioAPI,
+  el: AnyNode,
+  config: ObjectChildConfig,
+  elementText: string,
+): string | undefined {
+  if (!config.regexPattern) return undefined;
+  const haystack = config.selector
+    ? ($(el).find(config.selector).first().text() ?? "")
+        .replaceAll(/\s+/g, " ")
+        .trim()
+    : elementText;
+  try {
+    const match = new RegExp(config.regexPattern).exec(haystack);
+    const group = config.regexGroup ?? 1;
+    return match?.[group]?.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+function extractByAttribute(
+  $: CheerioAPI,
+  el: AnyNode,
+  config: ObjectChildConfig,
+): string | undefined {
+  if (!config.selector || !config.attribute) return undefined;
+  const child = $(el).find(config.selector);
+  if (child.length === 0) return undefined;
+  return child.first().attr(config.attribute);
+}
+
+/**
+ * Default text extraction. With no selector, returns the parent element's
+ * full text. With a selector, returns the first matching descendant's text
+ * (whitespace-collapsed, trimmed).
+ */
+function extractByText(
+  $: CheerioAPI,
+  el: AnyNode,
+  config: ObjectChildConfig,
+  elementText: string,
+): string | undefined {
+  if (!config.selector) {
+    return elementText || undefined;
+  }
+  const child = $(el).find(config.selector);
+  if (child.length === 0) return undefined;
+  return child.first().text().replaceAll(/\s+/g, " ").trim() || undefined;
+}
+
 /**
  * Object-form ChildFieldConfig — full extraction method + optional
  * transform. Mirrors the semantics of top-level FieldMapping but at
@@ -116,54 +184,22 @@ function extractFromShortcut(
 function extractFromObjectConfig(
   $: CheerioAPI,
   el: AnyNode,
-  config: Exclude<ChildFieldConfig, string>,
+  config: ObjectChildConfig,
   elementText: string,
   baseUrl?: string,
 ): string | undefined {
-  // Default extraction method: regex if only a pattern is given, else text
-  const method =
-    config.extractionMethod ?? (config.regexPattern ? "regex" : "text");
-
+  const method = resolveExtractionMethod(config);
   let value: string | undefined;
-
   switch (method) {
-    case "regex": {
-      if (!config.regexPattern) return undefined;
-      // For regex method: optionally narrow to a sub-element first via
-      // selector, otherwise run against the parent element's full text.
-      const haystack = config.selector
-        ? ($(el).find(config.selector).first().text() ?? "")
-            .replaceAll(/\s+/g, " ")
-            .trim()
-        : elementText;
-      try {
-        const match = new RegExp(config.regexPattern).exec(haystack);
-        const group = config.regexGroup ?? 1;
-        value = match?.[group]?.trim();
-      } catch {
-        return undefined;
-      }
+    case "regex":
+      value = extractByRegex($, el, config, elementText);
       break;
-    }
-    case "attribute": {
-      if (!config.selector || !config.attribute) return undefined;
-      const child = $(el).find(config.selector);
-      if (child.length === 0) return undefined;
-      value = child.first().attr(config.attribute);
+    case "attribute":
+      value = extractByAttribute($, el, config);
       break;
-    }
-    case "text":
-    default: {
-      // Text from selector, or whole element if no selector given
-      if (!config.selector) {
-        value = elementText || undefined;
-        break;
-      }
-      const child = $(el).find(config.selector);
-      if (child.length === 0) return undefined;
-      value = child.first().text().replaceAll(/\s+/g, " ").trim() || undefined;
+    default:
+      value = extractByText($, el, config, elementText);
       break;
-    }
   }
 
   if (value && config.transform) {

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -332,13 +332,26 @@ export function cleanPropositionTitle(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return trimmed;
 
-  // Strip leading "<MEASURE_ID> (<author>) " — measure id is letters and
-  // digits with optional whitespace, author is anything inside parens.
+  // Strip leading "<MEASURE_ID> (<author>) ". The character classes are
+  // disjoint (`[A-Z]`, `\s`, `\d`, `[^)]`), each quantifier operates on
+  // a non-overlapping set, and the pattern is anchored at `^` — no
+  // ambiguous match positions, so backtracking stays linear in input
+  // length even if the regex doesn't match.
   let cleaned = trimmed.replace(/^[A-Z]+\s*\d+\s*\([^)]*\)\s*/, "");
 
-  // Strip trailing "(...) (...) (...)" parentheticals (chapter info,
-  // PDF suffix, etc.). One or more groups, each separated by whitespace.
-  cleaned = cleaned.replace(/\s*(?:\([^)]*\)\s*)+$/, "");
+  // Strip trailing parentheticals one at a time via a single-match regex
+  // per iteration. The original `(?:\([^)]*\)\s*)+$` form was flagged by
+  // Sonar's ReDoS heuristic for nested quantifiers (`+` outer + `*`
+  // inside) — even though the inner content classes are disjoint and
+  // can't actually backtrack super-linearly, the loop form is provably
+  // O(n) per iteration with at most O(n) iterations (each strip removes
+  // at least 2 chars: `()`), keeping worst-case total at O(n²) without
+  // any backtracking ambiguity for the static analyzer to flag.
+  let prev: string;
+  do {
+    prev = cleaned;
+    cleaned = cleaned.replace(/\s*\([^)]*\)\s*$/, "");
+  } while (cleaned !== prev);
 
   // Strip a single trailing period that was the original end-of-title
   // punctuation in the SOS anchor.

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -117,7 +117,15 @@ export class DomainMapperService {
   }
 
   private mapProposition(record: Record<string, unknown>): Proposition | null {
-    const result = PropositionSchema.safeParse(record);
+    // The CA SOS qualified-ballot-measures page emits each measure as an
+    // anchor whose href points to the bill PDF. The regions config
+    // extracts that href as `detailUrl`, but the proposition domain
+    // type stores it as `sourceUrl`. Map across so the field lands.
+    const enriched = {
+      ...record,
+      sourceUrl: record.sourceUrl ?? record.detailUrl,
+    };
+    const result = PropositionSchema.safeParse(enriched);
     if (!result.success) {
       this.logger.debug(
         `Proposition validation failed: ${result.error.message}`,
@@ -287,10 +295,68 @@ const coerceFlexibleDateOptional = z
   .transform(parseFlexibleDate)
   .pipe(z.date().optional());
 
+/**
+ * Clean a CA SOS qualified-ballot-measures anchor text down to the bare
+ * descriptive title.
+ *
+ * The SOS page emits each measure as one anchor of the form:
+ *
+ *   `ACA 13 (Ward) Voting thresholds. (Res. Ch. 176, 2023) (PDF)`
+ *
+ * which has four glued-on parts beyond the actual title:
+ *  1. The leading `<MEASURE_ID>` (already extracted as externalId).
+ *  2. The author parenthetical `(Ward)`.
+ *  3. A trailing chapter-info parenthetical `(Res. Ch. 176, 2023)`.
+ *  4. A `(PDF)` document-format suffix.
+ *
+ * Region-config hint #29 in `california.json` deliberately captures the
+ * full anchor text and leaves cleanup to the consumer ("title: ... .
+ * Cleanup is the consumer's job; do NOT add a transform"). A previous
+ * attempt to push cleanup into a regex_replace transform broke the
+ * pipeline (the manifest fanned out into mismatched groups). This is
+ * the consumer side of that contract.
+ *
+ * Examples:
+ *   `"ACA 13 (Ward) Voting thresholds. (Res. Ch. 176, 2023) (PDF)"`
+ *     → `"Voting thresholds"`
+ *   `"SB 42 (Umberg) Political Reform Act of 1974: public campaign financing. (Ch. 245, 2025) (PDF)"`
+ *     → `"Political Reform Act of 1974: public campaign financing"`
+ *   `"SCA 1 (Newman) Elections: recall of state officers. (Res. Ch. 204, 2024) (PDF)"`
+ *     → `"Elections: recall of state officers"`
+ *
+ * If the input doesn't match the expected shape (e.g. titles already
+ * cleaned upstream, or a future SOS layout change), returns the input
+ * trimmed — never empty.
+ */
+export function cleanPropositionTitle(raw: string): string {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+
+  // Strip leading "<MEASURE_ID> (<author>) " — measure id is letters and
+  // digits with optional whitespace, author is anything inside parens.
+  let cleaned = trimmed.replace(/^[A-Z]+\s*\d+\s*\([^)]*\)\s*/, "");
+
+  // Strip trailing "(...) (...) (...)" parentheticals (chapter info,
+  // PDF suffix, etc.). One or more groups, each separated by whitespace.
+  cleaned = cleaned.replace(/\s*(?:\([^)]*\)\s*)+$/, "");
+
+  // Strip a single trailing period that was the original end-of-title
+  // punctuation in the SOS anchor.
+  cleaned = cleaned.replace(/\.\s*$/, "");
+
+  cleaned = cleaned.trim();
+
+  // Defensive: if cleanup produced an empty string (the input was just
+  // a measure id + parentheticals with no descriptor), fall back to
+  // the trimmed input so the downstream `min(1)` validator doesn't
+  // reject the row.
+  return cleaned || trimmed;
+}
+
 const PropositionSchema = z
   .object({
     externalId: z.string().min(1),
-    title: z.string().min(1),
+    title: z.string().min(1).transform(cleanPropositionTitle),
     summary: z.string().default(""),
     fullText: z.string().optional(),
     status: z.nativeEnum(PropositionStatus).default(PropositionStatus.PENDING),

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -328,34 +328,64 @@ const coerceFlexibleDateOptional = z
  * cleaned upstream, or a future SOS layout change), returns the input
  * trimmed — never empty.
  */
+/**
+ * Strip a single trailing balanced parenthetical group (and any whitespace
+ * preceding it) from a string. Returns the original string when no such
+ * group exists.
+ *
+ * Uses imperative paren-matching instead of regex to avoid Sonar's
+ * ReDoS heuristic, which flags any pattern combining `\s*` with `[^)]*`
+ * because those character classes overlap (`\s` is a subset of `[^)]`)
+ * — even though the actual match has no ambiguous positions and runs
+ * in linear time. Each call here is strictly O(n).
+ */
+function stripTrailingParenGroup(s: string): string | null {
+  const trimmed = s.trimEnd();
+  if (!trimmed.endsWith(")")) return null;
+
+  // Walk backward from the closing `)` to find the matching `(`,
+  // accounting for nesting (real titles don't use nested parens but
+  // costs nothing to handle them correctly).
+  let depth = 1;
+  let i = trimmed.length - 2;
+  while (i >= 0 && depth > 0) {
+    if (trimmed[i] === ")") depth++;
+    else if (trimmed[i] === "(") depth--;
+    i--;
+  }
+  if (depth !== 0) return null;
+
+  // i + 1 is the position of the opening `(`. Slice everything before
+  // it, then trim trailing whitespace that preceded the parenthetical.
+  return trimmed.slice(0, i + 1).trimEnd();
+}
+
 export function cleanPropositionTitle(raw: string): string {
   const trimmed = raw.trim();
   if (!trimmed) return trimmed;
 
-  // Strip leading "<MEASURE_ID> (<author>) ". The character classes are
-  // disjoint (`[A-Z]`, `\s`, `\d`, `[^)]`), each quantifier operates on
-  // a non-overlapping set, and the pattern is anchored at `^` — no
-  // ambiguous match positions, so backtracking stays linear in input
-  // length even if the regex doesn't match.
+  // Strip leading "<MEASURE_ID> (<author>) ". Quantifier character
+  // classes are disjoint here (`[A-Z]`, `\d`, `\s`, `[^)]` only after
+  // the literal `(`), the pattern is anchored at `^`, and each `*`/`+`
+  // operates on a single-shot greedy match — no ambiguous match
+  // positions for the regex engine to backtrack across.
   let cleaned = trimmed.replace(/^[A-Z]+\s*\d+\s*\([^)]*\)\s*/, "");
 
-  // Strip trailing parentheticals one at a time via a single-match regex
-  // per iteration. The original `(?:\([^)]*\)\s*)+$` form was flagged by
-  // Sonar's ReDoS heuristic for nested quantifiers (`+` outer + `*`
-  // inside) — even though the inner content classes are disjoint and
-  // can't actually backtrack super-linearly, the loop form is provably
-  // O(n) per iteration with at most O(n) iterations (each strip removes
-  // at least 2 chars: `()`), keeping worst-case total at O(n²) without
-  // any backtracking ambiguity for the static analyzer to flag.
-  let prev: string;
-  do {
-    prev = cleaned;
-    cleaned = cleaned.replace(/\s*\([^)]*\)\s*$/, "");
-  } while (cleaned !== prev);
+  // Strip trailing parentheticals one at a time. Imperative scan in
+  // {@link stripTrailingParenGroup} avoids the regex-based ReDoS
+  // heuristic and is strictly O(n) per call, with at most O(n / 2)
+  // calls (each strip removes at least two chars: `()`).
+  let next = stripTrailingParenGroup(cleaned);
+  while (next !== null) {
+    cleaned = next;
+    next = stripTrailingParenGroup(cleaned);
+  }
 
   // Strip a single trailing period that was the original end-of-title
   // punctuation in the SOS anchor.
-  cleaned = cleaned.replace(/\.\s*$/, "");
+  if (cleaned.endsWith(".")) {
+    cleaned = cleaned.slice(0, -1);
+  }
 
   cleaned = cleaned.trim();
 

--- a/packages/scraping-pipeline/src/types/mupdf.d.ts
+++ b/packages/scraping-pipeline/src/types/mupdf.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Ambient module declaration for `mupdf`.
+ *
+ * `mupdf` is consumed by `@opuspopuli/extraction-provider` (specifically
+ * `pdf-extractor.ts`'s tier-2/tier-3 PDF text extraction paths). When this
+ * package's jest config compiles extraction-provider source via
+ * `moduleNameMapper` (so tests run against the live source instead of the
+ * built `dist/`), ts-jest tries to type-check the dynamic
+ * `await import("mupdf")` from THIS package's context — where `mupdf`
+ * isn't a direct dependency in pnpm's strict node_modules layout, even
+ * though it lives in the workspace.
+ *
+ * Local dev sees mupdf via pnpm hoisting and the resolution succeeds; CI
+ * (`pnpm install --frozen-lockfile` on pnpm 9, no hoisting fallback)
+ * fails with `TS2307: Cannot find module 'mupdf'`, taking down
+ * `pipeline.spec.ts` and `pipeline.integration.spec.ts` even though
+ * neither test actually exercises the PDF path at runtime.
+ *
+ * Stubbing the module here as a wildcard `any` lets the compiler resolve
+ * the import without touching the runtime — `pnpm install` still puts
+ * the real mupdf in `extraction-provider/node_modules/`, and Node's
+ * resolver finds it there at runtime when the PDF path is exercised.
+ *
+ * The actual type signatures we care about live in
+ * `extraction-provider/src/utils/pdf-extractor.ts`'s structural types,
+ * not here — this declaration is purely a compile-resolution shim.
+ */
+declare module "mupdf";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1033,6 +1033,9 @@ importers:
       jest:
         specifier: ^30.0.0
         version: 30.3.0(@types/node@22.19.15)
+      mupdf:
+        specifier: ^1.27.0
+        version: 1.27.0
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -716,6 +716,9 @@ importers:
       ioredis:
         specifier: ^5.9.2
         version: 5.10.1
+      mupdf:
+        specifier: ^1.27.0
+        version: 1.27.0
       pdf-parse:
         specifier: ^2.4.5
         version: 2.4.5
@@ -9605,6 +9608,9 @@ packages:
   multer@2.1.1:
     resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
     engines: {node: '>= 10.16.0'}
+
+  mupdf@1.27.0:
+    resolution: {integrity: sha512-vEPUYwZeu5NgiFLz4e20R7Vp2pNY7szirGEvTxHyQQpQs6ab4DeGdonwT6sH1JZG5EhyHSrojZrZn2/0ee6qZQ==}
 
   murmurhash-js@1.0.0:
     resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
@@ -22497,6 +22503,8 @@ snapshots:
       busboy: 1.6.0
       concat-stream: 2.0.0
       type-is: 1.6.18
+
+  mupdf@1.27.0: {}
 
   murmurhash-js@1.0.0: {}
 


### PR DESCRIPTION
## Summary

Releases #663 to main. Single PR's worth of changes since #660.

- **Proposition title cleanup + sourceUrl wiring** — `cleanPropositionTitle` strips the SOS anchor pollution (`ACA 13 (Ward) Voting thresholds. (Res. Ch. 176, 2023) (PDF)` → `Voting thresholds`); `mapProposition` routes `detailUrl` → stored `sourceUrl`. Closes the propositions side of #632.

- **Tiered PDF text extractor with OCR fallback** — new `PdfExtractor` cascade: pdf-parse (tier 1) → mupdf text (tier 2) → mupdf rasterize + Tesseract OCR (tier 3). Tier gates are quality-based (`looksMeaningful`), not exception-based — handles the SCA 1 case where pdf-parse returns 80 chars of page-marker junk successfully without throwing. OCR wired via the new `OCR_SERVICE` token + structural type, keeping `extraction-provider` runtime-decoupled from `@opuspopuli/ocr-provider`'s dep tree.

- **Sonar refactors** — `syncRepresentatives` extracted `normalizeRep` helper (cognitive complexity 16 → ≤15); `extractFromObjectConfig` extracted per-method helpers (18 → ≤15); `cleanPropositionTitle` switched from a nested-quantifier regex to an imperative paren-matching scanner (eliminated ReDoS heuristic flag).

- **CI fix** — ambient `declare module \"mupdf\";` shim in `scraping-pipeline/src/types/` so cross-package ts-jest compilation resolves without depending on pnpm's local hoisting (the failure mode that cost a few iterations to diagnose).

## Live verification (post-merge to develop)

California propositions sync, all 3 measures clean:

| Prop   | PDF chars | Path   | Provisions | Analysis |
|--------|-----------|--------|------------|----------|
| ACA 13 | 7,917     | tier 1 | 4          | ✓        |
| SB 42  | 18,756    | tier 1 | 6          | ✓        |
| SCA 1  | **7,140 (OCR)** | **tier 3** | 5    | ✓        |

Quality bars all 0: no polluted titles, no missing `source_url`, no empty `full_text`, no missing analyses.

## Test plan

- [x] CI green on #663 (after the cross-package ts-jest fix)
- [x] Live propositions sync verified end-to-end against UAT (including Tesseract OCR firing on the image-based SCA 1 PDF)
- [ ] Reviewer: confirm no breaking changes for downstream consumers of `ExtractionModule.forRoot` (added optional `extraImports` and `extraProviders` fields — backward compatible)
- [ ] Reviewer: confirm `mupdf` native binding loads in the production docker image (it does in UAT)

## Issues closed

- Closes #663
- Partially addresses #632 (propositions side; expenditures side already shipped in #645)

## Open follow-ups (not in this release)

- #661 — Validate required fields before detail-crawl (CA props sync currently spends ~129s OCRing AB 440, a non-measure that the mapper drops anyway)
- #662 — OCR test fixture + benchmarks for petition-scanner regression coverage
- #657 — Senate committees still need a separate listing source

🤖 Generated with [Claude Code](https://claude.com/claude-code)