### PR TITLE
feat: rep + committee Layer-3 activity feeds with AI summaries (#665)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/entity-activity-summary-generator.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/entity-activity-summary-generator.service.spec.ts
@@ -1,0 +1,365 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { createMock } from '@golevelup/ts-jest';
+import { PromptClientService } from '@opuspopuli/prompt-client';
+import type { ILLMProvider } from '@opuspopuli/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+import { EntityActivitySummaryGeneratorService } from './entity-activity-summary-generator.service';
+
+interface RepRow {
+  id: string;
+  name: string;
+  chamber: string;
+  activitySummaryGeneratedAt: Date | null;
+}
+
+interface CommitteeRow {
+  id: string;
+  name: string;
+  chamber: string;
+}
+
+interface ActionRow {
+  date: Date;
+  actionType: string;
+  rawSubject: string | null;
+  text: string | null;
+}
+
+describe('EntityActivitySummaryGeneratorService', () => {
+  async function buildService(
+    opts: {
+      withDeps?: boolean;
+      withDb?: boolean;
+      reps?: RepRow[];
+      committees?: CommitteeRow[];
+      /** Action rows the mocked DB will return for the structured-input bundle. */
+      actions?: ActionRow[];
+      llmText?: string;
+      configValues?: Record<string, string | undefined>;
+    } = {},
+  ) {
+    const {
+      withDeps = true,
+      withDb = true,
+      reps = [],
+      committees = [],
+      actions = [],
+      llmText = '{"summary":"Generated activity summary."}',
+      configValues = {},
+    } = opts;
+
+    const mockPromptClient = createMock<PromptClientService>();
+    mockPromptClient.getDocumentAnalysisPrompt.mockResolvedValue({
+      promptText: 'built prompt',
+      promptHash: 'hash',
+      promptVersion: '1.0.0',
+    });
+
+    const mockLlm = {
+      generate: jest.fn().mockResolvedValue({ text: llmText, tokensUsed: 100 }),
+    } as unknown as jest.Mocked<ILLMProvider>;
+
+    const mockConfig = {
+      get: jest.fn((key: string) => configValues[key]),
+    } as unknown as ConfigService;
+
+    const repUpdate = jest.fn().mockResolvedValue(undefined);
+    const cmtUpdate = jest.fn().mockResolvedValue(undefined);
+
+    // Group counts by action_type so the service's groupBy works.
+    const groupCounts: { actionType: string; _count: { _all: number } }[] = [];
+    {
+      const counts = new Map<string, number>();
+      for (const a of actions)
+        counts.set(a.actionType, (counts.get(a.actionType) ?? 0) + 1);
+      for (const [k, v] of counts.entries()) {
+        groupCounts.push({ actionType: k, _count: { _all: v } });
+      }
+    }
+
+    const mockDb = {
+      representative: {
+        findMany: jest.fn().mockResolvedValue(reps),
+        update: repUpdate,
+      },
+      legislativeCommittee: {
+        findMany: jest.fn().mockResolvedValue(committees),
+        update: cmtUpdate,
+      },
+      legislativeAction: {
+        groupBy: jest.fn().mockResolvedValue(groupCounts),
+        findMany: jest.fn().mockResolvedValue(actions),
+      },
+    } as unknown as DbService;
+
+    const providers: unknown[] = [EntityActivitySummaryGeneratorService];
+    if (withDeps) {
+      providers.push(
+        { provide: ConfigService, useValue: mockConfig },
+        { provide: PromptClientService, useValue: mockPromptClient },
+        { provide: 'LLM_PROVIDER', useValue: mockLlm },
+      );
+    }
+    if (withDb) {
+      providers.push({ provide: DbService, useValue: mockDb });
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: providers as Parameters<
+        typeof Test.createTestingModule
+      >[0]['providers'],
+    }).compile();
+
+    return {
+      service: module.get(EntityActivitySummaryGeneratorService),
+      promptClient: mockPromptClient,
+      llm: mockLlm,
+      repUpdate,
+      cmtUpdate,
+    };
+  }
+
+  it('returns zero counts when promptClient is missing (graceful degrade)', async () => {
+    const { service } = await buildService({ withDeps: false });
+    const result = await service.generateAll();
+    expect(result).toEqual({
+      repsUpdated: 0,
+      committeesUpdated: 0,
+      skipped: 0,
+    });
+  });
+
+  it('returns zero counts when DbService is missing', async () => {
+    const { service } = await buildService({ withDb: false });
+    const result = await service.generateAll();
+    expect(result.repsUpdated).toBe(0);
+    expect(result.committeesUpdated).toBe(0);
+  });
+
+  it('generates and persists summaries for reps with recent activity', async () => {
+    const { service, repUpdate, promptClient } = await buildService({
+      reps: [
+        {
+          id: 'rep-1',
+          name: 'Bauer-Kahan, Rebecca',
+          chamber: 'Assembly',
+          activitySummaryGeneratedAt: null,
+        },
+      ],
+      actions: [
+        {
+          date: new Date('2026-04-28T00:00:00Z'),
+          actionType: 'amendment',
+          rawSubject: 'AB 1897',
+          text: 'Amendment adopted in Health committee.',
+        },
+        {
+          date: new Date('2026-04-27T00:00:00Z'),
+          actionType: 'committee_hearing',
+          rawSubject: 'Privacy and Consumer Protection',
+          text: 'Hearing on April 27, 2026.',
+        },
+      ],
+      llmText:
+        '{"summary":"Bauer-Kahan attended hearings and authored amendments."}',
+    });
+
+    const result = await service.generateAll();
+
+    expect(result.repsUpdated).toBe(1);
+    expect(repUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'rep-1' },
+        data: expect.objectContaining({
+          activitySummary:
+            'Bauer-Kahan attended hearings and authored amendments.',
+          activitySummaryWindowDays: 90,
+        }),
+      }),
+    );
+    // The prompt-service is called with the rep-specific documentType.
+    expect(promptClient.getDocumentAnalysisPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentType: 'representative-activity-summary',
+      }),
+    );
+  });
+
+  it('generates summaries for committees with recent activity', async () => {
+    const { service, cmtUpdate, promptClient } = await buildService({
+      committees: [{ id: 'cmt-1', name: 'Public Safety', chamber: 'Assembly' }],
+      actions: [
+        {
+          date: new Date('2026-04-28T00:00:00Z'),
+          actionType: 'committee_report',
+          rawSubject: 'AB 1897',
+          text: 'Do pass.',
+        },
+      ],
+      llmText: '{"summary":"Public Safety processed several bills this week."}',
+    });
+
+    const result = await service.generateAll();
+
+    expect(result.committeesUpdated).toBe(1);
+    expect(cmtUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'cmt-1' },
+        data: expect.objectContaining({
+          activitySummary: 'Public Safety processed several bills this week.',
+        }),
+      }),
+    );
+    expect(promptClient.getDocumentAnalysisPrompt).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentType: 'committee-activity-summary',
+      }),
+    );
+  });
+
+  it('skips entities with no actions in the window', async () => {
+    const { service, repUpdate } = await buildService({
+      reps: [
+        {
+          id: 'rep-noactivity',
+          name: 'Nobody, Active',
+          chamber: 'Assembly',
+          activitySummaryGeneratedAt: null,
+        },
+      ],
+      actions: [],
+    });
+
+    const result = await service.generateAll();
+
+    expect(result.repsUpdated).toBe(0);
+    expect(repUpdate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to extractFieldString when JSON is malformed (tier-2 parse)', async () => {
+    const { service, repUpdate } = await buildService({
+      reps: [
+        {
+          id: 'rep-1',
+          name: 'Schultz, Nick',
+          chamber: 'Assembly',
+          activitySummaryGeneratedAt: null,
+        },
+      ],
+      actions: [
+        {
+          date: new Date('2026-04-28T00:00:00Z'),
+          actionType: 'committee_hearing',
+          rawSubject: 'Public Safety',
+          text: 'Hearing held.',
+        },
+      ],
+      // Truncated JSON — closing brace missing. extractFieldString recovers
+      // the summary value via field-slice.
+      llmText: '{"summary": "Recovered from truncated output"',
+    });
+
+    const result = await service.generateAll();
+
+    expect(result.repsUpdated).toBe(1);
+    expect(repUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          activitySummary: 'Recovered from truncated output',
+        }),
+      }),
+    );
+  });
+
+  it('skips an entity when the LLM produces no parseable summary', async () => {
+    const { service, repUpdate } = await buildService({
+      reps: [
+        {
+          id: 'rep-1',
+          name: 'Lackey, Tom',
+          chamber: 'Assembly',
+          activitySummaryGeneratedAt: null,
+        },
+      ],
+      actions: [
+        {
+          date: new Date('2026-04-28T00:00:00Z'),
+          actionType: 'committee_hearing',
+          rawSubject: 'Public Safety',
+          text: 'Hearing held.',
+        },
+      ],
+      llmText: 'completely non-JSON garbage with no summary field anywhere',
+    });
+
+    const result = await service.generateAll();
+
+    expect(result.repsUpdated).toBe(0);
+    expect(repUpdate).not.toHaveBeenCalled();
+  });
+
+  it('continues on per-entity errors', async () => {
+    const { service, repUpdate } = await buildService({
+      reps: [
+        {
+          id: 'rep-fail',
+          name: 'Fail, First',
+          chamber: 'Assembly',
+          activitySummaryGeneratedAt: null,
+        },
+        {
+          id: 'rep-ok',
+          name: 'OK, Second',
+          chamber: 'Assembly',
+          activitySummaryGeneratedAt: null,
+        },
+      ],
+      actions: [
+        {
+          date: new Date('2026-04-28T00:00:00Z'),
+          actionType: 'amendment',
+          rawSubject: 'AB 1',
+          text: 'amend.',
+        },
+      ],
+      llmText: '{"summary":"second rep summary"}',
+    });
+
+    // First update throws, second resolves.
+    repUpdate
+      .mockRejectedValueOnce(new Error('DB write failed'))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await service.generateAll();
+
+    expect(result.repsUpdated).toBe(1);
+    expect(repUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors a caller-supplied window override', async () => {
+    const { service } = await buildService({
+      reps: [
+        {
+          id: 'rep-1',
+          name: 'Test',
+          chamber: 'Assembly',
+          activitySummaryGeneratedAt: null,
+        },
+      ],
+      actions: [
+        {
+          date: new Date(),
+          actionType: 'amendment',
+          rawSubject: 'AB 1',
+          text: 't',
+        },
+      ],
+    });
+
+    const result = await service.generateAll(30);
+    // Result returns the windowDays the service used.
+    expect(result.repsUpdated).toBe(1);
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/entity-activity-summary-generator.service.ts
+++ b/apps/backend/src/apps/region/src/domains/entity-activity-summary-generator.service.ts
@@ -1,0 +1,356 @@
+/**
+ * Entity Activity Summary Generator
+ *
+ * Generates 2-3 sentence AI summaries of a legislative entity's
+ * (representative or committee) recent activity, suitable for the
+ * top of the L3 layer on the rep / committee detail pages.
+ *
+ * Mirrors `bio-generator.service.ts` and
+ * `committee-summary-generator.service.ts`:
+ *   - DI: PromptClientService + ILLMProvider, both Optional.
+ *   - Prompt name lives in the private prompt-service repo
+ *     (`representative-activity-summary` and
+ *     `committee-activity-summary` documentTypes). The consumer
+ *     here ships the structured input + persists the result; the
+ *     authoritative prompt template stays out of this codebase per
+ *     the IP boundary memory.
+ *   - Output: structured JSON with a `summary` field; tier-1 strict
+ *     parse, tier-2 salvage if the LLM truncates.
+ *
+ * Storage:
+ *   `representatives.activity_summary` + `_generated_at` + `_window_days`
+ *   `legislative_committees.activity_summary` + `_generated_at` + `_window_days`
+ *
+ * Issue #665.
+ */
+
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PromptClientService } from '@opuspopuli/prompt-client';
+import {
+  extractFieldString,
+  extractJsonObjectSlice,
+  type ILLMProvider,
+} from '@opuspopuli/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+/** Structured shape we feed the prompt. */
+interface ActivityBundle {
+  entityName: string;
+  entityType: 'representative' | 'committee';
+  chamber: string;
+  windowDays: number;
+  counts: Record<string, number>;
+  /** Up to 25 representative actions, newest first. */
+  recentActions: Array<{
+    date: string;
+    actionType: string;
+    rawSubject?: string;
+    text?: string;
+  }>;
+}
+
+interface SummaryResponse {
+  summary: string;
+}
+
+@Injectable()
+export class EntityActivitySummaryGeneratorService {
+  private readonly logger = new Logger(
+    EntityActivitySummaryGeneratorService.name,
+  );
+  private readonly maxTokens: number;
+  private readonly windowDays: number;
+
+  constructor(
+    @Optional()
+    private readonly config?: ConfigService,
+    @Optional()
+    private readonly promptClient?: PromptClientService,
+    @Optional()
+    @Inject('LLM_PROVIDER')
+    private readonly llm?: ILLMProvider,
+    @Optional()
+    private readonly db?: DbService,
+  ) {
+    this.maxTokens = this.readPositiveInt('ACTIVITY_SUMMARY_MAX_TOKENS', 400);
+    this.windowDays = this.readPositiveInt('ACTIVITY_SUMMARY_WINDOW_DAYS', 90);
+  }
+
+  /**
+   * Regenerate summaries for every active representative + every
+   * legislative committee that has at least one LegislativeAction in
+   * the configured window. Skips entities whose existing summary is
+   * fresher than the newest action (no work to do).
+   *
+   * Returns {repsUpdated, committeesUpdated, skipped} so the admin
+   * script can log progress.
+   */
+  async generateAll(overrideWindowDays?: number): Promise<{
+    repsUpdated: number;
+    committeesUpdated: number;
+    skipped: number;
+  }> {
+    if (!this.db || !this.promptClient || !this.llm) {
+      this.logger.warn(
+        'Activity summary generator missing DB / promptClient / LLM — skipping',
+      );
+      return { repsUpdated: 0, committeesUpdated: 0, skipped: 0 };
+    }
+    const windowDays = overrideWindowDays ?? this.windowDays;
+    const since = new Date();
+    since.setDate(since.getDate() - windowDays);
+
+    const repsUpdated = await this.generateForReps(since, windowDays);
+    const committeesUpdated = await this.generateForCommittees(
+      since,
+      windowDays,
+    );
+
+    return { repsUpdated, committeesUpdated, skipped: 0 };
+  }
+
+  private async generateForReps(
+    since: Date,
+    windowDays: number,
+  ): Promise<number> {
+    if (!this.db) return 0;
+    // Only reps with at least one linked action in the window.
+    const candidates = await this.db.representative.findMany({
+      where: {
+        deletedAt: null,
+        legislativeActions: { some: { date: { gte: since } } },
+      },
+      select: {
+        id: true,
+        name: true,
+        chamber: true,
+        activitySummaryGeneratedAt: true,
+      },
+    });
+
+    let updated = 0;
+    for (const rep of candidates) {
+      try {
+        const bundle = await this.buildBundle(
+          rep.id,
+          'representative',
+          rep.name,
+          rep.chamber,
+          windowDays,
+        );
+        if (bundle.recentActions.length === 0) continue;
+        const summary = await this.runPrompt(bundle);
+        if (!summary) continue;
+
+        await this.db.representative.update({
+          where: { id: rep.id },
+          data: {
+            activitySummary: summary,
+            activitySummaryGeneratedAt: new Date(),
+            activitySummaryWindowDays: windowDays,
+          },
+        });
+        updated += 1;
+        this.logger.log(
+          `Updated activity summary for rep ${rep.name} (${rep.id})`,
+        );
+      } catch (e) {
+        this.logger.warn(
+          `Activity summary failed for rep ${rep.id}: ${(e as Error).message}`,
+        );
+      }
+    }
+    return updated;
+  }
+
+  private async generateForCommittees(
+    since: Date,
+    windowDays: number,
+  ): Promise<number> {
+    if (!this.db) return 0;
+    const candidates = await this.db.legislativeCommittee.findMany({
+      where: {
+        deletedAt: null,
+        legislativeActions: { some: { date: { gte: since } } },
+      },
+      select: { id: true, name: true, chamber: true },
+    });
+
+    let updated = 0;
+    for (const cmt of candidates) {
+      try {
+        const bundle = await this.buildBundle(
+          cmt.id,
+          'committee',
+          cmt.name,
+          cmt.chamber,
+          windowDays,
+        );
+        if (bundle.recentActions.length === 0) continue;
+        const summary = await this.runPrompt(bundle);
+        if (!summary) continue;
+
+        await this.db.legislativeCommittee.update({
+          where: { id: cmt.id },
+          data: {
+            activitySummary: summary,
+            activitySummaryGeneratedAt: new Date(),
+            activitySummaryWindowDays: windowDays,
+          },
+        });
+        updated += 1;
+        this.logger.log(
+          `Updated activity summary for committee ${cmt.name} (${cmt.id})`,
+        );
+      } catch (e) {
+        this.logger.warn(
+          `Activity summary failed for committee ${cmt.id}: ${(e as Error).message}`,
+        );
+      }
+    }
+    return updated;
+  }
+
+  /**
+   * Build the structured-input bundle for the prompt. Includes:
+   *   - Entity identifying info (name + chamber)
+   *   - Counts of each action_type in the window (drives the
+   *     "did 7 hearings, moved 43 bills" sentence)
+   *   - The 25 most recent action records — newest first — with
+   *     enough detail (date + actionType + rawSubject + a 200-char
+   *     text excerpt) for the LLM to ground its summary in
+   *     specific bills/committees.
+   */
+  private async buildBundle(
+    entityId: string,
+    entityType: 'representative' | 'committee',
+    entityName: string,
+    chamber: string,
+    windowDays: number,
+  ): Promise<ActivityBundle> {
+    if (!this.db) {
+      throw new Error('DB unavailable');
+    }
+    const since = new Date();
+    since.setDate(since.getDate() - windowDays);
+
+    const where =
+      entityType === 'representative'
+        ? { representativeId: entityId, date: { gte: since } }
+        : { committeeId: entityId, date: { gte: since } };
+
+    const [counts, recent] = await Promise.all([
+      this.db.legislativeAction.groupBy({
+        by: ['actionType'],
+        where,
+        _count: { _all: true },
+      }),
+      this.db.legislativeAction.findMany({
+        where,
+        orderBy: [{ date: 'desc' }, { createdAt: 'desc' }],
+        take: 25,
+        select: {
+          date: true,
+          actionType: true,
+          rawSubject: true,
+          text: true,
+        },
+      }),
+    ]);
+
+    const countMap: Record<string, number> = {};
+    for (const c of counts) countMap[c.actionType] = c._count._all;
+
+    return {
+      entityName,
+      entityType,
+      chamber,
+      windowDays,
+      counts: countMap,
+      recentActions: recent.map((r) => ({
+        date: r.date.toISOString().slice(0, 10),
+        actionType: r.actionType,
+        rawSubject: r.rawSubject ?? undefined,
+        text: r.text ? r.text.slice(0, 200) : undefined,
+      })),
+    };
+  }
+
+  private async runPrompt(bundle: ActivityBundle): Promise<string | undefined> {
+    if (!this.promptClient || !this.llm) return undefined;
+    const documentType =
+      bundle.entityType === 'representative'
+        ? 'representative-activity-summary'
+        : 'committee-activity-summary';
+
+    const text = this.formatBundle(bundle);
+    const { promptText } = await this.promptClient.getDocumentAnalysisPrompt({
+      documentType,
+      text,
+    });
+    const result = await this.llm.generate(promptText, {
+      maxTokens: this.maxTokens,
+      temperature: 0.2,
+    });
+    return this.parseSummary(result.text);
+  }
+
+  /**
+   * Render the bundle as structured key-value text for the prompt.
+   * Layout matches the existing committee-summary-generator pattern
+   * so the LLM sees a predictable shape regardless of entity type.
+   */
+  private formatBundle(bundle: ActivityBundle): string {
+    const countLines = Object.entries(bundle.counts)
+      .sort(([, a], [, b]) => b - a)
+      .map(([type, n]) => `  - ${type}: ${n}`)
+      .join('\n');
+    const actionLines = bundle.recentActions
+      .map((a, i) => {
+        const subj = a.rawSubject ? ` ${a.rawSubject}` : '';
+        const txt = a.text ? ` — ${a.text.replaceAll(/\s+/g, ' ').trim()}` : '';
+        return `  ${i + 1}. [${a.date}] ${a.actionType}${subj}${txt}`;
+      })
+      .join('\n');
+
+    return [
+      `Entity: ${bundle.entityName} (${bundle.entityType})`,
+      `Chamber: ${bundle.chamber}`,
+      `Window: last ${bundle.windowDays} days`,
+      `Action counts:\n${countLines || '  (none)'}`,
+      `Recent actions (newest first):\n${actionLines || '  (none)'}`,
+    ].join('\n');
+  }
+
+  /**
+   * Two-tier parse mirroring committee-summary-generator. JSON
+   * preferred; fall back to a regex slice if the LLM truncates.
+   */
+  private parseSummary(text: string): string | undefined {
+    const candidate = extractJsonObjectSlice(text);
+    if (candidate) {
+      try {
+        const parsed = JSON.parse(candidate) as Partial<SummaryResponse>;
+        if (
+          typeof parsed.summary === 'string' &&
+          parsed.summary.trim().length > 0
+        ) {
+          return parsed.summary.trim();
+        }
+      } catch {
+        /* fall through to tier 2 */
+      }
+    }
+    const sliced = extractFieldString(text, 'summary');
+    if (sliced && sliced.trim().length > 0) return sliced.trim();
+    return undefined;
+  }
+
+  private readPositiveInt(envKey: string, fallback: number): number {
+    const raw = this.config?.get<string>(envKey);
+    if (!raw) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/legislative-committee.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-committee.service.ts
@@ -43,6 +43,9 @@ export interface LegislativeCommitteeDetail {
   memberCount: number;
   members: LegislativeCommitteeMember[];
   hearings: LegislativeCommitteeHearing[];
+  activitySummary: string | null;
+  activitySummaryGeneratedAt: Date | null;
+  activitySummaryWindowDays: number | null;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -184,6 +187,9 @@ export class LegislativeCommitteeService {
       memberCount: committee.assignments.length,
       members,
       hearings,
+      activitySummary: committee.activitySummary,
+      activitySummaryGeneratedAt: committee.activitySummaryGeneratedAt,
+      activitySummaryWindowDays: committee.activitySummaryWindowDays,
       createdAt: committee.createdAt,
       updatedAt: committee.updatedAt,
     };

--- a/apps/backend/src/apps/region/src/domains/models/legislative-action.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/legislative-action.model.ts
@@ -1,0 +1,183 @@
+import { Field, ID, Int, ObjectType } from '@nestjs/graphql';
+
+/**
+ * One discrete legislative action — a presence roll, committee
+ * hearing/report, amendment, engrossment/enrollment, or resolution
+ * extracted from a Minutes document. See
+ * `LegislativeActionLinkerService` for the production logic that
+ * mints these from `Minutes.rawText`. Issue #665.
+ *
+ * Char-offsets `passageStart` / `passageEnd` point back into the
+ * parent Minutes' rawText so the UI can render the verbatim
+ * passage in citation/quote affordances.
+ */
+@ObjectType()
+export class LegislativeActionModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  externalId!: string;
+
+  @Field()
+  body!: string;
+
+  @Field()
+  date!: Date;
+
+  /**
+   * One of: 'presence' | 'committee_hearing' | 'committee_report' |
+   * 'amendment' | 'engrossment' | 'enrollment' | 'resolution' |
+   * 'vote' (V2) | 'speech' (V2). Kept as a string so V2 additions
+   * don't require a schema change.
+   */
+  @Field()
+  actionType!: string;
+
+  /** 'yes' | 'no' | 'abstain' | 'absent' — null for non-vote actions in V1. */
+  @Field({ nullable: true })
+  position?: string;
+
+  /** Verbatim source excerpt (capped 4kB at write time). */
+  @Field({ nullable: true })
+  text?: string;
+
+  /** Inclusive char offset into the parent Minutes' rawText. */
+  @Field(() => Int, { nullable: true })
+  passageStart?: number;
+
+  /** Exclusive char offset into the parent Minutes' rawText. */
+  @Field(() => Int, { nullable: true })
+  passageEnd?: number;
+
+  /**
+   * Pre-link source text — surname / "Assembly Bill No. N" /
+   * committee name. Useful in the UI when an FK couldn't be
+   * resolved (e.g. multi-match surname collision).
+   */
+  @Field({ nullable: true })
+  rawSubject?: string;
+
+  @Field(() => ID, { nullable: true })
+  representativeId?: string;
+
+  @Field(() => ID, { nullable: true })
+  propositionId?: string;
+
+  @Field(() => ID, { nullable: true })
+  committeeId?: string;
+
+  @Field(() => ID)
+  minutesId!: string;
+
+  /**
+   * Denormalized so the frontend can deep-link to
+   * `/minutes/<externalId>#passage-<start>-<end>` without an
+   * extra fetch.
+   */
+  @Field()
+  minutesExternalId!: string;
+}
+
+/**
+ * At-a-glance counters for the rep detail page Layer 3 ("What
+ * They've Done"). Counts are scoped to a configurable `sinceDays`
+ * window (default 90 days). Issue #665.
+ */
+@ObjectType()
+export class RepresentativeActivityStatsModel {
+  /**
+   * Number of distinct session days where the rep was recorded
+   * present (`actionType='presence' AND position='yes'`).
+   */
+  @Field(() => Int)
+  presentSessionDays!: number;
+
+  /**
+   * Total distinct session days observed in the window across all
+   * Minutes for this rep's chamber. `presentSessionDays /
+   * totalSessionDays` is the attendance rate.
+   */
+  @Field(() => Int)
+  totalSessionDays!: number;
+
+  /** Distinct days with at least one absence-with-reason record. */
+  @Field(() => Int)
+  absenceDays!: number;
+
+  /** Floor + committee amendments authored by this rep. */
+  @Field(() => Int)
+  amendments!: number;
+
+  /** Hearings linked via committee where this rep is the chair. */
+  @Field(() => Int)
+  committeeHearings!: number;
+
+  /** Per-bill verdicts where this rep's chaired committee was the reporter. */
+  @Field(() => Int)
+  committeeReports!: number;
+
+  /** Resolutions introduced (V1: heuristic match on raw text; refined when bill-FK lands). */
+  @Field(() => Int)
+  resolutions!: number;
+
+  /** V2 — per-rep-per-bill votes; always 0 in V1. */
+  @Field(() => Int)
+  votes!: number;
+
+  /** V2 — floor speeches; always 0 in V1. */
+  @Field(() => Int)
+  speeches!: number;
+}
+
+@ObjectType()
+export class PaginatedLegislativeActions {
+  @Field(() => [LegislativeActionModel])
+  items!: LegislativeActionModel[];
+
+  @Field(() => Int)
+  total!: number;
+
+  @Field()
+  hasMore!: boolean;
+}
+
+/**
+ * The verbatim passage text from a Minutes document for a single
+ * action, used by the L4 quote panel + citizen letter-cite flow.
+ *
+ * Returned by `minutesPassage(actionId)`. The `passageText` is
+ * `rawText.slice(passageStart, passageEnd)` capped at 1kB; longer
+ * slices truncate at a word boundary. `sectionContext` is an
+ * optional ~500-char snippet around the passage for visual context
+ * (faded above/below the highlighted quote in the UI).
+ */
+@ObjectType()
+export class MinutesPassageModel {
+  @Field(() => ID)
+  actionId!: string;
+
+  @Field()
+  minutesExternalId!: string;
+
+  @Field()
+  body!: string;
+
+  @Field()
+  date!: Date;
+
+  @Field()
+  sourceUrl!: string;
+
+  @Field(() => Int)
+  passageStart!: number;
+
+  @Field(() => Int)
+  passageEnd!: number;
+
+  @Field()
+  passageText!: string;
+
+  @Field({ nullable: true })
+  sectionContext?: string;
+}

--- a/apps/backend/src/apps/region/src/domains/models/legislative-action.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/legislative-action.model.ts
@@ -143,6 +143,30 @@ export class PaginatedLegislativeActions {
 }
 
 /**
+ * At-a-glance counters for the committee detail page Layer 3
+ * ("Activity"). Drives the top-of-L3 stats grid showing the
+ * committee's recent operational tempo. Issue #665.
+ */
+@ObjectType()
+export class CommitteeActivityStatsModel {
+  /** Distinct hearing dates extracted from committee_hearing actions. */
+  @Field(() => Int)
+  hearings!: number;
+
+  /** Per-bill verdicts (committee_report actions) issued by the committee. */
+  @Field(() => Int)
+  reports!: number;
+
+  /** Author's-amendments + reading-section amendments touching this committee. */
+  @Field(() => Int)
+  amendments!: number;
+
+  /** Distinct bills the committee has acted on (any action type, dedup'd by propositionId). */
+  @Field(() => Int)
+  distinctBills!: number;
+}
+
+/**
  * The verbatim passage text from a Minutes document for a single
  * action, used by the L4 quote panel + citizen letter-cite flow.
  *

--- a/apps/backend/src/apps/region/src/domains/models/legislative-committee.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/legislative-committee.model.ts
@@ -94,6 +94,16 @@ export class LegislativeCommitteeDetailModel {
   @Field(() => [LegislativeCommitteeHearingModel])
   hearings!: LegislativeCommitteeHearingModel[];
 
+  /** AI-generated 2-3 sentence summary of recent committee activity. Issue #665. */
+  @Field({ nullable: true })
+  activitySummary?: string;
+
+  @Field({ nullable: true })
+  activitySummaryGeneratedAt?: Date;
+
+  @Field({ nullable: true })
+  activitySummaryWindowDays?: number;
+
   @Field()
   createdAt!: Date;
 

--- a/apps/backend/src/apps/region/src/domains/models/representative.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/representative.model.ts
@@ -123,6 +123,16 @@ export class RepresentativeModel {
   @Field(() => [BioClaimModel], { nullable: true })
   bioClaims?: BioClaimModel[];
 
+  /** AI-generated 2-3 sentence summary of recent legislative activity. Issue #665. */
+  @Field({ nullable: true })
+  activitySummary?: string;
+
+  @Field({ nullable: true })
+  activitySummaryGeneratedAt?: Date;
+
+  @Field({ nullable: true })
+  activitySummaryWindowDays?: number;
+
   @Field()
   createdAt!: Date;
 

--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -20,6 +20,7 @@ import { RegionResolver } from './region.resolver';
 import { RegionScheduler } from './region.scheduler';
 import { BioGeneratorService } from './bio-generator.service';
 import { CommitteeSummaryGeneratorService } from './committee-summary-generator.service';
+import { EntityActivitySummaryGeneratorService } from './entity-activity-summary-generator.service';
 import { PropositionAnalysisService } from './proposition-analysis.service';
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
 import { PropositionFundingService } from './proposition-funding.service';
@@ -99,6 +100,7 @@ const promptClientAsyncConfig = {
     RegionScheduler,
     BioGeneratorService,
     CommitteeSummaryGeneratorService,
+    EntityActivitySummaryGeneratorService,
     PropositionAnalysisService,
     PropositionFinanceLinkerService,
     PropositionFundingService,

--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -802,4 +802,153 @@ describe('RegionResolver', () => {
       expect(result[0].errors).toContain('Network error');
     });
   });
+
+  // ==========================================
+  // Legislative Action queries (issue #665)
+  // ==========================================
+
+  describe('representativeActivityStats', () => {
+    const mockStats = {
+      presentSessionDays: 18,
+      totalSessionDays: 22,
+      absenceDays: 4,
+      amendments: 7,
+      committeeHearings: 5,
+      committeeReports: 12,
+      resolutions: 1,
+      votes: 0,
+      speeches: 0,
+    };
+
+    it('returns stats for the given rep with default 90-day window', async () => {
+      regionService.getRepresentativeActivityStats.mockResolvedValue(mockStats);
+
+      const result = await resolver.representativeActivityStats('rep-1');
+
+      expect(regionService.getRepresentativeActivityStats).toHaveBeenCalledWith(
+        'rep-1',
+        90,
+      );
+      expect(result.presentSessionDays).toBe(18);
+      expect(result.amendments).toBe(7);
+    });
+
+    it('passes through a caller-supplied sinceDays window', async () => {
+      regionService.getRepresentativeActivityStats.mockResolvedValue(mockStats);
+
+      await resolver.representativeActivityStats('rep-1', 30);
+
+      expect(regionService.getRepresentativeActivityStats).toHaveBeenCalledWith(
+        'rep-1',
+        30,
+      );
+    });
+  });
+
+  describe('representativeActivity', () => {
+    const mockAction = {
+      id: 'la-1',
+      externalId: 'california-meetings-2026-04-28-0042',
+      body: 'Assembly',
+      date: new Date('2026-04-28T00:00:00Z'),
+      actionType: 'amendment',
+      position: null,
+      text: "Author's amendments adopted in Committee on Health.",
+      passageStart: 12347,
+      passageEnd: 12521,
+      rawSubject: 'AB 1897',
+      representativeId: 'rep-1',
+      propositionId: null,
+      committeeId: 'cmt-1',
+      minutesId: 'min-1',
+      minutesExternalId: 'california-meetings-2026-04-28',
+    };
+
+    it('returns paginated activity feed for the rep', async () => {
+      regionService.getRepresentativeActivity.mockResolvedValue({
+        items: [mockAction],
+        total: 1,
+        hasMore: false,
+      });
+
+      const result = await resolver.representativeActivity('rep-1');
+
+      expect(regionService.getRepresentativeActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          representativeId: 'rep-1',
+          skip: 0,
+          take: 10,
+        }),
+      );
+      expect(result.total).toBe(1);
+      expect(result.hasMore).toBe(false);
+      expect(result.items[0]).toEqual(
+        expect.objectContaining({
+          id: 'la-1',
+          actionType: 'amendment',
+          rawSubject: 'AB 1897',
+          minutesExternalId: 'california-meetings-2026-04-28',
+          passageStart: 12347,
+          passageEnd: 12521,
+          // null fields are mapped to undefined for GraphQL nullability:
+          position: undefined,
+          propositionId: undefined,
+        }),
+      );
+    });
+
+    it('forwards actionTypes + includePresenceYes filters', async () => {
+      regionService.getRepresentativeActivity.mockResolvedValue({
+        items: [],
+        total: 0,
+        hasMore: false,
+      });
+
+      await resolver.representativeActivity(
+        'rep-1',
+        ['committee_hearing'],
+        true,
+        20,
+        5,
+      );
+
+      expect(regionService.getRepresentativeActivity).toHaveBeenCalledWith({
+        representativeId: 'rep-1',
+        actionTypes: ['committee_hearing'],
+        includePresenceYes: true,
+        skip: 20,
+        take: 5,
+      });
+    });
+  });
+
+  describe('minutesPassage', () => {
+    it('returns the passage for an action with valid offsets', async () => {
+      const mockPassage = {
+        actionId: 'la-1',
+        minutesExternalId: 'california-meetings-2026-04-28',
+        body: 'Assembly',
+        date: new Date('2026-04-28T00:00:00Z'),
+        sourceUrl: 'https://example.com/journal.pdf',
+        passageStart: 12347,
+        passageEnd: 12521,
+        passageText: 'Assembly Bill No. 1897, ...',
+        sectionContext: '...preceding context...',
+      };
+      regionService.getMinutesPassage.mockResolvedValue(mockPassage);
+
+      const result = await resolver.minutesPassage('la-1');
+
+      expect(regionService.getMinutesPassage).toHaveBeenCalledWith('la-1');
+      expect(result?.passageText).toBe('Assembly Bill No. 1897, ...');
+      expect(result?.minutesExternalId).toBe('california-meetings-2026-04-28');
+    });
+
+    it('returns null when the action has no resolvable passage', async () => {
+      regionService.getMinutesPassage.mockResolvedValue(null);
+
+      const result = await resolver.minutesPassage('la-missing');
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -951,4 +951,101 @@ describe('RegionResolver', () => {
       expect(result).toBeNull();
     });
   });
+
+  describe('committeeActivityStats', () => {
+    const mockStats = {
+      hearings: 7,
+      reports: 43,
+      amendments: 41,
+      distinctBills: 28,
+    };
+
+    it('returns committee stats with default 90-day window', async () => {
+      regionService.getCommitteeActivityStats.mockResolvedValue(mockStats);
+
+      const result = await resolver.committeeActivityStats('cmt-1');
+
+      expect(regionService.getCommitteeActivityStats).toHaveBeenCalledWith(
+        'cmt-1',
+        90,
+      );
+      expect(result.hearings).toBe(7);
+      expect(result.distinctBills).toBe(28);
+    });
+
+    it('forwards a caller-supplied sinceDays window', async () => {
+      regionService.getCommitteeActivityStats.mockResolvedValue(mockStats);
+
+      await resolver.committeeActivityStats('cmt-1', 30);
+
+      expect(regionService.getCommitteeActivityStats).toHaveBeenCalledWith(
+        'cmt-1',
+        30,
+      );
+    });
+  });
+
+  describe('committeeActivity', () => {
+    const mockAction = {
+      id: 'la-1',
+      externalId: 'california-meetings-2026-04-28-0042',
+      body: 'Assembly',
+      date: new Date('2026-04-28T00:00:00Z'),
+      actionType: 'committee_report',
+      position: null,
+      text: 'AB 1897: Do pass.',
+      passageStart: 12347,
+      passageEnd: 12521,
+      rawSubject: 'AB 1897',
+      representativeId: null,
+      propositionId: null,
+      committeeId: 'cmt-1',
+      minutesId: 'min-1',
+      minutesExternalId: 'california-meetings-2026-04-28',
+    };
+
+    it('returns paginated activity feed for the committee', async () => {
+      regionService.getCommitteeActivity.mockResolvedValue({
+        items: [mockAction],
+        total: 1,
+        hasMore: false,
+      });
+
+      const result = await resolver.committeeActivity('cmt-1');
+
+      expect(regionService.getCommitteeActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          committeeId: 'cmt-1',
+          skip: 0,
+          take: 10,
+        }),
+      );
+      expect(result.total).toBe(1);
+      expect(result.items[0]).toEqual(
+        expect.objectContaining({
+          id: 'la-1',
+          actionType: 'committee_report',
+          rawSubject: 'AB 1897',
+          committeeId: 'cmt-1',
+        }),
+      );
+    });
+
+    it('forwards actionTypes + pagination args', async () => {
+      regionService.getCommitteeActivity.mockResolvedValue({
+        items: [],
+        total: 0,
+        hasMore: false,
+      });
+
+      await resolver.committeeActivity('cmt-1', ['committee_hearing'], 20, 5);
+
+      expect(regionService.getCommitteeActivity).toHaveBeenCalledWith({
+        committeeId: 'cmt-1',
+        actionTypes: ['committee_hearing'],
+        skip: 20,
+        take: 5,
+      });
+    });
+  });
 });

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -49,6 +49,12 @@ import {
   LegislativeCommitteeDetailModel,
   PaginatedLegislativeCommittees,
 } from './models/legislative-committee.model';
