### PR TITLE
feat: California Assembly daily-journal ingestion (#665)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,7 +76,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.34",
+    "@opuspopuli/regions": "^1.0.35",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -76,7 +76,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.35",
+    "@opuspopuli/regions": "^1.0.36",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.spec.ts
@@ -103,17 +103,25 @@ describe('LegislativeActionLinkerService', () => {
     'Legislative business: Members Garcia and Lee.',
     'Illness: Members Smith.',
     '',
+    'ENGROSSMENT AND ENROLLMENT REPORTS',
+    'Mr. Speaker: Pursuant to your instructions the Chief Clerk has examined:',
+    'Assembly Bill No. 1897',
+    'Above bill correctly engrossed.',
+    '',
     'REPORTS OF STANDING COMMITTEES',
     'Committee on Public Safety',
     'Date of Hearing: April 21, 2026',
     'Your Committee on Public Safety reports:',
     'Assembly Bill No. 1897',
     'With the recommendation: Do pass.',
-    'Above bill correctly engrossed.',
     'JONES, Chair',
+    'Above bill ordered to second reading.',
+    '',
+    'RESOLUTIONS',
+    'ASSEMBLY CONCURRENT RESOLUTION NO. 999—Smith. Relative to testing.',
     '',
     'SECOND READING OF ASSEMBLY BILLS',
-    'ASSEMBLY BILL NO. 500',
+    'Assembly Bill No. 500',
     'Bill read second time, and amendments proposed by the Committee on Judiciary read and adopted.',
   ].join('\n');
 
@@ -245,7 +253,10 @@ describe('LegislativeActionLinkerService', () => {
     );
     expect(amendments.length).toBeGreaterThanOrEqual(1);
     expect(amendments[0].committeeId).toBe('cmt-judiciary');
-    expect(amendments[0].rawSubject).toBe('Committee on Judiciary');
+    // Amendment is now attributed to the nearest preceding bill in the
+    // SECOND READING block — better than just naming the committee.
+    expect(amendments[0].rawSubject).toBe('AB 500');
+    expect(amendments[0].text).toMatch(/Committee on Judiciary/);
   });
 
   it('emits engrossment actions and links bill citations to propositions', async () => {

--- a/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.spec.ts
@@ -1,0 +1,321 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { LegislativeActionLinkerService } from './legislative-action-linker.service';
+import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
+
+interface MinutesRow {
+  id: string;
+  externalId: string;
+  body: string;
+  date: Date;
+  isActive: boolean;
+  rawText: string | null;
+}
+
+interface RepRow {
+  id: string;
+  lastName: string | null;
+  chamber: string | null;
+}
+
+interface PropositionRow {
+  id: string;
+  externalId: string;
+}
+
+interface CommitteeRow {
+  id: string;
+  externalId: string;
+}
+
+const buildLinker = (opts: {
+  minutes: MinutesRow[];
+  reps?: RepRow[];
+  propositions?: PropositionRow[];
+  committees?: CommitteeRow[];
+}) => {
+  const reps = opts.reps ?? [];
+  const propositions = opts.propositions ?? [];
+  const committees = opts.committees ?? [];
+  const persistedActions: any[] = [];
+
+  const db = {
+    minutes: {
+      findMany: jest.fn(async (args: any) => {
+        const ids: string[] = args?.where?.id?.in ?? [];
+        return opts.minutes.filter(
+          (m) =>
+            ids.includes(m.id) && (args.where?.isActive ? m.isActive : true),
+        );
+      }),
+    },
+    representative: {
+      findMany: jest.fn(async () => reps),
+    },
+    proposition: {
+      findMany: jest.fn(async () => propositions),
+    },
+    legislativeCommittee: {
+      findMany: jest.fn(async () => committees),
+    },
+    legislativeAction: {
+      deleteMany: jest.fn(async (args: any) => {
+        for (let i = persistedActions.length - 1; i >= 0; i--) {
+          if (persistedActions[i].minutesId === args.where.minutesId) {
+            persistedActions.splice(i, 1);
+          }
+        }
+        return { count: 0 };
+      }),
+      createMany: jest.fn(async (args: any) => {
+        for (const r of args.data) persistedActions.push(r);
+        return { count: args.data.length };
+      }),
+    },
+    $transaction: jest.fn(async (ops: any[]) => {
+      for (const op of ops) await op;
+    }),
+  };
+
+  // The committee-linker dependency is used only for `externalIdFor`.
+  // Constructor signature is (config?, db?); pass a stub ConfigService so
+  // its constructor's `readPositiveInt` doesn't blow up on undefined.get.
+  const committeeLinker = new LegislativeCommitteeLinkerService(
+    { get: jest.fn().mockReturnValue(undefined) } as any,
+    db as any,
+  );
+
+  const linker = new LegislativeActionLinkerService(db as any, committeeLinker);
+
+  return { linker, db, persistedActions };
+};
+
+describe('LegislativeActionLinkerService', () => {
+  const FIXTURE_RAWTEXT = [
+    'Tuesday, April 28, 2026',
+    '',
+    'ROLLCALL',
+    'The following members answered the morning rollcall — 3:',
+    'Aguiar-Curry',
+    'Bauer-Kahan',
+    'Mr. Speaker',
+    '',
+    'LEAVES OF ABSENCE FOR THE DAY',
+    'Legislative business: Members Garcia and Lee.',
+    'Illness: Members Smith.',
+    '',
+    'REPORTS OF STANDING COMMITTEES',
+    'Committee on Public Safety',
+    'Date of Hearing: April 21, 2026',
+    'Your Committee on Public Safety reports:',
+    'Assembly Bill No. 1897',
+    'With the recommendation: Do pass.',
+    'Above bill correctly engrossed.',
+    'JONES, Chair',
+    '',
+    'SECOND READING OF ASSEMBLY BILLS',
+    'ASSEMBLY BILL NO. 500',
+    'Bill read second time, and amendments proposed by the Committee on Judiciary read and adopted.',
+  ].join('\n');
+
+  it('skips Minutes with empty rawText and reports 0 actions', async () => {
+    const { linker } = buildLinker({
+      minutes: [
+        {
+          id: 'm-1',
+          externalId: 'ca-2026-04-28',
+          body: 'Assembly',
+          date: new Date('2026-04-28T00:00:00Z'),
+          isActive: true,
+          rawText: null,
+        },
+      ],
+    });
+    const result = await linker.linkMinutes(['m-1']);
+    // "Processed" counts rows examined; an empty rawText still gets
+    // examined, just produces no action rows.
+    expect(result.actionsCreated).toBe(0);
+  });
+
+  it('extracts presence rolls (yes) from the rollcall block, including Mr. Speaker', async () => {
+    const { linker, persistedActions } = buildLinker({
+      minutes: [
+        {
+          id: 'm-1',
+          externalId: 'ca-2026-04-28',
+          body: 'Assembly',
+          date: new Date('2026-04-28T00:00:00Z'),
+          isActive: true,
+          rawText: FIXTURE_RAWTEXT,
+        },
+      ],
+    });
+
+    await linker.linkMinutes(['m-1']);
+
+    const presence = persistedActions.filter(
+      (a) => a.actionType === 'presence' && a.position === 'yes',
+    );
+    expect(presence.length).toBeGreaterThanOrEqual(3);
+    const subjects = presence.map((a) => a.rawSubject);
+    expect(subjects).toContain('Aguiar-Curry');
+    expect(subjects).toContain('Bauer-Kahan');
+    expect(subjects).toContain('Mr. Speaker');
+  });
+
+  it('extracts absence records and resolves single-match surnames to representatives', async () => {
+    const { linker, persistedActions } = buildLinker({
+      minutes: [
+        {
+          id: 'm-1',
+          externalId: 'ca-2026-04-28',
+          body: 'Assembly',
+          date: new Date('2026-04-28T00:00:00Z'),
+          isActive: true,
+          rawText: FIXTURE_RAWTEXT,
+        },
+      ],
+      reps: [
+        { id: 'rep-garcia', lastName: 'Garcia', chamber: 'Assembly' },
+        { id: 'rep-smith', lastName: 'Smith', chamber: 'Assembly' },
+        // Note: NO 'Lee' rep — leaves a null FK + rawSubject for the UI.
+      ],
+    });
+
+    await linker.linkMinutes(['m-1']);
+
+    const absent = persistedActions.filter(
+      (a) => a.actionType === 'presence' && a.position === 'absent',
+    );
+    expect(absent.length).toBe(3); // Garcia, Lee, Smith
+    const resolved = absent.find((a) => a.rawSubject === 'Garcia');
+    expect(resolved?.representativeId).toBe('rep-garcia');
+    const unresolved = absent.find((a) => a.rawSubject === 'Lee');
+    expect(unresolved?.representativeId).toBeNull();
+    expect(unresolved?.rawSubject).toBe('Lee');
+  });
+
+  it('records committee_hearing actions with date attribution + committee FK resolution', async () => {
+    const { linker, persistedActions } = buildLinker({
+      minutes: [
+        {
+          id: 'm-1',
+          externalId: 'ca-2026-04-28',
+          body: 'Assembly',
+          date: new Date('2026-04-28T00:00:00Z'),
+          isActive: true,
+          rawText: FIXTURE_RAWTEXT,
+        },
+      ],
+      committees: [
+        { id: 'cmt-public-safety', externalId: 'assembly:public safety' },
+        { id: 'cmt-judiciary', externalId: 'assembly:judiciary' },
+      ],
+    });
+
+    await linker.linkMinutes(['m-1']);
+
+    const hearings = persistedActions.filter(
+      (a) => a.actionType === 'committee_hearing',
+    );
+    expect(hearings).toHaveLength(1);
+    expect(hearings[0].rawSubject).toBe('Public Safety');
+    expect(hearings[0].committeeId).toBe('cmt-public-safety');
+    expect(hearings[0].text).toMatch(/April 21, 2026/);
+  });
+
+  it('emits an amendment action when a committee floor amendment is read and adopted', async () => {
+    const { linker, persistedActions } = buildLinker({
+      minutes: [
+        {
+          id: 'm-1',
+          externalId: 'ca-2026-04-28',
+          body: 'Assembly',
+          date: new Date('2026-04-28T00:00:00Z'),
+          isActive: true,
+          rawText: FIXTURE_RAWTEXT,
+        },
+      ],
+      committees: [{ id: 'cmt-judiciary', externalId: 'assembly:judiciary' }],
+    });
+
+    await linker.linkMinutes(['m-1']);
+
+    const amendments = persistedActions.filter(
+      (a) => a.actionType === 'amendment',
+    );
+    expect(amendments.length).toBeGreaterThanOrEqual(1);
+    expect(amendments[0].committeeId).toBe('cmt-judiciary');
+    expect(amendments[0].rawSubject).toBe('Committee on Judiciary');
+  });
+
+  it('emits engrossment actions and links bill citations to propositions', async () => {
+    const { linker, persistedActions } = buildLinker({
+      minutes: [
+        {
+          id: 'm-1',
+          externalId: 'ca-2026-04-28',
+          body: 'Assembly',
+          date: new Date('2026-04-28T00:00:00Z'),
+          isActive: true,
+          rawText: FIXTURE_RAWTEXT,
+        },
+      ],
+      propositions: [{ id: 'prop-ab1897', externalId: 'AB 1897' }],
+    });
+
+    await linker.linkMinutes(['m-1']);
+
+    const engrossments = persistedActions.filter(
+      (a) => a.actionType === 'engrossment',
+    );
+    expect(engrossments.length).toBeGreaterThanOrEqual(1);
+    const ab1897 = engrossments.find((a) => a.rawSubject === 'AB 1897');
+    expect(ab1897).toBeDefined();
+    expect(ab1897!.propositionId).toBe('prop-ab1897');
+  });
+
+  it('every action carries valid passage offsets into the source rawText', async () => {
+    const { linker, persistedActions } = buildLinker({
+      minutes: [
+        {
+          id: 'm-1',
+          externalId: 'ca-2026-04-28',
+          body: 'Assembly',
+          date: new Date('2026-04-28T00:00:00Z'),
+          isActive: true,
+          rawText: FIXTURE_RAWTEXT,
+        },
+      ],
+    });
+
+    await linker.linkMinutes(['m-1']);
+
+    expect(persistedActions.length).toBeGreaterThan(0);
+    for (const a of persistedActions) {
+      expect(a.passageStart).toBeGreaterThanOrEqual(0);
+      expect(a.passageEnd).toBeGreaterThan(a.passageStart);
+      expect(a.passageEnd).toBeLessThanOrEqual(FIXTURE_RAWTEXT.length);
+    }
+  });
+
+  it('mints unique externalIds per action with the parent minutes prefix', async () => {
+    const { linker, persistedActions } = buildLinker({
+      minutes: [
+        {
+          id: 'm-1',
+          externalId: 'ca-2026-04-28',
+          body: 'Assembly',
+          date: new Date('2026-04-28T00:00:00Z'),
+          isActive: true,
+          rawText: FIXTURE_RAWTEXT,
+        },
+      ],
+    });
+    await linker.linkMinutes(['m-1']);
+    const ids = new Set(persistedActions.map((a) => a.externalId));
+    expect(ids.size).toBe(persistedActions.length);
+    for (const id of ids) {
+      expect(id).toMatch(/^ca-2026-04-28-\d{4}$/);
+    }
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
@@ -110,18 +110,22 @@ const SPEAKER_LINE_RE = /^Mr\.\s*Speaker\s*$/im;
  * Absence groups within the LEAVES OF ABSENCE section. Format:
  *   <reason>: Assembly Member(s) <name1>, <name2>, ..., and <nameN>.
  *
- * Reason group `[^:.\n]+` excludes newlines + period + colon — keeps
- * the reason on a single line, no cross-paragraph greediness. Names
- * group `[^.]+?` is non-greedy and bounded by the next period; runs
- * within the section text only (caller scopes), so a stray period
- * elsewhere in the journal can't truncate it.
+ * Reason group `[^:.\n]{1,200}` excludes newlines + period + colon.
+ * Names group `[^.\n\r]{1,1000}?` is bounded and non-greedy. The
+ * length caps + char-class exclusions prevent the super-linear
+ * backtracking Sonar flags (S5852) on unbounded `+?` chains —
+ * defensive even though section-scoping already limits the input.
  */
 const ABSENCE_GROUP_RE =
-  /([^:.\n]+):\s*(?:Assembly\s+)?Members?\s+([^.]+?)(?:\.|$)/g;
-const COMMITTEE_HEADER_RE = /^Committee on\s+(.+?)\s*$/m;
-const HEARING_DATE_RE = /^Date of Hearing:\s*([^\n]+)$/m;
+  /([^:.\n]{1,200}):\s*(?:Assembly\s+)?Members?\s+((?:[^.\n]|\n(?!\s*\n)){1,1000}?)(?:\.|$)/g;
+// Bounded `[^\n]{1,200}` instead of `(.+?)\s*$` — eliminates the
+// non-greedy / trailing-whitespace backtracking pair that Sonar
+// would flag on long lines. Committee names run < 100 chars in real
+// journals; 200 is generous defensive ceiling.
+const COMMITTEE_HEADER_RE = /^Committee on\s+([^\n]{1,200})$/m;
+const HEARING_DATE_RE = /^Date of Hearing:\s*([^\n]{1,200})$/m;
 const AMENDMENT_ADOPTED_RE =
-  /amendments proposed by the Committee on\s+([^\n]+?)\s+read and adopted/gi;
+  /amendments proposed by the Committee on\s+([^\n]{1,200}?)\s+read and adopted/gi;
 // Real journal phrasing is "And reports the same correctly engrossed."
 // (chief clerk's report) — NOT "Above bills correctly engrossed." which
 // is a separate next-action sentence that follows. Match the chief
@@ -134,9 +138,14 @@ const ENROLLED_RE = /correctly\s+enrolled/i;
  * Capture groups: 1 = canonical resolution id phrase, 2 = introducer,
  * 3 = subject. The em-dash (U+2014), en-dash (U+2013), or ASCII '-'
  * are all accepted between the id and introducer.
+ *
+ * Quantifiers are bounded (introducer ≤ 200 chars, subject ≤ 500
+ * chars) and char classes exclude `\n` so the engine can't backtrack
+ * across line boundaries. Eliminates the super-linear-runtime risk
+ * Sonar flags on unbounded `+?`/`.+?` chains (rule S5852).
  */
 const RESOLUTION_LINE_RE =
-  /^(ASSEMBLY (?:CONCURRENT |JOINT )?RESOLUTION NO\.\s*\d+)[—–-]\s*([^.]+?)\.\s*(.+?)$/m;
+  /^(ASSEMBLY (?:CONCURRENT |JOINT )?RESOLUTION NO\.\s*\d{1,6})[—–-]\s*([^.\n]{1,200})\.\s*([^\n]{1,500})$/m;
 
 @Injectable()
 export class LegislativeActionLinkerService {
@@ -497,8 +506,11 @@ export class LegislativeActionLinkerService {
       const committeeName = cmtMatch?.[1]?.trim();
       const hearingMatch = HEARING_DATE_RE.exec(block.text);
       const hearingDate = hearingMatch?.[1]?.trim();
+      // Bounded char class + length cap — no nested quantifiers, no
+      // backtracking. Recommendations in real journals run to a few
+      // hundred chars at most; cap at 800 as a defensive ceiling.
       const recommendationMatch =
-        /With the recommendation:\s*([^.]+(?:\.[^.]+)*?\.)/i.exec(block.text);
+        /With the recommendation:\s*([^\n]{1,800}?\.)/i.exec(block.text);
       const recommendation = recommendationMatch?.[1]?.trim();
 
       const committeeId = committeeName

--- a/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
@@ -1,0 +1,442 @@
+/**
+ * Legislative Action Linker
+ *
+ * V1 deterministic post-sync pass that mines `Minutes.rawText` and
+ * produces `LegislativeAction` rows attributing presence rolls,
+ * committee reports/hearings, amendments, engrossments/enrollments,
+ * and resolutions to representatives, propositions, and committees.
+ *
+ * Each emitted action carries char-offset references back into the
+ * source Minutes (`passageStart` / `passageEnd`) so citizen-facing
+ * UIs can quote the verbatim passage in a "letter to my rep"
+ * workflow. AI summarization + per-claim attribution is V2.
+ *
+ * Idempotent — safe to re-run after a Minutes ingest. Existing
+ * action rows for a given Minutes are deleted before regeneration so
+ * superseded revisions don't accumulate stale records.
+ *
+ * Issue #665.
+ */
+
+import { Injectable, Logger } from '@nestjs/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
+
+interface LinkerCaches {
+  /** lowercase last-name → rep ids, scoped per chamber. */
+  repsByLastName: Map<string, Map<string, string[]>>;
+  /** canonical proposition externalId (e.g., 'AB 1863') → proposition id. */
+  propositionsByExternalId: Map<string, string>;
+  /** chamber-scoped normalized committee name → committee id. */
+  committeesByExternalId: Map<string, string>;
+}
+
+interface MinutesContext {
+  id: string;
+  body: string;
+  date: Date;
+  externalId: string;
+  rawText: string;
+  caches: LinkerCaches;
+}
+
+interface CandidateAction {
+  actionType: string;
+  rawSubject?: string;
+  text?: string;
+  position?: 'yes' | 'no' | 'abstain' | 'absent';
+  passageStart: number;
+  passageEnd: number;
+  representativeId?: string;
+  propositionId?: string;
+  committeeId?: string;
+}
+
+const SURNAME_LINE_RE = /^[A-ZÀ-ſ][A-Za-zÀ-ſ.,\s'\-’]*$/;
+const BILL_CITATION_RE =
+  /(Assembly|ASSEMBLY|Senate|SENATE)\s+(Bill|BILL|Joint Resolution|JOINT RESOLUTION|Concurrent Resolution|CONCURRENT RESOLUTION|Constitutional Amendment|CONSTITUTIONAL AMENDMENT)\s+(?:No\.|NO\.)?\s*(\d+)/g;
+const ROLLCALL_INTRO_RE = /^The following.*morning rollcall/im;
+const SPEAKER_LINE_RE = /^Mr\.\s*Speaker\s*$/im;
+const ABSENCE_GROUP_RE =
+  /([^:.]+):\s*(?:Assembly\s+)?Members?\s+([^.]+?)(?:\.|$)/g;
+const COMMITTEE_HEARING_RE =
+  /Committee on\s+([^\n]+?)\nDate of Hearing:\s*([^\n]+)/g;
+const AMENDMENT_ADOPTED_RE =
+  /amendments proposed by the Committee on\s+([^\n]+?)\s+read and adopted/gi;
+const ENGROSSED_RE = /Above\s+bill[s]?\s+correctly\s+engrossed/i;
+const ENROLLED_RE = /Above\s+bill[s]?\s+correctly\s+enrolled/i;
+
+@Injectable()
+export class LegislativeActionLinkerService {
+  private readonly logger = new Logger(LegislativeActionLinkerService.name);
+
+  constructor(
+    private readonly db: DbService,
+    private readonly committeeLinker: LegislativeCommitteeLinkerService,
+  ) {}
+
+  /**
+   * Re-link all active Minutes whose rawText hasn't been linked since
+   * its last update. The simple "delete + re-insert" idempotency model
+   * means we can run this on every Minutes ingest — expensive linking
+   * doesn't happen for already-processed rows because the loop only
+   * walks rows whose IDs are passed in.
+   */
+  async linkMinutes(minutesIds: string[]): Promise<{
+    minutesProcessed: number;
+    actionsCreated: number;
+  }> {
+    if (minutesIds.length === 0) {
+      return { minutesProcessed: 0, actionsCreated: 0 };
+    }
+
+    const minutesRows = await this.db.minutes.findMany({
+      where: { id: { in: minutesIds }, isActive: true },
+    });
+
+    if (minutesRows.length === 0) {
+      return { minutesProcessed: 0, actionsCreated: 0 };
+    }
+
+    const caches = await this.loadCaches();
+    let actionsCreated = 0;
+
+    for (const row of minutesRows) {
+      if (!row.rawText) {
+        this.logger.warn(
+          `Minutes ${row.externalId}: empty rawText, skipping linker`,
+        );
+        continue;
+      }
+
+      const ctx: MinutesContext = {
+        id: row.id,
+        body: row.body,
+        date: row.date,
+        externalId: row.externalId,
+        rawText: row.rawText,
+        caches,
+      };
+
+      const candidates = this.extractCandidates(ctx);
+      const persisted = await this.persistActions(ctx, candidates);
+      actionsCreated += persisted;
+    }
+
+    this.logger.log(
+      `Linker complete: ${minutesRows.length} minutes processed, ${actionsCreated} actions created`,
+    );
+
+    return {
+      minutesProcessed: minutesRows.length,
+      actionsCreated,
+    };
+  }
+
+  // ============================================
+  // Cache construction
+  // ============================================
+
+  private async loadCaches(): Promise<LinkerCaches> {
+    const [reps, propositions, committees] = await Promise.all([
+      this.db.representative.findMany({
+        where: { deletedAt: null },
+        select: { id: true, lastName: true, chamber: true },
+      }),
+      this.db.proposition.findMany({
+        where: { deletedAt: null },
+        select: { id: true, externalId: true },
+      }),
+      this.db.legislativeCommittee.findMany({
+        where: { deletedAt: null },
+        select: { id: true, externalId: true },
+      }),
+    ]);
+
+    const repsByLastName = new Map<string, Map<string, string[]>>();
+    for (const rep of reps) {
+      const chamber = rep.chamber;
+      if (!chamber) continue;
+      if (!repsByLastName.has(chamber)) {
+        repsByLastName.set(chamber, new Map());
+      }
+      const ln = (rep.lastName ?? '').toLowerCase().trim();
+      if (!ln) continue;
+      const bucket = repsByLastName.get(chamber)!;
+      const existing = bucket.get(ln) ?? [];
+      existing.push(rep.id);
+      bucket.set(ln, existing);
+    }
+
+    const propositionsByExternalId = new Map<string, string>();
+    for (const p of propositions) {
+      propositionsByExternalId.set(p.externalId, p.id);
+    }
+
+    const committeesByExternalId = new Map<string, string>();
+    for (const c of committees) {
+      committeesByExternalId.set(c.externalId, c.id);
+    }
+
+    return { repsByLastName, propositionsByExternalId, committeesByExternalId };
+  }
+
+  // ============================================
+  // Candidate extraction
+  // ============================================
+
+  private extractCandidates(ctx: MinutesContext): CandidateAction[] {
+    const out: CandidateAction[] = [];
+    out.push(...this.extractPresence(ctx));
+    out.push(...this.extractAbsences(ctx));
+    out.push(...this.extractCommitteeHearings(ctx));
+    out.push(...this.extractAmendments(ctx));
+    out.push(...this.extractEngrossmentsAndEnrollments(ctx));
+    return out;
+  }
+
+  /**
+   * Presence rolls: bracket text between the rollcall intro line and
+   * the line "Mr. Speaker" (which is implicitly present), emitting one
+   * 'presence' (position='yes') per surname-shaped line in between.
+   */
+  private extractPresence(ctx: MinutesContext): CandidateAction[] {
+    const intro = ROLLCALL_INTRO_RE.exec(ctx.rawText);
+    if (!intro) return [];
+    const tail = ctx.rawText.slice(intro.index);
+    const speaker = SPEAKER_LINE_RE.exec(tail);
+    if (!speaker) return [];
+    const block = tail.slice(0, speaker.index);
+    const blockStart = intro.index;
+
+    const out: CandidateAction[] = [];
+    let cursor = blockStart;
+    for (const line of block.split('\n')) {
+      const trimmed = line.trim();
+      const start = cursor;
+      const end = cursor + line.length + 1;
+      cursor = end;
+      if (!trimmed || !SURNAME_LINE_RE.test(trimmed)) continue;
+      if (/morning rollcall/i.test(trimmed)) continue;
+
+      const repId = this.resolveRep(ctx, trimmed);
+      out.push({
+        actionType: 'presence',
+        position: 'yes',
+        rawSubject: trimmed,
+        passageStart: start,
+        passageEnd: end,
+        representativeId: repId,
+      });
+    }
+
+    // The matched "Mr. Speaker" line is itself a presence entry.
+    const speakerStart = blockStart + speaker.index;
+    const speakerEnd = speakerStart + speaker[0].length;
+    out.push({
+      actionType: 'presence',
+      position: 'yes',
+      rawSubject: 'Mr. Speaker',
+      passageStart: speakerStart,
+      passageEnd: speakerEnd,
+    });
+    return out;
+  }
+
+  private extractAbsences(ctx: MinutesContext): CandidateAction[] {
+    // Reset stateful regex
+    ABSENCE_GROUP_RE.lastIndex = 0;
+    const out: CandidateAction[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = ABSENCE_GROUP_RE.exec(ctx.rawText)) !== null) {
+      const reason = m[1].trim();
+      const namesBlob = m[2];
+      const matchStart = m.index;
+      const matchEnd = m.index + m[0].length;
+
+      const names = this.splitAbsenceNames(namesBlob);
+      for (const name of names) {
+        if (!name) continue;
+        const repId = this.resolveRep(ctx, name);
+        out.push({
+          actionType: 'presence',
+          position: 'absent',
+          rawSubject: name,
+          text: this.truncate(`${reason}: ${name}`, 4000),
+          passageStart: matchStart,
+          passageEnd: matchEnd,
+          representativeId: repId,
+        });
+      }
+    }
+    return out;
+  }
+
+  private splitAbsenceNames(blob: string): string[] {
+    return blob
+      .replaceAll(/\band\s+/gi, ',')
+      .split(',')
+      .map((n) => n.trim())
+      .filter((n) => n.length > 0);
+  }
+
+  private extractCommitteeHearings(ctx: MinutesContext): CandidateAction[] {
+    COMMITTEE_HEARING_RE.lastIndex = 0;
+    const out: CandidateAction[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = COMMITTEE_HEARING_RE.exec(ctx.rawText)) !== null) {
+      const committeeName = m[1].trim();
+      const hearingDate = m[2].trim();
+      const committeeId = this.resolveCommittee(ctx, committeeName);
+      out.push({
+        actionType: 'committee_hearing',
+        rawSubject: committeeName,
+        text: this.truncate(
+          `Committee on ${committeeName} — Date of Hearing: ${hearingDate}`,
+          4000,
+        ),
+        passageStart: m.index,
+        passageEnd: m.index + m[0].length,
+        committeeId,
+      });
+    }
+    return out;
+  }
+
+  private extractAmendments(ctx: MinutesContext): CandidateAction[] {
+    AMENDMENT_ADOPTED_RE.lastIndex = 0;
+    const out: CandidateAction[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = AMENDMENT_ADOPTED_RE.exec(ctx.rawText)) !== null) {
+      const committeeName = m[1].trim();
+      const committeeId = this.resolveCommittee(ctx, committeeName);
+      out.push({
+        actionType: 'amendment',
+        rawSubject: `Committee on ${committeeName}`,
+        text: this.truncate(this.sliceAround(ctx.rawText, m.index, 240), 4000),
+        passageStart: m.index,
+        passageEnd: m.index + m[0].length,
+        committeeId,
+      });
+    }
+    return out;
+  }
+
+  private extractEngrossmentsAndEnrollments(
+    ctx: MinutesContext,
+  ): CandidateAction[] {
+    BILL_CITATION_RE.lastIndex = 0;
+    const out: CandidateAction[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = BILL_CITATION_RE.exec(ctx.rawText)) !== null) {
+      const canonical = this.normalizeBillCitation(m[1], m[2], m[3]);
+      const propId = ctx.caches.propositionsByExternalId.get(canonical);
+      const window = this.sliceAround(ctx.rawText, m.index, 240);
+      let actionType: string | undefined;
+      if (ENROLLED_RE.test(window)) {
+        actionType = 'enrollment';
+      } else if (ENGROSSED_RE.test(window)) {
+        actionType = 'engrossment';
+      }
+      if (!actionType) continue;
+      out.push({
+        actionType,
+        rawSubject: canonical,
+        text: this.truncate(window, 4000),
+        passageStart: m.index,
+        passageEnd: m.index + m[0].length,
+        propositionId: propId,
+      });
+    }
+    return out;
+  }
+
+  private normalizeBillCitation(
+    chamber: string,
+    type: string,
+    number: string,
+  ): string {
+    const c = /^assembly$/i.test(chamber) ? 'A' : 'S';
+    let t = '';
+    if (/^bill$/i.test(type)) t = 'B';
+    else if (/^joint resolution$/i.test(type)) t = 'JR';
+    else if (/^concurrent resolution$/i.test(type)) t = 'CR';
+    else if (/^constitutional amendment$/i.test(type)) t = 'CA';
+    return `${c}${t} ${number}`;
+  }
+
+  // ============================================
+  // FK resolution
+  // ============================================
+
+  private resolveRep(ctx: MinutesContext, name: string): string | undefined {
+    const surname = name.split(',')[0].trim().toLowerCase();
+    if (!surname) return undefined;
+    const bucket = ctx.caches.repsByLastName.get(ctx.body);
+    const matches = bucket?.get(surname) ?? [];
+    if (matches.length === 1) return matches[0];
+    return undefined;
+  }
+
+  private resolveCommittee(
+    ctx: MinutesContext,
+    name: string,
+  ): string | undefined {
+    const ext = this.committeeLinker.externalIdFor(ctx.body, name);
+    if (!ext) return undefined;
+    return ctx.caches.committeesByExternalId.get(ext);
+  }
+
+  // ============================================
+  // Persistence
+  // ============================================
+
+  private async persistActions(
+    ctx: MinutesContext,
+    candidates: CandidateAction[],
+  ): Promise<number> {
+    if (candidates.length === 0) {
+      await this.db.legislativeAction.deleteMany({
+        where: { minutesId: ctx.id },
+      });
+      return 0;
+    }
+
+    const records = candidates.map((c, i) => ({
+      externalId: `${ctx.externalId}-${String(i + 1).padStart(4, '0')}`,
+      minutesId: ctx.id,
+      body: ctx.body,
+      date: ctx.date,
+      actionType: c.actionType,
+      representativeId: c.representativeId ?? null,
+      propositionId: c.propositionId ?? null,
+      committeeId: c.committeeId ?? null,
+      position: c.position ?? null,
+      text: c.text ?? null,
+      passageStart: c.passageStart,
+      passageEnd: c.passageEnd,
+      rawSubject: c.rawSubject ?? null,
+    }));
+
+    await this.db.$transaction([
+      this.db.legislativeAction.deleteMany({ where: { minutesId: ctx.id } }),
+      this.db.legislativeAction.createMany({ data: records }),
+    ]);
+
+    return records.length;
+  }
+
+  // ============================================
+  // Helpers
+  // ============================================
+
+  private sliceAround(text: string, idx: number, halfWindow: number): string {
+    const start = Math.max(0, idx - halfWindow);
+    const end = Math.min(text.length, idx + halfWindow);
+    return text.slice(start, end).trim();
+  }
+
+  private truncate(s: string, max: number): string {
+    return s.length > max ? s.slice(0, max) : s;
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
@@ -52,19 +52,91 @@ interface CandidateAction {
   committeeId?: string;
 }
 
+/**
+ * One contiguous section of a journal, anchored on a recognized
+ * uppercase section header. `startOffset` / `endOffset` are
+ * char-offsets into the parent rawText so per-extractor regex matches
+ * can be re-anchored back to the document for passageStart/passageEnd.
+ */
+interface JournalSection {
+  header: string;
+  text: string;
+  startOffset: number;
+  endOffset: number;
+}
+
+/**
+ * Recognized section headers in CA Assembly daily journals. Matched
+ * verbatim against lines (anchored, all-caps). Headers seen in real
+ * journals but not extracted from (`PROCEEDINGS OF THE ASSEMBLY`,
+ * `INTRODUCTION OF GUESTS`, `MESSAGES FROM THE GOVERNOR`,
+ * `COMMUNICATIONS`, `INTRODUCTION AND REFERENCE OF BILLS`, etc.) are
+ * still treated as section boundaries so unrelated text doesn't leak
+ * into the extractors.
+ */
+const SECTION_HEADERS = new Set<string>([
+  'ROLLCALL',
+  'LEAVES OF ABSENCE FOR THE DAY',
+  'ENGROSSMENT AND ENROLLMENT REPORTS',
+  'RESOLUTIONS',
+  "AUTHOR'S AMENDMENTS",
+  'AUTHOR’S AMENDMENTS', // curly apostrophe variant
+  'REPORTS OF STANDING COMMITTEES',
+  'SECOND READING OF ASSEMBLY BILLS',
+  'THIRD READING OF ASSEMBLY BILLS',
+  // Recognized boundaries — not extracted from but used to bound others:
+  'PROCEEDINGS OF THE ASSEMBLY',
+  'IN ASSEMBLY',
+  'INTRODUCTION OF GUESTS',
+  'INTRODUCTION AND REFERENCE OF BILLS',
+  'COMMUNICATIONS',
+  'MESSAGES FROM THE GOVERNOR',
+  'MESSAGES FROM THE SENATE',
+  'MOTIONS AND RESOLUTIONS',
+  'ROLLCALL VOTES',
+  'PRESENTATION OF FLAG',
+  'ADJOURNMENT',
+  'PRAYER',
+  'PLEDGE OF ALLEGIANCE',
+]);
+
 const SURNAME_LINE_RE = /^[A-ZÀ-ſ][A-Za-zÀ-ſ.,\s'\-’]*$/;
 const BILL_CITATION_RE =
   /(Assembly|ASSEMBLY|Senate|SENATE)\s+(Bill|BILL|Joint Resolution|JOINT RESOLUTION|Concurrent Resolution|CONCURRENT RESOLUTION|Constitutional Amendment|CONSTITUTIONAL AMENDMENT)\s+(?:No\.|NO\.)?\s*(\d+)/g;
-const ROLLCALL_INTRO_RE = /^The following.*morning rollcall/im;
+const ROLLCALL_INTRO_RE =
+  /^The (?:following.*morning rollcall|rollcall was completed.*?\bnames)/im;
 const SPEAKER_LINE_RE = /^Mr\.\s*Speaker\s*$/im;
+/**
+ * Absence groups within the LEAVES OF ABSENCE section. Format:
+ *   <reason>: Assembly Member(s) <name1>, <name2>, ..., and <nameN>.
+ *
+ * Reason group `[^:.\n]+` excludes newlines + period + colon — keeps
+ * the reason on a single line, no cross-paragraph greediness. Names
+ * group `[^.]+?` is non-greedy and bounded by the next period; runs
+ * within the section text only (caller scopes), so a stray period
+ * elsewhere in the journal can't truncate it.
+ */
 const ABSENCE_GROUP_RE =
-  /([^:.]+):\s*(?:Assembly\s+)?Members?\s+([^.]+?)(?:\.|$)/g;
-const COMMITTEE_HEARING_RE =
-  /Committee on\s+([^\n]+?)\nDate of Hearing:\s*([^\n]+)/g;
+  /([^:.\n]+):\s*(?:Assembly\s+)?Members?\s+([^.]+?)(?:\.|$)/g;
+const COMMITTEE_HEADER_RE = /^Committee on\s+(.+?)\s*$/m;
+const HEARING_DATE_RE = /^Date of Hearing:\s*([^\n]+)$/m;
 const AMENDMENT_ADOPTED_RE =
   /amendments proposed by the Committee on\s+([^\n]+?)\s+read and adopted/gi;
-const ENGROSSED_RE = /Above\s+bill[s]?\s+correctly\s+engrossed/i;
-const ENROLLED_RE = /Above\s+bill[s]?\s+correctly\s+enrolled/i;
+// Real journal phrasing is "And reports the same correctly engrossed."
+// (chief clerk's report) — NOT "Above bills correctly engrossed." which
+// is a separate next-action sentence that follows. Match the chief
+// clerk's verb regardless of preamble.
+const ENGROSSED_RE = /correctly\s+engrossed/i;
+const ENROLLED_RE = /correctly\s+enrolled/i;
+/**
+ * One newly-offered resolution. Source format:
+ *   ASSEMBLY [CONCURRENT|JOINT] RESOLUTION NO. <n>—<introducer>. <subject>.
+ * Capture groups: 1 = canonical resolution id phrase, 2 = introducer,
+ * 3 = subject. The em-dash (U+2014), en-dash (U+2013), or ASCII '-'
+ * are all accepted between the id and introducer.
+ */
+const RESOLUTION_LINE_RE =
+  /^(ASSEMBLY (?:CONCURRENT |JOINT )?RESOLUTION NO\.\s*\d+)[—–-]\s*([^.]+?)\.\s*(.+?)$/m;
 
 @Injectable()
 export class LegislativeActionLinkerService {
@@ -76,16 +148,13 @@ export class LegislativeActionLinkerService {
   ) {}
 
   /**
-   * Re-link all active Minutes whose rawText hasn't been linked since
-   * its last update. The simple "delete + re-insert" idempotency model
-   * means we can run this on every Minutes ingest — expensive linking
-   * doesn't happen for already-processed rows because the loop only
-   * walks rows whose IDs are passed in.
+   * Link the given Minutes ids. When `relinkAll` is true, re-runs over
+   * every active Minutes for the body — useful after linker code
+   * improvements to refresh actions without re-fetching PDFs.
    */
-  async linkMinutes(minutesIds: string[]): Promise<{
-    minutesProcessed: number;
-    actionsCreated: number;
-  }> {
+  async linkMinutes(
+    minutesIds: string[],
+  ): Promise<{ minutesProcessed: number; actionsCreated: number }> {
     if (minutesIds.length === 0) {
       return { minutesProcessed: 0, actionsCreated: 0 };
     }
@@ -133,6 +202,23 @@ export class LegislativeActionLinkerService {
     };
   }
 
+  /**
+   * Re-link every active Minutes row. Used by the
+   * `run-relink-minutes` admin script and could be exposed as an
+   * admin GraphQL mutation later. Bypasses the watermark — operates
+   * on whatever is already in the DB.
+   */
+  async relinkAll(): Promise<{
+    minutesProcessed: number;
+    actionsCreated: number;
+  }> {
+    const rows = await this.db.minutes.findMany({
+      where: { isActive: true },
+      select: { id: true },
+    });
+    return this.linkMinutes(rows.map((r) => r.id));
+  }
+
   // ============================================
   // Cache construction
   // ============================================
@@ -144,7 +230,6 @@ export class LegislativeActionLinkerService {
         select: { id: true, lastName: true, chamber: true },
       }),
       this.db.proposition.findMany({
-        where: { deletedAt: null },
         select: { id: true, externalId: true },
       }),
       this.db.legislativeCommittee.findMany({
@@ -182,16 +267,95 @@ export class LegislativeActionLinkerService {
   }
 
   // ============================================
+  // Section splitter
+  // ============================================
+
+  /**
+   * Split rawText into named sections by recognizing all-caps section
+   * headers (verbatim from CA Assembly journal layout). Each section's
+   * `text` is bounded by its header and the next recognized header,
+   * with offsets preserved so per-extractor matches can be projected
+   * back into the parent document for passage offsets.
+   *
+   * Headers seen multiple times in one document (e.g. multiple
+   * "ROLLCALL" appearances on different session days) all get
+   * collected and dispatched independently.
+   */
+  private splitSections(rawText: string): JournalSection[] {
+    const sections: JournalSection[] = [];
+    const lineStarts: number[] = [0];
+    for (let i = 0; i < rawText.length; i++) {
+      if (rawText[i] === '\n') lineStarts.push(i + 1);
+    }
+
+    const boundaries: { offset: number; header: string }[] = [];
+    for (const start of lineStarts) {
+      const lineEnd = rawText.indexOf('\n', start);
+      const line = rawText
+        .slice(start, lineEnd === -1 ? rawText.length : lineEnd)
+        .trim();
+      if (!line) continue;
+      // Quick reject: must be all-caps-ish (allow digits, punctuation).
+      if (/[a-z]/.test(line)) continue;
+      if (SECTION_HEADERS.has(line)) {
+        boundaries.push({ offset: start, header: line });
+      }
+    }
+
+    for (let i = 0; i < boundaries.length; i++) {
+      const cur = boundaries[i];
+      const next = boundaries[i + 1];
+      const startOffset = cur.offset;
+      const endOffset = next ? next.offset : rawText.length;
+      sections.push({
+        header: cur.header,
+        text: rawText.slice(startOffset, endOffset),
+        startOffset,
+        endOffset,
+      });
+    }
+
+    return sections;
+  }
+
+  // ============================================
   // Candidate extraction
   // ============================================
 
   private extractCandidates(ctx: MinutesContext): CandidateAction[] {
     const out: CandidateAction[] = [];
-    out.push(...this.extractPresence(ctx));
-    out.push(...this.extractAbsences(ctx));
-    out.push(...this.extractCommitteeHearings(ctx));
-    out.push(...this.extractAmendments(ctx));
-    out.push(...this.extractEngrossmentsAndEnrollments(ctx));
+    const sections = this.splitSections(ctx.rawText);
+
+    for (const section of sections) {
+      switch (section.header) {
+        case 'ROLLCALL':
+          out.push(...this.extractPresence(ctx, section));
+          break;
+        case 'LEAVES OF ABSENCE FOR THE DAY':
+          out.push(...this.extractAbsences(ctx, section));
+          break;
+        case 'REPORTS OF STANDING COMMITTEES':
+          out.push(...this.extractCommitteeReports(ctx, section));
+          break;
+        case "AUTHOR'S AMENDMENTS":
+        case 'AUTHOR’S AMENDMENTS':
+          out.push(...this.extractAuthorsAmendments(ctx, section));
+          break;
+        case 'SECOND READING OF ASSEMBLY BILLS':
+        case 'THIRD READING OF ASSEMBLY BILLS':
+          out.push(...this.extractReadingAmendments(ctx, section));
+          break;
+        case 'ENGROSSMENT AND ENROLLMENT REPORTS':
+          out.push(...this.extractEngrossmentsAndEnrollments(ctx, section));
+          break;
+        case 'RESOLUTIONS':
+          out.push(...this.extractResolutions(ctx, section));
+          break;
+        // Other recognized headers (PROCEEDINGS, COMMUNICATIONS, etc.)
+        // bound the others but yield no actions in V1.
+      }
+    }
+
     return out;
   }
 
@@ -200,34 +364,51 @@ export class LegislativeActionLinkerService {
    * the line "Mr. Speaker" (which is implicitly present), emitting one
    * 'presence' (position='yes') per surname-shaped line in between.
    */
-  private extractPresence(ctx: MinutesContext): CandidateAction[] {
-    const intro = ROLLCALL_INTRO_RE.exec(ctx.rawText);
+  private extractPresence(
+    ctx: MinutesContext,
+    section: JournalSection,
+  ): CandidateAction[] {
+    const intro = ROLLCALL_INTRO_RE.exec(section.text);
     if (!intro) return [];
-    const tail = ctx.rawText.slice(intro.index);
+    const tail = section.text.slice(intro.index);
     const speaker = SPEAKER_LINE_RE.exec(tail);
     if (!speaker) return [];
     const block = tail.slice(0, speaker.index);
-    const blockStart = intro.index;
+    const blockStart = section.startOffset + intro.index;
 
     const out: CandidateAction[] = [];
     let cursor = blockStart;
     for (const line of block.split('\n')) {
-      const trimmed = line.trim();
+      const lineLength = line.length + 1; // +1 for the consumed '\n'
       const start = cursor;
-      const end = cursor + line.length + 1;
+      const end = cursor + lineLength;
       cursor = end;
-      if (!trimmed || !SURNAME_LINE_RE.test(trimmed)) continue;
-      if (/morning rollcall/i.test(trimmed)) continue;
 
-      const repId = this.resolveRep(ctx, trimmed);
-      out.push({
-        actionType: 'presence',
-        position: 'yes',
-        rawSubject: trimmed,
-        passageStart: start,
-        passageEnd: end,
-        representativeId: repId,
-      });
+      // Some rollcall variants use multi-column layouts, e.g.:
+      //   "Addis   Davies  Johnson         Rogers"
+      // Split on multi-space gaps to recover individual surnames.
+      const cells = line.split(/\s{2,}/).map((c) => c.trim());
+      let cellOffset = start;
+      for (const cell of cells) {
+        if (!cell || !SURNAME_LINE_RE.test(cell)) {
+          cellOffset += cell.length + 1;
+          continue;
+        }
+        if (/morning rollcall|rollcall|the following/i.test(cell)) {
+          cellOffset += cell.length + 1;
+          continue;
+        }
+        const repId = this.resolveRep(ctx, cell);
+        out.push({
+          actionType: 'presence',
+          position: 'yes',
+          rawSubject: cell,
+          passageStart: cellOffset,
+          passageEnd: Math.min(cellOffset + cell.length, end),
+          representativeId: repId,
+        });
+        cellOffset += cell.length + 1;
+      }
     }
 
     // The matched "Mr. Speaker" line is itself a presence entry.
@@ -243,16 +424,23 @@ export class LegislativeActionLinkerService {
     return out;
   }
 
-  private extractAbsences(ctx: MinutesContext): CandidateAction[] {
-    // Reset stateful regex
+  /**
+   * Absences: only run within the LEAVES OF ABSENCE FOR THE DAY
+   * section so unrelated `<text>: Assembly Member <name>` constructs
+   * elsewhere (vote-change reports, motions) don't false-positive.
+   */
+  private extractAbsences(
+    ctx: MinutesContext,
+    section: JournalSection,
+  ): CandidateAction[] {
     ABSENCE_GROUP_RE.lastIndex = 0;
     const out: CandidateAction[] = [];
     let m: RegExpExecArray | null;
-    while ((m = ABSENCE_GROUP_RE.exec(ctx.rawText)) !== null) {
+    while ((m = ABSENCE_GROUP_RE.exec(section.text)) !== null) {
       const reason = m[1].trim();
       const namesBlob = m[2];
-      const matchStart = m.index;
-      const matchEnd = m.index + m[0].length;
+      const matchStart = section.startOffset + m.index;
+      const matchEnd = section.startOffset + m.index + m[0].length;
 
       const names = this.splitAbsenceNames(namesBlob);
       for (const name of names) {
@@ -276,80 +464,249 @@ export class LegislativeActionLinkerService {
     return blob
       .replaceAll(/\band\s+/gi, ',')
       .split(',')
-      .map((n) => n.trim())
+      .map((n) => n.replaceAll(/\s+/g, ' ').trim())
       .filter((n) => n.length > 0);
   }
 
-  private extractCommitteeHearings(ctx: MinutesContext): CandidateAction[] {
-    COMMITTEE_HEARING_RE.lastIndex = 0;
+  /**
+   * REPORTS OF STANDING COMMITTEES has a repeating block shape:
+   *
+   *   Committee on <name>
+   *   Date of Hearing: <date>
+   *   Mr. Speaker: Your Committee on <name> reports:
+   *   <bill1>
+   *   <bill2>
+   *   ...
+   *   With the recommendation: <verdict>.
+   *   <CHAIR_SURNAME>, Chair
+   *   Above bill[s] <disposition>.
+   *
+   * Emits one `committee_hearing` per (committee, hearing date) and
+   * one `committee_report` per bill, both with the committee FK.
+   */
+  private extractCommitteeReports(
+    ctx: MinutesContext,
+    section: JournalSection,
+  ): CandidateAction[] {
     const out: CandidateAction[] = [];
-    let m: RegExpExecArray | null;
-    while ((m = COMMITTEE_HEARING_RE.exec(ctx.rawText)) !== null) {
-      const committeeName = m[1].trim();
-      const hearingDate = m[2].trim();
+    const blocks = this.splitOnLookahead(section.text, /^Committee on\s+/m);
+
+    for (const block of blocks) {
+      const blockOffset = section.startOffset + block.startInParent;
+      const cmtMatch = COMMITTEE_HEADER_RE.exec(block.text);
+      const committeeName = cmtMatch?.[1]?.trim();
+      const hearingMatch = HEARING_DATE_RE.exec(block.text);
+      const hearingDate = hearingMatch?.[1]?.trim();
+      const recommendationMatch =
+        /With the recommendation:\s*([^.]+(?:\.[^.]+)*?\.)/i.exec(block.text);
+      const recommendation = recommendationMatch?.[1]?.trim();
+
+      const committeeId = committeeName
+        ? this.resolveCommittee(ctx, committeeName)
+        : undefined;
+
+      // Hearing action — one per block when we have both committee + date.
+      if (committeeName && hearingDate) {
+        const matchOffset = hearingMatch ? hearingMatch.index : 0;
+        out.push({
+          actionType: 'committee_hearing',
+          rawSubject: committeeName,
+          text: this.truncate(
+            `Committee on ${committeeName} — Date of Hearing: ${hearingDate}`,
+            4000,
+          ),
+          passageStart: blockOffset + matchOffset,
+          passageEnd:
+            blockOffset +
+            matchOffset +
+            (hearingMatch?.[0]?.length ?? committeeName.length),
+          committeeId,
+        });
+      }
+
+      // Per-bill committee_report actions.
+      BILL_CITATION_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = BILL_CITATION_RE.exec(block.text)) !== null) {
+        const canonical = this.normalizeBillCitation(m[1], m[2], m[3]);
+        const propId = ctx.caches.propositionsByExternalId.get(canonical);
+        out.push({
+          actionType: 'committee_report',
+          rawSubject: canonical,
+          text: this.truncate(
+            recommendation
+              ? `${canonical}: ${recommendation}`
+              : `${canonical}: reported by Committee on ${committeeName ?? '?'}.`,
+            4000,
+          ),
+          passageStart: blockOffset + m.index,
+          passageEnd: blockOffset + m.index + m[0].length,
+          committeeId,
+          propositionId: propId,
+        });
+      }
+    }
+
+    return out;
+  }
+
+  /**
+   * AUTHOR'S AMENDMENTS — repeating "Committee on X / Mr. Speaker: ...
+   * / <bill> / With author's amendments..." blocks.
+   */
+  private extractAuthorsAmendments(
+    ctx: MinutesContext,
+    section: JournalSection,
+  ): CandidateAction[] {
+    const out: CandidateAction[] = [];
+    const blocks = this.splitOnLookahead(section.text, /^Committee on\s+/m);
+
+    for (const block of blocks) {
+      const blockOffset = section.startOffset + block.startInParent;
+      const cmtMatch = COMMITTEE_HEADER_RE.exec(block.text);
+      const committeeName = cmtMatch?.[1]?.trim();
+      if (!committeeName) continue;
       const committeeId = this.resolveCommittee(ctx, committeeName);
-      out.push({
-        actionType: 'committee_hearing',
-        rawSubject: committeeName,
-        text: this.truncate(
-          `Committee on ${committeeName} — Date of Hearing: ${hearingDate}`,
-          4000,
-        ),
-        passageStart: m.index,
-        passageEnd: m.index + m[0].length,
-        committeeId,
-      });
+
+      BILL_CITATION_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = BILL_CITATION_RE.exec(block.text)) !== null) {
+        const canonical = this.normalizeBillCitation(m[1], m[2], m[3]);
+        const propId = ctx.caches.propositionsByExternalId.get(canonical);
+        out.push({
+          actionType: 'amendment',
+          rawSubject: canonical,
+          text: this.truncate(
+            `${canonical}: author's amendments adopted in Committee on ${committeeName}.`,
+            4000,
+          ),
+          passageStart: blockOffset + m.index,
+          passageEnd: blockOffset + m.index + m[0].length,
+          committeeId,
+          propositionId: propId,
+        });
+      }
     }
     return out;
   }
 
-  private extractAmendments(ctx: MinutesContext): CandidateAction[] {
+  /**
+   * SECOND/THIRD READING OF ASSEMBLY BILLS — per-bill blocks where
+   * "amendments proposed by the Committee on X read and adopted"
+   * yields one `amendment` action per bill where the floor adopts a
+   * committee amendment.
+   */
+  private extractReadingAmendments(
+    ctx: MinutesContext,
+    section: JournalSection,
+  ): CandidateAction[] {
     AMENDMENT_ADOPTED_RE.lastIndex = 0;
     const out: CandidateAction[] = [];
     let m: RegExpExecArray | null;
-    while ((m = AMENDMENT_ADOPTED_RE.exec(ctx.rawText)) !== null) {
+    while ((m = AMENDMENT_ADOPTED_RE.exec(section.text)) !== null) {
       const committeeName = m[1].trim();
       const committeeId = this.resolveCommittee(ctx, committeeName);
+
+      // Find the nearest preceding bill citation to attribute this
+      // amendment to. Scan backward up to ~600 chars.
+      const lookback = Math.max(0, m.index - 600);
+      const window = section.text.slice(lookback, m.index);
+      const bills = this.lastBillCitation(window);
+
       out.push({
         actionType: 'amendment',
-        rawSubject: `Committee on ${committeeName}`,
-        text: this.truncate(this.sliceAround(ctx.rawText, m.index, 240), 4000),
-        passageStart: m.index,
-        passageEnd: m.index + m[0].length,
+        rawSubject: bills?.canonical ?? `Committee on ${committeeName}`,
+        text: this.truncate(
+          bills
+            ? `${bills.canonical}: amendments by Committee on ${committeeName} read and adopted.`
+            : `Committee on ${committeeName} amendments read and adopted.`,
+          4000,
+        ),
+        passageStart: section.startOffset + m.index,
+        passageEnd: section.startOffset + m.index + m[0].length,
         committeeId,
+        propositionId: bills?.propId,
       });
     }
     return out;
   }
 
+  /**
+   * ENGROSSMENT AND ENROLLMENT REPORTS — block-scoped on "Mr. Speaker:"
+   * intro lines. Each block has N bill citations followed by ONE
+   * disposition line (`Above bill[s] correctly engrossed/enrolled.`).
+   * One action per bill per block, type from the block's disposition.
+   */
   private extractEngrossmentsAndEnrollments(
     ctx: MinutesContext,
+    section: JournalSection,
   ): CandidateAction[] {
-    BILL_CITATION_RE.lastIndex = 0;
     const out: CandidateAction[] = [];
-    let m: RegExpExecArray | null;
-    while ((m = BILL_CITATION_RE.exec(ctx.rawText)) !== null) {
-      const canonical = this.normalizeBillCitation(m[1], m[2], m[3]);
-      const propId = ctx.caches.propositionsByExternalId.get(canonical);
-      const window = this.sliceAround(ctx.rawText, m.index, 240);
-      let actionType: string | undefined;
-      if (ENROLLED_RE.test(window)) {
-        actionType = 'enrollment';
-      } else if (ENGROSSED_RE.test(window)) {
-        actionType = 'engrossment';
-      }
+    const blocks = this.splitOnLookahead(section.text, /^\s*Mr\.\s*Speaker:/m);
+
+    for (const block of blocks) {
+      const blockOffset = section.startOffset + block.startInParent;
+      let actionType: 'engrossment' | 'enrollment' | undefined;
+      if (ENROLLED_RE.test(block.text)) actionType = 'enrollment';
+      else if (ENGROSSED_RE.test(block.text)) actionType = 'engrossment';
       if (!actionType) continue;
+
+      BILL_CITATION_RE.lastIndex = 0;
+      let m: RegExpExecArray | null;
+      while ((m = BILL_CITATION_RE.exec(block.text)) !== null) {
+        const canonical = this.normalizeBillCitation(m[1], m[2], m[3]);
+        const propId = ctx.caches.propositionsByExternalId.get(canonical);
+        out.push({
+          actionType,
+          rawSubject: canonical,
+          text: this.truncate(
+            `${canonical}: Chief Clerk reports ${actionType === 'enrollment' ? 'enrolled' : 'engrossed'}.`,
+            4000,
+          ),
+          passageStart: blockOffset + m.index,
+          passageEnd: blockOffset + m.index + m[0].length,
+          propositionId: propId,
+        });
+      }
+    }
+    return out;
+  }
+
+  /**
+   * RESOLUTIONS section — one resolution per matching line.
+   */
+  private extractResolutions(
+    ctx: MinutesContext,
+    section: JournalSection,
+  ): CandidateAction[] {
+    const out: CandidateAction[] = [];
+    // Iterate line-by-line so passage offsets are precise.
+    const re = new RegExp(RESOLUTION_LINE_RE.source, 'gm');
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(section.text)) !== null) {
+      const idPhrase = m[1].trim();
+      const introducer = m[2].trim();
+      const subject = m[3].trim();
+      const canonical = this.normalizeResolutionId(idPhrase);
+      const propId = canonical
+        ? ctx.caches.propositionsByExternalId.get(canonical)
+        : undefined;
+
       out.push({
-        actionType,
-        rawSubject: canonical,
-        text: this.truncate(window, 4000),
-        passageStart: m.index,
-        passageEnd: m.index + m[0].length,
+        actionType: 'resolution',
+        rawSubject: canonical ?? idPhrase,
+        text: this.truncate(`${introducer}: ${subject}`, 4000),
+        passageStart: section.startOffset + m.index,
+        passageEnd: section.startOffset + m.index + m[0].length,
         propositionId: propId,
       });
     }
     return out;
   }
+
+  // ============================================
+  // Bill-citation normalization
+  // ============================================
 
   private normalizeBillCitation(
     chamber: string,
@@ -365,16 +722,66 @@ export class LegislativeActionLinkerService {
     return `${c}${t} ${number}`;
   }
 
+  private normalizeResolutionId(phrase: string): string | undefined {
+    const m = /ASSEMBLY (CONCURRENT |JOINT )?RESOLUTION NO\.\s*(\d+)/.exec(
+      phrase,
+    );
+    if (!m) return undefined;
+    const kind = m[1]?.trim();
+    let prefix = 'AR';
+    if (kind === 'CONCURRENT') prefix = 'ACR';
+    else if (kind === 'JOINT') prefix = 'AJR';
+    return `${prefix} ${m[2]}`;
+  }
+
+  private lastBillCitation(
+    window: string,
+  ): { canonical: string; propId?: string } | undefined {
+    BILL_CITATION_RE.lastIndex = 0;
+    let last: RegExpExecArray | null = null;
+    let m: RegExpExecArray | null;
+    while ((m = BILL_CITATION_RE.exec(window)) !== null) {
+      last = m;
+    }
+    if (!last) return undefined;
+    const canonical = this.normalizeBillCitation(last[1], last[2], last[3]);
+    return { canonical };
+  }
+
   // ============================================
   // FK resolution
   // ============================================
 
+  /**
+   * Resolve a presence/absence subject to a representative id.
+   * Strategy (single-match conservative — V1 leaves multi-matches null):
+   *   1. Split on `,` and try the first token as surname (handles
+   *      "Rodriguez, M.").
+   *   2. If that doesn't match a single rep, fall back to the LAST
+   *      whitespace-separated token (handles "Celeste Rodriguez").
+   *   3. Multi-match ambiguity → null + log a warning so V2 work can
+   *      add disambiguation (district, first-initial).
+   */
   private resolveRep(ctx: MinutesContext, name: string): string | undefined {
-    const surname = name.split(',')[0].trim().toLowerCase();
-    if (!surname) return undefined;
     const bucket = ctx.caches.repsByLastName.get(ctx.body);
-    const matches = bucket?.get(surname) ?? [];
-    if (matches.length === 1) return matches[0];
+    if (!bucket) return undefined;
+
+    const commaToken = name.split(',')[0].trim().toLowerCase();
+    if (commaToken) {
+      const matches = bucket.get(commaToken) ?? [];
+      if (matches.length === 1) return matches[0];
+      if (matches.length > 1) return undefined;
+    }
+
+    // Fallback: last whitespace token (First Last → Last).
+    const wsTokens = name.replaceAll(/[,.]/g, '').trim().split(/\s+/);
+    if (wsTokens.length > 1) {
+      const last = wsTokens[wsTokens.length - 1].toLowerCase();
+      if (last && last !== commaToken) {
+        const matches = bucket.get(last) ?? [];
+        if (matches.length === 1) return matches[0];
+      }
+    }
     return undefined;
   }
 
@@ -430,10 +837,31 @@ export class LegislativeActionLinkerService {
   // Helpers
   // ============================================
 
-  private sliceAround(text: string, idx: number, halfWindow: number): string {
-    const start = Math.max(0, idx - halfWindow);
-    const end = Math.min(text.length, idx + halfWindow);
-    return text.slice(start, end).trim();
+  /**
+   * Split text on a regex lookahead, preserving the offset of each
+   * resulting block in the parent. The first chunk (before any
+   * lookahead match) is dropped — extractors only care about
+   * blocks beginning at a recognized boundary.
+   */
+  private splitOnLookahead(
+    text: string,
+    boundaryRe: RegExp,
+  ): { text: string; startInParent: number }[] {
+    const out: { text: string; startInParent: number }[] = [];
+    const re = new RegExp(boundaryRe.source, boundaryRe.flags + 'g');
+    const starts: number[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      starts.push(m.index);
+      // Avoid zero-length match infinite loops.
+      if (m[0].length === 0) re.lastIndex++;
+    }
+    for (let i = 0; i < starts.length; i++) {
+      const start = starts[i];
+      const end = starts[i + 1] ?? text.length;
+      out.push({ text: text.slice(start, end), startInParent: start });
+    }
+    return out;
   }
 
   private truncate(s: string, max: number): string {

--- a/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
@@ -100,12 +100,25 @@ const SECTION_HEADERS = new Set<string>([
   'PLEDGE OF ALLEGIANCE',
 ]);
 
-const SURNAME_LINE_RE = /^[A-ZÀ-ſ][A-Za-zÀ-ſ.,\s'\-’]*$/;
+// Every regex below uses bounded quantifiers (`{n,m}` instead of `*`
+// and `+`) and char classes that exclude `\n` where applicable, so
+// the regex engine cannot backtrack past a line boundary or beyond a
+// realistic per-token budget. This is defensive belt-and-braces
+// against Sonar S5852 (super-linear runtime risk) — the inputs are
+// already bounded by section-scoping in extractCandidates(), but
+// bounded quantifiers also pass static analysis without an
+// exception.
+
+const SURNAME_LINE_RE = /^[A-ZÀ-ſ][A-Za-zÀ-ſ.,'\-’ ]{0,200}$/;
+// Case-insensitive flag (`i`) eliminates the doubled UPPERCASE
+// alternatives in the original pattern; bounded `\s{1,5}` between
+// tokens replaces unbounded `\s+`. Number captured at `\d{1,6}` —
+// CA Assembly bills max at ~3-4 digits, 6 is a defensive ceiling.
 const BILL_CITATION_RE =
-  /(Assembly|ASSEMBLY|Senate|SENATE)\s+(Bill|BILL|Joint Resolution|JOINT RESOLUTION|Concurrent Resolution|CONCURRENT RESOLUTION|Constitutional Amendment|CONSTITUTIONAL AMENDMENT)\s+(?:No\.|NO\.)?\s*(\d+)/g;
+  /(Assembly|Senate)\s{1,5}(Bill|Joint Resolution|Concurrent Resolution|Constitutional Amendment)\s{1,5}(?:No\.\s{0,5})?(\d{1,6})/gi;
 const ROLLCALL_INTRO_RE =
-  /^The (?:following.*morning rollcall|rollcall was completed.*?\bnames)/im;
-const SPEAKER_LINE_RE = /^Mr\.\s*Speaker\s*$/im;
+  /^The (?:following[^\n]{0,200}morning rollcall|rollcall was completed[^\n]{0,200}?\bnames)/im;
+const SPEAKER_LINE_RE = /^Mr\.\s{0,5}Speaker\s{0,5}$/im;
 /**
  * Absence groups within the LEAVES OF ABSENCE section. Format:
  *   <reason>: Assembly Member(s) <name1>, <name2>, ..., and <nameN>.
@@ -117,21 +130,21 @@ const SPEAKER_LINE_RE = /^Mr\.\s*Speaker\s*$/im;
  * defensive even though section-scoping already limits the input.
  */
 const ABSENCE_GROUP_RE =
-  /([^:.\n]{1,200}):\s*(?:Assembly\s+)?Members?\s+((?:[^.\n]|\n(?!\s*\n)){1,1000}?)(?:\.|$)/g;
+  /([^:.\n]{1,200}):\s{0,5}(?:Assembly\s{1,5})?Members?\s{1,5}((?:[^.\n]|\n(?!\s{0,10}\n)){1,1000}?)(?:\.|$)/g;
 // Bounded `[^\n]{1,200}` instead of `(.+?)\s*$` — eliminates the
 // non-greedy / trailing-whitespace backtracking pair that Sonar
 // would flag on long lines. Committee names run < 100 chars in real
 // journals; 200 is generous defensive ceiling.
-const COMMITTEE_HEADER_RE = /^Committee on\s+([^\n]{1,200})$/m;
-const HEARING_DATE_RE = /^Date of Hearing:\s*([^\n]{1,200})$/m;
+const COMMITTEE_HEADER_RE = /^Committee on\s{1,5}([^\n]{1,200})$/m;
+const HEARING_DATE_RE = /^Date of Hearing:\s{0,5}([^\n]{1,200})$/m;
 const AMENDMENT_ADOPTED_RE =
-  /amendments proposed by the Committee on\s+([^\n]{1,200}?)\s+read and adopted/gi;
+  /amendments proposed by the Committee on\s{1,5}([^\n]{1,200}?)\s{1,5}read and adopted/gi;
 // Real journal phrasing is "And reports the same correctly engrossed."
 // (chief clerk's report) — NOT "Above bills correctly engrossed." which
 // is a separate next-action sentence that follows. Match the chief
 // clerk's verb regardless of preamble.
-const ENGROSSED_RE = /correctly\s+engrossed/i;
-const ENROLLED_RE = /correctly\s+enrolled/i;
+const ENGROSSED_RE = /correctly\s{1,5}engrossed/i;
+const ENROLLED_RE = /correctly\s{1,5}enrolled/i;
 /**
  * One newly-offered resolution. Source format:
  *   ASSEMBLY [CONCURRENT|JOINT] RESOLUTION NO. <n>—<introducer>. <subject>.
@@ -145,7 +158,7 @@ const ENROLLED_RE = /correctly\s+enrolled/i;
  * Sonar flags on unbounded `+?`/`.+?` chains (rule S5852).
  */
 const RESOLUTION_LINE_RE =
-  /^(ASSEMBLY (?:CONCURRENT |JOINT )?RESOLUTION NO\.\s*\d{1,6})[—–-]\s*([^.\n]{1,200})\.\s*([^\n]{1,500})$/m;
+  /^(ASSEMBLY (?:CONCURRENT |JOINT )?RESOLUTION NO\.\s{0,5}\d{1,6})[—–-]\s{0,5}([^.\n]{1,200})\.\s{0,5}([^\n]{1,500})$/m;
 
 @Injectable()
 export class LegislativeActionLinkerService {
@@ -498,7 +511,7 @@ export class LegislativeActionLinkerService {
     section: JournalSection,
   ): CandidateAction[] {
     const out: CandidateAction[] = [];
-    const blocks = this.splitOnLookahead(section.text, /^Committee on\s+/m);
+    const blocks = this.splitOnLookahead(section.text, /^Committee on\s{1,5}/m);
 
     for (const block of blocks) {
       const blockOffset = section.startOffset + block.startInParent;
@@ -510,7 +523,7 @@ export class LegislativeActionLinkerService {
       // backtracking. Recommendations in real journals run to a few
       // hundred chars at most; cap at 800 as a defensive ceiling.
       const recommendationMatch =
-        /With the recommendation:\s*([^\n]{1,800}?\.)/i.exec(block.text);
+        /With the recommendation:\s{0,5}([^\n]{1,800}?\.)/i.exec(block.text);
       const recommendation = recommendationMatch?.[1]?.trim();
 
       const committeeId = committeeName
@@ -571,7 +584,7 @@ export class LegislativeActionLinkerService {
     section: JournalSection,
   ): CandidateAction[] {
     const out: CandidateAction[] = [];
-    const blocks = this.splitOnLookahead(section.text, /^Committee on\s+/m);
+    const blocks = this.splitOnLookahead(section.text, /^Committee on\s{1,5}/m);
 
     for (const block of blocks) {
       const blockOffset = section.startOffset + block.startInParent;
@@ -654,7 +667,10 @@ export class LegislativeActionLinkerService {
     section: JournalSection,
   ): CandidateAction[] {
     const out: CandidateAction[] = [];
-    const blocks = this.splitOnLookahead(section.text, /^\s*Mr\.\s*Speaker:/m);
+    const blocks = this.splitOnLookahead(
+      section.text,
+      /^\s{0,10}Mr\.\s{0,5}Speaker:/m,
+    );
 
     for (const block of blocks) {
       const blockOffset = section.startOffset + block.startInParent;
@@ -735,9 +751,10 @@ export class LegislativeActionLinkerService {
   }
 
   private normalizeResolutionId(phrase: string): string | undefined {
-    const m = /ASSEMBLY (CONCURRENT |JOINT )?RESOLUTION NO\.\s*(\d+)/.exec(
-      phrase,
-    );
+    const m =
+      /ASSEMBLY (CONCURRENT |JOINT )?RESOLUTION NO\.\s{0,5}(\d{1,6})/.exec(
+        phrase,
+      );
     if (!m) return undefined;
     const kind = m[1]?.trim();
     let prefix = 'AR';

--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -24,9 +24,11 @@ import { PropositionAnalysisService } from './proposition-analysis.service';
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
 import { PropositionFundingService } from './proposition-funding.service';
 import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
+import { LegislativeActionLinkerService } from './legislative-action-linker.service';
 import { LegislativeCommitteeService } from './legislative-committee.service';
 import { LegislativeCommitteeDescriptionGeneratorService } from './legislative-committee-description-generator.service';
 import { PrismaManifestRepository } from '../infrastructure/prisma-manifest-repository';
+import { PrismaIngestionWatermarkRepository } from '../infrastructure/prisma-ingestion-watermark-repository';
 import { REGION_CACHE } from './region.tokens';
 
 // RelationalDbModule is global, no need to import
@@ -83,6 +85,11 @@ const promptClientAsyncConfig = {
           provide: 'MANIFEST_REPOSITORY',
           useExisting: PrismaManifestRepository,
         },
+        PrismaIngestionWatermarkRepository,
+        {
+          provide: 'INGESTION_WATERMARK_REPOSITORY',
+          useExisting: PrismaIngestionWatermarkRepository,
+        },
       ],
     }),
   ],
@@ -98,6 +105,7 @@ const promptClientAsyncConfig = {
     LegislativeCommitteeLinkerService,
     LegislativeCommitteeService,
     LegislativeCommitteeDescriptionGeneratorService,
+    LegislativeActionLinkerService,
     // Alias for injecting the pipeline into RegionDomainService
     {
       provide: 'SCRAPING_PIPELINE',

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -28,6 +28,7 @@ import {
   type Meeting,
   type Representative,
   type CampaignFinanceResult,
+  type MinutesWithActions,
 } from '@opuspopuli/common';
 import { SECRETS_PROVIDER } from '@opuspopuli/secrets-provider';
 import { REGION_CACHE } from './region.tokens';
@@ -40,6 +41,7 @@ import {
   type PropositionFunding,
 } from './proposition-funding.service';
 import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
+import { LegislativeActionLinkerService } from './legislative-action-linker.service';
 import {
   LegislativeCommitteeService,
   type LegislativeCommitteeDetail,
@@ -58,6 +60,7 @@ interface DataFetcher {
   fetchCampaignFinance?(
     onBatch?: (items: Record<string, unknown>[]) => Promise<void>,
   ): Promise<CampaignFinanceResult>;
+  fetchLegislativeActions?(): Promise<MinutesWithActions[]>;
 }
 import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
 import { RegionInfoModel, DataTypeGQL } from './models/region-info.model';
@@ -396,6 +399,8 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     private readonly legislativeCommittees?: LegislativeCommitteeService,
     @Optional()
     private readonly legislativeCommitteeDescriptions?: LegislativeCommitteeDescriptionGeneratorService,
+    @Optional()
+    private readonly legislativeActionLinker?: LegislativeActionLinkerService,
   ) {}
 
   async onModuleDestroy(): Promise<void> {
@@ -677,6 +682,8 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       [DataType.REPRESENTATIVES]: () =>
         this.syncRepresentatives(provider, maxReps),
       [DataType.CAMPAIGN_FINANCE]: () => this.syncCampaignFinance(provider),
+      [DataType.LEGISLATIVE_ACTIONS]: () =>
+        this.syncLegislativeActions(provider),
     };
 
     const handler = syncHandlers[dataType];
@@ -871,6 +878,107 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     ).length;
 
     return { processed: meetings.length, created, updated };
+  }
+
+  /**
+   * Sync `Minutes` documents from `legislative_actions` data sources
+   * (CA Assembly daily journals etc.) and run the post-sync linker
+   * pass. Two phases:
+   *
+   *   1. Upsert each MinutesWithActions.minutes row by externalId.
+   *      Revisions (`revisionSeq>0`) supersede their predecessors:
+   *      after the new row is upserted, all rows for the same
+   *      (body, date) with a lower revisionSeq get isActive=false.
+   *
+   *   2. Hand the inserted minutes ids to LegislativeActionLinkerService,
+   *      which mines rawText to produce LegislativeAction rows with
+   *      passage offsets attributing the actions to representatives,
+   *      propositions, and committees.
+   *
+   * Issue #665.
+   */
+  private async syncLegislativeActions(
+    provider: DataFetcher = this.regionService,
+  ): Promise<{
+    processed: number;
+    created: number;
+    updated: number;
+  }> {
+    if (!provider.fetchLegislativeActions) {
+      return { processed: 0, created: 0, updated: 0 };
+    }
+
+    const bundles = await provider.fetchLegislativeActions();
+    if (bundles.length === 0) {
+      return { processed: 0, created: 0, updated: 0 };
+    }
+
+    const externalIds = bundles.map((b) => b.minutes.externalId);
+    const existingRecords = await this.db.minutes.findMany({
+      where: { externalId: { in: externalIds } },
+      select: { externalId: true },
+    });
+    const existingExternalIds = new Set(
+      existingRecords.map((r: ExternalIdRecord) => r.externalId),
+    );
+
+    const upsertedIds: string[] = [];
+    for (const { minutes } of bundles) {
+      const row = await this.db.minutes.upsert({
+        where: { externalId: minutes.externalId },
+        update: {
+          body: minutes.body,
+          date: minutes.date,
+          revisionSeq: minutes.revisionSeq,
+          isActive: true,
+          pageCount: minutes.pageCount,
+          sourceUrl: minutes.sourceUrl,
+          rawText: minutes.rawText,
+          parsedAt: minutes.parsedAt ?? new Date(),
+        },
+        create: {
+          externalId: minutes.externalId,
+          body: minutes.body,
+          date: minutes.date,
+          revisionSeq: minutes.revisionSeq,
+          isActive: true,
+          pageCount: minutes.pageCount,
+          sourceUrl: minutes.sourceUrl,
+          rawText: minutes.rawText,
+          parsedAt: minutes.parsedAt ?? new Date(),
+        },
+        select: { id: true },
+      });
+      upsertedIds.push(row.id);
+
+      // Supersede older revisions for the same (body, date).
+      if (minutes.revisionSeq > 0) {
+        await this.db.minutes.updateMany({
+          where: {
+            body: minutes.body,
+            date: minutes.date,
+            revisionSeq: { lt: minutes.revisionSeq },
+          },
+          data: { isActive: false },
+        });
+      }
+    }
+
+    // Run the deterministic linker over the freshly-upserted rows.
+    // Optional injection: when the linker isn't bound, Minutes are
+    // still persisted but no LegislativeAction rows are produced.
+    if (upsertedIds.length > 0 && this.legislativeActionLinker) {
+      await this.legislativeActionLinker.linkMinutes(upsertedIds);
+    }
+
+    const created = bundles.filter(
+      (b) => !existingExternalIds.has(b.minutes.externalId),
+    ).length;
+    const updated = bundles.filter((b) =>
+      existingExternalIds.has(b.minutes.externalId),
+    ).length;
+
+    return { processed: bundles.length, created, updated };
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -60,7 +60,7 @@ interface DataFetcher {
   fetchCampaignFinance?(
     onBatch?: (items: Record<string, unknown>[]) => Promise<void>,
   ): Promise<CampaignFinanceResult>;
-  fetchLegislativeActions?(): Promise<MinutesWithActions[]>;
+  fetchMeetingMinutes?(): Promise<MinutesWithActions[]>;
 }
 import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
 import { RegionInfoModel, DataTypeGQL } from './models/region-info.model';
@@ -682,8 +682,6 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       [DataType.REPRESENTATIVES]: () =>
         this.syncRepresentatives(provider, maxReps),
       [DataType.CAMPAIGN_FINANCE]: () => this.syncCampaignFinance(provider),
-      [DataType.LEGISLATIVE_ACTIONS]: () =>
-        this.syncLegislativeActions(provider),
     };
 
     const handler = syncHandlers[dataType];
@@ -827,7 +825,10 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
   }> {
     const meetings = await provider.fetchMeetings();
     if (meetings.length === 0) {
-      return { processed: 0, created: 0, updated: 0 };
+      // Daily-file may be empty between sessions, but pdf_archive
+      // (minutes) sources can still be live — fall through to the
+      // Minutes sync.
+      return this.syncMeetingMinutes(provider);
     }
 
     // Get existing externalIds in a single query to calculate created vs updated
@@ -877,38 +878,51 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       existingExternalIds.has(m.externalId),
     ).length;
 
-    return { processed: meetings.length, created, updated };
+    // Daily-journal / committee-minutes documents come in under the
+    // same MEETINGS dataType but as `pdf_archive` sources. Persist
+    // them as Minutes rows + run the downstream LegislativeAction
+    // linker. Counts are summed into the meetings sync result so the
+    // caller sees a single total.
+    const minutesResult = await this.syncMeetingMinutes(provider);
+    return {
+      processed: meetings.length + minutesResult.processed,
+      created: created + minutesResult.created,
+      updated: updated + minutesResult.updated,
+    };
   }
 
   /**
-   * Sync `Minutes` documents from `legislative_actions` data sources
-   * (CA Assembly daily journals etc.) and run the post-sync linker
-   * pass. Two phases:
+   * Sync `Minutes` documents from `pdf_archive` sources within the
+   * `meetings` dataType (CA Assembly daily journals etc.) and run the
+   * downstream linker pass. Invoked from `syncMeetings`. Two phases:
    *
    *   1. Upsert each MinutesWithActions.minutes row by externalId.
    *      Revisions (`revisionSeq>0`) supersede their predecessors:
    *      after the new row is upserted, all rows for the same
    *      (body, date) with a lower revisionSeq get isActive=false.
    *
-   *   2. Hand the inserted minutes ids to LegislativeActionLinkerService,
-   *      which mines rawText to produce LegislativeAction rows with
-   *      passage offsets attributing the actions to representatives,
-   *      propositions, and committees.
+   *   2. Hand the upserted minutes ids to
+   *      LegislativeActionLinkerService, which mines rawText to
+   *      produce LegislativeAction rows with passage offsets
+   *      attributing the actions to representatives, propositions,
+   *      and committees. ACTIONS are downstream of MINUTES — the
+   *      linker is optional injection, so when it isn't bound the
+   *      Minutes still persist but no actions get produced.
    *
    * Issue #665.
    */
-  private async syncLegislativeActions(
+  private async syncMeetingMinutes(
     provider: DataFetcher = this.regionService,
   ): Promise<{
     processed: number;
     created: number;
     updated: number;
   }> {
-    if (!provider.fetchLegislativeActions) {
+    if (!provider.fetchMeetingMinutes) {
       return { processed: 0, created: 0, updated: 0 };
     }
 
-    const bundles = await provider.fetchLegislativeActions();
+    const bundles = await provider.fetchMeetingMinutes();
     if (bundles.length === 0) {
       return { processed: 0, created: 0, updated: 0 };
     }

--- a/apps/backend/src/apps/region/src/infrastructure/prisma-ingestion-watermark-repository.ts
+++ b/apps/backend/src/apps/region/src/infrastructure/prisma-ingestion-watermark-repository.ts
@@ -1,0 +1,37 @@
+/**
+ * Prisma Ingestion-Watermark Repository
+ *
+ * Adapts DbService (PrismaClient) to the IngestionWatermarkRepository
+ * interface expected by the scraping pipeline's
+ * IngestionWatermarkService. Mirrors PrismaManifestRepository's shape.
+ */
+
+import { Injectable } from '@nestjs/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+@Injectable()
+export class PrismaIngestionWatermarkRepository {
+  constructor(private readonly db: DbService) {}
+
+  async findFirst(args: {
+    where: { regionId: string; sourceUrl: string; dataType: string };
+  }) {
+    return this.db.ingestionWatermark.findFirst({
+      where: args.where,
+    });
+  }
+
+  async upsert(args: {
+    where: { regionId: string; sourceUrl: string; dataType: string };
+    create: Record<string, unknown>;
+    update: Record<string, unknown>;
+  }) {
+    return this.db.ingestionWatermark.upsert({
+      where: {
+        regionId_sourceUrl_dataType: args.where,
+      } as never,
+      create: args.create as never,
+      update: args.update as never,
+    });
+  }
+}

--- a/apps/backend/src/apps/region/src/scripts/run-relink-minutes.ts
+++ b/apps/backend/src/apps/region/src/scripts/run-relink-minutes.ts
@@ -1,0 +1,41 @@
+/**
+ * One-off: re-run the legislative-action linker over every active
+ * Minutes row in the database. Useful after the linker is improved —
+ * regenerates LegislativeAction rows from the already-stored
+ * `rawText` without re-fetching the source PDFs.
+ *
+ * Idempotent (existing actions for each Minutes are deleted before
+ * re-insert), so running it twice in a row is a no-op on the second
+ * pass.
+ *
+ * Usage (assumes the region container is running):
+ *   docker compose -f docker-compose-uat.yml exec region \
+ *     node dist/src/apps/region/apps/region/src/scripts/run-relink-minutes.js
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
+import { AppModule } from '../app.module';
+import { LegislativeActionLinkerService } from '../domains/legislative-action-linker.service';
+
+async function main(): Promise<void> {
+  const logger = new Logger('run-relink-minutes');
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'warn', 'error'],
+  });
+  try {
+    const linker = app.get(LegislativeActionLinkerService, { strict: false });
+    logger.log('Re-linking all active Minutes…');
+    const result = await linker.relinkAll();
+    logger.log(
+      `Done. minutesProcessed=${result.minutesProcessed} actionsCreated=${result.actionsCreated}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Relink failed:', err);
+  process.exit(1);
+});

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -11,13 +11,16 @@
  */
 export enum DataType {
   PROPOSITIONS = "propositions",
+  /// Both scheduled meetings (calendar/daily-file sources) AND past
+  /// meeting minutes / journals (pdf_archive sources). The plugin
+  /// partitions sources by sourceType inside fetchMeetings /
+  /// fetchMeetingMinutes. The downstream LegislativeAction linker
+  /// runs after Minutes upsert as part of the meetings sync.
+  /// Issue #665.
   MEETINGS = "meetings",
   REPRESENTATIVES = "representatives",
   CAMPAIGN_FINANCE = "campaign_finance",
   LOBBYING = "lobbying",
-  /// Per-action records from legislative daily journals (votes, motions,
-  /// amendments, committee reports, presence). Issue #665.
-  LEGISLATIVE_ACTIONS = "legislative_actions",
 }
 
 /**
@@ -521,19 +524,22 @@ export interface IRegionProvider {
   ): Promise<CampaignFinanceResult>;
 
   /**
-   * Fetch meeting-minutes / journal documents. V1 returns Minutes
-   * records with empty `actions`; the backend linker mines `rawText`
-   * post-sync to produce the action records. Returning the bundled
-   * shape now keeps the door open for fetcher-side extraction in V2
-   * (e.g. AI-driven structural analysis at fetch time) without
-   * changing the interface.
+   * Fetch meeting-minutes / journal documents from `pdf_archive`
+   * sources within the `meetings` dataType. Optional — only
+   * implemented by plugins with at least one `pdf_archive` source.
    *
-   * Optional — only implemented by plugins with legislative_actions
-   * data sources. The handler walks the listing page descending by
-   * date and stops at a watermark (`ingestion_watermarks` table) or a
-   * configured `maxNew` cap to bound cold-start work. Issue #665.
+   * V1 returns Minutes records with empty `actions`; the backend's
+   * downstream linker mines `rawText` post-sync to produce
+   * `LegislativeAction` rows. Returning the bundled shape leaves
+   * room for fetcher-side extraction in V2 (e.g. AI structural
+   * analysis at fetch time) without changing the interface.
+   *
+   * The pipeline's `pdf_archive` handler walks the listing page
+   * descending by date and stops at a watermark
+   * (`ingestion_watermarks`) or a configured `maxNew` cap to bound
+   * cold-start work. Issue #665.
    */
-  fetchLegislativeActions?(): Promise<MinutesWithActions[]>;
+  fetchMeetingMinutes?(): Promise<MinutesWithActions[]>;
 }
 
 /**

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -15,6 +15,9 @@ export enum DataType {
   REPRESENTATIVES = "representatives",
   CAMPAIGN_FINANCE = "campaign_finance",
   LOBBYING = "lobbying",
+  /// Per-action records from legislative daily journals (votes, motions,
+  /// amendments, committee reports, presence). Issue #665.
+  LEGISLATIVE_ACTIONS = "legislative_actions",
 }
 
 /**
@@ -199,6 +202,153 @@ export interface Representative {
 }
 
 // ============================================
+// MEETING MINUTES + LEGISLATIVE ACTIONS (issue #665)
+// ============================================
+
+/**
+ * A meeting-minutes / journal document. The canonical PDF that records
+ * what happened in a chamber session or committee hearing — daily
+ * journals, committee hearing minutes, etc.
+ *
+ * V1 stores the document as opaque text + audit metadata at ingest
+ * time; downstream passes (the legislative-action linker for V1, AI
+ * summarization for V2) mine `rawText` to produce structured records.
+ *
+ * `committeeId` is set when the document is single-committee minutes;
+ * null for chamber-wide daily journals. `meetingId` is set when the
+ * document corresponds to a calendared meeting (most chamber-wide
+ * daily journals leave it null).
+ *
+ * Revision handling: when the clerk re-publishes the same session
+ * day's PDF (e.g. `adj042826_r1.pdf`), it lands as a new row with
+ * `revisionSeq=1` and `isActive=true`; the original's `isActive` is
+ * flipped to false.
+ */
+export interface Minutes {
+  externalId: string;
+  /** "Assembly" | "Senate" — V1 is CA Assembly only. */
+  body: string;
+  date: Date;
+  /** 0 for the original publication, 1+ for revisions in publication order. */
+  revisionSeq: number;
+  /** True for the canonical-current version. */
+  isActive: boolean;
+  /** Set when the document is single-committee minutes. Null for chamber-wide daily journals. */
+  committeeId?: string;
+  /** Set when the document corresponds to a calendared meeting. */
+  meetingId?: string;
+  pageCount?: number;
+  sourceUrl: string;
+  /** Full pdf-parse output. Capped ~256kB at write time. */
+  rawText?: string;
+  /** V2 — AI-generated plain-language summary. */
+  summary?: string;
+  /** V2 — per-claim attribution into rawText for citizen-facing
+   *  "letter to representative with quote" features. Mirrors the
+   *  PropositionAnalysisClaim shape (sourceStart/sourceEnd offsets). */
+  summaryClaims?: PropositionAnalysisClaim[];
+  parsedAt?: Date;
+}
+
+/**
+ * Action types extracted from a Minutes document.
+ */
+export type LegislativeActionType =
+  /** Roll-call presence on the morning rollcall. */
+  | "presence"
+  /**
+   * A scheduled or recorded committee hearing referenced in the
+   * minutes (e.g. "Committee on Public Safety / Date of Hearing:
+   * April 21, 2026"). Has `committeeId` set; may have `propositionId`
+   * for hearings on a specific measure.
+   */
+  | "committee_hearing"
+  /**
+   * Committee reporting back on a bill out of hearing — typically a
+   * "do pass" / "do pass as amended" / "hold" verdict. Distinct from
+   * `committee_hearing` (the scheduled meeting) — a hearing produces
+   * zero or more reports.
+   */
+  | "committee_report"
+  | "amendment"
+  | "engrossment"
+  | "enrollment"
+  | "resolution"
+  /** V2 — per-rep-per-bill vote tables */
+  | "vote"
+  /** V2 — floor speech text + summarization */
+  | "speech";
+
+export type LegislativeVotePosition = "yes" | "no" | "abstain" | "absent";
+
+/**
+ * One discrete legislative action extracted from a Minutes document.
+ *
+ * `passageStart` / `passageEnd` are character offsets into the parent
+ * Minutes' `rawText`. Citizens building a "letter to my rep" with a
+ * quoted action use these offsets to pull the verbatim passage out of
+ * the source. `text` is the already-extracted excerpt (denormalized for
+ * query performance); offsets let the UI re-anchor the quote in
+ * context.
+ *
+ * `body` and `date` are denormalized from the parent Minutes so the
+ * canonical "rep activity feed" / "bill history" / "committee history"
+ * queries don't require a JOIN to filter by date.
+ */
+export interface LegislativeAction {
+  externalId: string;
+  /**
+   * Parent Minutes database id. Set after the Minutes row is inserted —
+   * undefined in fetcher output. The fetcher returns actions nested
+   * inside `MinutesWithActions` so the parent→child relationship is
+   * preserved without this field.
+   */
+  minutesId?: string;
+  /** "Assembly" | "Senate" — denormalized from minutes. */
+  body: string;
+  /** Denormalized from minutes. */
+  date: Date;
+  actionType: LegislativeActionType;
+  /** Set by the linker. Null when the linker can't resolve to a known rep. */
+  representativeId?: string;
+  /** Set by the linker. Null when the bill isn't yet a qualified proposition. */
+  propositionId?: string;
+  /** Set by the linker. Null for non-committee actions. */
+  committeeId?: string;
+  /** Vote-only. Null for non-vote actions in V1. */
+  position?: LegislativeVotePosition;
+  /** Verbatim source excerpt. Truncate at 4kB at write time. */
+  text?: string;
+  /** V2 — AI-generated summary for long-form actions. */
+  summary?: string;
+  /** Inclusive char offset into the parent Minutes' rawText where the
+   *  action's source passage begins. */
+  passageStart?: number;
+  /** Exclusive char offset into the parent Minutes' rawText where the
+   *  action's source passage ends. */
+  passageEnd?: number;
+  /** Page within the parent minutes document. */
+  sourcePage?: number;
+  /** Pre-link reference text. Surname / "Assembly Bill No. N" / committee name. */
+  rawSubject?: string;
+}
+
+/**
+ * Fetcher output shape — a Minutes record bundled with any actions
+ * already extracted at fetch time. V1 fetchers return Minutes only
+ * (empty `actions`); the backend linker fills in actions in a
+ * downstream pass after the Minutes row has a database id.
+ *
+ * Used as the `IRegionProvider.fetchLegislativeActions()` return type
+ * so the parent→children relationship is explicit through the pipeline
+ * boundary (before any DB ids exist).
+ */
+export interface MinutesWithActions {
+  minutes: Minutes;
+  actions: LegislativeAction[];
+}
+
+// ============================================
 // CAMPAIGN FINANCE
 // ============================================
 
@@ -369,6 +519,21 @@ export interface IRegionProvider {
   fetchCampaignFinance?(
     onBatch?: (items: Record<string, unknown>[]) => Promise<void>,
   ): Promise<CampaignFinanceResult>;
+
+  /**
+   * Fetch meeting-minutes / journal documents. V1 returns Minutes
+   * records with empty `actions`; the backend linker mines `rawText`
+   * post-sync to produce the action records. Returning the bundled
+   * shape now keeps the door open for fetcher-side extraction in V2
+   * (e.g. AI-driven structural analysis at fetch time) without
+   * changing the interface.
+   *
+   * Optional — only implemented by plugins with legislative_actions
+   * data sources. The handler walks the listing page descending by
+   * date and stops at a watermark (`ingestion_watermarks` table) or a
+   * configured `maxNew` cap to bound cold-start work. Issue #665.
+   */
+  fetchLegislativeActions?(): Promise<MinutesWithActions[]>;
 }
 
 /**

--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -274,7 +274,7 @@ export interface DataSourceConfig {
   rateLimitOverride?: number;
 
   /** Source type determines the extraction strategy. Defaults to 'html_scrape'. */
-  sourceType?: "html_scrape" | "bulk_download" | "api" | "pdf";
+  sourceType?: "html_scrape" | "bulk_download" | "api" | "pdf" | "pdf_archive";
 
   /** Configuration for bulk_download sources (ZIP/CSV/TSV files) */
   bulk?: BulkDownloadConfig;
@@ -285,12 +285,42 @@ export interface DataSourceConfig {
   /** Configuration for PDF sources (text extraction + AI analysis) */
   pdf?: PdfSourceConfig;
 
+  /** Configuration for pdf_archive sources (paginated listing of dated PDF documents) */
+  pdfArchive?: PdfArchiveConfig;
+
   /** Detail page extraction plan: maps domain field names to CSS selectors
    *  or structured field configs for array extraction.
    *  When provided, the detail crawler uses these directly instead of AI derivation.
    *  - String values: CSS selector (supports dot notation and "|attr:href" suffix)
    *  - Object values: structured array extraction (e.g., multiple offices) */
   detailFields?: Record<string, string | StructuredFieldConfig>;
+}
+
+/**
+ * Configuration for `sourceType: 'pdf_archive'` — a paginated listing
+ * page that links to a series of dated PDF documents. Each linked PDF
+ * is fetched, pdf-parsed, and stored as a `Minutes` record on the
+ * consumer side. Per-document parsing (text → action records) is a
+ * downstream backend pass — this block carries no parser DSL.
+ *
+ * Cold-start work is bounded by `maxNew` (default 10) so the first
+ * sync doesn't ingest years of historical archives.
+ */
+export interface PdfArchiveConfig {
+  /** CSS selector for PDF anchor elements on the listing page. Each match yields a candidate document. */
+  linkSelector: string;
+  /** Regex applied to the link href (falling back to anchor text) to extract the document's date. Capture groups depend on `dateFormat`. */
+  datePattern?: string;
+  /** Date format hint for interpreting `datePattern` captures. Supported: 'MMDDYY' (3 captures: month, day, two-digit year — assumed 20YY), 'YYYY-MM-DD' (3 captures), 'MM/DD/YYYY' (3 captures). */
+  dateFormat?: string;
+  /** Regex against the link href whose match indicates this URL is a revision. Capture group 1 is the revision sequence number. Unmatched URLs are revisionSeq=0. */
+  revisionPattern?: string;
+  /** Maximum number of listing pages to walk during a single sync cycle. Default: 10. */
+  maxPages?: number;
+  /** Hard cap on number of new documents ingested per sync cycle. Cold-start protection. Default: 10. */
+  maxNew?: number;
+  /** Query parameter name used to paginate the listing page (e.g. 'page'). Omitted when the listing isn't paginated. */
+  paginationParam?: string;
 }
 
 /**

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.34"
+    "@opuspopuli/regions": "^1.0.35"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.35"
+    "@opuspopuli/regions": "^1.0.36"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/src/declarative/declarative-region-plugin.ts
+++ b/packages/region-provider/src/declarative/declarative-region-plugin.ts
@@ -78,7 +78,14 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
   }
 
   async fetchMeetings(): Promise<Meeting[]> {
-    return this.fetchByDataType<Meeting>("meetings");
+    // Filter out `pdf_archive` sources — those emit Minutes documents
+    // and are handled by `fetchMeetingMinutes` instead. Mixing them
+    // here would type-pollute the Meeting[] return.
+    return this.fetchByDataType<Meeting>(
+      "meetings",
+      undefined,
+      (s) => s.sourceType !== "pdf_archive",
+    );
   }
 
   async fetchRepresentatives(): Promise<Representative[]> {
@@ -86,15 +93,20 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
   }
 
   /**
-   * Fetch meeting-minutes / journal documents from `legislative_actions`
-   * data sources. The pipeline's `pdf_archive` handler walks each
-   * source's listing page, fetches per-day PDFs, and returns
-   * MinutesWithActions records with `actions: []` (V1) — the backend's
-   * LegislativeActionLinkerService mines the stored rawText post-sync
-   * to produce action records. Issue #665.
+   * Fetch meeting-minutes / journal documents from `pdf_archive`
+   * sources under the `meetings` dataType. The pipeline's
+   * `MinutesIngestHandler` walks each source's listing page, fetches
+   * per-day PDFs, and returns one MinutesWithActions per document
+   * with empty actions (V1) — the backend's
+   * LegislativeActionLinkerService mines the stored rawText
+   * post-sync to produce action records. Issue #665.
    */
-  async fetchLegislativeActions(): Promise<MinutesWithActions[]> {
-    return this.fetchByDataType<MinutesWithActions>("legislative_actions");
+  async fetchMeetingMinutes(): Promise<MinutesWithActions[]> {
+    return this.fetchByDataType<MinutesWithActions>(
+      "meetings",
+      undefined,
+      (s) => s.sourceType === "pdf_archive",
+    );
   }
 
   async fetchCampaignFinance(
@@ -176,13 +188,20 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
    * Fetch all data sources matching a data type and concatenate results.
    * When onBatch is provided, bulk_download sources stream batches via callback
    * instead of accumulating all items in memory.
+   *
+   * `sourceFilter` further narrows the matched sources by sourceType
+   * (used to partition `meetings` between scheduled-meeting sources
+   * and `pdf_archive` minutes sources without inventing a second
+   * dataType).
    */
   private async fetchByDataType<T>(
     dataType: string,
     onBatch?: (items: T[]) => Promise<void>,
+    sourceFilter?: (source: DataSourceConfig) => boolean,
   ): Promise<T[]> {
     const sources = this.regionConfig.dataSources.filter(
-      (ds) => ds.dataType === dataType,
+      (ds) =>
+        ds.dataType === dataType && (sourceFilter ? sourceFilter(ds) : true),
     );
 
     if (sources.length === 0) {

--- a/packages/region-provider/src/declarative/declarative-region-plugin.ts
+++ b/packages/region-provider/src/declarative/declarative-region-plugin.ts
@@ -18,6 +18,7 @@ import type {
   Meeting,
   Representative,
   CampaignFinanceResult,
+  MinutesWithActions,
   DeclarativeRegionConfig,
   DataSourceConfig,
   ExtractionResult,
@@ -82,6 +83,18 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
 
   async fetchRepresentatives(): Promise<Representative[]> {
     return this.fetchByDataType<Representative>("representatives");
+  }
+
+  /**
+   * Fetch meeting-minutes / journal documents from `legislative_actions`
+   * data sources. The pipeline's `pdf_archive` handler walks each
+   * source's listing page, fetches per-day PDFs, and returns
+   * MinutesWithActions records with `actions: []` (V1) — the backend's
+   * LegislativeActionLinkerService mines the stored rawText post-sync
+   * to produce action records. Issue #665.
+   */
+  async fetchLegislativeActions(): Promise<MinutesWithActions[]> {
+    return this.fetchByDataType<MinutesWithActions>("legislative_actions");
   }
 
   async fetchCampaignFinance(

--- a/packages/region-provider/src/region.service.ts
+++ b/packages/region-provider/src/region.service.ts
@@ -6,6 +6,7 @@ import {
   Proposition,
   Meeting,
   Representative,
+  MinutesWithActions,
   SyncResult,
 } from "@opuspopuli/common";
 
@@ -94,6 +95,30 @@ export class RegionService {
     );
 
     return representatives;
+  }
+
+  /**
+   * Fetch meeting-minutes / journal documents from `pdf_archive`
+   * sources under the `meetings` dataType. Optional — only available
+   * on providers that implement the method (declarative plugins
+   * with at least one `pdf_archive` source). Returns an empty array
+   * when the underlying provider doesn't support it. Issue #665.
+   */
+  async fetchMeetingMinutes(): Promise<MinutesWithActions[]> {
+    if (!this.provider.fetchMeetingMinutes) {
+      return [];
+    }
+    this.logger.log("Fetching meeting minutes from provider");
+    const startTime = Date.now();
+
+    const bundles = await this.provider.fetchMeetingMinutes();
+
+    const duration = Date.now() - startTime;
+    this.logger.log(
+      `Fetched ${bundles.length} meeting-minutes documents in ${duration}ms`,
+    );
+
+    return bundles;
   }
 
   /**

--- a/packages/relationaldb-provider/prisma/migrations/20260503214913_add_minutes_and_legislative_actions/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260503214913_add_minutes_and_legislative_actions/migration.sql
@@ -1,0 +1,126 @@
+-- Issue #665: Meeting minutes / journal documents (`minutes`) and the
+-- per-action records extracted from them (`legislative_actions`).
+--
+-- The `minutes` table stores chamber daily journals and committee
+-- hearing minutes as opaque text + audit metadata. Downstream passes
+-- (the legislative-action linker for V1, AI summarization for V2) mine
+-- the rawText to produce structured records. Optional FKs to
+-- `legislative_committees` (per-committee minutes) and `meetings`
+-- (when the document corresponds to a calendared meeting).
+--
+-- `legislative_actions` carries char-offset references back into the
+-- parent Minutes' rawText (`passage_start` / `passage_end`) so the
+-- citizen-facing "letter to my rep with quoted action" feature can
+-- pull the verbatim passage out of the source.
+
+CREATE TABLE "minutes" (
+    "id"             TEXT        NOT NULL,
+    "external_id"    TEXT        NOT NULL,
+    "body"           VARCHAR(20) NOT NULL,
+    "date"           DATE        NOT NULL,
+    "revision_seq"   INTEGER     NOT NULL DEFAULT 0,
+    "is_active"      BOOLEAN     NOT NULL DEFAULT true,
+    "committee_id"   TEXT,
+    "meeting_id"     TEXT,
+    "page_count"     INTEGER,
+    "source_url"     TEXT        NOT NULL,
+    "raw_text"       TEXT,
+    "summary"        TEXT,
+    "summary_claims" JSONB,
+    "parsed_at"      TIMESTAMPTZ,
+    "created_at"     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"     TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "minutes_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "minutes_external_id_key"               ON "minutes"("external_id");
+CREATE INDEX        "minutes_date_idx"                      ON "minutes"("date" DESC);
+CREATE INDEX        "minutes_body_date_idx"                 ON "minutes"("body", "date" DESC);
+CREATE INDEX        "minutes_committee_id_date_idx"         ON "minutes"("committee_id", "date" DESC);
+CREATE INDEX        "minutes_meeting_id_idx"                ON "minutes"("meeting_id");
+CREATE INDEX        "minutes_is_active_idx"                 ON "minutes"("is_active");
+
+ALTER TABLE "minutes"
+    ADD CONSTRAINT "minutes_committee_id_fkey"
+    FOREIGN KEY ("committee_id") REFERENCES "legislative_committees"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "minutes"
+    ADD CONSTRAINT "minutes_meeting_id_fkey"
+    FOREIGN KEY ("meeting_id") REFERENCES "meetings"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+
+CREATE TABLE "legislative_actions" (
+    "id"                TEXT        NOT NULL,
+    "external_id"       TEXT        NOT NULL,
+    "minutes_id"        TEXT        NOT NULL,
+    "body"              VARCHAR(20) NOT NULL,
+    "date"              DATE        NOT NULL,
+    "action_type"       VARCHAR(40) NOT NULL,
+    "representative_id" TEXT,
+    "proposition_id"    TEXT,
+    "committee_id"      TEXT,
+    "position"          VARCHAR(20),
+    "text"              TEXT,
+    "summary"           TEXT,
+    "passage_start"     INTEGER,
+    "passage_end"       INTEGER,
+    "source_page"       INTEGER,
+    "raw_subject"       VARCHAR(500),
+    "created_at"        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"        TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "legislative_actions_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "legislative_actions_external_id_key"          ON "legislative_actions"("external_id");
+CREATE INDEX        "legislative_actions_minutes_id_idx"           ON "legislative_actions"("minutes_id");
+CREATE INDEX        "legislative_actions_rep_date_idx"             ON "legislative_actions"("representative_id", "date" DESC);
+CREATE INDEX        "legislative_actions_proposition_date_idx"     ON "legislative_actions"("proposition_id", "date" DESC);
+CREATE INDEX        "legislative_actions_committee_date_idx"       ON "legislative_actions"("committee_id", "date" DESC);
+CREATE INDEX        "legislative_actions_body_date_idx"            ON "legislative_actions"("body", "date" DESC);
+CREATE INDEX        "legislative_actions_action_type_idx"          ON "legislative_actions"("action_type");
+
+ALTER TABLE "legislative_actions"
+    ADD CONSTRAINT "legislative_actions_minutes_id_fkey"
+    FOREIGN KEY ("minutes_id") REFERENCES "minutes"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "legislative_actions"
+    ADD CONSTRAINT "legislative_actions_representative_id_fkey"
+    FOREIGN KEY ("representative_id") REFERENCES "representatives"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "legislative_actions"
+    ADD CONSTRAINT "legislative_actions_proposition_id_fkey"
+    FOREIGN KEY ("proposition_id") REFERENCES "propositions"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+ALTER TABLE "legislative_actions"
+    ADD CONSTRAINT "legislative_actions_committee_id_fkey"
+    FOREIGN KEY ("committee_id") REFERENCES "legislative_committees"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+
+-- Watermark for cold-start protection on listing-walk sources (daily
+-- journals etc.). One row per (region, source_url, data_type) tracks
+-- the most recently ingested item so subsequent syncs can stop at the
+-- watermark instead of re-walking historical archives.
+CREATE TABLE "ingestion_watermarks" (
+    "id"               TEXT          NOT NULL,
+    "region_id"        VARCHAR(100)  NOT NULL,
+    "source_url"       VARCHAR(1000) NOT NULL,
+    "data_type"        VARCHAR(50)   NOT NULL,
+    "last_external_id" VARCHAR(255),
+    "last_ingested_at" TIMESTAMPTZ,
+    "items_ingested"   INTEGER       NOT NULL DEFAULT 0,
+    "created_at"       TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"       TIMESTAMPTZ   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ingestion_watermarks_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "ingestion_watermarks_region_source_type_key"
+    ON "ingestion_watermarks"("region_id", "source_url", "data_type");

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -583,6 +583,7 @@ model Representative {
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
 
   committeeAssignments RepresentativeCommitteeAssignment[]
+  legislativeActions   LegislativeAction[]
 
   @@index([name])
   @@index([lastName])
@@ -608,7 +609,9 @@ model LegislativeCommittee {
   updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
 
-  assignments RepresentativeCommitteeAssignment[]
+  assignments        RepresentativeCommitteeAssignment[]
+  legislativeActions LegislativeAction[]
+  minutes            Minutes[]
 
   @@index([chamber])
   @@index([name])
@@ -672,10 +675,156 @@ model Proposition {
   committeePositions      CommitteeMeasurePosition[]
   expenditures            Expenditure[]
   independentExpenditures IndependentExpenditure[]
+  legislativeActions      LegislativeAction[]
 
   @@index([status])
   @@index([electionDate])
   @@map("propositions")
+}
+
+// ============================================
+// MEETING MINUTES + LEGISLATIVE ACTIONS (issue #665)
+// ============================================
+
+/// A meeting-minutes / journal document. The canonical PDF that records
+/// what happened in a chamber session or committee hearing — daily
+/// journals (chamber-wide), committee hearing minutes, etc.
+///
+/// Stored as opaque text + audit metadata at ingest time; downstream
+/// passes (the legislative-action linker for V1, AI summarization for
+/// V2) mine `rawText` to produce structured records.
+///
+/// Optional FKs:
+///   - committeeId — set when the document is a single-committee
+///     minutes (e.g. Assembly Public Safety hearing). Null for a
+///     chamber-wide daily journal that spans many committees.
+///   - meetingId   — set when this minutes record corresponds to a
+///     specific scheduled meeting from `meetings`. Null when the source
+///     PDF doesn't map to a calendared meeting (most chamber-wide
+///     daily journals).
+///
+/// Revision handling: when the clerk re-publishes the same session
+/// day's PDF as `…_r1.pdf`, it lands as a new row with `revisionSeq=1`
+/// and `isActive=true`; the original row's `isActive` is flipped to
+/// false. Downstream pass output (LegislativeAction rows) is regenerated
+/// against the active revision; superseded rows stay in-place for
+/// audit but UI queries should filter `minutes.isActive = true`.
+model Minutes {
+  id              String    @id @default(uuid())
+  /// `${region}-${body-lowercase}-${YYYY-MM-DD}` for chamber-wide r0;
+  /// `${region}-${body-lowercase}-${committee-slug}-${YYYY-MM-DD}` for
+  /// per-committee minutes; suffixed `-r${n}` for revisions.
+  externalId      String    @unique @map("external_id")
+  body            String    @db.VarChar(20)
+  date            DateTime  @db.Date
+  /// Revision sequence: 0 for the original publication, 1+ for
+  /// re-issues. Combined with (body, date, committeeId) gives a stable
+  /// natural key.
+  revisionSeq     Int       @default(0) @map("revision_seq")
+  /// True for the canonical-current version; false for superseded
+  /// predecessors. UI queries filter on this.
+  isActive        Boolean   @default(true) @map("is_active")
+  /// Set when the document is a single-committee minutes. Null for
+  /// chamber-wide daily journals.
+  committeeId     String?   @map("committee_id")
+  /// Set when this minutes record corresponds to a specific scheduled
+  /// meeting. Null when the source PDF doesn't map to a calendared
+  /// meeting.
+  meetingId       String?   @map("meeting_id")
+  pageCount       Int?      @map("page_count")
+  sourceUrl       String    @map("source_url")
+  /// Full pdf-parse output. Capped at ~256kB at write time; longer
+  /// documents are truncated. Used by downstream passes (linker, AI
+  /// summarization) so they can be re-run without re-fetching the PDF.
+  rawText         String?   @map("raw_text") @db.Text
+  /// V2: AI-generated plain-language summary. Reserved column.
+  summary         String?   @db.Text
+  /// V2: per-claim attribution into rawText for citizen-facing
+  /// "letter to representative with quote" features. Mirrors the
+  /// PropositionAnalysisClaim shape (sourceStart/sourceEnd offsets).
+  summaryClaims   Json?     @map("summary_claims")
+  parsedAt        DateTime? @map("parsed_at") @db.Timestamptz
+  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt       DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  committee LegislativeCommittee? @relation(fields: [committeeId], references: [id], onDelete: SetNull)
+  meeting   Meeting?              @relation(fields: [meetingId],   references: [id], onDelete: SetNull)
+  actions   LegislativeAction[]
+
+  @@index([date(sort: Desc)])
+  @@index([body, date(sort: Desc)])
+  @@index([committeeId, date(sort: Desc)])
+  @@index([meetingId])
+  @@index([isActive])
+  @@map("minutes")
+}
+
+/// One discrete legislative action extracted from a Minutes document:
+/// a roll-call presence entry, a committee report, an author's
+/// amendment, an engrossment/enrollment, a resolution introduced, or
+/// (V2) a per-rep vote on a specific bill or a quoted floor speech.
+///
+/// Each action is attributable to zero or more of:
+///   - representativeId — who took/introduced the action (null when
+///     not attributable or when the linker can't resolve the surname)
+///   - propositionId    — the bill/measure it concerns (null when the
+///     bill isn't yet a qualified ballot measure in `propositions`)
+///   - committeeId      — the committee that issued the report
+///
+/// `passageStart` / `passageEnd` are character offsets into the parent
+/// Minutes' `rawText` pointing to the source passage. Citizens building
+/// a "letter to my rep" with a quoted action will use these offsets to
+/// pull the verbatim passage out of the document. `text` is the
+/// already-extracted excerpt (denormalized for query performance);
+/// offsets let the UI re-anchor the quote in context.
+///
+/// `body` and `date` are denormalized from the parent Minutes so the
+/// canonical "rep activity feed" / "bill history" / "committee history"
+/// indexes don't require a JOIN to filter by date.
+model LegislativeAction {
+  id               String    @id @default(uuid())
+  externalId       String    @unique @map("external_id")
+  minutesId        String    @map("minutes_id")
+  body             String    @db.VarChar(20)
+  date             DateTime  @db.Date
+  actionType       String    @map("action_type") @db.VarChar(40)
+  representativeId String?   @map("representative_id")
+  propositionId    String?   @map("proposition_id")
+  committeeId      String?   @map("committee_id")
+  /// 'yes' | 'no' | 'abstain' | 'absent' — null for non-vote actions in V1.
+  position         String?   @db.VarChar(20)
+  /// Verbatim source excerpt. Capped at 4kB at write time. For the
+  /// full source text reach into the parent Minutes' `rawText`.
+  text             String?   @db.Text
+  /// V2: AI-generated summary for long-form actions (speeches, etc.).
+  summary          String?   @db.Text
+  /// Char offset into the parent Minutes' `rawText` where the action's
+  /// source passage begins. Inclusive. Null when offsets can't be
+  /// determined (e.g. synthesized from heterogeneous sections).
+  passageStart     Int?      @map("passage_start")
+  /// Char offset into the parent Minutes' `rawText` where the action's
+  /// source passage ends. Exclusive. Null when offsets aren't available.
+  passageEnd       Int?      @map("passage_end")
+  sourcePage       Int?      @map("source_page")
+  /// Pre-link source text (surname, bill number, committee name). Set
+  /// by the linker; useful in the UI when the FK is null because no
+  /// matching entity exists yet.
+  rawSubject       String?   @map("raw_subject") @db.VarChar(500)
+  createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  minutes        Minutes               @relation(fields: [minutesId],        references: [id], onDelete: Cascade)
+  representative Representative?       @relation(fields: [representativeId], references: [id], onDelete: SetNull)
+  proposition    Proposition?          @relation(fields: [propositionId],    references: [id], onDelete: SetNull)
+  committee      LegislativeCommittee? @relation(fields: [committeeId],      references: [id], onDelete: SetNull)
+
+  @@index([minutesId])
+  @@index([representativeId, date(sort: Desc)])
+  @@index([propositionId, date(sort: Desc)])
+  @@index([committeeId, date(sort: Desc)])
+  @@index([body, date(sort: Desc)])
+  @@index([actionType])
+  @@map("legislative_actions")
 }
 
 // ============================================
@@ -718,6 +867,8 @@ model Meeting {
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
+
+  minutesDocuments Minutes[]
 
   @@index([body])
   @@index([scheduledAt])
@@ -993,6 +1144,38 @@ model PipelineExecution {
   @@index([manifestId])
   @@index([executedAt])
   @@map("pipeline_executions")
+}
+
+/// Per-source incremental-ingestion checkpoint for handlers that walk a
+/// paginated source descending by date — they stop walking when they hit
+/// an `externalId` (or date) ≤ the watermark. Used by the daily-journal
+/// ingestion handler to avoid re-processing already-ingested journals on
+/// every run, and to bound cold-start work via a `maxNew` cap.
+///
+/// One row per (regionId, sourceUrl, dataType). Updated atomically at
+/// the end of each successful ingestion run with the most-recent item
+/// ingested, so a partial-failure mid-run leaves the watermark at the
+/// last fully-completed item — re-running resumes there.
+///
+/// Reusable: not journal-specific. Future consumers (bulk_download with
+/// FILING_ID watermarks, rep-active-on-date watermarks, etc.) can share
+/// this table by choosing a stable `lastExternalId` form per dataType.
+model IngestionWatermark {
+  id              String    @id @default(uuid())
+  regionId        String    @map("region_id") @db.VarChar(100)
+  sourceUrl       String    @map("source_url") @db.VarChar(1000)
+  dataType        String    @map("data_type") @db.VarChar(50)
+  /// Most recent externalId (or date string) successfully ingested.
+  /// Format depends on dataType: for journals, ISO date `YYYY-MM-DD`.
+  /// Null on first run (handler treats absence as "ingest the cap").
+  lastExternalId  String?   @map("last_external_id") @db.VarChar(255)
+  lastIngestedAt  DateTime? @map("last_ingested_at") @db.Timestamptz
+  itemsIngested   Int       @default(0) @map("items_ingested")
+  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt       DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@unique([regionId, sourceUrl, dataType])
+  @@map("ingestion_watermarks")
 }
 
 // ============================================

--- a/packages/scraping-pipeline/__tests__/ingestion-watermark.spec.ts
+++ b/packages/scraping-pipeline/__tests__/ingestion-watermark.spec.ts
@@ -1,0 +1,131 @@
+import {
+  IngestionWatermarkService,
+  type IngestionWatermarkRecord,
+  type IngestionWatermarkRepository,
+} from "../src/manifest/ingestion-watermark.service";
+
+class InMemoryWatermarkRepo implements IngestionWatermarkRepository {
+  private store = new Map<string, IngestionWatermarkRecord>();
+
+  private key(regionId: string, sourceUrl: string, dataType: string): string {
+    return `${regionId}::${sourceUrl}::${dataType}`;
+  }
+
+  async findFirst(args: {
+    where: { regionId: string; sourceUrl: string; dataType: string };
+  }): Promise<IngestionWatermarkRecord | null> {
+    return (
+      this.store.get(
+        this.key(
+          args.where.regionId,
+          args.where.sourceUrl,
+          args.where.dataType,
+        ),
+      ) ?? null
+    );
+  }
+
+  async upsert(args: {
+    where: { regionId: string; sourceUrl: string; dataType: string };
+    create: Omit<IngestionWatermarkRecord, "createdAt" | "updatedAt">;
+    update: Partial<IngestionWatermarkRecord>;
+  }): Promise<IngestionWatermarkRecord> {
+    const k = this.key(
+      args.where.regionId,
+      args.where.sourceUrl,
+      args.where.dataType,
+    );
+    const existing = this.store.get(k);
+    const now = new Date();
+    if (!existing) {
+      const record: IngestionWatermarkRecord = {
+        ...args.create,
+        createdAt: now,
+        updatedAt: now,
+      };
+      this.store.set(k, record);
+      return record;
+    }
+
+    // Mimic Prisma's `{ increment: N }` semantics for itemsIngested.
+    const itemsIngested = (() => {
+      const u = args.update.itemsIngested;
+      if (typeof u === "number") return u;
+      if (
+        u &&
+        typeof u === "object" &&
+        "increment" in (u as Record<string, unknown>)
+      ) {
+        return (
+          existing.itemsIngested +
+          ((u as unknown as { increment: number }).increment ?? 0)
+        );
+      }
+      return existing.itemsIngested;
+    })();
+
+    const updated: IngestionWatermarkRecord = {
+      ...existing,
+      ...args.update,
+      itemsIngested,
+      updatedAt: now,
+    };
+    this.store.set(k, updated);
+    return updated;
+  }
+}
+
+describe("IngestionWatermarkService", () => {
+  let repo: InMemoryWatermarkRepo;
+  let svc: IngestionWatermarkService;
+
+  beforeEach(() => {
+    repo = new InMemoryWatermarkRepo();
+    svc = new IngestionWatermarkService(repo);
+  });
+
+  it("returns undefined when no watermark exists", async () => {
+    const wm = await svc.read(
+      "ca",
+      "https://example/journals",
+      "legislative_actions",
+    );
+    expect(wm).toBeUndefined();
+  });
+
+  it("creates a fresh watermark on first advance", async () => {
+    const wm = await svc.advance(
+      "ca",
+      "https://example/journals",
+      "legislative_actions",
+      "ca-legislative_actions-2026-04-28",
+      1,
+    );
+    expect(wm.lastExternalId).toBe("ca-legislative_actions-2026-04-28");
+    expect(wm.itemsIngested).toBe(1);
+    expect(wm.lastIngestedAt).toBeInstanceOf(Date);
+  });
+
+  it("advances an existing watermark and increments itemsIngested", async () => {
+    await svc.advance("ca", "https://x", "legislative_actions", "id-1", 1);
+    const second = await svc.advance(
+      "ca",
+      "https://x",
+      "legislative_actions",
+      "id-2",
+      3,
+    );
+    expect(second.lastExternalId).toBe("id-2");
+    expect(second.itemsIngested).toBe(4);
+  });
+
+  it("scopes watermarks per (region, sourceUrl, dataType)", async () => {
+    await svc.advance("ca", "https://x", "legislative_actions", "ca-id", 1);
+    await svc.advance("tx", "https://x", "legislative_actions", "tx-id", 1);
+
+    const ca = await svc.read("ca", "https://x", "legislative_actions");
+    const tx = await svc.read("tx", "https://x", "legislative_actions");
+    expect(ca?.lastExternalId).toBe("ca-id");
+    expect(tx?.lastExternalId).toBe("tx-id");
+  });
+});

--- a/packages/scraping-pipeline/__tests__/ingestion-watermark.spec.ts
+++ b/packages/scraping-pipeline/__tests__/ingestion-watermark.spec.ts
@@ -85,11 +85,7 @@ describe("IngestionWatermarkService", () => {
   });
 
   it("returns undefined when no watermark exists", async () => {
-    const wm = await svc.read(
-      "ca",
-      "https://example/journals",
-      "legislative_actions",
-    );
+    const wm = await svc.read("ca", "https://example/journals", "meetings");
     expect(wm).toBeUndefined();
   });
 
@@ -97,34 +93,28 @@ describe("IngestionWatermarkService", () => {
     const wm = await svc.advance(
       "ca",
       "https://example/journals",
-      "legislative_actions",
-      "ca-legislative_actions-2026-04-28",
+      "meetings",
+      "ca-meetings-2026-04-28",
       1,
     );
-    expect(wm.lastExternalId).toBe("ca-legislative_actions-2026-04-28");
+    expect(wm.lastExternalId).toBe("ca-meetings-2026-04-28");
     expect(wm.itemsIngested).toBe(1);
     expect(wm.lastIngestedAt).toBeInstanceOf(Date);
   });
 
   it("advances an existing watermark and increments itemsIngested", async () => {
-    await svc.advance("ca", "https://x", "legislative_actions", "id-1", 1);
-    const second = await svc.advance(
-      "ca",
-      "https://x",
-      "legislative_actions",
-      "id-2",
-      3,
-    );
+    await svc.advance("ca", "https://x", "meetings", "id-1", 1);
+    const second = await svc.advance("ca", "https://x", "meetings", "id-2", 3);
     expect(second.lastExternalId).toBe("id-2");
     expect(second.itemsIngested).toBe(4);
   });
 
   it("scopes watermarks per (region, sourceUrl, dataType)", async () => {
-    await svc.advance("ca", "https://x", "legislative_actions", "ca-id", 1);
-    await svc.advance("tx", "https://x", "legislative_actions", "tx-id", 1);
+    await svc.advance("ca", "https://x", "meetings", "ca-id", 1);
+    await svc.advance("tx", "https://x", "meetings", "tx-id", 1);
 
-    const ca = await svc.read("ca", "https://x", "legislative_actions");
-    const tx = await svc.read("tx", "https://x", "legislative_actions");
+    const ca = await svc.read("ca", "https://x", "meetings");
+    const tx = await svc.read("tx", "https://x", "meetings");
     expect(ca?.lastExternalId).toBe("ca-id");
     expect(tx?.lastExternalId).toBe("tx-id");
   });

--- a/packages/scraping-pipeline/__tests__/minutes-ingest.handler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/minutes-ingest.handler.spec.ts
@@ -45,7 +45,7 @@ class FakeExtraction {
 
 const SOURCE: DataSourceConfig = {
   url: "https://clerk.example/journals",
-  dataType: "legislative_actions" as DataSourceConfig["dataType"],
+  dataType: "meetings" as DataSourceConfig["dataType"],
   contentGoal: "test",
   category: "Assembly",
   sourceType: "pdf_archive",
@@ -141,9 +141,9 @@ describe("MinutesIngestHandler", () => {
 
     const externalIds = result.items.map((b) => b.minutes.externalId).sort();
     expect(externalIds).toEqual([
-      "ca-legislative_actions-2026-04-21-r1",
-      "ca-legislative_actions-2026-04-27",
-      "ca-legislative_actions-2026-04-28",
+      "ca-meetings-2026-04-21-r1",
+      "ca-meetings-2026-04-27",
+      "ca-meetings-2026-04-28",
     ]);
     // Each Minutes carries the PDF text + body (from category).
     for (const bundle of result.items) {
@@ -177,7 +177,7 @@ describe("MinutesIngestHandler", () => {
       "ca",
       SOURCE.url,
       SOURCE.dataType,
-      "ca-legislative_actions-2026-04-27",
+      "ca-meetings-2026-04-27",
       0,
     );
 
@@ -186,13 +186,11 @@ describe("MinutesIngestHandler", () => {
 
     // Only Apr 28 is new — listing walk halts when it hits the watermark id.
     expect(result.items).toHaveLength(1);
-    expect(result.items[0].minutes.externalId).toBe(
-      "ca-legislative_actions-2026-04-28",
-    );
+    expect(result.items[0].minutes.externalId).toBe("ca-meetings-2026-04-28");
 
     // Watermark advances to the newest ingested.
     const wm = await watermarks.read("ca", SOURCE.url, SOURCE.dataType);
-    expect(wm?.lastExternalId).toBe("ca-legislative_actions-2026-04-28");
+    expect(wm?.lastExternalId).toBe("ca-meetings-2026-04-28");
   });
 
   it("caps cold-start ingestion at maxNew", async () => {
@@ -205,10 +203,7 @@ describe("MinutesIngestHandler", () => {
     expect(result.items).toHaveLength(2);
     // The two newest documents win (Apr 28 + Apr 27).
     const ids = result.items.map((b) => b.minutes.externalId).sort();
-    expect(ids).toEqual([
-      "ca-legislative_actions-2026-04-27",
-      "ca-legislative_actions-2026-04-28",
-    ]);
+    expect(ids).toEqual(["ca-meetings-2026-04-27", "ca-meetings-2026-04-28"]);
   });
 
   it("captures revisionSeq from filenames matching revisionPattern", async () => {
@@ -216,7 +211,7 @@ describe("MinutesIngestHandler", () => {
     const handler = new MinutesIngestHandler(fake as never);
     const result = await handler.execute(SOURCE, "ca");
     const revised = result.items.find(
-      (b) => b.minutes.externalId === "ca-legislative_actions-2026-04-21-r1",
+      (b) => b.minutes.externalId === "ca-meetings-2026-04-21-r1",
     );
     expect(revised).toBeDefined();
     expect(revised!.minutes.revisionSeq).toBe(1);

--- a/packages/scraping-pipeline/__tests__/minutes-ingest.handler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/minutes-ingest.handler.spec.ts
@@ -1,0 +1,235 @@
+import type { DataSourceConfig } from "@opuspopuli/common";
+import { MinutesIngestHandler } from "../src/handlers/minutes-ingest.handler";
+import {
+  IngestionWatermarkService,
+  type IngestionWatermarkRepository,
+} from "../src/manifest/ingestion-watermark.service";
+
+interface FetchedHtml {
+  content: string;
+  fromCache?: boolean;
+  statusCode?: number;
+  contentType?: string;
+}
+
+class FakeExtraction {
+  // Map url → html or pdf-text content
+  htmlByUrl = new Map<string, string>();
+  pdfTextByUrl = new Map<string, string>();
+  fetchHtmlCalls: string[] = [];
+  fetchPdfCalls: string[] = [];
+
+  async fetchWithRetry(url: string): Promise<FetchedHtml> {
+    this.fetchHtmlCalls.push(url);
+    const content = this.htmlByUrl.get(url);
+    if (content === undefined) {
+      throw new Error(`Unexpected fetchWithRetry for ${url}`);
+    }
+    return {
+      content,
+      fromCache: false,
+      statusCode: 200,
+      contentType: "text/html",
+    };
+  }
+
+  async fetchPdfText(url: string): Promise<string> {
+    this.fetchPdfCalls.push(url);
+    const content = this.pdfTextByUrl.get(url);
+    if (content === undefined) {
+      throw new Error(`Unexpected fetchPdfText for ${url}`);
+    }
+    return content;
+  }
+}
+
+const SOURCE: DataSourceConfig = {
+  url: "https://clerk.example/journals",
+  dataType: "legislative_actions" as DataSourceConfig["dataType"],
+  contentGoal: "test",
+  category: "Assembly",
+  sourceType: "pdf_archive",
+  pdfArchive: {
+    linkSelector: "a[href$='.pdf']",
+    datePattern: "adj(\\d{2})(\\d{2})(\\d{2})(?:_r\\d+)?\\.pdf",
+    dateFormat: "MMDDYY",
+    revisionPattern: "_r(\\d+)\\.pdf$",
+    maxNew: 10,
+    maxPages: 1,
+  },
+};
+
+const LISTING_HTML = `
+  <html><body>
+    <a href="/files/adj042826.pdf">April 28, 2026</a>
+    <a href="/files/adj042726.pdf">April 27, 2026</a>
+    <a href="/files/adj042126_r1.pdf">April 21, 2026 (revised)</a>
+    <a href="/files/skip-me.html">irrelevant link</a>
+  </body></html>
+`;
+
+const PDF_TEXT_2026_04_28 = "Tuesday, April 28, 2026\nROLLCALL\n[ ... ]";
+const PDF_TEXT_2026_04_27 = "Monday, April 27, 2026\nROLLCALL\n[ ... ]";
+const PDF_TEXT_2026_04_21_R1 = "Monday, April 21, 2026 (revised)\n[ ... ]";
+
+class InMemoryWatermarkRepo implements IngestionWatermarkRepository {
+  records = new Map<string, any>();
+
+  async findFirst(args: {
+    where: { regionId: string; sourceUrl: string; dataType: string };
+  }) {
+    const key = `${args.where.regionId}::${args.where.sourceUrl}::${args.where.dataType}`;
+    return this.records.get(key) ?? null;
+  }
+
+  async upsert(args: {
+    where: { regionId: string; sourceUrl: string; dataType: string };
+    create: any;
+    update: any;
+  }) {
+    const key = `${args.where.regionId}::${args.where.sourceUrl}::${args.where.dataType}`;
+    const existing = this.records.get(key);
+    const now = new Date();
+    if (!existing) {
+      const record = { ...args.create, createdAt: now, updatedAt: now };
+      this.records.set(key, record);
+      return record;
+    }
+    let itemsIngested = existing.itemsIngested;
+    const u = args.update.itemsIngested;
+    if (u && typeof u === "object" && "increment" in u) {
+      itemsIngested += u.increment;
+    }
+    const updated = {
+      ...existing,
+      ...args.update,
+      itemsIngested,
+      updatedAt: now,
+    };
+    this.records.set(key, updated);
+    return updated;
+  }
+}
+
+const setupExtraction = (): FakeExtraction => {
+  const fake = new FakeExtraction();
+  fake.htmlByUrl.set("https://clerk.example/journals", LISTING_HTML);
+  fake.pdfTextByUrl.set(
+    "https://clerk.example/files/adj042826.pdf",
+    PDF_TEXT_2026_04_28,
+  );
+  fake.pdfTextByUrl.set(
+    "https://clerk.example/files/adj042726.pdf",
+    PDF_TEXT_2026_04_27,
+  );
+  fake.pdfTextByUrl.set(
+    "https://clerk.example/files/adj042126_r1.pdf",
+    PDF_TEXT_2026_04_21_R1,
+  );
+  return fake;
+};
+
+describe("MinutesIngestHandler", () => {
+  it("walks the listing, fetches each PDF, and emits one Minutes per document", async () => {
+    const fake = setupExtraction();
+    const handler = new MinutesIngestHandler(fake as never);
+    const result = await handler.execute(SOURCE, "ca");
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.items).toHaveLength(3);
+
+    const externalIds = result.items.map((b) => b.minutes.externalId).sort();
+    expect(externalIds).toEqual([
+      "ca-legislative_actions-2026-04-21-r1",
+      "ca-legislative_actions-2026-04-27",
+      "ca-legislative_actions-2026-04-28",
+    ]);
+    // Each Minutes carries the PDF text + body (from category).
+    for (const bundle of result.items) {
+      expect(bundle.minutes.body).toBe("Assembly");
+      expect(
+        bundle.minutes.rawText && bundle.minutes.rawText.length,
+      ).toBeGreaterThan(0);
+      expect(bundle.minutes.isActive).toBe(true);
+      // V1 fetcher returns empty actions; the backend linker fills these in.
+      expect(bundle.actions).toEqual([]);
+    }
+  });
+
+  it("processes oldest → newest (so a partial failure leaves watermark advanced only to last success)", async () => {
+    const fake = setupExtraction();
+    const handler = new MinutesIngestHandler(fake as never);
+    await handler.execute(SOURCE, "ca");
+    expect(fake.fetchPdfCalls).toEqual([
+      "https://clerk.example/files/adj042126_r1.pdf",
+      "https://clerk.example/files/adj042726.pdf",
+      "https://clerk.example/files/adj042826.pdf",
+    ]);
+  });
+
+  it("respects the watermark and stops at previously-ingested documents", async () => {
+    const fake = setupExtraction();
+    const repo = new InMemoryWatermarkRepo();
+    const watermarks = new IngestionWatermarkService(repo);
+    // Pretend Apr 27 is already ingested.
+    await watermarks.advance(
+      "ca",
+      SOURCE.url,
+      SOURCE.dataType,
+      "ca-legislative_actions-2026-04-27",
+      0,
+    );
+
+    const handler = new MinutesIngestHandler(fake as never, watermarks);
+    const result = await handler.execute(SOURCE, "ca");
+
+    // Only Apr 28 is new — listing walk halts when it hits the watermark id.
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].minutes.externalId).toBe(
+      "ca-legislative_actions-2026-04-28",
+    );
+
+    // Watermark advances to the newest ingested.
+    const wm = await watermarks.read("ca", SOURCE.url, SOURCE.dataType);
+    expect(wm?.lastExternalId).toBe("ca-legislative_actions-2026-04-28");
+  });
+
+  it("caps cold-start ingestion at maxNew", async () => {
+    const fake = setupExtraction();
+    const handler = new MinutesIngestHandler(fake as never);
+    const result = await handler.execute(
+      { ...SOURCE, pdfArchive: { ...SOURCE.pdfArchive!, maxNew: 2 } },
+      "ca",
+    );
+    expect(result.items).toHaveLength(2);
+    // The two newest documents win (Apr 28 + Apr 27).
+    const ids = result.items.map((b) => b.minutes.externalId).sort();
+    expect(ids).toEqual([
+      "ca-legislative_actions-2026-04-27",
+      "ca-legislative_actions-2026-04-28",
+    ]);
+  });
+
+  it("captures revisionSeq from filenames matching revisionPattern", async () => {
+    const fake = setupExtraction();
+    const handler = new MinutesIngestHandler(fake as never);
+    const result = await handler.execute(SOURCE, "ca");
+    const revised = result.items.find(
+      (b) => b.minutes.externalId === "ca-legislative_actions-2026-04-21-r1",
+    );
+    expect(revised).toBeDefined();
+    expect(revised!.minutes.revisionSeq).toBe(1);
+  });
+
+  it("fails gracefully when the source is missing pdfArchive config", async () => {
+    const fake = setupExtraction();
+    const handler = new MinutesIngestHandler(fake as never);
+    const result = await handler.execute(
+      { ...SOURCE, pdfArchive: undefined },
+      "ca",
+    );
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toMatch(/missing 'pdfArchive'/);
+  });
+});

--- a/packages/scraping-pipeline/__tests__/pipeline.integration.spec.ts
+++ b/packages/scraping-pipeline/__tests__/pipeline.integration.spec.ts
@@ -183,6 +183,7 @@ describe("Pipeline Integration Tests", () => {
       bulkDownload,
       apiIngest,
       {} as any,
+      {} as any,
       { enrichItems: jest.fn().mockImplementation((r: any) => r) } as any,
     );
   });

--- a/packages/scraping-pipeline/__tests__/pipeline.spec.ts
+++ b/packages/scraping-pipeline/__tests__/pipeline.spec.ts
@@ -135,6 +135,7 @@ describe("ScrapingPipelineService", () => {
       {} as unknown as BulkDownloadHandler,
       {} as unknown as ApiIngestHandler,
       {} as any,
+      {} as any,
       { enrichItems: jest.fn().mockImplementation((r: any) => r) } as any,
     );
   });
@@ -320,6 +321,7 @@ describe("ScrapingPipelineService", () => {
         mockHealing,
         mockBulkDownload,
         mockApiIngest,
+        {} as any,
         {} as any,
         { enrichItems: jest.fn().mockImplementation((r: any) => r) } as any,
       );

--- a/packages/scraping-pipeline/src/handlers/minutes-ingest.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/minutes-ingest.handler.ts
@@ -1,0 +1,412 @@
+/**
+ * Minutes Ingest Handler
+ *
+ * Handles `sourceType: pdf_archive` — paginated listing pages that
+ * link to a series of dated PDF documents (CA Assembly daily journals,
+ * federal Congressional Record, etc.). Each linked PDF is fetched,
+ * pdf-parsed, and emitted as a `Minutes` record. Per-document parsing
+ * (text → action records) is a downstream backend pass, not this
+ * handler's responsibility.
+ *
+ * Cold-start protection: the handler reads the watermark for the
+ * source before walking, sorts candidates descending by date, and
+ * stops at either the watermark's `lastExternalId` or the configured
+ * `maxNew` cap (default 10). Documents are processed in ASCENDING
+ * order so a partial failure leaves the watermark advanced only as
+ * far as the last successful document.
+ *
+ * Issue #665.
+ */
+
+import { Inject, Injectable, Logger, Optional } from "@nestjs/common";
+import * as cheerio from "cheerio";
+import {
+  type DataSourceConfig,
+  type ExtractionResult,
+  type Minutes,
+  type MinutesWithActions,
+  type PdfArchiveConfig,
+} from "@opuspopuli/common";
+import { ExtractionProvider } from "@opuspopuli/extraction-provider";
+import { IngestionWatermarkService } from "../manifest/ingestion-watermark.service.js";
+
+/** Maximum bytes of pdf-parse output stored on Minutes.rawText. */
+const MAX_RAW_TEXT_CHARS = 256 * 1024;
+
+interface ListingCandidate {
+  url: string;
+  date: Date;
+  revisionSeq: number;
+  externalIdHint: string;
+}
+
+@Injectable()
+export class MinutesIngestHandler {
+  private readonly logger = new Logger(MinutesIngestHandler.name);
+
+  constructor(
+    private readonly extraction: ExtractionProvider,
+    @Optional() private readonly watermarks?: IngestionWatermarkService,
+  ) {}
+
+  async execute(
+    source: DataSourceConfig,
+    regionId: string,
+  ): Promise<ExtractionResult<MinutesWithActions>> {
+    const start = Date.now();
+    const warnings: string[] = [];
+    const errors: string[] = [];
+
+    if (!source.pdfArchive) {
+      errors.push("pdf_archive source missing 'pdfArchive' configuration");
+      return this.emptyResult(errors, warnings, start);
+    }
+
+    const cfg = source.pdfArchive;
+    const maxPages = cfg.maxPages ?? 10;
+    const maxNew = cfg.maxNew ?? 10;
+
+    this.logger.log(
+      `Pipeline started [pdf_archive]: ${regionId}/${source.dataType} from ${source.url} (maxNew=${maxNew})`,
+    );
+
+    let watermarkLastId: string | undefined;
+    if (this.watermarks) {
+      const watermark = await this.watermarks.read(
+        regionId,
+        source.url,
+        source.dataType,
+      );
+      watermarkLastId = watermark?.lastExternalId;
+      if (watermarkLastId) {
+        this.logger.debug(`Watermark for ${source.url}: ${watermarkLastId}`);
+      }
+    }
+
+    let candidates: ListingCandidate[];
+    try {
+      candidates = await this.walkListing(
+        source.url,
+        cfg,
+        maxPages,
+        maxNew,
+        watermarkLastId,
+        regionId,
+        source.dataType,
+      );
+    } catch (e) {
+      errors.push(
+        `Listing walk failed for ${source.url}: ${(e as Error).message}`,
+      );
+      return this.emptyResult(errors, warnings, start);
+    }
+
+    if (candidates.length === 0) {
+      this.logger.log(
+        `No new documents at ${source.url} (watermark hit or empty listing)`,
+      );
+      return {
+        items: [],
+        manifestVersion: 0,
+        success: true,
+        warnings,
+        errors,
+        extractionTimeMs: Date.now() - start,
+      };
+    }
+
+    this.logger.log(
+      `Discovered ${candidates.length} new document(s) at ${source.url}`,
+    );
+
+    // Process oldest → newest so a mid-stream failure leaves the
+    // watermark advanced only to the last successful row.
+    candidates.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    const results: MinutesWithActions[] = [];
+    for (const candidate of candidates) {
+      try {
+        const minutes = await this.fetchAndParseDocument(
+          candidate,
+          source,
+          regionId,
+        );
+        results.push({ minutes, actions: [] });
+        if (this.watermarks) {
+          await this.watermarks.advance(
+            regionId,
+            source.url,
+            source.dataType,
+            minutes.externalId,
+            1,
+          );
+        }
+      } catch (e) {
+        const msg = `Failed to ingest ${candidate.url}: ${(e as Error).message}`;
+        this.logger.warn(msg);
+        warnings.push(msg);
+      }
+    }
+
+    const totalMs = Date.now() - start;
+    this.logger.log(
+      `Pipeline complete [pdf_archive]: ${results.length} Minutes ingested in ${totalMs}ms (${warnings.length} warnings)`,
+    );
+
+    return {
+      items: results,
+      manifestVersion: 0,
+      success: results.length > 0 || candidates.length === 0,
+      warnings,
+      errors,
+      extractionTimeMs: totalMs,
+    };
+  }
+
+  private async walkListing(
+    listingUrl: string,
+    cfg: PdfArchiveConfig,
+    maxPages: number,
+    maxNew: number,
+    watermarkLastId: string | undefined,
+    regionId: string,
+    dataType: string,
+  ): Promise<ListingCandidate[]> {
+    const collected: ListingCandidate[] = [];
+    const seenUrls = new Set<string>();
+
+    for (let page = 1; page <= maxPages; page++) {
+      const pageUrl = this.pageUrl(listingUrl, cfg.paginationParam, page);
+      const fetched = await this.extraction.fetchWithRetry(pageUrl);
+      const $ = cheerio.load(fetched.content);
+
+      const elements = $(cfg.linkSelector);
+      if (elements.length === 0) {
+        if (page === 1) {
+          this.logger.warn(
+            `No matches for selector '${cfg.linkSelector}' on ${pageUrl}`,
+          );
+        }
+        break;
+      }
+
+      let pageProducedNew = false;
+      for (const el of elements.toArray()) {
+        const href = $(el).attr("href");
+        if (!href) continue;
+
+        const absoluteUrl = this.resolveUrl(href, pageUrl);
+        if (seenUrls.has(absoluteUrl)) continue;
+        seenUrls.add(absoluteUrl);
+
+        const candidate = this.parseCandidate(
+          absoluteUrl,
+          $(el).text() ?? "",
+          cfg,
+          regionId,
+          dataType,
+        );
+        if (!candidate) continue;
+
+        // Stop walking once we hit the watermark — the listing is
+        // descending by date, so anything beyond is already ingested.
+        if (watermarkLastId && candidate.externalIdHint === watermarkLastId) {
+          this.logger.debug(
+            `Watermark hit at ${absoluteUrl} — stopping listing walk`,
+          );
+          return collected;
+        }
+
+        collected.push(candidate);
+        pageProducedNew = true;
+
+        if (collected.length >= maxNew) {
+          this.logger.log(`Hit maxNew=${maxNew} cap — stopping listing walk`);
+          return collected;
+        }
+      }
+
+      // Defensive: if a page yields no NEW candidates (all duplicates
+      // or unparseable) the listing isn't progressing — bail out
+      // instead of fetching maxPages identical pages.
+      if (!pageProducedNew) {
+        break;
+      }
+
+      if (!cfg.paginationParam) {
+        // Unpaginated listing — one fetch is the whole listing.
+        break;
+      }
+    }
+
+    return collected;
+  }
+
+  private pageUrl(
+    base: string,
+    paginationParam: string | undefined,
+    page: number,
+  ): string {
+    if (!paginationParam || page === 1) return base;
+    const sep = base.includes("?") ? "&" : "?";
+    return `${base}${sep}${paginationParam}=${page}`;
+  }
+
+  private resolveUrl(href: string, baseUrl: string): string {
+    try {
+      return new URL(href, baseUrl).toString();
+    } catch {
+      return href;
+    }
+  }
+
+  private parseCandidate(
+    url: string,
+    anchorText: string,
+    cfg: PdfArchiveConfig,
+    regionId: string,
+    dataType: string,
+  ): ListingCandidate | undefined {
+    const date = this.extractDate(url, anchorText, cfg);
+    if (!date) return undefined;
+
+    const revisionSeq = this.extractRevisionSeq(url, cfg);
+    const externalIdHint = this.candidateExternalId(
+      regionId,
+      dataType,
+      date,
+      revisionSeq,
+    );
+    return { url, date, revisionSeq, externalIdHint };
+  }
+
+  private extractDate(
+    url: string,
+    anchorText: string,
+    cfg: PdfArchiveConfig,
+  ): Date | undefined {
+    if (!cfg.datePattern) return undefined;
+    const re = new RegExp(cfg.datePattern);
+    const match = re.exec(url) ?? re.exec(anchorText);
+    if (!match) return undefined;
+
+    const format = cfg.dateFormat ?? "MMDDYY";
+    switch (format) {
+      case "MMDDYY": {
+        const [, mm, dd, yy] = match;
+        if (!mm || !dd || !yy) return undefined;
+        return this.utcDate(2000 + Number(yy), Number(mm), Number(dd));
+      }
+      case "YYYY-MM-DD": {
+        const [, yyyy, mm, dd] = match;
+        if (!yyyy || !mm || !dd) return undefined;
+        return this.utcDate(Number(yyyy), Number(mm), Number(dd));
+      }
+      case "MM/DD/YYYY": {
+        const [, mm, dd, yyyy] = match;
+        if (!mm || !dd || !yyyy) return undefined;
+        return this.utcDate(Number(yyyy), Number(mm), Number(dd));
+      }
+      default:
+        return undefined;
+    }
+  }
+
+  private utcDate(year: number, month: number, day: number): Date | undefined {
+    if (
+      Number.isNaN(year) ||
+      Number.isNaN(month) ||
+      Number.isNaN(day) ||
+      month < 1 ||
+      month > 12 ||
+      day < 1 ||
+      day > 31
+    ) {
+      return undefined;
+    }
+    return new Date(Date.UTC(year, month - 1, day));
+  }
+
+  private extractRevisionSeq(url: string, cfg: PdfArchiveConfig): number {
+    if (!cfg.revisionPattern) return 0;
+    const m = new RegExp(cfg.revisionPattern).exec(url);
+    if (!m || !m[1]) return 0;
+    const n = Number(m[1]);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  }
+
+  private candidateExternalId(
+    regionId: string,
+    dataType: string,
+    date: Date,
+    revisionSeq: number,
+  ): string {
+    const ymd = date.toISOString().slice(0, 10);
+    const base = `${regionId}-${dataType}-${ymd}`;
+    return revisionSeq > 0 ? `${base}-r${revisionSeq}` : base;
+  }
+
+  private async fetchAndParseDocument(
+    candidate: ListingCandidate,
+    source: DataSourceConfig,
+    regionId: string,
+  ): Promise<Minutes> {
+    this.logger.log(`Fetching PDF: ${candidate.url}`);
+    const rawText = await this.extraction.fetchPdfText(candidate.url);
+    const truncated =
+      rawText.length > MAX_RAW_TEXT_CHARS
+        ? rawText.slice(0, MAX_RAW_TEXT_CHARS)
+        : rawText;
+    const pageCount = this.estimatePageCount(rawText);
+    const body = this.deriveBody(source);
+
+    return {
+      externalId: candidate.externalIdHint,
+      body,
+      date: candidate.date,
+      revisionSeq: candidate.revisionSeq,
+      isActive: true,
+      pageCount,
+      sourceUrl: candidate.url,
+      rawText: truncated,
+      parsedAt: new Date(),
+    };
+  }
+
+  /**
+   * Page-count estimate from raw text. pdf-parse emits a `\f`
+   * form-feed between pages; falls back to character heuristics when
+   * the source PDF doesn't preserve those.
+   */
+  private estimatePageCount(rawText: string): number | undefined {
+    if (!rawText) return undefined;
+    const formFeeds = (rawText.match(/\f/g) ?? []).length;
+    if (formFeeds > 0) return formFeeds + 1;
+    return undefined;
+  }
+
+  /**
+   * Best-effort `body` derivation. For the MVP this leans on the
+   * source `category` (e.g. 'Assembly', 'Senate') — the
+   * categories already present on every CA dataSource. Falls back
+   * to '' when not present; the linker can refine downstream.
+   */
+  private deriveBody(source: DataSourceConfig): string {
+    return source.category ?? "";
+  }
+
+  private emptyResult(
+    errors: string[],
+    warnings: string[],
+    start: number,
+  ): ExtractionResult<MinutesWithActions> {
+    return {
+      items: [],
+      manifestVersion: 0,
+      success: false,
+      warnings,
+      errors,
+      extractionTimeMs: Date.now() - start,
+    };
+  }
+}

--- a/packages/scraping-pipeline/src/manifest/ingestion-watermark.service.ts
+++ b/packages/scraping-pipeline/src/manifest/ingestion-watermark.service.ts
@@ -1,0 +1,121 @@
+/**
+ * Ingestion Watermark Service
+ *
+ * Tracks the most recently ingested item per (region, sourceUrl,
+ * dataType) for cold-start protection on listing-walk sources (CA
+ * Assembly daily journals, federal Congressional Record, etc.).
+ *
+ * The pdf_archive handler reads the watermark before walking the
+ * listing page and stops descending once it hits a previously-seen
+ * `lastExternalId`. After a successful walk, the watermark advances
+ * to the most recent ingested item.
+ *
+ * Repository abstraction mirrors `manifest-store.service.ts` so
+ * consumers can wire any persistence backend (Prisma is the prod
+ * default; tests use an in-memory fake).
+ */
+
+import { Injectable, Logger } from "@nestjs/common";
+
+export interface IngestionWatermarkRecord {
+  id: string;
+  regionId: string;
+  sourceUrl: string;
+  dataType: string;
+  lastExternalId: string | null;
+  lastIngestedAt: Date | null;
+  itemsIngested: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface IngestionWatermarkRepository {
+  findFirst(args: {
+    where: { regionId: string; sourceUrl: string; dataType: string };
+  }): Promise<IngestionWatermarkRecord | null>;
+
+  upsert(args: {
+    where: { regionId: string; sourceUrl: string; dataType: string };
+    create: Omit<IngestionWatermarkRecord, "createdAt" | "updatedAt">;
+    update: Partial<
+      Omit<
+        IngestionWatermarkRecord,
+        "id" | "regionId" | "sourceUrl" | "dataType" | "createdAt"
+      >
+    >;
+  }): Promise<IngestionWatermarkRecord>;
+}
+
+export interface IngestionWatermark {
+  regionId: string;
+  sourceUrl: string;
+  dataType: string;
+  lastExternalId?: string;
+  lastIngestedAt?: Date;
+  itemsIngested: number;
+}
+
+@Injectable()
+export class IngestionWatermarkService {
+  private readonly logger = new Logger(IngestionWatermarkService.name);
+
+  constructor(private readonly repository: IngestionWatermarkRepository) {}
+
+  async read(
+    regionId: string,
+    sourceUrl: string,
+    dataType: string,
+  ): Promise<IngestionWatermark | undefined> {
+    const record = await this.repository.findFirst({
+      where: { regionId, sourceUrl, dataType },
+    });
+    return record ? this.toWatermark(record) : undefined;
+  }
+
+  /**
+   * Advance the watermark to a new high-water mark. `itemsIngestedDelta`
+   * is added to the running counter so the per-cycle volume can be
+   * surfaced on a long-lived row without read-modify-write churn.
+   */
+  async advance(
+    regionId: string,
+    sourceUrl: string,
+    dataType: string,
+    lastExternalId: string,
+    itemsIngestedDelta: number,
+  ): Promise<IngestionWatermark> {
+    const now = new Date();
+    const record = await this.repository.upsert({
+      where: { regionId, sourceUrl, dataType },
+      create: {
+        id: crypto.randomUUID(),
+        regionId,
+        sourceUrl,
+        dataType,
+        lastExternalId,
+        lastIngestedAt: now,
+        itemsIngested: itemsIngestedDelta,
+      },
+      update: {
+        lastExternalId,
+        lastIngestedAt: now,
+        itemsIngested: { increment: itemsIngestedDelta } as unknown as number,
+      },
+    });
+    this.logger.log(
+      `Watermark advanced: ${regionId}/${dataType}@${sourceUrl} → ${lastExternalId} (+${itemsIngestedDelta})`,
+    );
+    return this.toWatermark(record);
+  }
+
+  private toWatermark(record: IngestionWatermarkRecord): IngestionWatermark {
+    return {
+      regionId: record.regionId,
+      sourceUrl: record.sourceUrl,
+      dataType: record.dataType,
+      lastExternalId: record.lastExternalId ?? undefined,
+      lastIngestedAt: record.lastIngestedAt ?? undefined,
+      itemsIngested: record.itemsIngested,
+    };
+  }
+}

--- a/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
+++ b/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
@@ -29,6 +29,7 @@ import { SelfHealingService } from "../healing/self-healing.service.js";
 import { BulkDownloadHandler } from "../handlers/bulk-download.handler.js";
 import { ApiIngestHandler } from "../handlers/api-ingest.handler.js";
 import { PdfExtractHandler } from "../handlers/pdf-extract.handler.js";
+import { MinutesIngestHandler } from "../handlers/minutes-ingest.handler.js";
 import { DetailCrawlerService } from "../crawling/detail-crawler.service.js";
 
 @Injectable()
@@ -46,6 +47,7 @@ export class ScrapingPipelineService {
     private readonly bulkDownload: BulkDownloadHandler,
     private readonly apiIngest: ApiIngestHandler,
     private readonly pdfExtract: PdfExtractHandler,
+    private readonly minutesIngest: MinutesIngestHandler,
     private readonly detailCrawler: DetailCrawlerService,
   ) {}
 
@@ -71,10 +73,27 @@ export class ScrapingPipelineService {
         return this.executeApiIngest<T>(source, regionId);
       case "pdf":
         return this.executePdfExtract<T>(source, regionId);
+      case "pdf_archive":
+        return this.executePdfArchive<T>(source, regionId);
       case "html_scrape":
       default:
         return this.executeHtmlScrape<T>(source, regionId);
     }
+  }
+
+  /**
+   * Execute pdf_archive ingestion: listing-walk → per-PDF fetch +
+   * pdf-parse → emit one MinutesWithActions per document. The
+   * downstream backend linker mines stored rawText to produce
+   * LegislativeAction rows post-sync.
+   */
+  private async executePdfArchive<T>(
+    source: DataSourceConfig,
+    regionId: string,
+  ): Promise<ExtractionResult<T>> {
+    return this.minutesIngest.execute(source, regionId) as unknown as Promise<
+      ExtractionResult<T>
+    >;
   }
 
   /**

--- a/packages/scraping-pipeline/src/scraping-pipeline.module.ts
+++ b/packages/scraping-pipeline/src/scraping-pipeline.module.ts
@@ -12,6 +12,10 @@ import {
   ManifestStoreService,
   type ManifestRepository,
 } from "./manifest/manifest-store.service.js";
+import {
+  IngestionWatermarkService,
+  type IngestionWatermarkRepository,
+} from "./manifest/ingestion-watermark.service.js";
 import { ManifestExtractorService } from "./extraction/manifest-extractor.service.js";
 import { ExtractionValidator } from "./extraction/extraction-validator.js";
 import { DomainMapperService } from "./mapping/domain-mapper.service.js";
@@ -19,6 +23,7 @@ import { SelfHealingService } from "./healing/self-healing.service.js";
 import { BulkDownloadHandler } from "./handlers/bulk-download.handler.js";
 import { ApiIngestHandler } from "./handlers/api-ingest.handler.js";
 import { PdfExtractHandler } from "./handlers/pdf-extract.handler.js";
+import { MinutesIngestHandler } from "./handlers/minutes-ingest.handler.js";
 import { TextExtractorService } from "./extraction/text-extractor.service.js";
 import { DetailCrawlerService } from "./crawling/detail-crawler.service.js";
 
@@ -55,6 +60,16 @@ export class ScrapingPipelineModule {
             new ManifestStoreService(repository),
           inject: ["MANIFEST_REPOSITORY"],
         },
+        // Watermark store (wraps the injected repository — optional;
+        // consumers without listing-walk sources can omit the binding
+        // and MinutesIngestHandler still functions, just without
+        // cold-start protection).
+        {
+          provide: IngestionWatermarkService,
+          useFactory: (repository?: IngestionWatermarkRepository) =>
+            repository ? new IngestionWatermarkService(repository) : undefined,
+          inject: [{ token: "INGESTION_WATERMARK_REPOSITORY", optional: true }],
+        },
         // Core services
         StructuralAnalyzerService,
         ManifestExtractorService,
@@ -65,6 +80,7 @@ export class ScrapingPipelineModule {
         BulkDownloadHandler,
         ApiIngestHandler,
         PdfExtractHandler,
+        MinutesIngestHandler,
         TextExtractorService,
         DetailCrawlerService,
         ScrapingPipelineService,
@@ -73,6 +89,7 @@ export class ScrapingPipelineModule {
         ScrapingPipelineService,
         StructuralAnalyzerService,
         ManifestStoreService,
+        IngestionWatermarkService,
         ManifestExtractorService,
         DomainMapperService,
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.35
-        version: 1.0.35
+        specifier: ^1.0.36
+        version: 1.0.36
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -908,8 +908,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.35
-        version: 1.0.35
+        specifier: ^1.0.36
+        version: 1.0.36
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4860,8 +4860,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.35':
-    resolution: {integrity: sha512-ymi+NzPpoL4j2sx5+zwX1K0u0Fd9keGkXT5wrcN0Oo4ydKkf1pZN4T7XUA/5k2z28c9DllVZpKlHPiVod+UKPA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.35/35969e5ad499bbb63d9f9c145f490fe31ff70bb1}
+  '@opuspopuli/regions@1.0.36':
+    resolution: {integrity: sha512-rAPNvt7EjvMS6BXU6grOBizSO23d3uTDoOezYhl4FJcVFijVCzQEYpRsFkAF5HXlBHynjJ7xkwsF9Gmv7Y1Drw==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.36/9a3b3b0d3293723c50a09c82da645e1b065c7b12}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -16569,7 +16569,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.35': {}
+  '@opuspopuli/regions@1.0.36': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.34
-        version: 1.0.34
+        specifier: ^1.0.35
+        version: 1.0.35
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -908,8 +908,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.34
-        version: 1.0.34
+        specifier: ^1.0.35
+        version: 1.0.35
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4860,8 +4860,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.34':
-    resolution: {integrity: sha512-nuOK63fHYaCqn4Oe8M8603kGogm2VbFAzfGWsTIt9A6BXbz8dhDzWok5Ljw5dXGTymb330uX6sN64DEeIE/DYA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.34/7205028767457f3b189ffa010fe0cfb4608ac1aa}
+  '@opuspopuli/regions@1.0.35':
+    resolution: {integrity: sha512-ymi+NzPpoL4j2sx5+zwX1K0u0Fd9keGkXT5wrcN0Oo4ydKkf1pZN4T7XUA/5k2z28c9DllVZpKlHPiVod+UKPA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.35/35969e5ad499bbb63d9f9c145f490fe31ff70bb1}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -16569,7 +16569,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.34': {}
+  '@opuspopuli/regions@1.0.35': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:


### PR DESCRIPTION
## Summary

End-to-end pipeline for ingesting California Assembly daily-journal PDFs as `Minutes` documents and mining them for `LegislativeAction` records — the foundation for "what did my rep do this week?" queries and the citizen-letter quote-attribution flow.

Companion regions PRs: OpusPopuli/opuspopuli-regions#14 (initial) + OpusPopuli/opuspopuli-regions#16 (move under MEETINGS dataType). Published as `@opuspopuli/regions@1.0.36`.

## What's in here

### Schema (3 new tables + 1 migration)
- `minutes` — meeting-minutes / journal documents. FKs to `legislative_committees` (per-committee minutes) + `meetings` (calendared hearings), both nullable. Stores `rawText` (capped 256kB) + revision metadata.
- `legislative_actions` — per-action records FK'd to Minutes (CASCADE). `passageStart`/`passageEnd` are char-offsets into the parent's rawText so the UI can quote the verbatim passage in a citizen letter.
- `ingestion_watermarks` — cold-start protection for listing-walk sources (one row per region+sourceUrl+dataType).

### Pipeline (`@opuspopuli/scraping-pipeline`)
- New `sourceType: "pdf_archive"` — paginated listing → per-PDF fetch + pdf-parse → emits one `MinutesWithActions` per document.
- `MinutesIngestHandler`: walks the listing newest-first, applies `maxNew` cap (default 10), processes oldest-first so partial failures only advance the watermark to the last success.
- `IngestionWatermarkService` (CRUD over the new table) with optional Prisma binding.

### Backend (`apps/backend`)
- `LegislativeActionLinkerService`: deterministic post-sync pass. Splits `Minutes.rawText` into named sections (ROLLCALL, LEAVES OF ABSENCE, ENGROSSMENT AND ENROLLMENT REPORTS, RESOLUTIONS, AUTHOR'S AMENDMENTS, REPORTS OF STANDING COMMITTEES, SECOND/THIRD READING) and dispatches each to a per-section extractor. Resolves reps (single-match surname conservative; First-Last fallback), bills (`Assembly Bill No. 1863` → `AB 1863`), committees (via existing `legislative-committee-linker.externalIdFor`).
- `syncMeetings` is now the umbrella: ingests scheduled meetings AND daily-journal minutes in one call, then runs the linker over newly upserted Minutes.
- `DeclarativeRegionPlugin.fetchMeetingMinutes()` partitions `meetings` sources by `sourceType` so `pdf_archive` documents flow to Minutes upsert, everything else through the existing meetings flow.
- Admin script: `run-relink-minutes.ts` re-runs the linker over every active Minutes without re-fetching PDFs.

### UAT verification (10 minutes ingested via Postman → API gateway → region subgraph)

```
action_type        | count | rep_linked | committee_linked
-------------------+-------+------------+-----------------
committee_report   |   847 |          0 |             698 (82%)
amendment          |   589 |          0 |             589 (100%)
engrossment        |   585 |          0 |               –
presence           |   190 |    176 (92%) |             –
committee_hearing  |   172 |          0 |             146 (85%)
enrollment         |    21 |          0 |               –
resolution         |     9 |          0 |               –
TOTAL              | 2,413 |          –  |               –
```

Bill linking is 0% by design — `propositions` only contains qualified ballot measures; in-flight bills (`AB 1897` etc.) are not yet propositions and remain null on the FK until a measure qualifies. All 2,413 actions have valid `passageStart < passageEnd` offsets so the citizen-quote feature has its anchors.

### Tests

- 8 linker tests (section dispatch, FK resolution, passage offsets, externalId minting) — 92% coverage on the service.
- 10 handler tests (listing walk, watermark stop, maxNew cap, revision detection, ordering).
- 4 watermark service tests (advance, increment, scope isolation).
- Full backend suite: **1,488 pass.** Full pipeline suite: **321 pass.**

## V1 limitations (deliberately deferred)

- **Per-rep-per-bill vote tables** — schema accommodates without migration (LegislativeAction.position + actionType='vote'). V2.
- **Floor speech text + AI summarization + per-claim attribution** — Minutes has `summary` + `summaryClaims` JSON columns reserved. V2.
- **Multi-match surname disambiguation** — multiple Rodriguez reps in CA Assembly leave `representative_id` null + log a warning. District/first-initial disambiguation lands V2.
- **CA Senate journals + federal Congressional Record** — parallel follow-ups; the linker is region-agnostic via section-header configuration.

## Test plan

- [x] All unit tests pass
- [x] Live UAT sync against `clerk.assembly.ca.gov/legislative-publications/daily-journals` (10 PDFs fetched in 3.1s)
- [x] Linker re-run over already-stored rawText (2,413 actions extracted)
- [x] Watermark idempotency (next sync correctly returns 0 new minutes when up-to-date)
- [ ] Re-issue handling (`adj{MMDDYY}_r1.pdf`) — verified in logs (Apr 20 r1 ingested correctly with `revisionSeq=1`); not yet observed superseding an earlier-ingested original (would require live timing)
- [ ] Frontend UI to surface the data — next PR

## Commits

1. `feat: California Assembly daily-journal ingestion (#665)` — schema, MinutesIngestHandler, IngestionWatermarkService, initial linker, Postman flow
2. `refactor: fold daily-journals under MEETINGS + harden linker (#665)` — drops separate LEGISLATIVE_ACTIONS dataType, section-scoped linker, missing extractors, surname fallback, regex fixes
3. `chore: bump @opuspopuli/regions to 1.0.36 (#665)` — pulls in published config

🤖 Generated with [Claude Code](https://claude.com/claude-code)