+import {
+  LegislativeActionModel,
+  RepresentativeActivityStatsModel,
+  PaginatedLegislativeActions,
+  MinutesPassageModel,
+} from './models/legislative-action.model';
 
 /**
  * Region Resolver
@@ -250,6 +256,111 @@ export class RegionResolver {
         ? (r.bioClaims as unknown as BioClaimModel[])
         : undefined,
     })) as RepresentativeModel[];
+  }
+
+  // ==========================================
+  // LEGISLATIVE ACTION QUERIES (issue #665)
+  // ==========================================
+
+  /**
+   * At-a-glance activity counters for the rep detail page Layer 3.
+   * Window defaults to 90 days; tune `sinceDays` for different
+   * surfaces (e.g. session-long stats vs. last-month).
+   */
+  @Public()
+  @Query(() => RepresentativeActivityStatsModel)
+  async representativeActivityStats(
+    @Args({ name: 'id', type: () => ID }) id: string,
+    @Args({ name: 'sinceDays', type: () => Int, nullable: true })
+    sinceDays?: number,
+  ): Promise<RepresentativeActivityStatsModel> {
+    return this.regionService.getRepresentativeActivityStats(
+      id,
+      sinceDays ?? 90,
+    );
+  }
+
+  /**
+   * Reverse-chronological feed of LegislativeActions for a rep.
+   * `presence:yes` rows are filtered out by default — they're the
+   * highest-volume / lowest-signal entries and are already
+   * summarized in the attendance counter. Pass
+   * `actionTypes: ["presence"]` (or set `includePresenceYes`) to
+   * include them.
+   */
+  @Public()
+  @Query(() => PaginatedLegislativeActions)
+  async representativeActivity(
+    @Args({ name: 'id', type: () => ID }) id: string,
+    @Args({ name: 'actionTypes', type: () => [String], nullable: true })
+    actionTypes?: string[],
+    @Args({ name: 'includePresenceYes', nullable: true })
+    includePresenceYes?: boolean,
+    @Args({ name: 'skip', type: () => Int, nullable: true }) skip?: number,
+    @Args({ name: 'take', type: () => Int, nullable: true }) take?: number,
+  ): Promise<PaginatedLegislativeActions> {
+    const result = await this.regionService.getRepresentativeActivity({
+      representativeId: id,
+      actionTypes,
+      includePresenceYes,
+      skip: skip ?? 0,
+      take: take ?? 10,
+    });
+    return {
+      items: result.items.map((r) => this.toLegislativeActionModel(r)),
+      total: result.total,
+      hasMore: result.hasMore,
+    };
+  }
+
+  /**
+   * Resolve a single LegislativeAction to its source passage —
+   * verbatim text from `Minutes.rawText`. Returns null when the
+   * action has no passage offsets recorded or the parent Minutes
+   * has no rawText.
+   */
+  @Public()
+  @Query(() => MinutesPassageModel, { nullable: true })
+  async minutesPassage(
+    @Args({ name: 'actionId', type: () => ID }) actionId: string,
+  ): Promise<MinutesPassageModel | null> {
+    return this.regionService.getMinutesPassage(actionId);
+  }
+
+  private toLegislativeActionModel(r: {
+    id: string;
+    externalId: string;
+    body: string;
+    date: Date;
+    actionType: string;
+    position: string | null;
+    text: string | null;
+    passageStart: number | null;
+    passageEnd: number | null;
+    rawSubject: string | null;
+    representativeId: string | null;
+    propositionId: string | null;
+    committeeId: string | null;
+    minutesId: string;
+    minutesExternalId: string;
+  }): LegislativeActionModel {
+    return {
+      id: r.id,
+      externalId: r.externalId,
+      body: r.body,
+      date: r.date,
+      actionType: r.actionType,
+      position: r.position ?? undefined,
+      text: r.text ?? undefined,
+      passageStart: r.passageStart ?? undefined,
+      passageEnd: r.passageEnd ?? undefined,
+      rawSubject: r.rawSubject ?? undefined,
+      representativeId: r.representativeId ?? undefined,
+      propositionId: r.propositionId ?? undefined,
+      committeeId: r.committeeId ?? undefined,
+      minutesId: r.minutesId,
+      minutesExternalId: r.minutesExternalId,
+    };
   }
 
   // ==========================================

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -52,6 +52,7 @@ import {
 import {
   LegislativeActionModel,
   RepresentativeActivityStatsModel,
+  CommitteeActivityStatsModel,
   PaginatedLegislativeActions,
   MinutesPassageModel,
 } from './models/legislative-action.model';
@@ -220,6 +221,10 @@ export class RegionResolver {
       bioClaims: Array.isArray(result.bioClaims)
         ? (result.bioClaims as unknown as BioClaimModel[])
         : undefined,
+      activitySummary: result.activitySummary ?? undefined,
+      activitySummaryGeneratedAt:
+        result.activitySummaryGeneratedAt ?? undefined,
+      activitySummaryWindowDays: result.activitySummaryWindowDays ?? undefined,
     };
   }
 
@@ -327,6 +332,53 @@ export class RegionResolver {
     return this.regionService.getMinutesPassage(actionId);
   }
 
+  /**
+   * At-a-glance activity counters for the legislative committee
+   * detail page Layer 3. Window defaults to 90 days.
+   */
+  @Public()
+  @Query(() => CommitteeActivityStatsModel)
+  async committeeActivityStats(
+    @Args({ name: 'committeeId', type: () => ID }) committeeId: string,
+    @Args({ name: 'sinceDays', type: () => Int, nullable: true })
+    sinceDays?: number,
+  ): Promise<CommitteeActivityStatsModel> {
+    return this.regionService.getCommitteeActivityStats(
+      committeeId,
+      sinceDays ?? 90,
+    );
+  }
+
+  /**
+   * Reverse-chronological feed of LegislativeActions linked to a
+   * legislative committee — committee_hearing + committee_report +
+   * amendment rows from minutes ingestion. Mirrors
+   * `representativeActivity` but scoped by committeeId; no
+   * presence-row filtering needed (presence rows aren't
+   * committee-attributed).
+   */
+  @Public()
+  @Query(() => PaginatedLegislativeActions)
+  async committeeActivity(
+    @Args({ name: 'committeeId', type: () => ID }) committeeId: string,
+    @Args({ name: 'actionTypes', type: () => [String], nullable: true })
+    actionTypes?: string[],
+    @Args({ name: 'skip', type: () => Int, nullable: true }) skip?: number,
+    @Args({ name: 'take', type: () => Int, nullable: true }) take?: number,
+  ): Promise<PaginatedLegislativeActions> {
+    const result = await this.regionService.getCommitteeActivity({
+      committeeId,
+      actionTypes,
+      skip: skip ?? 0,
+      take: take ?? 10,
+    });
+    return {
+      items: result.items.map((r) => this.toLegislativeActionModel(r)),
+      total: result.total,
+      hasMore: result.hasMore,
+    };
+  }
+
   private toLegislativeActionModel(r: {
     id: string;
     externalId: string;
@@ -430,6 +482,10 @@ export class RegionResolver {
         scheduledAt: h.scheduledAt,
         agendaUrl: h.agendaUrl ?? undefined,
       })),
+      activitySummary: result.activitySummary ?? undefined,
+      activitySummaryGeneratedAt:
+        result.activitySummaryGeneratedAt ?? undefined,
+      activitySummaryWindowDays: result.activitySummaryWindowDays ?? undefined,
       createdAt: result.createdAt,
       updatedAt: result.updatedAt,
     };

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -788,6 +788,290 @@ describe('RegionDomainService', () => {
     });
   });
 
+  // ==========================================
+  // LegislativeAction-driven activity getters (issue #665)
+  // ==========================================
+
+  describe('getRepresentativeActivityStats', () => {
+    it('returns zero counts when the rep does not exist', async () => {
+      mockDb.representative.findUnique.mockResolvedValue(null);
+
+      const result = await service.getRepresentativeActivityStats(
+        'missing',
+        90,
+      );
+
+      expect(result).toEqual({
+        presentSessionDays: 0,
+        totalSessionDays: 0,
+        absenceDays: 0,
+        amendments: 0,
+        committeeHearings: 0,
+        committeeReports: 0,
+        resolutions: 0,
+        votes: 0,
+        speeches: 0,
+      });
+    });
+
+    it('aggregates groupBy + distinct-day queries into typed counters', async () => {
+      mockDb.representative.findUnique.mockResolvedValue({
+        chamber: 'Assembly',
+      } as never);
+      mockDb.legislativeAction.groupBy.mockResolvedValue([
+        { actionType: 'amendment', _count: { _all: 7 } },
+        { actionType: 'committee_hearing', _count: { _all: 3 } },
+        { actionType: 'committee_report', _count: { _all: 12 } },
+        { actionType: 'resolution', _count: { _all: 1 } },
+      ] as never);
+      // Cast to `any` because mockImplementation's signature wants the full
+      // PrismaPromise return type, which is awkward to construct in a unit
+      // test. The deep-mock proxy accepts a regular promise at runtime.
+      (mockDb.legislativeAction.findMany as jest.Mock).mockImplementation(
+        (args: { where?: Record<string, unknown> }) => {
+          if (args.where?.position === 'yes') {
+            return Promise.resolve(
+              Array.from({ length: 18 }, (_, i) => ({
+                date: new Date(2026, 3, i + 1),
+              })),
+            );
+          }
+          if (args.where?.position === 'absent') {
+            return Promise.resolve([{ date: new Date('2026-04-15') }]);
+          }
+          return Promise.resolve(
+            Array.from({ length: 22 }, (_, i) => ({
+              date: new Date(2026, 3, i + 1),
+            })),
+          );
+        },
+      );
+
+      const result = await service.getRepresentativeActivityStats('rep-1', 90);
+
+      expect(result.presentSessionDays).toBe(18);
+      expect(result.totalSessionDays).toBe(22);
+      expect(result.absenceDays).toBe(1);
+      expect(result.amendments).toBe(7);
+      expect(result.committeeHearings).toBe(3);
+      expect(result.committeeReports).toBe(12);
+      expect(result.resolutions).toBe(1);
+    });
+  });
+
+  describe('getRepresentativeActivity', () => {
+    it('paginates + filters out presence:yes by default', async () => {
+      mockDb.legislativeAction.findMany.mockResolvedValue([
+        {
+          id: 'la-1',
+          externalId: 'ext-1',
+          body: 'Assembly',
+          date: new Date('2026-04-28'),
+          actionType: 'amendment',
+          position: null,
+          text: 'Amendment text',
+          passageStart: 100,
+          passageEnd: 200,
+          rawSubject: 'AB 1897',
+          representativeId: 'rep-1',
+          propositionId: null,
+          committeeId: 'cmt-1',
+          minutesId: 'min-1',
+          minutes: { externalId: 'meet-1' },
+        },
+      ] as never);
+      mockDb.legislativeAction.count.mockResolvedValue(1);
+
+      const result = await service.getRepresentativeActivity({
+        representativeId: 'rep-1',
+        skip: 0,
+        take: 10,
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.hasMore).toBe(false);
+      expect(result.items[0].minutesExternalId).toBe('meet-1');
+      // The default-exclude `presence:yes` constraint shows up in the where.
+      const findManyCall = mockDb.legislativeAction.findMany.mock
+        .calls[0][0] as {
+        where: Record<string, unknown>;
+      };
+      expect(findManyCall.where.NOT).toBeDefined();
+    });
+
+    it('forwards explicit actionTypes when provided', async () => {
+      mockDb.legislativeAction.findMany.mockResolvedValue([] as never);
+      mockDb.legislativeAction.count.mockResolvedValue(0);
+
+      await service.getRepresentativeActivity({
+        representativeId: 'rep-1',
+        actionTypes: ['committee_hearing'],
+      });
+
+      const findManyCall = mockDb.legislativeAction.findMany.mock
+        .calls[0][0] as {
+        where: Record<string, unknown>;
+      };
+      expect(findManyCall.where.actionType).toEqual({
+        in: ['committee_hearing'],
+      });
+    });
+
+    it('hasMore=true when results exceed take', async () => {
+      // Service fetches `take + 1` to detect hasMore without a second count.
+      mockDb.legislativeAction.findMany.mockResolvedValue(
+        Array.from({ length: 11 }, (_, i) => ({
+          id: `la-${i}`,
+          externalId: `ext-${i}`,
+          body: 'Assembly',
+          date: new Date('2026-04-28'),
+          actionType: 'amendment',
+          position: null,
+          text: null,
+          passageStart: null,
+          passageEnd: null,
+          rawSubject: null,
+          representativeId: 'rep-1',
+          propositionId: null,
+          committeeId: null,
+          minutesId: 'min-1',
+          minutes: { externalId: 'meet-1' },
+        })) as never,
+      );
+      mockDb.legislativeAction.count.mockResolvedValue(50);
+
+      const result = await service.getRepresentativeActivity({
+        representativeId: 'rep-1',
+        take: 10,
+      });
+
+      expect(result.items).toHaveLength(10);
+      expect(result.hasMore).toBe(true);
+    });
+  });
+
+  describe('getMinutesPassage', () => {
+    it('returns null when the action does not exist', async () => {
+      mockDb.legislativeAction.findUnique.mockResolvedValue(null);
+      const result = await service.getMinutesPassage('missing');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the parent Minutes has no rawText', async () => {
+      mockDb.legislativeAction.findUnique.mockResolvedValue({
+        id: 'la-1',
+        passageStart: 0,
+        passageEnd: 10,
+        minutes: { rawText: null },
+      } as never);
+      const result = await service.getMinutesPassage('la-1');
+      expect(result).toBeNull();
+    });
+
+    it('slices passageText, caps at 1kB, and snaps context window', async () => {
+      const rawText =
+        'Lots of preceding context. ' +
+        'PASSAGE_BEGIN here is the action body PASSAGE_END ' +
+        'And then trailing context that flows on for some chars.';
+      const start = rawText.indexOf('PASSAGE_BEGIN');
+      const end = rawText.indexOf('PASSAGE_END') + 'PASSAGE_END'.length;
+
+      mockDb.legislativeAction.findUnique.mockResolvedValue({
+        id: 'la-1',
+        passageStart: start,
+        passageEnd: end,
+        minutes: {
+          externalId: 'meet-1',
+          body: 'Assembly',
+          date: new Date('2026-04-28'),
+          sourceUrl: 'https://example/journal.pdf',
+          rawText,
+        },
+      } as never);
+
+      const result = await service.getMinutesPassage('la-1');
+      expect(result).not.toBeNull();
+      expect(result?.passageText).toContain('PASSAGE_BEGIN');
+      expect(result?.passageText).toContain('PASSAGE_END');
+      expect(result?.minutesExternalId).toBe('meet-1');
+      // Context window includes surrounding text
+      expect(result?.sectionContext).toContain('preceding context');
+    });
+  });
+
+  describe('getCommitteeActivityStats', () => {
+    it('aggregates groupBy + distinct propositionIds', async () => {
+      mockDb.legislativeAction.groupBy.mockResolvedValue([
+        { actionType: 'committee_hearing', _count: { _all: 7 } },
+        { actionType: 'committee_report', _count: { _all: 43 } },
+        { actionType: 'amendment', _count: { _all: 41 } },
+      ] as never);
+      mockDb.legislativeAction.findMany.mockResolvedValue([
+        { propositionId: 'p1' },
+        { propositionId: 'p2' },
+        { propositionId: 'p3' },
+      ] as never);
+
+      const result = await service.getCommitteeActivityStats('cmt-1', 90);
+
+      expect(result.hearings).toBe(7);
+      expect(result.reports).toBe(43);
+      expect(result.amendments).toBe(41);
+      expect(result.distinctBills).toBe(3);
+    });
+  });
+
+  describe('getCommitteeActivity', () => {
+    it('returns paginated feed scoped by committeeId', async () => {
+      mockDb.legislativeAction.findMany.mockResolvedValue([
+        {
+          id: 'la-1',
+          externalId: 'ext-1',
+          body: 'Assembly',
+          date: new Date('2026-04-28'),
+          actionType: 'committee_report',
+          position: null,
+          text: 'Do pass.',
+          passageStart: 100,
+          passageEnd: 110,
+          rawSubject: 'AB 1897',
+          representativeId: null,
+          propositionId: null,
+          committeeId: 'cmt-1',
+          minutesId: 'min-1',
+          minutes: { externalId: 'meet-1' },
+        },
+      ] as never);
+      mockDb.legislativeAction.count.mockResolvedValue(1);
+
+      const result = await service.getCommitteeActivity({
+        committeeId: 'cmt-1',
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.items[0].committeeId).toBe('cmt-1');
+      expect(result.items[0].minutesExternalId).toBe('meet-1');
+    });
+
+    it('forwards actionTypes filter to Prisma', async () => {
+      mockDb.legislativeAction.findMany.mockResolvedValue([] as never);
+      mockDb.legislativeAction.count.mockResolvedValue(0);
+
+      await service.getCommitteeActivity({
+        committeeId: 'cmt-1',
+        actionTypes: ['committee_hearing'],
+      });
+
+      const findManyCall = mockDb.legislativeAction.findMany.mock
+        .calls[0][0] as {
+        where: Record<string, unknown>;
+      };
+      expect(findManyCall.where.actionType).toEqual({
+        in: ['committee_hearing'],
+      });
+    });
+  });
+
   describe('getRepresentativesByDistricts', () => {
     it('should return empty array when no districts provided', async () => {
       // Reset call tracking so we only see calls from our method

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -87,6 +87,35 @@ import { PaginatedIndependentExpenditures } from './models/independent-expenditu
 
 // Type aliases for database query results and generic upsert
 type ExternalIdRecord = { externalId: string };
+
+/**
+ * Single row in a paginated LegislativeAction feed (rep + committee
+ * activity surfaces share this shape). Issue #665.
+ */
+interface LegislativeActionFeedItem {
+  id: string;
+  externalId: string;
+  body: string;
+  date: Date;
+  actionType: string;
+  position: string | null;
+  text: string | null;
+  passageStart: number | null;
+  passageEnd: number | null;
+  rawSubject: string | null;
+  representativeId: string | null;
+  propositionId: string | null;
+  committeeId: string | null;
+  minutesId: string;
+  minutesExternalId: string;
+}
+
+interface LegislativeActionFeedPage {
+  items: LegislativeActionFeedItem[];
+  total: number;
+  hasMore: boolean;
+}
+
 type PrismaModelDelegate = {
   findMany(args: unknown): Promise<ExternalIdRecord[]>;
   upsert(args: unknown): Prisma.PrismaPromise<unknown>;
@@ -1868,63 +1897,36 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       };
     }
 
-    const since = new Date();
-    since.setDate(since.getDate() - sinceDays);
+    const since = this.windowSince(sinceDays);
+    const repWhere = { representativeId, date: { gte: since } };
 
-    const [byType, presentDays, absenceDays, totalSessionDays] =
+    const [counts, presentDays, absenceDays, totalSessionDays] =
       await Promise.all([
-        // Counts of FK-linked actions for this rep, grouped by type.
-        this.db.legislativeAction.groupBy({
-          by: ['actionType'],
-          where: {
-            representativeId,
-            date: { gte: since },
-          },
-          _count: { _all: true },
+        this.actionCountsByType(repWhere),
+        this.distinctActionDates({
+          ...repWhere,
+          actionType: 'presence',
+          position: 'yes',
         }),
-        // Distinct days where rep was marked present.
-        this.db.legislativeAction.findMany({
-          where: {
-            representativeId,
-            actionType: 'presence',
-            position: 'yes',
-            date: { gte: since },
-          },
-          distinct: ['date'],
-          select: { date: true },
-        }),
-        // Distinct days with an absence record for this rep.
-        this.db.legislativeAction.findMany({
-          where: {
-            representativeId,
-            actionType: 'presence',
-            position: 'absent',
-            date: { gte: since },
-          },
-          distinct: ['date'],
-          select: { date: true },
+        this.distinctActionDates({
+          ...repWhere,
+          actionType: 'presence',
+          position: 'absent',
         }),
         // Distinct session days observed in the chamber overall —
         // any presence row from the same body. Acts as the
         // attendance denominator.
-        this.db.legislativeAction.findMany({
-          where: {
-            body: rep.chamber,
-            actionType: 'presence',
-            date: { gte: since },
-          },
-          distinct: ['date'],
-          select: { date: true },
+        this.distinctActionDates({
+          body: rep.chamber,
+          actionType: 'presence',
+          date: { gte: since },
         }),
       ]);
 
-    const counts = new Map<string, number>();
-    for (const g of byType) counts.set(g.actionType, g._count._all);
-
     return {
-      presentSessionDays: presentDays.length,
-      totalSessionDays: totalSessionDays.length,
-      absenceDays: absenceDays.length,
+      presentSessionDays: presentDays,
+      totalSessionDays: totalSessionDays,
+      absenceDays: absenceDays,
       amendments: counts.get('amendment') ?? 0,
       committeeHearings: counts.get('committee_hearing') ?? 0,
       committeeReports: counts.get('committee_report') ?? 0,
@@ -1947,76 +1949,19 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     includePresenceYes?: boolean;
     skip?: number;
     take?: number;
-  }): Promise<{
-    items: Array<{
-      id: string;
-      externalId: string;
-      body: string;
-      date: Date;
-      actionType: string;
-      position: string | null;
-      text: string | null;
-      passageStart: number | null;
-      passageEnd: number | null;
-      rawSubject: string | null;
-      representativeId: string | null;
-      propositionId: string | null;
-      committeeId: string | null;
-      minutesId: string;
-      minutesExternalId: string;
-    }>;
-    total: number;
-    hasMore: boolean;
-  }> {
-    const skip = args.skip ?? 0;
-    const take = args.take ?? 10;
-    const where: Record<string, unknown> = {
+  }): Promise<LegislativeActionFeedPage> {
+    const where: Record<string, unknown> = this.buildActionFeedWhere({
       representativeId: args.representativeId,
-    };
-    if (args.actionTypes && args.actionTypes.length > 0) {
-      where.actionType = { in: args.actionTypes };
-    }
-    // Default: hide presence:yes from the feed unless caller asks
-    // for it OR has explicitly listed `presence` in actionTypes.
+      actionTypes: args.actionTypes,
+    });
+    // Default: hide presence:yes from the rep feed unless caller
+    // asks for it OR has explicitly listed `presence` in actionTypes.
+    // (Committee feeds don't carry presence rows, so this guard
+    // lives on the rep-side wrapper rather than in the shared helper.)
     if (!args.includePresenceYes && !args.actionTypes?.includes('presence')) {
       where.NOT = { AND: [{ actionType: 'presence' }, { position: 'yes' }] };
     }
-
-    const [rows, total] = await Promise.all([
-      this.db.legislativeAction.findMany({
-        where,
-        orderBy: [{ date: 'desc' }, { createdAt: 'desc' }],
-        skip,
-        take: take + 1,
-        include: { minutes: { select: { externalId: true } } },
-      }),
-      this.db.legislativeAction.count({ where }),
-    ]);
-
-    const hasMore = rows.length > take;
-    const trimmed = rows.slice(0, take);
-
-    return {
-      items: trimmed.map((r) => ({
-        id: r.id,
-        externalId: r.externalId,
-        body: r.body,
-        date: r.date,
-        actionType: r.actionType,
-        position: r.position,
-        text: r.text,
-        passageStart: r.passageStart,
-        passageEnd: r.passageEnd,
-        rawSubject: r.rawSubject,
-        representativeId: r.representativeId,
-        propositionId: r.propositionId,
-        committeeId: r.committeeId,
-        minutesId: r.minutesId,
-        minutesExternalId: r.minutes.externalId,
-      })),
-      total,
-      hasMore,
-    };
+    return this.paginateLegislativeActions(where, args.skip, args.take);
   }
 
   /**
@@ -2067,13 +2012,15 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     const passageText = raw.slice(start, end);
 
     // Context window snapped to whitespace boundaries on each end.
-    const ctxStart = this.snapToBoundaryBack(
+    const ctxStart = this.snapToWhitespace(
       raw,
       Math.max(0, start - CONTEXT_HALF),
+      'back',
     );
-    const ctxEnd = this.snapToBoundaryForward(
+    const ctxEnd = this.snapToWhitespace(
       raw,
       Math.min(raw.length, end + CONTEXT_HALF),
+      'forward',
     );
     const sectionContext = raw.slice(ctxStart, ctxEnd);
 
@@ -2091,20 +2038,26 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     };
   }
 
-  private snapToBoundaryBack(text: string, idx: number): number {
-    const probe = Math.max(0, idx);
-    if (probe === 0) return 0;
-    // Walk back at most 50 chars to find a whitespace boundary.
-    for (let i = probe; i > Math.max(0, probe - 50); i--) {
-      if (/\s/.test(text[i])) return i + 1;
+  /**
+   * Walk up to 50 chars in `direction` from `idx` looking for a
+   * whitespace boundary, so the context window doesn't truncate
+   * mid-word. Falls back to the original index if nothing is found.
+   */
+  private snapToWhitespace(
+    text: string,
+    idx: number,
+    direction: 'back' | 'forward',
+  ): number {
+    if (direction === 'back') {
+      const probe = Math.max(0, idx);
+      if (probe === 0) return 0;
+      for (let i = probe; i > Math.max(0, probe - 50); i--) {
+        if (/\s/.test(text[i])) return i + 1;
+      }
+      return probe;
     }
-    return probe;
-  }
-
-  private snapToBoundaryForward(text: string, idx: number): number {
     const probe = Math.min(text.length, idx);
     if (probe === text.length) return probe;
-    // Walk forward at most 50 chars to find a whitespace boundary.
     for (let i = probe; i < Math.min(text.length, probe + 50); i++) {
       if (/\s/.test(text[i])) return i;
     }
@@ -2129,31 +2082,18 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     amendments: number;
     distinctBills: number;
   }> {
-    const since = new Date();
-    since.setDate(since.getDate() - sinceDays);
+    const since = this.windowSince(sinceDays);
+    const cmtWhere = { committeeId, date: { gte: since } };
 
-    const [byType, distinctBills] = await Promise.all([
-      this.db.legislativeAction.groupBy({
-        by: ['actionType'],
-        where: { committeeId, date: { gte: since } },
-        _count: { _all: true },
-      }),
+    const [counts, distinctBills] = await Promise.all([
+      this.actionCountsByType(cmtWhere),
       // Distinct propositions touched by any action of this committee.
-      // We can't `groupBy` + filter on non-null in one Prisma call cleanly,
-      // so do it as a raw findMany + Set.
       this.db.legislativeAction.findMany({
-        where: {
-          committeeId,
-          date: { gte: since },
-          propositionId: { not: null },
-        },
+        where: { ...cmtWhere, propositionId: { not: null } },
         distinct: ['propositionId'],
         select: { propositionId: true },
       }),
     ]);
-
-    const counts = new Map<string, number>();
-    for (const g of byType) counts.set(g.actionType, g._count._all);
 
     return {
       hearings: counts.get('committee_hearing') ?? 0,
@@ -2174,34 +2114,85 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     actionTypes?: string[];
     skip?: number;
     take?: number;
-  }): Promise<{
-    items: Array<{
-      id: string;
-      externalId: string;
-      body: string;
-      date: Date;
-      actionType: string;
-      position: string | null;
-      text: string | null;
-      passageStart: number | null;
-      passageEnd: number | null;
-      rawSubject: string | null;
-      representativeId: string | null;
-      propositionId: string | null;
-      committeeId: string | null;
-      minutesId: string;
-      minutesExternalId: string;
-    }>;
-    total: number;
-    hasMore: boolean;
-  }> {
-    const skip = args.skip ?? 0;
-    const take = args.take ?? 10;
-    const where: Record<string, unknown> = { committeeId: args.committeeId };
+  }): Promise<LegislativeActionFeedPage> {
+    const where = this.buildActionFeedWhere({
+      committeeId: args.committeeId,
+      actionTypes: args.actionTypes,
+    });
+    return this.paginateLegislativeActions(where, args.skip, args.take);
+  }
+
+  // ==========================================
+  // Shared helpers for the LegislativeAction feed (issue #665)
+  // ==========================================
+
+  /** ISO-shifted "now minus N days" window start. */
+  private windowSince(sinceDays: number): Date {
+    const since = new Date();
+    since.setDate(since.getDate() - sinceDays);
+    return since;
+  }
+
+  /** groupBy(actionType) → Map<actionType, count>. Used by both *ActivityStats. */
+  private async actionCountsByType(
+    where: Record<string, unknown>,
+  ): Promise<Map<string, number>> {
+    const groups = await this.db.legislativeAction.groupBy({
+      by: ['actionType'],
+      where,
+      _count: { _all: true },
+    });
+    const m = new Map<string, number>();
+    for (const g of groups) m.set(g.actionType, g._count._all);
+    return m;
+  }
+
+  /** Distinct-day count for a where clause. Used 3x in rep stats. */
+  private async distinctActionDates(
+    where: Record<string, unknown>,
+  ): Promise<number> {
+    const rows = await this.db.legislativeAction.findMany({
+      where,
+      distinct: ['date'],
+      select: { date: true },
+    });
+    return rows.length;
+  }
+
+  /**
+   * Build the Prisma `where` shape used by both the rep- and
+   * committee-scoped activity feeds. Encapsulates the (entityId,
+   * actionTypes) → where mapping so both wrappers stay tiny.
+   */
+  private buildActionFeedWhere(args: {
+    representativeId?: string;
+    committeeId?: string;
+    actionTypes?: string[];
+  }): Record<string, unknown> {
+    const where: Record<string, unknown> = {};
+    if (args.representativeId) where.representativeId = args.representativeId;
+    if (args.committeeId) where.committeeId = args.committeeId;
     if (args.actionTypes && args.actionTypes.length > 0) {
       where.actionType = { in: args.actionTypes };
     }
+    return where;
+  }
 
+  /**
+   * Run the paginated `findMany + count` against
+   * `legislative_actions` for any caller-supplied `where` clause and
+   * return the typed feed-page shape. Both rep + committee feeds
+   * call this; only their `where` differs.
+   *
+   * Uses the standard `take + 1` trick so `hasMore` is computed
+   * without a second count query — the count we DO run is for
+   * `total` which the UI surfaces independently.
+   */
+  private async paginateLegislativeActions(
+    where: Record<string, unknown>,
+    skip = 0,
+    take = 10,
+  ): Promise<LegislativeActionFeedPage> {
     const [rows, total] = await Promise.all([
       this.db.legislativeAction.findMany({
         where,
@@ -2214,28 +2205,46 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     ]);
 
     const hasMore = rows.length > take;
-    const trimmed = rows.slice(0, take);
-
     return {
-      items: trimmed.map((r) => ({
-        id: r.id,
-        externalId: r.externalId,
-        body: r.body,
-        date: r.date,
-        actionType: r.actionType,
-        position: r.position,
-        text: r.text,
-        passageStart: r.passageStart,
-        passageEnd: r.passageEnd,
-        rawSubject: r.rawSubject,
-        representativeId: r.representativeId,
-        propositionId: r.propositionId,
-        committeeId: r.committeeId,
-        minutesId: r.minutesId,
-        minutesExternalId: r.minutes.externalId,
-      })),
+      items: rows.slice(0, take).map((r) => this.toFeedItem(r)),
       total,
       hasMore,
+    };
+  }
+
+  private toFeedItem(r: {
+    id: string;
+    externalId: string;
+    body: string;
+    date: Date;
+    actionType: string;
+    position: string | null;
+    text: string | null;
+    passageStart: number | null;
+    passageEnd: number | null;
+    rawSubject: string | null;
+    representativeId: string | null;
+    propositionId: string | null;
+    committeeId: string | null;
+    minutesId: string;
+    minutes: { externalId: string };
+  }): LegislativeActionFeedItem {
+    return {
+      id: r.id,
+      externalId: r.externalId,
+      body: r.body,
+      date: r.date,
+      actionType: r.actionType,
+      position: r.position,
+      text: r.text,
+      passageStart: r.passageStart,
+      passageEnd: r.passageEnd,
+      rawSubject: r.rawSubject,
+      representativeId: r.representativeId,
+      propositionId: r.propositionId,
+      committeeId: r.committeeId,
+      minutesId: r.minutesId,
+      minutesExternalId: r.minutes.externalId,
     };
   }
 

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -1818,6 +1818,300 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
   }
 
   // ==========================================
+  // LEGISLATIVE ACTION GETTERS (issue #665)
+  // ==========================================
+
+  /**
+   * At-a-glance activity stats for a representative over the last
+   * `sinceDays` days. Drives the Layer-3 counters on the rep detail
+   * page (attendance %, amendments, hearings chaired, etc.).
+   *
+   * Three Prisma reads:
+   *   1. legislativeAction.groupBy on action_type (counts).
+   *   2. distinct dates with presence='yes' for the rep.
+   *   3. distinct dates with ANY presence row for the rep's body
+   *      (used as the denominator for attendance — total session
+   *      days the chamber convened in the window).
+   *
+   * Returns zero counts when the rep doesn't exist or has no
+   * linked actions.
+   */
+  async getRepresentativeActivityStats(
+    representativeId: string,
+    sinceDays: number = 90,
+  ): Promise<{
+    presentSessionDays: number;
+    totalSessionDays: number;
+    absenceDays: number;
+    amendments: number;
+    committeeHearings: number;
+    committeeReports: number;
+    resolutions: number;
+    votes: number;
+    speeches: number;
+  }> {
+    const rep = await this.db.representative.findUnique({
+      where: { id: representativeId },
+      select: { chamber: true },
+    });
+    if (!rep) {
+      return {
+        presentSessionDays: 0,
+        totalSessionDays: 0,
+        absenceDays: 0,
+        amendments: 0,
+        committeeHearings: 0,
+        committeeReports: 0,
+        resolutions: 0,
+        votes: 0,
+        speeches: 0,
+      };
+    }
+
+    const since = new Date();
+    since.setDate(since.getDate() - sinceDays);
+
+    const [byType, presentDays, absenceDays, totalSessionDays] =
+      await Promise.all([
+        // Counts of FK-linked actions for this rep, grouped by type.
+        this.db.legislativeAction.groupBy({
+          by: ['actionType'],
+          where: {
+            representativeId,
+            date: { gte: since },
+          },
+          _count: { _all: true },
+        }),
+        // Distinct days where rep was marked present.
+        this.db.legislativeAction.findMany({
+          where: {
+            representativeId,
+            actionType: 'presence',
+            position: 'yes',
+            date: { gte: since },
+          },
+          distinct: ['date'],
+          select: { date: true },
+        }),
+        // Distinct days with an absence record for this rep.
+        this.db.legislativeAction.findMany({
+          where: {
+            representativeId,
+            actionType: 'presence',
+            position: 'absent',
+            date: { gte: since },
+          },
+          distinct: ['date'],
+          select: { date: true },
+        }),
+        // Distinct session days observed in the chamber overall —
+        // any presence row from the same body. Acts as the
+        // attendance denominator.
+        this.db.legislativeAction.findMany({
+          where: {
+            body: rep.chamber,
+            actionType: 'presence',
+            date: { gte: since },
+          },
+          distinct: ['date'],
+          select: { date: true },
+        }),
+      ]);
+
+    const counts = new Map<string, number>();
+    for (const g of byType) counts.set(g.actionType, g._count._all);
+
+    return {
+      presentSessionDays: presentDays.length,
+      totalSessionDays: totalSessionDays.length,
+      absenceDays: absenceDays.length,
+      amendments: counts.get('amendment') ?? 0,
+      committeeHearings: counts.get('committee_hearing') ?? 0,
+      committeeReports: counts.get('committee_report') ?? 0,
+      resolutions: counts.get('resolution') ?? 0,
+      votes: counts.get('vote') ?? 0,
+      speeches: counts.get('speech') ?? 0,
+    };
+  }
+
+  /**
+   * Reverse-chronological feed of LegislativeAction records linked
+   * to a representative. By default filters out `presence:yes` rows
+   * (too noisy for the activity feed — they're already summarized
+   * in the attendance counter). Passes through other action types
+   * including absence records, hearings, amendments, resolutions.
+   */
+  async getRepresentativeActivity(args: {
+    representativeId: string;
+    actionTypes?: string[];
+    includePresenceYes?: boolean;
+    skip?: number;
+    take?: number;
+  }): Promise<{
+    items: Array<{
+      id: string;
+      externalId: string;
+      body: string;
+      date: Date;
+      actionType: string;
+      position: string | null;
+      text: string | null;
+      passageStart: number | null;
+      passageEnd: number | null;
+      rawSubject: string | null;
+      representativeId: string | null;
+      propositionId: string | null;
+      committeeId: string | null;
+      minutesId: string;
+      minutesExternalId: string;
+    }>;
+    total: number;
+    hasMore: boolean;
+  }> {
+    const skip = args.skip ?? 0;
+    const take = args.take ?? 10;
+    const where: Record<string, unknown> = {
+      representativeId: args.representativeId,
+    };
+    if (args.actionTypes && args.actionTypes.length > 0) {
+      where.actionType = { in: args.actionTypes };
+    }
+    // Default: hide presence:yes from the feed unless caller asks
+    // for it OR has explicitly listed `presence` in actionTypes.
+    if (!args.includePresenceYes && !args.actionTypes?.includes('presence')) {
+      where.NOT = { AND: [{ actionType: 'presence' }, { position: 'yes' }] };
+    }
+
+    const [rows, total] = await Promise.all([
+      this.db.legislativeAction.findMany({
+        where,
+        orderBy: [{ date: 'desc' }, { createdAt: 'desc' }],
+        skip,
+        take: take + 1,
+        include: { minutes: { select: { externalId: true } } },
+      }),
+      this.db.legislativeAction.count({ where }),
+    ]);
+
+    const hasMore = rows.length > take;
+    const trimmed = rows.slice(0, take);
+
+    return {
+      items: trimmed.map((r) => ({
+        id: r.id,
+        externalId: r.externalId,
+        body: r.body,
+        date: r.date,
+        actionType: r.actionType,
+        position: r.position,
+        text: r.text,
+        passageStart: r.passageStart,
+        passageEnd: r.passageEnd,
+        rawSubject: r.rawSubject,
+        representativeId: r.representativeId,
+        propositionId: r.propositionId,
+        committeeId: r.committeeId,
+        minutesId: r.minutesId,
+        minutesExternalId: r.minutes.externalId,
+      })),
+      total,
+      hasMore,
+    };
+  }
+
+  /**
+   * Resolve a single LegislativeAction to its source passage —
+   * `Minutes.rawText.slice(passageStart, passageEnd)` plus a
+   * surrounding context window. Used by the L4 quote panel and the
+   * citation flow on rep + committee pages.
+   *
+   * Caps the passage at 1kB and the context at 500 chars on either
+   * side. Snaps both to whitespace boundaries to avoid mid-word
+   * truncation.
+   */
+  async getMinutesPassage(actionId: string): Promise<{
+    actionId: string;
+    minutesExternalId: string;
+    body: string;
+    date: Date;
+    sourceUrl: string;
+    passageStart: number;
+    passageEnd: number;
+    passageText: string;
+    sectionContext?: string;
+  } | null> {
+    const action = await this.db.legislativeAction.findUnique({
+      where: { id: actionId },
+      include: {
+        minutes: {
+          select: {
+            externalId: true,
+            body: true,
+            date: true,
+            sourceUrl: true,
+            rawText: true,
+          },
+        },
+      },
+    });
+    if (!action || !action.minutes.rawText) return null;
+    if (action.passageStart === null || action.passageEnd === null) return null;
+
+    const raw = action.minutes.rawText;
+    const PASSAGE_CAP = 1024;
+    const CONTEXT_HALF = 500;
+
+    const start = Math.max(0, action.passageStart);
+    const cappedEnd = Math.min(raw.length, start + PASSAGE_CAP);
+    const end = Math.min(action.passageEnd, cappedEnd);
+    const passageText = raw.slice(start, end);
+
+    // Context window snapped to whitespace boundaries on each end.
+    const ctxStart = this.snapToBoundaryBack(
+      raw,
+      Math.max(0, start - CONTEXT_HALF),
+    );
+    const ctxEnd = this.snapToBoundaryForward(
+      raw,
+      Math.min(raw.length, end + CONTEXT_HALF),
+    );
+    const sectionContext = raw.slice(ctxStart, ctxEnd);
+
+    return {
+      actionId: action.id,
+      minutesExternalId: action.minutes.externalId,
+      body: action.minutes.body,
+      date: action.minutes.date,
+      sourceUrl: action.minutes.sourceUrl,
+      passageStart: start,
+      passageEnd: end,
+      passageText,
+      sectionContext:
+        sectionContext === passageText ? undefined : sectionContext,
+    };
+  }
+
+  private snapToBoundaryBack(text: string, idx: number): number {
+    const probe = Math.max(0, idx);
+    if (probe === 0) return 0;
+    // Walk back at most 50 chars to find a whitespace boundary.
+    for (let i = probe; i > Math.max(0, probe - 50); i--) {
+      if (/\s/.test(text[i])) return i + 1;
+    }
+    return probe;
+  }
+
+  private snapToBoundaryForward(text: string, idx: number): number {
+    const probe = Math.min(text.length, idx);
+    if (probe === text.length) return probe;
+    // Walk forward at most 50 chars to find a whitespace boundary.
+    for (let i = probe; i < Math.min(text.length, probe + 50); i++) {
+      if (/\s/.test(text[i])) return i;
+    }
+    return probe;
+  }
+
+  // ==========================================
   // CAMPAIGN FINANCE GETTERS
   // ==========================================
 

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -2111,6 +2111,134 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     return probe;
   }
 
+  /**
+   * At-a-glance activity stats for a legislative committee over the
+   * last `sinceDays` days. Drives the Layer-3 counters on the
+   * committee detail page (recent hearings, bills reported out,
+   * amendments touching the committee).
+   *
+   * Returns zero counts when the committee doesn't exist or has no
+   * linked actions.
+   */
+  async getCommitteeActivityStats(
+    committeeId: string,
+    sinceDays: number = 90,
+  ): Promise<{
+    hearings: number;
+    reports: number;
+    amendments: number;
+    distinctBills: number;
+  }> {
+    const since = new Date();
+    since.setDate(since.getDate() - sinceDays);
+
+    const [byType, distinctBills] = await Promise.all([
+      this.db.legislativeAction.groupBy({
+        by: ['actionType'],
+        where: { committeeId, date: { gte: since } },
+        _count: { _all: true },
+      }),
+      // Distinct propositions touched by any action of this committee.
+      // We can't `groupBy` + filter on non-null in one Prisma call cleanly,
+      // so do it as a raw findMany + Set.
+      this.db.legislativeAction.findMany({
+        where: {
+          committeeId,
+          date: { gte: since },
+          propositionId: { not: null },
+        },
+        distinct: ['propositionId'],
+        select: { propositionId: true },
+      }),
+    ]);
+
+    const counts = new Map<string, number>();
+    for (const g of byType) counts.set(g.actionType, g._count._all);
+
+    return {
+      hearings: counts.get('committee_hearing') ?? 0,
+      reports: counts.get('committee_report') ?? 0,
+      amendments: counts.get('amendment') ?? 0,
+      distinctBills: distinctBills.length,
+    };
+  }
+
+  /**
+   * Reverse-chronological feed of LegislativeActions linked to a
+   * legislative committee. Mirrors `getRepresentativeActivity` but
+   * filters by committeeId. No presence-row noise to filter out
+   * because presence rows aren't committee-attributed.
+   */
+  async getCommitteeActivity(args: {
+    committeeId: string;
+    actionTypes?: string[];
+    skip?: number;
+    take?: number;
+  }): Promise<{
+    items: Array<{
+      id: string;
+      externalId: string;
+      body: string;
+      date: Date;
+      actionType: string;
+      position: string | null;
+      text: string | null;
+      passageStart: number | null;
+      passageEnd: number | null;
+      rawSubject: string | null;
+      representativeId: string | null;
+      propositionId: string | null;
+      committeeId: string | null;
+      minutesId: string;
+      minutesExternalId: string;
+    }>;
+    total: number;
+    hasMore: boolean;
+  }> {
+    const skip = args.skip ?? 0;
+    const take = args.take ?? 10;
+    const where: Record<string, unknown> = { committeeId: args.committeeId };
+    if (args.actionTypes && args.actionTypes.length > 0) {
+      where.actionType = { in: args.actionTypes };
+    }
+
+    const [rows, total] = await Promise.all([
+      this.db.legislativeAction.findMany({
+        where,
+        orderBy: [{ date: 'desc' }, { createdAt: 'desc' }],
+        skip,
+        take: take + 1,
+        include: { minutes: { select: { externalId: true } } },
+      }),
+      this.db.legislativeAction.count({ where }),
+    ]);
+
+    const hasMore = rows.length > take;
+    const trimmed = rows.slice(0, take);
+
+    return {
+      items: trimmed.map((r) => ({
+        id: r.id,
+        externalId: r.externalId,
+        body: r.body,
+        date: r.date,
+        actionType: r.actionType,
+        position: r.position,
+        text: r.text,
+        passageStart: r.passageStart,
+        passageEnd: r.passageEnd,
+        rawSubject: r.rawSubject,
+        representativeId: r.representativeId,
+        propositionId: r.propositionId,
+        committeeId: r.committeeId,
+        minutesId: r.minutesId,
+        minutesExternalId: r.minutes.externalId,
+      })),
+      total,
+      hasMore,
+    };
+  }
+
   // ==========================================
   // CAMPAIGN FINANCE GETTERS
   // ==========================================

--- a/apps/backend/src/apps/region/src/scripts/run-generate-activity-summaries.ts
+++ b/apps/backend/src/apps/region/src/scripts/run-generate-activity-summaries.ts
@@ -1,0 +1,63 @@
+/**
+ * One-off: regenerate AI-driven activity summaries for every
+ * representative and legislative committee with at least one
+ * LegislativeAction in the configured window.
+ *
+ * Mirrors the existing `run-rep-sync.ts` shape.
+ *
+ * Usage (assumes the region container is running and dist is built):
+ *   docker compose -f docker-compose-uat.yml exec region \
+ *     node dist/src/apps/region/apps/region/src/scripts/run-generate-activity-summaries.js
+ *
+ * Optional: pass an override window in days as the first arg.
+ *   ... run-generate-activity-summaries.js 30
+ *
+ * Idempotent — re-running is safe; entities whose underlying actions
+ * haven't changed will produce roughly the same summary (modulo LLM
+ * non-determinism). The persist step always overwrites.
+ *
+ * Issue #665.
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
+import { AppModule } from '../app.module';
+import { EntityActivitySummaryGeneratorService } from '../domains/entity-activity-summary-generator.service';
+
+async function main(): Promise<void> {
+  const logger = new Logger('run-generate-activity-summaries');
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'warn', 'error'],
+  });
+  try {
+    const generator = app.get(EntityActivitySummaryGeneratorService, {
+      strict: false,
+    });
+    const overrideArg = process.argv[2];
+    const overrideWindow = overrideArg
+      ? Number.parseInt(overrideArg, 10)
+      : undefined;
+    if (
+      overrideArg &&
+      (!Number.isFinite(overrideWindow) || (overrideWindow ?? 0) <= 0)
+    ) {
+      logger.warn(`Invalid window arg "${overrideArg}", using default`);
+    }
+    logger.log('Generating activity summaries…');
+    const result = await generator.generateAll(
+      Number.isFinite(overrideWindow) && (overrideWindow ?? 0) > 0
+        ? overrideWindow
+        : undefined,
+    );
+    logger.log(
+      `Done. repsUpdated=${result.repsUpdated} committeesUpdated=${result.committeesUpdated}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Activity summary generation failed:', err);
+  process.exit(1);
+});

--- a/apps/frontend/__tests__/lib/format-action.test.ts
+++ b/apps/frontend/__tests__/lib/format-action.test.ts
@@ -1,0 +1,443 @@
+import {
+  formatActionTitle,
+  formatActionTypeLabel,
+  formatActionExcerpt,
+  actionTypeAccentClass,
+  actionTypeSortKey,
+  groupActionsByType,
+  groupBillBatches,
+} from "@/lib/format-action";
+import type { LegislativeAction } from "@/lib/graphql/region";
+
+const baseAction = (
+  overrides: Partial<LegislativeAction>,
+): LegislativeAction => ({
+  id: overrides.id ?? "la-1",
+  externalId: overrides.externalId ?? "ext-1",
+  body: overrides.body ?? "Assembly",
+  date: overrides.date ?? "2026-04-28",
+  actionType: overrides.actionType ?? "amendment",
+  position: overrides.position,
+  text: overrides.text,
+  passageStart: overrides.passageStart,
+  passageEnd: overrides.passageEnd,
+  rawSubject: overrides.rawSubject,
+  representativeId: overrides.representativeId,
+  propositionId: overrides.propositionId,
+  committeeId: overrides.committeeId,
+  minutesId: overrides.minutesId ?? "min-1",
+  minutesExternalId: overrides.minutesExternalId ?? "meet-1",
+});
+
+describe("formatActionTitle", () => {
+  it("renders presence:yes with subject", () => {
+    expect(
+      formatActionTitle(
+        baseAction({
+          actionType: "presence",
+          position: "yes",
+          rawSubject: "Smith",
+        }),
+      ),
+    ).toBe("Present — Smith");
+  });
+
+  it("renders presence:absent with subject", () => {
+    expect(
+      formatActionTitle(
+        baseAction({
+          actionType: "presence",
+          position: "absent",
+          rawSubject: "Smith",
+        }),
+      ),
+    ).toBe("Absent — Smith");
+  });
+
+  it("falls back when no subject", () => {
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "presence", position: "yes" }),
+      ),
+    ).toBe("Present at rollcall");
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "presence", position: "absent" }),
+      ),
+    ).toBe("Absent from session");
+  });
+
+  it("renders committee_hearing", () => {
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "committee_hearing", rawSubject: "Health" }),
+      ),
+    ).toBe("Hearing: Committee on Health");
+  });
+
+  it("renders committee_report", () => {
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "committee_report", rawSubject: "AB 1897" }),
+      ),
+    ).toBe("Committee reported AB 1897");
+  });
+
+  it("renders amendment", () => {
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "amendment", rawSubject: "AB 500" }),
+      ),
+    ).toBe("Amendment to AB 500");
+  });
+
+  it("renders engrossment + enrollment", () => {
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "engrossment", rawSubject: "AB 1" }),
+      ),
+    ).toBe("AB 1 engrossed");
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "enrollment", rawSubject: "AB 1" }),
+      ),
+    ).toBe("AB 1 enrolled");
+  });
+
+  it("renders resolution", () => {
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "resolution", rawSubject: "ACR 999" }),
+      ),
+    ).toBe("Introduced ACR 999");
+  });
+
+  it("renders V2 vote/speech types", () => {
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "vote", rawSubject: "AB 1897" }),
+      ),
+    ).toBe("Voted on AB 1897");
+    expect(formatActionTitle(baseAction({ actionType: "speech" }))).toBe(
+      "Floor speech",
+    );
+  });
+
+  it("falls back to generic shape for unknown action types", () => {
+    expect(
+      formatActionTitle(
+        baseAction({ actionType: "novel_type", rawSubject: "Subj" }),
+      ),
+    ).toBe("novel_type: Subj");
+    expect(formatActionTitle(baseAction({ actionType: "novel_type" }))).toBe(
+      "novel_type",
+    );
+  });
+
+  it("falls back for empty rawSubject on every type", () => {
+    expect(
+      formatActionTitle(baseAction({ actionType: "committee_hearing" })),
+    ).toBe("Committee hearing");
+    expect(
+      formatActionTitle(baseAction({ actionType: "committee_report" })),
+    ).toBe("Committee report");
+    expect(formatActionTitle(baseAction({ actionType: "amendment" }))).toBe(
+      "Amendment",
+    );
+    expect(formatActionTitle(baseAction({ actionType: "resolution" }))).toBe(
+      "Resolution introduced",
+    );
+    expect(formatActionTitle(baseAction({ actionType: "vote" }))).toBe(
+      "Floor vote",
+    );
+  });
+});
+
+describe("formatActionTypeLabel + actionTypeAccentClass", () => {
+  it("returns human labels for known types", () => {
+    expect(formatActionTypeLabel("presence")).toBe("Attendance");
+    expect(formatActionTypeLabel("committee_hearing")).toBe(
+      "Committee hearing",
+    );
+    expect(formatActionTypeLabel("committee_report")).toBe("Committee report");
+  });
+
+  it("falls back to the raw key for unknown types", () => {
+    expect(formatActionTypeLabel("totally_new")).toBe("totally_new");
+  });
+
+  it("returns a Tailwind class per known type", () => {
+    expect(actionTypeAccentClass("amendment")).toMatch(/amber/);
+    expect(actionTypeAccentClass("committee_hearing")).toMatch(/blue/);
+    expect(actionTypeAccentClass("committee_report")).toMatch(/indigo/);
+    expect(actionTypeAccentClass("engrossment")).toMatch(/emerald/);
+    expect(actionTypeAccentClass("enrollment")).toMatch(/emerald/);
+    expect(actionTypeAccentClass("resolution")).toMatch(/purple/);
+    expect(actionTypeAccentClass("presence")).toMatch(/slate/);
+    expect(actionTypeAccentClass("unknown")).toMatch(/slate/);
+  });
+});
+
+describe("formatActionExcerpt", () => {
+  it("returns undefined when text is missing or whitespace", () => {
+    expect(formatActionExcerpt(baseAction({}))).toBeUndefined();
+    expect(formatActionExcerpt(baseAction({ text: "   " }))).toBeUndefined();
+  });
+
+  it("collapses whitespace + returns full text under cap", () => {
+    expect(
+      formatActionExcerpt(baseAction({ text: "Short  passage\n  here" })),
+    ).toBe("Short passage here");
+  });
+
+  it("truncates long text with an ellipsis", () => {
+    const long = "a".repeat(200);
+    const excerpt = formatActionExcerpt(baseAction({ text: long }), 50);
+    expect(excerpt?.length).toBeLessThanOrEqual(50);
+    expect(excerpt?.endsWith("…")).toBe(true);
+  });
+});
+
+describe("actionTypeSortKey", () => {
+  it("orders higher-signal types first", () => {
+    expect(actionTypeSortKey("committee_hearing")).toBeLessThan(
+      actionTypeSortKey("presence"),
+    );
+    expect(actionTypeSortKey("amendment")).toBeLessThan(
+      actionTypeSortKey("engrossment"),
+    );
+  });
+
+  it("falls back to a high sort key for unknown types", () => {
+    expect(actionTypeSortKey("totally_new")).toBeGreaterThanOrEqual(99);
+  });
+});
+
+describe("groupActionsByType", () => {
+  it("buckets actions by type, preserving within-bucket order", () => {
+    const actions = [
+      baseAction({ id: "1", actionType: "amendment" }),
+      baseAction({ id: "2", actionType: "committee_hearing" }),
+      baseAction({ id: "3", actionType: "amendment" }),
+      baseAction({ id: "4", actionType: "presence" }),
+    ];
+
+    const groups = groupActionsByType(actions);
+
+    expect(groups).toHaveLength(3);
+    // Sort: hearing → amendment → presence
+    expect(groups[0].actionType).toBe("committee_hearing");
+    expect(groups[1].actionType).toBe("amendment");
+    expect(groups[2].actionType).toBe("presence");
+    // Within-bucket order preserved
+    expect(groups[1].items.map((i) => i.id)).toEqual(["1", "3"]);
+  });
+
+  it("populates a human label per bucket", () => {
+    const groups = groupActionsByType([
+      baseAction({ actionType: "committee_report" }),
+    ]);
+    expect(groups[0].label).toBe("Committee report");
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(groupActionsByType([])).toEqual([]);
+  });
+});
+
+describe("groupBillBatches", () => {
+  it("collapses N consecutive engrossments under same date+verdict", () => {
+    const actions = Array.from({ length: 5 }, (_, i) =>
+      baseAction({
+        id: `eng-${i}`,
+        actionType: "engrossment",
+        date: "2026-04-28",
+        rawSubject: `AB 100${i}`,
+        text: `AB 100${i}: Chief Clerk reports engrossed.`,
+      }),
+    );
+
+    const entries = groupBillBatches(actions, 3);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].type).toBe("batch");
+    if (entries[0].type === "batch") {
+      expect(entries[0].actions).toHaveLength(5);
+      expect(entries[0].verdict).toContain("chief clerk reports engrossed");
+    }
+  });
+
+  it("does not batch when the run is below threshold", () => {
+    const actions = [
+      baseAction({
+        id: "1",
+        actionType: "engrossment",
+        date: "2026-04-28",
+        text: "AB 1: engrossed.",
+      }),
+      baseAction({
+        id: "2",
+        actionType: "engrossment",
+        date: "2026-04-28",
+        text: "AB 2: engrossed.",
+      }),
+    ];
+
+    const entries = groupBillBatches(actions, 3);
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.type === "single")).toBe(true);
+  });
+
+  it("breaks the batch on date change", () => {
+    const actions = [
+      baseAction({
+        id: "1",
+        actionType: "engrossment",
+        date: "2026-04-28",
+        text: "Engrossed.",
+      }),
+      baseAction({
+        id: "2",
+        actionType: "engrossment",
+        date: "2026-04-28",
+        text: "Engrossed.",
+      }),
+      baseAction({
+        id: "3",
+        actionType: "engrossment",
+        date: "2026-04-28",
+        text: "Engrossed.",
+      }),
+      baseAction({
+        id: "4",
+        actionType: "engrossment",
+        date: "2026-04-27",
+        text: "Engrossed.",
+      }),
+    ];
+
+    const entries = groupBillBatches(actions, 3);
+    // First three batched, last one single (only 1 entry on its date).
+    expect(entries).toHaveLength(2);
+    expect(entries[0].type).toBe("batch");
+    expect(entries[1].type).toBe("single");
+  });
+
+  it("breaks the batch on verdict change", () => {
+    const actions = [
+      baseAction({
+        id: "1",
+        actionType: "committee_report",
+        date: "2026-04-28",
+        text: "AB 1: Do pass.",
+      }),
+      baseAction({
+        id: "2",
+        actionType: "committee_report",
+        date: "2026-04-28",
+        text: "AB 2: Do pass.",
+      }),
+      baseAction({
+        id: "3",
+        actionType: "committee_report",
+        date: "2026-04-28",
+        text: "AB 3: Do pass.",
+      }),
+      baseAction({
+        id: "4",
+        actionType: "committee_report",
+        date: "2026-04-28",
+        text: "AB 4: Hold.",
+      }),
+      baseAction({
+        id: "5",
+        actionType: "committee_report",
+        date: "2026-04-28",
+        text: "AB 5: Hold.",
+      }),
+      baseAction({
+        id: "6",
+        actionType: "committee_report",
+        date: "2026-04-28",
+        text: "AB 6: Hold.",
+      }),
+    ];
+
+    const entries = groupBillBatches(actions, 3);
+    expect(entries).toHaveLength(2);
+    expect(entries.every((e) => e.type === "batch")).toBe(true);
+    if (entries[0].type === "batch" && entries[1].type === "batch") {
+      expect(entries[0].actions).toHaveLength(3);
+      expect(entries[1].actions).toHaveLength(3);
+    }
+  });
+
+  it("never batches non-batchable types like presence", () => {
+    const actions = Array.from({ length: 5 }, (_, i) =>
+      baseAction({
+        id: `p-${i}`,
+        actionType: "presence",
+        date: "2026-04-28",
+        text: "Present",
+      }),
+    );
+
+    const entries = groupBillBatches(actions, 3);
+    expect(entries.every((e) => e.type === "single")).toBe(true);
+  });
+
+  it("preserves order of single entries between batches", () => {
+    const actions = [
+      baseAction({
+        id: "h-1",
+        actionType: "committee_hearing",
+        date: "2026-04-28",
+      }),
+      baseAction({
+        id: "e-1",
+        actionType: "engrossment",
+        date: "2026-04-28",
+        text: "Engrossed.",
+      }),
+      baseAction({
+        id: "e-2",
+        actionType: "engrossment",
+        date: "2026-04-28",
+        text: "Engrossed.",
+      }),
+      baseAction({
+        id: "e-3",
+        actionType: "engrossment",
+        date: "2026-04-28",
+        text: "Engrossed.",
+      }),
+      baseAction({
+        id: "h-2",
+        actionType: "committee_hearing",
+        date: "2026-04-28",
+      }),
+    ];
+
+    const entries = groupBillBatches(actions, 3);
+    expect(entries).toHaveLength(3);
+    expect(entries[0].type).toBe("single");
+    expect(entries[1].type).toBe("batch");
+    expect(entries[2].type).toBe("single");
+  });
+
+  it("handles missing text without crashing (verdict key falls back)", () => {
+    const actions = Array.from({ length: 3 }, (_, i) =>
+      baseAction({
+        id: `n-${i}`,
+        actionType: "engrossment",
+        date: "2026-04-28",
+        text: undefined,
+      }),
+    );
+
+    const entries = groupBillBatches(actions, 3);
+    expect(entries).toHaveLength(1);
+    if (entries[0].type === "batch") {
+      expect(entries[0].verdict).toBe("(no recorded verdict)");
+    }
+  });
+});

--- a/apps/frontend/__tests__/pages/region/legislative-committee-detail.test.tsx
+++ b/apps/frontend/__tests__/pages/region/legislative-committee-detail.test.tsx
@@ -169,22 +169,23 @@ describe("LegislativeCommitteeDetailPage", () => {
     expect(chairLink).toBeDefined();
   });
 
-  it("shows a hint and the matched hearing on the Hearings layer", async () => {
+  it("shows the live activity feed + scheduled meetings on the Hearings layer", async () => {
     const user = userEvent.setup();
     render(<LegislativeCommitteeDetailPage />);
 
     await user.click(screen.getByRole("button", { name: "See members" }));
     await user.click(screen.getByRole("button", { name: "See hearings" }));
 
-    expect(
-      screen.getByText(/Best-effort match against scheduled meetings/i),
-    ).toBeInTheDocument();
+    // Section headings — the new feed leads, scheduled meetings follow
+    // for forward-looking context. (Issue #665.)
+    expect(screen.getByText("Recent activity")).toBeInTheDocument();
+    expect(screen.getByText("Upcoming scheduled meetings")).toBeInTheDocument();
     expect(
       screen.getByText(/Budget Subcommittee — Hearing/),
     ).toBeInTheDocument();
   });
 
-  it("shows the empty hearings message when none match", async () => {
+  it("shows just the activity feed when no scheduled meetings match", async () => {
     mockQueryResult = {
       data: { legislativeCommittee: { ...mockCommittee, hearings: [] } },
       loading: false,
@@ -196,8 +197,12 @@ describe("LegislativeCommitteeDetailPage", () => {
     await user.click(screen.getByRole("button", { name: "See members" }));
     await user.click(screen.getByRole("button", { name: "See hearings" }));
 
+    // The new "Recent activity" section is always present; the
+    // "Upcoming scheduled meetings" section only renders when the
+    // legacy `committee.hearings` array is non-empty.
+    expect(screen.getByText("Recent activity")).toBeInTheDocument();
     expect(
-      screen.getByText(/No recent hearings matched in the last 12 months/i),
-    ).toBeInTheDocument();
+      screen.queryByText("Upcoming scheduled meetings"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/__tests__/pages/region/page.test.tsx
+++ b/apps/frontend/__tests__/pages/region/page.test.tsx
@@ -106,7 +106,10 @@ describe("RegionPage", () => {
       render(<RegionPage />);
 
       expect(screen.getByText("Propositions")).toBeInTheDocument();
-      expect(screen.getByText("Meetings")).toBeInTheDocument();
+      // MEETINGS card removed from the home page (issue #665) — past
+      // meeting minutes flow through the rep + committee L3 feeds and
+      // forward-looking calendar entries are lower civic-action value.
+      expect(screen.queryByText("Meetings")).not.toBeInTheDocument();
       expect(screen.getByText("Representatives")).toBeInTheDocument();
       // The CAMPAIGN_FINANCE data-type slot now displays as the
       // Legislative Committees card on the home page; the campaign-finance
@@ -122,9 +125,6 @@ describe("RegionPage", () => {
         screen.getByText("Ballot measures and initiatives"),
       ).toBeInTheDocument();
       expect(
-        screen.getByText("Legislative sessions and hearings"),
-      ).toBeInTheDocument();
-      expect(
         screen.getByText("Elected officials and legislators"),
       ).toBeInTheDocument();
       expect(
@@ -132,6 +132,10 @@ describe("RegionPage", () => {
           "Where bills get debated and shaped before the floor vote",
         ),
       ).toBeInTheDocument();
+      // Meetings description should no longer appear (#665).
+      expect(
+        screen.queryByText("Legislative sessions and hearings"),
+      ).not.toBeInTheDocument();
     });
 
     it("should render navigation links to sub-pages", () => {
@@ -140,17 +144,19 @@ describe("RegionPage", () => {
       const propositionsLink = screen.getByRole("link", {
         name: /Propositions/i,
       });
-      const meetingsLink = screen.getByRole("link", { name: /Meetings/i });
       const representativesLink = screen.getByRole("link", {
         name: /Representatives/i,
       });
 
       expect(propositionsLink).toHaveAttribute("href", "/region/propositions");
-      expect(meetingsLink).toHaveAttribute("href", "/region/meetings");
       expect(representativesLink).toHaveAttribute(
         "href",
         "/region/representatives",
       );
+      // No meetings card link on the home page anymore.
+      expect(
+        screen.queryByRole("link", { name: /^Meetings$/i }),
+      ).not.toBeInTheDocument();
 
       const legislativeCommitteesLink = screen.getByRole("link", {
         name: /Legislative Committees/i,

--- a/apps/frontend/__tests__/pages/region/representative-detail.test.tsx
+++ b/apps/frontend/__tests__/pages/region/representative-detail.test.tsx
@@ -184,8 +184,10 @@ describe("RepresentativeDetailPage", () => {
         screen.getByRole("button", { name: /What They'?ve Done/ }),
       );
 
+      // L3 now leads with the live activity feed (issue #665);
+      // "Authored Bills" remains as a ComingSoon section.
+      expect(screen.getByText("Recent activity")).toBeInTheDocument();
       expect(screen.getByText("Authored Bills")).toBeInTheDocument();
-      expect(screen.getByText("Voting Record")).toBeInTheDocument();
     });
 
     it("advances to How They Are Supported (layer 4) via CTA", async () => {

--- a/apps/frontend/app/region/legislative-committees/[id]/page.tsx
+++ b/apps/frontend/app/region/legislative-committees/[id]/page.tsx
@@ -20,6 +20,9 @@ import { ComingSoon } from "@/components/region/ComingSoon";
 import { LayerButton } from "@/components/region/LayerButton";
 import { LayerNav } from "@/components/region/LayerNav";
 import { PartyBadge } from "@/components/region/PartyBadge";
+import { CommitteeActivityStats } from "@/components/region/CommitteeActivityStats";
+import { CommitteeActivityFeed } from "@/components/region/CommitteeActivityFeed";
+import { ActivitySummary } from "@/components/region/ActivitySummary";
 import { formatDate } from "@/lib/format";
 
 const LAYERS = [
@@ -217,34 +220,61 @@ function HearingRow({
   );
 }
 
+/**
+ * Layer 3 — Activity. Live feed of committee_hearing /
+ * committee_report / amendment LegislativeActions extracted from
+ * the committee's recent minutes. Replaces the previous best-effort
+ * title-match against scheduled meetings (which only ever surfaced
+ * upcoming meetings, not past activity). Issue #665.
+ *
+ * The legacy `committee.hearings` field (scheduled meetings list) is
+ * still rendered as a small "Upcoming meetings" section for
+ * forward-looking context.
+ */
 function Hearings({
   committee,
   onNext,
   onBack,
+  onSeePassage,
 }: {
   readonly committee: LegislativeCommitteeDetail;
   readonly onNext: () => void;
   readonly onBack: () => void;
+  readonly onSeePassage?: (actionId: string) => void;
 }) {
   return (
     <div className="animate-layer-enter">
-      <SectionTitle>Recent hearings</SectionTitle>
-      <p className="text-sm text-[#4d4d4d] mb-4">
-        Best-effort match against scheduled meetings in the {committee.chamber}{" "}
-        whose title mentions {committee.name}. An explicit hearing-to-committee
-        link is planned for a later release.
-      </p>
-      {committee.hearings.length === 0 ? (
-        <p className="italic text-slate-400 mb-6">
-          No recent hearings matched in the last 12 months.
-        </p>
-      ) : (
-        <ul className="space-y-2 mb-6">
-          {committee.hearings.map((h) => (
-            <HearingRow key={h.id} hearing={h} />
-          ))}
-        </ul>
+      <ActivitySummary
+        summary={committee.activitySummary}
+        generatedAt={committee.activitySummaryGeneratedAt}
+        windowDays={committee.activitySummaryWindowDays}
+      />
+
+      <CommitteeActivityStats committeeId={committee.id} />
+
+      <div className="mb-8">
+        <SectionTitle>Recent activity</SectionTitle>
+        <CommitteeActivityFeed
+          committeeId={committee.id}
+          onSeePassage={onSeePassage}
+        />
+      </div>
+
+      {committee.hearings.length > 0 && (
+        <div className="mb-8">
+          <SectionTitle>Upcoming scheduled meetings</SectionTitle>
+          <p className="text-sm text-[#4d4d4d] mb-3">
+            Best-effort match against the chamber&apos;s daily file for
+            forward-looking context.
+          </p>
+          <ul className="space-y-2">
+            {committee.hearings.map((h) => (
+              <HearingRow key={h.id} hearing={h} />
+            ))}
+          </ul>
+        </div>
       )}
+
       <div className="flex flex-wrap gap-3">
         <LayerButton onClick={onNext}>Sources & deep dive</LayerButton>
         <LayerButton onClick={onBack} variant="secondary">

--- a/apps/frontend/app/region/page.tsx
+++ b/apps/frontend/app/region/page.tsx
@@ -13,9 +13,11 @@ import {
 import { GET_MY_ADDRESSES, type MyAddressesData } from "@/lib/graphql/profile";
 import { PartyBadge } from "@/components/region/PartyBadge";
 
-const DATA_TYPE_CARDS: Record<
-  DataType,
-  { title: string; description: string; href: string; icon: string }
+const DATA_TYPE_CARDS: Partial<
+  Record<
+    DataType,
+    { title: string; description: string; href: string; icon: string }
+  >
 > = {
   PROPOSITIONS: {
     title: "Propositions",
@@ -23,12 +25,15 @@ const DATA_TYPE_CARDS: Record<
     href: "/region/propositions",
     icon: "ballot",
   },
-  MEETINGS: {
-    title: "Meetings",
-    description: "Legislative sessions and hearings",
-    href: "/region/meetings",
-    icon: "calendar",
-  },
+  // MEETINGS card removed from the home page (issue #665). The
+  // standalone meetings hub mostly surfaces forward-looking
+  // calendar entries, which is lower civic-action value than the
+  // representative + committee + proposition surfaces. Past
+  // meeting minutes (the daily-journal data) are now woven into
+  // the rep + committee Layer-3 activity feeds, not browsed
+  // standalone — daily-journals don't deserve a top-nav entry.
+  // The /region/meetings route stays deployed and reachable by
+  // direct URL; only the home front door changes.
   REPRESENTATIVES: {
     title: "Representatives",
     description: "Elected officials and legislators",

--- a/apps/frontend/app/region/representatives/[id]/page.tsx
+++ b/apps/frontend/app/region/representatives/[id]/page.tsx
@@ -25,6 +25,7 @@ import { LayerButton } from "@/components/region/LayerButton";
 import { LayerNav } from "@/components/region/LayerNav";
 import { ActivityStats } from "@/components/region/ActivityStats";
 import { ActivityFeed } from "@/components/region/ActivityFeed";
+import { ActivitySummary } from "@/components/region/ActivitySummary";
 
 const LAYERS = [
   { n: 1, label: "Who They Are" },
@@ -533,6 +534,12 @@ function WhatTheyveDone({
 }) {
   return (
     <div className="animate-layer-enter">
+      <ActivitySummary
+        summary={rep.activitySummary}
+        generatedAt={rep.activitySummaryGeneratedAt}
+        windowDays={rep.activitySummaryWindowDays}
+      />
+
       <ActivityStats representativeId={rep.id} />
 
       <div className="mb-8">

--- a/apps/frontend/app/region/representatives/[id]/page.tsx
+++ b/apps/frontend/app/region/representatives/[id]/page.tsx
@@ -23,6 +23,8 @@ import { SectionTitle } from "@/components/region/SectionTitle";
 import { ComingSoon } from "@/components/region/ComingSoon";
 import { LayerButton } from "@/components/region/LayerButton";
 import { LayerNav } from "@/components/region/LayerNav";
+import { ActivityStats } from "@/components/region/ActivityStats";
+import { ActivityFeed } from "@/components/region/ActivityFeed";
 
 const LAYERS = [
   { n: 1, label: "Who They Are" },
@@ -510,29 +512,39 @@ function WhatTheyCareAbout({
   );
 }
 
-/** Layer 3 — What They've Done: authored bills + voting record. */
+/**
+ * Layer 3 — What They've Done. Live activity feed driven by the
+ * `legislative_actions` data backing the rep, plus an at-a-glance
+ * stats grid. Click "See passage →" on any action card to surface
+ * the verbatim source text in L4 (citation panel — Phase 3).
+ *
+ * Issue #665.
+ */
 function WhatTheyveDone({
+  rep,
   onNext,
   onBack,
+  onSeePassage,
 }: {
+  readonly rep: Representative;
   readonly onNext: () => void;
   readonly onBack: () => void;
+  readonly onSeePassage?: (actionId: string) => void;
 }) {
   return (
     <div className="animate-layer-enter">
+      <ActivityStats representativeId={rep.id} />
+
+      <div className="mb-8">
+        <SectionTitle>Recent activity</SectionTitle>
+        <ActivityFeed representativeId={rep.id} onSeePassage={onSeePassage} />
+      </div>
+
       <div className="mb-8">
         <SectionTitle>Authored Bills</SectionTitle>
         <ComingSoon
           title="Coming Soon"
           description="Bills authored or co-authored by this representative, with status and subject tags. Tracked in #594."
-        />
-      </div>
-
-      <div className="mb-8">
-        <SectionTitle>Voting Record</SectionTitle>
-        <ComingSoon
-          title="Coming Soon"
-          description="Recent floor and committee votes, with alignment against the caucus and public position statements."
         />
       </div>
 
@@ -838,6 +850,7 @@ export default function RepresentativeDetailPage() {
         )}
         {layer === 3 && (
           <WhatTheyveDone
+            rep={rep}
             onNext={() => setLayer(4)}
             onBack={() => setLayer(1)}
           />

--- a/apps/frontend/components/region/ActionCard.tsx
+++ b/apps/frontend/components/region/ActionCard.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { LegislativeAction } from "@/lib/graphql/region";
+import { formatDate } from "@/lib/format";
+import {
+  formatActionTitle,
+  formatActionTypeLabel,
+  formatActionExcerpt,
+  actionTypeAccentClass,
+} from "@/lib/format-action";
+
+/**
+ * One activity-feed row. Renders a type-coded badge, the
+ * one-line title, the date, and (when available) a short excerpt
+ * pulled from the action's stored text. Clicking "See passage →"
+ * fires `onSeePassage(actionId)` so the parent can open the L4
+ * quote panel or expand inline.
+ *
+ * Issue #665.
+ */
+export function ActionCard({
+  action,
+  onSeePassage,
+}: {
+  readonly action: LegislativeAction;
+  readonly onSeePassage?: (actionId: string) => void;
+}) {
+  const title = formatActionTitle(action);
+  const typeLabel = formatActionTypeLabel(action.actionType);
+  const accent = actionTypeAccentClass(action.actionType);
+  const excerpt = formatActionExcerpt(action);
+  const hasPassageOffsets =
+    typeof action.passageStart === "number" &&
+    typeof action.passageEnd === "number";
+
+  return (
+    <article className="bg-white rounded-lg border border-slate-200 p-4 hover:shadow-sm transition-shadow">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${accent}`}
+            >
+              {typeLabel}
+            </span>
+            <time dateTime={action.date} className="text-xs text-[#595959]">
+              {formatDate(action.date)}
+            </time>
+          </div>
+          <p className="font-medium text-[#222222]">{title}</p>
+          {excerpt && (
+            <p className="mt-1.5 text-sm text-[#4d4d4d] leading-relaxed">
+              {excerpt}
+            </p>
+          )}
+        </div>
+        {hasPassageOffsets && onSeePassage && (
+          <button
+            type="button"
+            onClick={() => onSeePassage(action.id)}
+            className="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline whitespace-nowrap"
+          >
+            See passage →
+          </button>
+        )}
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/components/region/ActionCard.tsx
+++ b/apps/frontend/components/region/ActionCard.tsx
@@ -5,30 +5,37 @@ import { formatDate } from "@/lib/format";
 import {
   formatActionTitle,
   formatActionTypeLabel,
-  formatActionExcerpt,
   actionTypeAccentClass,
 } from "@/lib/format-action";
 
 /**
- * One activity-feed row. Renders a type-coded badge, the
- * one-line title, the date, and (when available) a short excerpt
- * pulled from the action's stored text. Clicking "See passage →"
- * fires `onSeePassage(actionId)` so the parent can open the L4
- * quote panel or expand inline.
+ * One activity-feed row. Renders a type-coded badge, the date,
+ * the one-line title, and (when available) the full verbatim
+ * passage stored on the action. The text column is capped at 4kB
+ * server-side already; rendering inline avoids the
+ * "click-to-expand-once-per-card" friction users hit when there
+ * are dozens of passages on a committee L3 — the column is
+ * scannable and citation-quotable as-is.
+ *
+ * Clicking "See passage →" (Phase 3) opens the source-document
+ * viewer with surrounding context.
  *
  * Issue #665.
  */
 export function ActionCard({
   action,
   onSeePassage,
+  compact = false,
 }: {
   readonly action: LegislativeAction;
   readonly onSeePassage?: (actionId: string) => void;
+  /** When true, drop the type badge + date — used by GroupedBillBatch
+   *  where the batch header already shows them. */
+  readonly compact?: boolean;
 }) {
   const title = formatActionTitle(action);
   const typeLabel = formatActionTypeLabel(action.actionType);
   const accent = actionTypeAccentClass(action.actionType);
-  const excerpt = formatActionExcerpt(action);
   const hasPassageOffsets =
     typeof action.passageStart === "number" &&
     typeof action.passageEnd === "number";
@@ -37,20 +44,22 @@ export function ActionCard({
     <article className="bg-white rounded-lg border border-slate-200 p-4 hover:shadow-sm transition-shadow">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1">
-            <span
-              className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${accent}`}
-            >
-              {typeLabel}
-            </span>
-            <time dateTime={action.date} className="text-xs text-[#595959]">
-              {formatDate(action.date)}
-            </time>
-          </div>
+          {!compact && (
+            <div className="flex items-center gap-2 mb-1.5">
+              <span
+                className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${accent}`}
+              >
+                {typeLabel}
+              </span>
+              <time dateTime={action.date} className="text-xs text-[#595959]">
+                {formatDate(action.date)}
+              </time>
+            </div>
+          )}
           <p className="font-medium text-[#222222]">{title}</p>
-          {excerpt && (
-            <p className="mt-1.5 text-sm text-[#4d4d4d] leading-relaxed">
-              {excerpt}
+          {action.text && (
+            <p className="mt-2 text-sm text-[#4d4d4d] leading-relaxed whitespace-pre-line">
+              {action.text}
             </p>
           )}
         </div>

--- a/apps/frontend/components/region/ActivityFeed.tsx
+++ b/apps/frontend/components/region/ActivityFeed.tsx
@@ -7,7 +7,9 @@ import {
   type LegislativeAction,
   type PaginatedLegislativeActions,
 } from "@/lib/graphql/region";
+import { groupActionsByType, groupBillBatches } from "@/lib/format-action";
 import { ActionCard } from "./ActionCard";
+import { GroupedBillBatch } from "./GroupedBillBatch";
 
 const PAGE_SIZE = 10;
 
@@ -111,13 +113,43 @@ export function ActivityFeed({
         </label>
       </div>
 
-      <ul className="space-y-3">
-        {items.map((action) => (
-          <li key={action.id}>
-            <ActionCard action={action} onSeePassage={onSeePassage} />
-          </li>
-        ))}
-      </ul>
+      {groupActionsByType(items).map((group) => (
+        <section key={group.actionType} className="mb-6">
+          <h3 className="text-xs font-bold uppercase tracking-wider text-[#595959] mb-2 flex items-baseline gap-2">
+            <span>{group.label}</span>
+            <span className="text-[10px] font-medium text-slate-400">
+              · {group.items.length} record
+              {group.items.length === 1 ? "" : "s"}
+            </span>
+          </h3>
+          <ul className="space-y-3">
+            {groupBillBatches(group.items).map((entry) => (
+              <li
+                key={
+                  entry.type === "single"
+                    ? entry.action.id
+                    : `${entry.actionType}-${entry.date}-${entry.actions[0].id}`
+                }
+              >
+                {entry.type === "single" ? (
+                  <ActionCard
+                    action={entry.action}
+                    onSeePassage={onSeePassage}
+                  />
+                ) : (
+                  <GroupedBillBatch
+                    actionType={entry.actionType}
+                    date={entry.date}
+                    verdict={entry.verdict}
+                    actions={entry.actions}
+                    onSeePassage={onSeePassage}
+                  />
+                )}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
 
       {hasMore && (
         <div className="mt-4">

--- a/apps/frontend/components/region/ActivityFeed.tsx
+++ b/apps/frontend/components/region/ActivityFeed.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_REP_ACTIVITY,
+  type LegislativeAction,
+  type PaginatedLegislativeActions,
+} from "@/lib/graphql/region";
+import { ActionCard } from "./ActionCard";
+
+const PAGE_SIZE = 10;
+
+interface Data {
+  representativeActivity: PaginatedLegislativeActions;
+}
+
+interface Vars {
+  id: string;
+  actionTypes?: string[];
+  includePresenceYes?: boolean;
+  skip?: number;
+  take?: number;
+}
+
+/**
+ * Reverse-chronological feed of LegislativeActions linked to a
+ * representative. Defaults to filtering out `presence:yes` (the
+ * highest-volume / lowest-signal entries — the attendance counter
+ * already summarizes them); a toggle reveals them when the user
+ * wants the full record.
+ *
+ * Pagination: first 10, "Load more" pulls 10 at a time.
+ *
+ * Issue #665.
+ */
+export function ActivityFeed({
+  representativeId,
+  onSeePassage,
+}: {
+  readonly representativeId: string;
+  readonly onSeePassage?: (actionId: string) => void;
+}) {
+  const [includePresenceYes, setIncludePresenceYes] = useState(false);
+  const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+  const { data, loading, error } = useQuery<Data, Vars>(GET_REP_ACTIVITY, {
+    variables: {
+      id: representativeId,
+      includePresenceYes,
+      skip: 0,
+      take: pageSize,
+    },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  if (loading && !data) {
+    return (
+      <div className="space-y-3" aria-busy="true" aria-live="polite">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div
+            key={`feed-skeleton-${i.toString()}`}
+            className="h-24 rounded-lg bg-slate-100 animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-600">
+        Couldn&apos;t load recent activity. Try refreshing.
+      </p>
+    );
+  }
+
+  // Defensive optional chaining at every level — the test environment
+  // uses a single global useQuery mock that returns the rep payload
+  // for every query, so `data` may be present but `representativeActivity`
+  // missing. Real queries always return the full shape.
+  const items: LegislativeAction[] = data?.representativeActivity?.items ?? [];
+  const total = data?.representativeActivity?.total ?? 0;
+  const hasMore = data?.representativeActivity?.hasMore ?? false;
+
+  if (total === 0) {
+    return (
+      <p className="italic text-slate-400 text-sm">
+        No recorded activity in the last 90 days.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-xs text-[#595959]">
+          Showing {items.length} of {total} record{total === 1 ? "" : "s"}
+        </p>
+        <label className="inline-flex items-center gap-2 text-xs text-[#595959] cursor-pointer">
+          <input
+            type="checkbox"
+            checked={includePresenceYes}
+            onChange={(e) => {
+              setIncludePresenceYes(e.target.checked);
+              setPageSize(PAGE_SIZE);
+            }}
+            className="h-3.5 w-3.5 rounded border-slate-300"
+          />
+          Include rollcall presence
+        </label>
+      </div>
+
+      <ul className="space-y-3">
+        {items.map((action) => (
+          <li key={action.id}>
+            <ActionCard action={action} onSeePassage={onSeePassage} />
+          </li>
+        ))}
+      </ul>
+
+      {hasMore && (
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setPageSize((p) => p + PAGE_SIZE)}
+            disabled={loading}
+            className="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/region/ActivityStats.tsx
+++ b/apps/frontend/components/region/ActivityStats.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_REP_ACTIVITY_STATS,
+  type RepresentativeActivityStats,
+} from "@/lib/graphql/region";
+
+interface Data {
+  representativeActivityStats: RepresentativeActivityStats;
+}
+
+interface Vars {
+  id: string;
+  sinceDays?: number;
+}
+
+/**
+ * At-a-glance counters for the rep detail page Layer 3 — top tile
+ * grid summarizing attendance + activity over a 90-day window
+ * (configurable via `sinceDays`).
+ *
+ * Designed to read in 5 seconds for a low-info voter: attendance
+ * percentage prominent, activity counts secondary, V2 columns
+ * (votes / speeches) only render when non-zero so they don't show
+ * as zeros while waiting for V2 data.
+ *
+ * Issue #665.
+ */
+export function ActivityStats({
+  representativeId,
+  sinceDays = 90,
+}: {
+  readonly representativeId: string;
+  readonly sinceDays?: number;
+}) {
+  const { data, loading, error } = useQuery<Data, Vars>(
+    GET_REP_ACTIVITY_STATS,
+    { variables: { id: representativeId, sinceDays } },
+  );
+
+  if (loading) {
+    return (
+      <div
+        className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6 animate-pulse"
+        aria-busy="true"
+      >
+        {Array.from({ length: 4 }, (_, i) => (
+          <div
+            key={`stat-skeleton-${i.toString()}`}
+            className="h-24 rounded-lg bg-slate-100"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (error || !data?.representativeActivityStats) {
+    return null; // Silently degrade — feed below still renders.
+  }
+
+  const stats = data.representativeActivityStats;
+  const attendanceRate =
+    stats.totalSessionDays > 0
+      ? Math.round((stats.presentSessionDays / stats.totalSessionDays) * 100)
+      : null;
+
+  return (
+    <section aria-label="Activity at a glance" className="mb-8">
+      <p className="text-xs font-bold uppercase tracking-wider text-[#595959] mb-3">
+        Last {sinceDays} days
+      </p>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatTile
+          label="Attendance"
+          value={attendanceRate !== null ? `${attendanceRate}%` : "—"}
+          sub={`${stats.presentSessionDays} of ${stats.totalSessionDays} session days`}
+          tone={attendanceTone(attendanceRate)}
+        />
+        <StatTile
+          label="Absences (recorded)"
+          value={String(stats.absenceDays)}
+          sub="with stated reason"
+        />
+        <StatTile
+          label="Amendments"
+          value={String(stats.amendments)}
+          sub="floor + committee"
+        />
+        <StatTile
+          label="Hearings"
+          value={String(stats.committeeHearings)}
+          sub="committee chaired"
+        />
+        {stats.committeeReports > 0 && (
+          <StatTile
+            label="Committee reports"
+            value={String(stats.committeeReports)}
+          />
+        )}
+        {stats.resolutions > 0 && (
+          <StatTile label="Resolutions" value={String(stats.resolutions)} />
+        )}
+        {stats.votes > 0 && (
+          <StatTile label="Floor votes" value={String(stats.votes)} />
+        )}
+        {stats.speeches > 0 && (
+          <StatTile label="Speeches" value={String(stats.speeches)} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function attendanceTone(rate: number | null): "neutral" | "good" | "warn" {
+  if (rate === null) return "neutral";
+  if (rate >= 80) return "good";
+  if (rate >= 50) return "neutral";
+  return "warn";
+}
+
+function StatTile({
+  label,
+  value,
+  sub,
+  tone = "neutral",
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly sub?: string;
+  readonly tone?: "neutral" | "good" | "warn";
+}) {
+  const valueClass =
+    tone === "good"
+      ? "text-emerald-700"
+      : tone === "warn"
+        ? "text-amber-700"
+        : "text-[#222222]";
+  return (
+    <div className="bg-slate-50 rounded-lg p-4 border border-slate-100">
+      <p className="text-[11px] font-bold uppercase tracking-wider text-[#595959] mb-1">
+        {label}
+      </p>
+      <p className={`text-2xl font-semibold ${valueClass}`}>{value}</p>
+      {sub && <p className="text-[11px] text-[#595959] mt-1 truncate">{sub}</p>}
+    </div>
+  );
+}

--- a/apps/frontend/components/region/ActivitySummary.tsx
+++ b/apps/frontend/components/region/ActivitySummary.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * AI-generated activity summary card. Renders at the top of Layer 3
+ * on the rep + committee detail pages to give a low-info voter a
+ * 2-3 sentence narrative of what the entity has been doing,
+ * grounded in the structured action records the linker produces.
+ *
+ * Carries the same "AI-generated" affordance treatment as the
+ * existing rep bio so users always know which content is
+ * deterministic vs. machine-summarized. Provenance footer shows the
+ * window and the generated-at timestamp.
+ *
+ * Issue #665.
+ */
+
+interface Props {
+  readonly summary?: string;
+  readonly generatedAt?: string;
+  readonly windowDays?: number;
+}
+
+export function ActivitySummary({ summary, generatedAt, windowDays }: Props) {
+  if (!summary || summary.trim().length === 0) return null;
+
+  const generatedLabel = generatedAt
+    ? new Date(generatedAt).toLocaleDateString(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      })
+    : null;
+
+  return (
+    <section
+      aria-label="Recent activity summary"
+      className="mb-6 bg-amber-50/40 border border-amber-200 rounded-lg p-5"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-800 border border-amber-200">
+          <svg
+            className="w-3 h-3"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 10V3L4 14h7v7l9-11h-7z"
+            />
+          </svg>
+          AI-generated
+        </span>
+        <span className="text-[11px] uppercase tracking-wider font-bold text-[#595959]">
+          Recent activity at a glance
+        </span>
+      </div>
+      <p className="text-[#334155] leading-relaxed whitespace-pre-line">
+        {summary}
+      </p>
+      {(generatedLabel || windowDays) && (
+        <p className="mt-3 text-[11px] text-[#94a3b8] italic">
+          Generated{generatedLabel ? ` ${generatedLabel}` : ""}
+          {windowDays ? ` over the last ${windowDays} days` : ""}. May contain
+          inaccuracies — verify against source records before citing.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/components/region/CommitteeActivityFeed.tsx
+++ b/apps/frontend/components/region/CommitteeActivityFeed.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_COMMITTEE_ACTIVITY,
+  type LegislativeAction,
+  type PaginatedLegislativeActions,
+} from "@/lib/graphql/region";
+import { groupActionsByType, groupBillBatches } from "@/lib/format-action";
+import { ActionCard } from "./ActionCard";
+import { GroupedBillBatch } from "./GroupedBillBatch";
+
+const PAGE_SIZE = 10;
+
+interface Data {
+  committeeActivity: PaginatedLegislativeActions;
+}
+
+interface Vars {
+  committeeId: string;
+  actionTypes?: string[];
+  skip?: number;
+  take?: number;
+}
+
+/**
+ * Reverse-chronological feed of LegislativeActions linked to a
+ * legislative committee — committee_hearing + committee_report +
+ * amendment rows from minutes ingestion. Optional type-filter
+ * dropdown lets the user narrow to just hearings, just reports,
+ * etc. Mirrors `ActivityFeed` but scoped by committeeId. Issue #665.
+ */
+export function CommitteeActivityFeed({
+  committeeId,
+  onSeePassage,
+}: {
+  readonly committeeId: string;
+  readonly onSeePassage?: (actionId: string) => void;
+}) {
+  const [filter, setFilter] = useState<string>("all");
+  const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+  const actionTypes = filter === "all" ? undefined : [filter];
+
+  const { data, loading, error } = useQuery<Data, Vars>(
+    GET_COMMITTEE_ACTIVITY,
+    {
+      variables: {
+        committeeId,
+        actionTypes,
+        skip: 0,
+        take: pageSize,
+      },
+      notifyOnNetworkStatusChange: true,
+    },
+  );
+
+  if (loading && !data) {
+    return (
+      <div className="space-y-3" aria-busy="true" aria-live="polite">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div
+            key={`cmt-feed-skel-${i.toString()}`}
+            className="h-24 rounded-lg bg-slate-100 animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-600">
+        Couldn&apos;t load committee activity. Try refreshing.
+      </p>
+    );
+  }
+
+  const items: LegislativeAction[] = data?.committeeActivity?.items ?? [];
+  const total = data?.committeeActivity?.total ?? 0;
+  const hasMore = data?.committeeActivity?.hasMore ?? false;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3 gap-3 flex-wrap">
+        <p className="text-xs text-[#595959]">
+          Showing {items.length} of {total} record{total === 1 ? "" : "s"}
+        </p>
+        <select
+          value={filter}
+          onChange={(e) => {
+            setFilter(e.target.value);
+            setPageSize(PAGE_SIZE);
+          }}
+          className="text-xs px-2 py-1 rounded border border-slate-300 bg-white text-[#334155] focus:outline-none focus:ring-2 focus:ring-blue-500"
+          aria-label="Filter activity by type"
+        >
+          <option value="all">All activity</option>
+          <option value="committee_hearing">Hearings</option>
+          <option value="committee_report">Bill reports</option>
+          <option value="amendment">Amendments</option>
+        </select>
+      </div>
+
+      {total === 0 ? (
+        <p className="italic text-slate-400 text-sm">
+          No recorded activity in the last 90 days.
+        </p>
+      ) : (
+        groupActionsByType(items).map((group) => (
+          <section key={group.actionType} className="mb-6">
+            <h3 className="text-xs font-bold uppercase tracking-wider text-[#595959] mb-2 flex items-baseline gap-2">
+              <span>{group.label}</span>
+              <span className="text-[10px] font-medium text-slate-400">
+                · {group.items.length} record
+                {group.items.length === 1 ? "" : "s"}
+              </span>
+            </h3>
+            <ul className="space-y-3">
+              {groupBillBatches(group.items).map((entry) => (
+                <li
+                  key={
+                    entry.type === "single"
+                      ? entry.action.id
+                      : `${entry.actionType}-${entry.date}-${entry.actions[0].id}`
+                  }
+                >
+                  {entry.type === "single" ? (
+                    <ActionCard
+                      action={entry.action}
+                      onSeePassage={onSeePassage}
+                    />
+                  ) : (
+                    <GroupedBillBatch
+                      actionType={entry.actionType}
+                      date={entry.date}
+                      verdict={entry.verdict}
+                      actions={entry.actions}
+                      onSeePassage={onSeePassage}
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
+      )}
+
+      {hasMore && (
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setPageSize((p) => p + PAGE_SIZE)}
+            disabled={loading}
+            className="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/region/CommitteeActivityStats.tsx
+++ b/apps/frontend/components/region/CommitteeActivityStats.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_COMMITTEE_ACTIVITY_STATS,
+  type CommitteeActivityStats as Stats,
+} from "@/lib/graphql/region";
+
+interface Data {
+  committeeActivityStats: Stats;
+}
+
+interface Vars {
+  committeeId: string;
+  sinceDays?: number;
+}
+
+/**
+ * At-a-glance counters for the legislative committee detail page
+ * Layer 3 — recent hearings held, bills reported out, amendments
+ * touching the committee. Mirrors the rep ActivityStats but with
+ * committee-specific tiles. Issue #665.
+ */
+export function CommitteeActivityStats({
+  committeeId,
+  sinceDays = 90,
+}: {
+  readonly committeeId: string;
+  readonly sinceDays?: number;
+}) {
+  const { data, loading, error } = useQuery<Data, Vars>(
+    GET_COMMITTEE_ACTIVITY_STATS,
+    { variables: { committeeId, sinceDays } },
+  );
+
+  if (loading) {
+    return (
+      <div
+        className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6 animate-pulse"
+        aria-busy="true"
+      >
+        {Array.from({ length: 4 }, (_, i) => (
+          <div
+            key={`cmt-stat-skel-${i.toString()}`}
+            className="h-24 rounded-lg bg-slate-100"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const stats = data?.committeeActivityStats;
+  if (error || !stats) {
+    return null;
+  }
+
+  return (
+    <section aria-label="Committee activity at a glance" className="mb-8">
+      <p className="text-xs font-bold uppercase tracking-wider text-[#595959] mb-3">
+        Last {sinceDays} days
+      </p>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatTile label="Hearings" value={String(stats.hearings)} />
+        <StatTile label="Bills reported" value={String(stats.reports)} />
+        <StatTile label="Amendments" value={String(stats.amendments)} />
+        <StatTile
+          label="Distinct bills"
+          value={String(stats.distinctBills)}
+          sub="touched by any action"
+        />
+      </div>
+    </section>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  sub,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly sub?: string;
+}) {
+  return (
+    <div className="bg-slate-50 rounded-lg p-4 border border-slate-100">
+      <p className="text-[11px] font-bold uppercase tracking-wider text-[#595959] mb-1">
+        {label}
+      </p>
+      <p className="text-2xl font-semibold text-[#222222]">{value}</p>
+      {sub && <p className="text-[11px] text-[#595959] mt-1 truncate">{sub}</p>}
+    </div>
+  );
+}

--- a/apps/frontend/components/region/GroupedBillBatch.tsx
+++ b/apps/frontend/components/region/GroupedBillBatch.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import type { LegislativeAction } from "@/lib/graphql/region";
+import { formatDate } from "@/lib/format";
+import {
+  formatActionTypeLabel,
+  actionTypeAccentClass,
+} from "@/lib/format-action";
+
+/**
+ * Renders a run of consecutive same-day-same-verdict actions as a
+ * single card with bill chips. Used for engrossment / enrollment /
+ * committee_report blocks where the source journal lists N bills
+ * under one disposition.
+ *
+ * Each bill chip is clickable — fires `onSeePassage(actionId)` for
+ * the underlying action so the citation flow still works on a
+ * per-bill basis. The batch header shows the verdict text once
+ * (e.g. "Chief Clerk reports engrossed").
+ *
+ * Issue #665.
+ */
+export function GroupedBillBatch({
+  actionType,
+  date,
+  verdict,
+  actions,
+  onSeePassage,
+}: {
+  readonly actionType: string;
+  readonly date: string;
+  readonly verdict: string;
+  readonly actions: readonly LegislativeAction[];
+  readonly onSeePassage?: (actionId: string) => void;
+}) {
+  const typeLabel = formatActionTypeLabel(actionType);
+  const accent = actionTypeAccentClass(actionType);
+  // Title-case the verdict for display since we lowercased it for hashing.
+  const verdictDisplay =
+    verdict.length > 0
+      ? verdict.charAt(0).toUpperCase() + verdict.slice(1)
+      : "Recorded";
+
+  return (
+    <article className="bg-white rounded-lg border border-slate-200 p-4 hover:shadow-sm transition-shadow">
+      <div className="flex items-center gap-2 mb-2">
+        <span
+          className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${accent}`}
+        >
+          {typeLabel}
+        </span>
+        <time dateTime={date} className="text-xs text-[#595959]">
+          {formatDate(date)}
+        </time>
+        <span className="text-xs text-[#595959]">·</span>
+        <span className="text-xs font-medium text-[#595959]">
+          {actions.length} bills
+        </span>
+      </div>
+
+      <p className="font-medium text-[#222222] mb-3">{verdictDisplay}</p>
+
+      <ul className="flex flex-wrap gap-1.5" aria-label="Bills in this batch">
+        {actions.map((a) => {
+          const label = a.rawSubject ?? "Bill";
+          const hasPassage =
+            typeof a.passageStart === "number" &&
+            typeof a.passageEnd === "number";
+          if (hasPassage && onSeePassage) {
+            return (
+              <li key={a.id}>
+                <button
+                  type="button"
+                  onClick={() => onSeePassage(a.id)}
+                  className="inline-flex items-center px-2 py-0.5 rounded-md border border-slate-200 bg-slate-50 text-xs font-medium text-[#334155] hover:bg-slate-100 hover:border-slate-300 transition-colors"
+                  title="See source passage"
+                >
+                  {label}
+                </button>
+              </li>
+            );
+          }
+          return (
+            <li key={a.id}>
+              <span className="inline-flex items-center px-2 py-0.5 rounded-md border border-slate-200 bg-slate-50 text-xs font-medium text-[#334155]">
+                {label}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </article>
+  );
+}

--- a/apps/frontend/e2e/region.spec.ts
+++ b/apps/frontend/e2e/region.spec.ts
@@ -436,7 +436,11 @@ test.describe("Region Page", () => {
     await page.goto("/region");
 
     await expect(page.getByText("Propositions")).toBeVisible();
-    await expect(page.getByText("Meetings")).toBeVisible();
+    // Meetings card removed from the home page (issue #665) — past
+    // meeting minutes flow through the rep + committee L3 feeds and
+    // the standalone /region/meetings hub is reachable by direct URL
+    // only.
+    await expect(page.getByText("Meetings")).not.toBeVisible();
     await expect(
       page.getByRole("link", { name: /Representatives.*Elected/i }),
     ).toBeVisible();
@@ -462,10 +466,13 @@ test.describe("Region Page", () => {
     await expect(page).toHaveURL(/\/region\/propositions/);
   });
 
-  test("should navigate to meetings page", async ({ page }) => {
-    await page.goto("/region");
-
-    await page.getByRole("link", { name: /Meetings/i }).click();
+  test("/region/meetings is still reachable by direct URL", async ({
+    page,
+  }) => {
+    // The Meetings card was removed from the home page (#665) but the
+    // route stays deployed for direct linking. Replaces the home-page
+    // click-through that the previous version of this test exercised.
+    await page.goto("/region/meetings");
     await expect(page).toHaveURL(/\/region\/meetings/);
   });
 
@@ -920,8 +927,11 @@ test.describe("Representative Detail Page", () => {
       .last()
       .click();
 
+    // L3 leads with the live activity feed (#665); "Authored Bills"
+    // remains as a placeholder section, while "Voting Record" was
+    // dropped because the per-rep vote attribution work is V2.
+    await expect(page.getByText("Recent activity")).toBeVisible();
     await expect(page.getByText("Authored Bills")).toBeVisible();
-    await expect(page.getByText("Voting Record")).toBeVisible();
   });
 
   test("should advance to How They Are Supported (Layer 4) via CTA", async ({
@@ -1149,9 +1159,11 @@ test.describe("Region Pages - Loading State", () => {
 
     await page.goto("/region");
 
-    // Check for loading skeleton (animate-pulse class)
-    const skeletons = await page.locator(".animate-pulse").count();
-    expect(skeletons).toBeGreaterThan(0);
+    // Use Playwright's auto-waiting expect — `count()` was racing the
+    // render and intermittently observed 0 skeletons after the response
+    // already resolved. `toBeVisible` retries until at least one skeleton
+    // node is in the DOM (within the test timeout).
+    await expect(page.locator(".animate-pulse").first()).toBeVisible();
   });
 });
 

--- a/apps/frontend/e2e/settings.spec.ts
+++ b/apps/frontend/e2e/settings.spec.ts
@@ -335,8 +335,10 @@ test.describe("Profile Settings Page", () => {
 
     await page.goto("/settings");
 
-    const skeletons = await page.locator(".animate-pulse").count();
-    expect(skeletons).toBeGreaterThan(0);
+    // Use Playwright's auto-waiting expect — `count()` was racing the
+    // render. `toBeVisible` retries until at least one skeleton is in
+    // the DOM.
+    await expect(page.locator(".animate-pulse").first()).toBeVisible();
   });
 
   test("should have no WCAG 2.2 AA violations", async ({ page }) => {

--- a/apps/frontend/lib/format-action.ts
+++ b/apps/frontend/lib/format-action.ts
@@ -86,3 +86,168 @@ export function formatActionExcerpt(
   if (text.length <= maxLength) return text;
   return text.slice(0, maxLength - 1).trimEnd() + "…";
 }
+
+// ============================================
+// Type sub-section grouping (issue #665, content expansion)
+// ============================================
+
+/**
+ * Order in which we want type sub-sections to appear in an L3
+ * activity feed. Higher-signal types (hearings, reports) lead;
+ * presence rows (highest volume / lowest signal) sink to the
+ * bottom when included.
+ */
+const TYPE_ORDER: Record<string, number> = {
+  committee_hearing: 1,
+  committee_report: 2,
+  amendment: 3,
+  resolution: 4,
+  engrossment: 5,
+  enrollment: 6,
+  vote: 7,
+  speech: 8,
+  presence: 9,
+};
+
+/** Stable position in the L3 feed for a given action type. */
+export function actionTypeSortKey(actionType: string): number {
+  return TYPE_ORDER[actionType] ?? 99;
+}
+
+/**
+ * Bucket a flat reverse-chronological action list into ordered
+ * `(actionType, items)` groups. Within each group, items keep
+ * their date-desc order — the bucket is purely a visual grouping;
+ * the underlying chronology isn't reshuffled within a type.
+ *
+ * Drives type-section sub-headers in the activity feed
+ * ("Hearings · 7 records", "Bill reports · 43 records", …).
+ */
+export interface ActionGroup {
+  actionType: string;
+  label: string;
+  items: LegislativeAction[];
+}
+
+export function groupActionsByType(
+  actions: readonly LegislativeAction[],
+): ActionGroup[] {
+  const buckets = new Map<string, LegislativeAction[]>();
+  for (const a of actions) {
+    const list = buckets.get(a.actionType) ?? [];
+    list.push(a);
+    buckets.set(a.actionType, list);
+  }
+  return Array.from(buckets.entries())
+    .map(([actionType, items]) => ({
+      actionType,
+      label: formatActionTypeLabel(actionType),
+      items,
+    }))
+    .sort(
+      (a, b) =>
+        actionTypeSortKey(a.actionType) - actionTypeSortKey(b.actionType),
+    );
+}
+
+// ============================================
+// Bill-batch grouping (issue #665, content expansion)
+// ============================================
+
+/**
+ * Within a single section header (e.g. ENGROSSMENT AND ENROLLMENT
+ * REPORTS) the journal lists N bills under one disposition. Each
+ * bill becomes its own LegislativeAction with the same actionType +
+ * date + similar text — so the L3 feed renders as 30 visually
+ * identical cards. Worse, this drowns out higher-signal records on
+ * the page.
+ *
+ * `groupBillBatches` collapses runs of consecutive actions sharing
+ * `(actionType, date, normalized verdict text)` into a single
+ * "batch" entry that can be rendered as one card with N bill chips.
+ *
+ * Returns a flat list where each entry is either a single action
+ * (`type: "single"`) or a batch (`type: "batch"`). The flat shape
+ * keeps integration with `groupActionsByType` simple — both
+ * single + batch entries belong to the same actionType bucket.
+ */
+export type FeedEntry =
+  | { type: "single"; action: LegislativeAction }
+  | {
+      type: "batch";
+      actionType: string;
+      date: string;
+      verdict: string;
+      actions: LegislativeAction[];
+    };
+
+/**
+ * Strip the canonical bill citation off the front of a verdict
+ * string so two bills under the same recommendation hash to the
+ * same key. e.g.
+ *   "AB 1897: Chief Clerk reports engrossed."
+ *   "AB 2333: Chief Clerk reports engrossed."
+ * both reduce to "Chief Clerk reports engrossed.".
+ */
+function normalizeVerdictKey(text: string | undefined): string {
+  if (!text) return "";
+  return text
+    .replace(/^[ASJ]?[A-Z]{1,3}\s*\d+\s*[:.]?\s*/i, "")
+    .trim()
+    .toLowerCase();
+}
+
+/** Action types that are worth batching when consecutive. */
+const BATCHABLE = new Set([
+  "engrossment",
+  "enrollment",
+  "committee_report",
+  "amendment",
+]);
+
+export function groupBillBatches(
+  actions: readonly LegislativeAction[],
+  minBatch = 3,
+): FeedEntry[] {
+  const out: FeedEntry[] = [];
+  let i = 0;
+  while (i < actions.length) {
+    const a = actions[i];
+    if (!BATCHABLE.has(a.actionType)) {
+      out.push({ type: "single", action: a });
+      i += 1;
+      continue;
+    }
+    const dateKey = a.date.slice(0, 10);
+    const verdictKey = normalizeVerdictKey(a.text);
+    const run: LegislativeAction[] = [a];
+    let j = i + 1;
+    while (j < actions.length) {
+      const b = actions[j];
+      if (
+        b.actionType !== a.actionType ||
+        b.date.slice(0, 10) !== dateKey ||
+        normalizeVerdictKey(b.text) !== verdictKey
+      ) {
+        break;
+      }
+      run.push(b);
+      j += 1;
+    }
+    if (run.length >= minBatch) {
+      out.push({
+        type: "batch",
+        actionType: a.actionType,
+        date: a.date,
+        verdict: verdictKey || "(no recorded verdict)",
+        actions: run,
+      });
+      i = j;
+    } else {
+      // Not enough to batch — emit each as a single.
+      for (const r of run) out.push({ type: "single", action: r });
+      i = j;
+    }
+  }
+  return out;
+}

--- a/apps/frontend/lib/format-action.ts
+++ b/apps/frontend/lib/format-action.ts
@@ -1,0 +1,88 @@
+/**
+ * Format a LegislativeAction into a one-line summary suitable for an
+ * activity-feed card. The mapping is defensive — if an action lacks
+ * the fields the per-type template expects, we fall back to a
+ * generic "{actionType}: {rawSubject}" so nothing renders as blank.
+ *
+ * Issue #665.
+ */
+
+import type { LegislativeAction } from "@/lib/graphql/region";
+
+const PUNCH_BY_TYPE: Record<string, string> = {
+  presence: "Attendance",
+  committee_hearing: "Committee hearing",
+  committee_report: "Committee report",
+  amendment: "Amendment",
+  engrossment: "Bill engrossed",
+  enrollment: "Bill enrolled",
+  resolution: "Resolution introduced",
+  vote: "Floor vote",
+  speech: "Floor speech",
+};
+
+export function formatActionTitle(action: LegislativeAction): string {
+  const subject = action.rawSubject?.trim() ?? "";
+  switch (action.actionType) {
+    case "presence":
+      if (action.position === "absent") {
+        return subject ? `Absent — ${subject}` : "Absent from session";
+      }
+      return subject ? `Present — ${subject}` : "Present at rollcall";
+    case "committee_hearing":
+      return subject ? `Hearing: Committee on ${subject}` : "Committee hearing";
+    case "committee_report":
+      return subject ? `Committee reported ${subject}` : "Committee report";
+    case "amendment":
+      return subject ? `Amendment to ${subject}` : "Amendment";
+    case "engrossment":
+      return subject ? `${subject} engrossed` : "Bill engrossed";
+    case "enrollment":
+      return subject ? `${subject} enrolled` : "Bill enrolled";
+    case "resolution":
+      return subject ? `Introduced ${subject}` : "Resolution introduced";
+    case "vote":
+      return subject ? `Voted on ${subject}` : "Floor vote";
+    case "speech":
+      return "Floor speech";
+    default:
+      return subject ? `${action.actionType}: ${subject}` : action.actionType;
+  }
+}
+
+/** A short type-label suitable for a colored badge on the card. */
+export function formatActionTypeLabel(actionType: string): string {
+  return PUNCH_BY_TYPE[actionType] ?? actionType;
+}
+
+/** Tailwind-friendly accent class per action type. Stable across renders. */
+export function actionTypeAccentClass(actionType: string): string {
+  switch (actionType) {
+    case "amendment":
+      return "bg-amber-100 text-amber-800";
+    case "committee_hearing":
+      return "bg-blue-100 text-blue-800";
+    case "committee_report":
+      return "bg-indigo-100 text-indigo-800";
+    case "engrossment":
+    case "enrollment":
+      return "bg-emerald-100 text-emerald-800";
+    case "resolution":
+      return "bg-purple-100 text-purple-800";
+    case "presence":
+      return "bg-slate-100 text-slate-700";
+    default:
+      return "bg-slate-100 text-slate-700";
+  }
+}
+
+/** Compact one-line excerpt of the action's stored text, capped. */
+export function formatActionExcerpt(
+  action: LegislativeAction,
+  maxLength = 140,
+): string | undefined {
+  const text = action.text?.replaceAll(/\s+/g, " ").trim();
+  if (!text) return undefined;
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 1).trimEnd() + "…";
+}

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -120,6 +120,10 @@ export interface Representative {
   bio?: string;
   bioSource?: string;
   bioClaims?: BioClaim[];
+  /** AI-generated 2-3 sentence summary of recent legislative activity. Issue #665. */
+  activitySummary?: string;
+  activitySummaryGeneratedAt?: string;
+  activitySummaryWindowDays?: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -219,6 +223,10 @@ export interface LegislativeCommitteeDetail {
   memberCount: number;
   members: LegislativeCommitteeMember[];
   hearings: LegislativeCommitteeHearing[];
+  /** AI-generated 2-3 sentence summary of recent committee activity. Issue #665. */
+  activitySummary?: string;
+  activitySummaryGeneratedAt?: string;
+  activitySummaryWindowDays?: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -272,6 +280,17 @@ export interface RepresentativeActivityStats {
   resolutions: number;
   votes: number;
   speeches: number;
+}
+
+/**
+ * At-a-glance counters for the legislative committee detail page
+ * Layer 3 ("Activity"). Drives the top-of-L3 stats grid.
+ */
+export interface CommitteeActivityStats {
+  hearings: number;
+  reports: number;
+  amendments: number;
+  distinctBills: number;
 }
 
 /** Verbatim passage from Minutes.rawText for an action. */
@@ -787,6 +806,9 @@ export const GET_REPRESENTATIVE = gql`
         sourceHint
         confidence
       }
+      activitySummary
+      activitySummaryGeneratedAt
+      activitySummaryWindowDays
       createdAt
       updatedAt
     }
@@ -907,6 +929,9 @@ export const GET_LEGISLATIVE_COMMITTEE = gql`
         scheduledAt
         agendaUrl
       }
+      activitySummary
+      activitySummaryGeneratedAt
+      activitySummaryWindowDays
       createdAt
       updatedAt
     }
@@ -1177,6 +1202,53 @@ export const GET_MINUTES_PASSAGE = gql`
       passageEnd
       passageText
       sectionContext
+    }
+  }
+`;
+
+export const GET_COMMITTEE_ACTIVITY_STATS = gql`
+  query GetCommitteeActivityStats($committeeId: ID!, $sinceDays: Int) {
+    committeeActivityStats(committeeId: $committeeId, sinceDays: $sinceDays) {
+      hearings
+      reports
+      amendments
+      distinctBills
+    }
+  }
+`;
+
+export const GET_COMMITTEE_ACTIVITY = gql`
+  query GetCommitteeActivity(
+    $committeeId: ID!
+    $actionTypes: [String!]
+    $skip: Int
+    $take: Int
+  ) {
+    committeeActivity(
+      committeeId: $committeeId
+      actionTypes: $actionTypes
+      skip: $skip
+      take: $take
+    ) {
+      items {
+        id
+        externalId
+        body
+        date
+        actionType
+        position
+        text
+        passageStart
+        passageEnd
+        rawSubject
+        representativeId
+        propositionId
+        committeeId
+        minutesId
+        minutesExternalId
+      }
+      total
+      hasMore
     }
   }
 `;

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -223,6 +223,70 @@ export interface LegislativeCommitteeDetail {
   updatedAt: string;
 }
 
+// ============================================
+// LEGISLATIVE ACTIONS (issue #665)
+// ============================================
+
+/** One discrete legislative action mined from a Minutes document. */
+export interface LegislativeAction {
+  id: string;
+  externalId: string;
+  body: string;
+  date: string;
+  /**
+   * 'presence' | 'committee_hearing' | 'committee_report' |
+   * 'amendment' | 'engrossment' | 'enrollment' | 'resolution' |
+   * 'vote' (V2) | 'speech' (V2)
+   */
+  actionType: string;
+  /** 'yes' | 'no' | 'abstain' | 'absent' — null for non-vote actions in V1. */
+  position?: string;
+  text?: string;
+  passageStart?: number;
+  passageEnd?: number;
+  rawSubject?: string;
+  representativeId?: string;
+  propositionId?: string;
+  committeeId?: string;
+  minutesId: string;
+  minutesExternalId: string;
+}
+
+export interface PaginatedLegislativeActions {
+  items: LegislativeAction[];
+  total: number;
+  hasMore: boolean;
+}
+
+/**
+ * At-a-glance counters for the rep detail page Layer 3
+ * ("What They've Done"). Drives the top-of-L3 stats grid.
+ */
+export interface RepresentativeActivityStats {
+  presentSessionDays: number;
+  totalSessionDays: number;
+  absenceDays: number;
+  amendments: number;
+  committeeHearings: number;
+  committeeReports: number;
+  resolutions: number;
+  votes: number;
+  speeches: number;
+}
+
+/** Verbatim passage from Minutes.rawText for an action. */
+export interface MinutesPassage {
+  actionId: string;
+  minutesExternalId: string;
+  body: string;
+  date: string;
+  sourceUrl: string;
+  passageStart: number;
+  passageEnd: number;
+  passageText: string;
+  sectionContext?: string;
+}
+
 export interface Contribution {
   id: string;
   externalId: string;
@@ -1039,6 +1103,80 @@ export const SYNC_DATA_TYPE = gql`
       itemsUpdated
       errors
       syncedAt
+    }
+  }
+`;
+
+// ============================================
+// LEGISLATIVE ACTIONS (issue #665)
+// ============================================
+
+export const GET_REP_ACTIVITY_STATS = gql`
+  query GetRepresentativeActivityStats($id: ID!, $sinceDays: Int) {
+    representativeActivityStats(id: $id, sinceDays: $sinceDays) {
+      presentSessionDays
+      totalSessionDays
+      absenceDays
+      amendments
+      committeeHearings
+      committeeReports
+      resolutions
+      votes
+      speeches
+    }
+  }
+`;
+
+export const GET_REP_ACTIVITY = gql`
+  query GetRepresentativeActivity(
+    $id: ID!
+    $actionTypes: [String!]
+    $includePresenceYes: Boolean
+    $skip: Int
+    $take: Int
+  ) {
+    representativeActivity(
+      id: $id
+      actionTypes: $actionTypes
+      includePresenceYes: $includePresenceYes
+      skip: $skip
+      take: $take
+    ) {
+      items {
+        id
+        externalId
+        body
+        date
+        actionType
+        position
+        text
+        passageStart
+        passageEnd
+        rawSubject
+        representativeId
+        propositionId
+        committeeId
+        minutesId
+        minutesExternalId
+      }
+      total
+      hasMore
+    }
+  }
+`;
+
+export const GET_MINUTES_PASSAGE = gql`
+  query GetMinutesPassage($actionId: ID!) {
+    minutesPassage(actionId: $actionId) {
+      actionId
+      minutesExternalId
+      body
+      date
+      sourceUrl
+      passageStart
+      passageEnd
+      passageText
+      sectionContext
     }
   }
 `;

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -578,6 +578,15 @@ model Representative {
   bio         String?   @db.Text
   bioSource   String?   @map("bio_source") @db.VarChar(20) /// 'scraped' | 'ai-generated'
   bioClaims   Json?     @map("bio_claims") /// BioClaim[] — per-sentence attribution for ai-generated bios
+  /// AI-generated 2-3 sentence summary of recent legislative activity
+  /// (presence + amendments + hearings + reports linked to this rep).
+  /// Refreshed by run-generate-activity-summaries when new minutes
+  /// ingest. Issue #665.
+  activitySummary           String?   @map("activity_summary") @db.Text
+  activitySummaryGeneratedAt DateTime? @map("activity_summary_generated_at") @db.Timestamptz
+  /// Window the summary covers, in days. Default 90 to match the L3
+  /// stats counters; overridable per-call.
+  activitySummaryWindowDays Int?      @map("activity_summary_window_days")
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz
@@ -605,6 +614,13 @@ model LegislativeCommittee {
   /// AI-generated description placeholder for Phase 2 — kept nullable so the
   /// column ships now and a future analyzer can populate later.
   description String?   @db.Text
+  /// AI-generated 2-3 sentence summary of recent committee activity
+  /// (hearings, bill reports, amendments). Refreshed by
+  /// run-generate-activity-summaries when new minutes ingest.
+  /// Issue #665.
+  activitySummary           String?   @map("activity_summary") @db.Text
+  activitySummaryGeneratedAt DateTime? @map("activity_summary_generated_at") @db.Timestamptz
+  activitySummaryWindowDays Int?      @map("activity_summary_window_days")
   createdAt   DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt   DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
   deletedAt   DateTime? @map("deleted_at") @db.Timestamptz


### PR DESCRIPTION
## Summary

Builds the citizen-facing surface for the daily-journal data shipped in #670. Layer 3 ("What They've Done" on rep pages, "Hearings" on committee pages) gets a live activity feed driven by the LegislativeAction data, plus an AI-generated 2-3 sentence summary at the top to give low-info voters a 5-second read of the entity's recent legislative tempo.

Companion data work: this PR consumes the Minutes + LegislativeAction data structures merged in OpusPopuli/opuspopuli#670 and the regions config in OpusPopuli/opuspopuli-regions#16.

## What's in here

### GraphQL backend (commit 1, `0e47e6d`)
- `representativeActivityStats(id, sinceDays=90)` — at-a-glance counters (attendance %, recorded absences, amendments, hearings chaired, etc.).
- `representativeActivity(id, actionTypes?, includePresenceYes?, skip?, take?)` — paginated reverse-chronological feed of LegislativeActions linked to the rep. Filters out `presence:yes` by default (highest-volume / lowest-signal).
- `minutesPassage(actionId)` — verbatim text from `Minutes.rawText` plus a ~500-char context window snapped to whitespace boundaries. Drives the future quote-and-cite flow.

### Rep page Layer 3 (commit 2, `00197d0`)
- `<ActivityStats>` — 6-tile counter grid; attendance % color-codes (good ≥80% / neutral 50-80% / warn <50%).
- `<ActivityFeed>` — paginated feed; toggle for rollcall presence (default off).
- `<ActionCard>` — type-coded badge + date + one-liner title + excerpt + "See passage →" affordance.
- Replaces the L3 "Authored Bills" + "Voting Record" ComingSoon stubs with the live feed; "Authored Bills" stays as a placeholder for the V2 bill-authorship work in #594.

### Committee feed + content expansion + AI summary (commit 3, `1303bbd`)

**Committee activity feed (Phase 4):**
- `committeeActivityStats(committeeId, sinceDays)` + `committeeActivity(committeeId, actionTypes?, …)` GraphQL queries mirror the rep-side ones.
- `<CommitteeActivityStats>` + `<CommitteeActivityFeed>` components reuse `<ActionCard>`.
- Committee detail page L3 ("Hearings") now leads with the live feed (committee_hearing + committee_report + amendment rows from minutes); legacy daily-file scheduled meetings render below as "Upcoming scheduled meetings" only when they match.

**Deterministic content expansion:**
- `<ActionCard>` renders the FULL `action.text` inline (column is 4kB-capped server-side) instead of a 140-char excerpt.
- `groupActionsByType()` buckets the feed into ordered type sub-sections — Hearings → Bill reports → Amendments → Resolutions → Engrossment → Enrollment — with running counts.
- `groupBillBatches()` collapses runs of consecutive same-day-same-verdict actions (engrossment/enrollment/committee_report/amendment) into a single `<GroupedBillBatch>` card with each bill rendered as a clickable chip. Drops the "30 nearly-identical cards" pattern that drowned higher-signal records.

**AI activity summary:**
- Schema: `representatives.activity_summary` + `_generated_at` + `_window_days` columns; same on `legislative_committees`. Additive — no data loss.
- `EntityActivitySummaryGeneratorService` mirrors `bio-generator.service.ts` exactly: structured-text input (counts + 25 most-recent actions) → `promptClient.getDocumentAnalysisPrompt({ documentType: 'representative-activity-summary' | 'committee-activity-summary' })` → LLM → JSON parse → persist. Prompt templates themselves live in the private prompt-service repo per the IP boundary memory.
- Admin script: `run-generate-activity-summaries.ts` regenerates summaries for every active entity with at least one LegislativeAction in the configured window.
- `<ActivitySummary>` renders at the top of L3 with an amber "AI-generated" badge + provenance footer; hidden when summary is null.

**Verified end-to-end against UAT** (10 minutes / 2,413 actions). Real summaries grounded in the data:

> **Public Safety committee** — "The Public Safety committee in the Assembly has been highly active over the last 90 days, processing 43 committee reports and 41 amendments. Recent actions include multiple hearings held on April 21, 2026, and a significant volume of bill amendments adopted on April 23, followed by a series of reports recommending adoption on April 22."

> **Bauer-Kahan rep** — "Representative Rebecca Bauer-Kahan of the Assembly has been present in the chamber three times within the last 90 days. Her attendance record includes a session on April 15, 2026, where she was noted to be absent due to illness, alongside two other presence records in mid-to-late April 2026."

### Drop Meetings card from home (commit 4, `536ee31`)
The standalone `/region/meetings` hub mostly surfaces forward-looking calendar entries; past meeting minutes flow through the rep + committee L3 feeds now. Home-page `DATA_TYPE_CARDS` becomes `Partial<Record<…>>` so omitting MEETINGS is a typed no-op via the existing render-loop guard. The `/region/meetings` route stays deployed and reachable by direct URL.

## Test plan

- [x] Backend: 1,498 tests pass (10 new resolver-spec cases for the new queries).
- [x] Frontend: 1,173 tests pass (rep-detail + committee-detail spec assertions updated for new sections).
- [x] Live UAT sync: rep + committee L3 render correctly with stats + grouped activity feed + AI summary on Public Safety, Appropriations, Privacy & Consumer Protection, Bauer-Kahan.
- [x] Home page renders only Propositions / Representatives / Legislative Committees cards.
- [x] AI summary generator successfully produced 77+ rep summaries + 31+ committee summaries on first pass.

## Out of scope (deferred)

- **Phase 3 — Citation tooling** (`<PassagePanel>` in L4 + `/minutes/[externalId]` permalink): "See passage →" buttons render but are no-ops until this lands.
- **AI summary auto-refresh on MEETINGS sync**: today the admin script is the trigger. Auto-trigger after sync is a small follow-up.
- **Per-action AI summaries**: `legislative_actions.summary` column is reserved; not populated. The per-entity narrative covers the V1 use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)