### PR TITLE
feat(region,frontend): civics education UI — CivicTerm tooltips, LifecycleProgressBar, /how-it-works hub (#678 #679 #680)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/civics-merge.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/civics-merge.service.spec.ts
@@ -1,0 +1,410 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Unit tests for getCivicsData merge logic and normalizeCivicText helper
+ * on RegionDomainService. Uses prototype-level mock — no NestJS DI needed.
+ */
+
+import { RegionDomainService } from './region.service';
+
+const SRC = 'https://example.gov/page';
+
+function buildSvc(dbRows: any[] = []): any {
+  const svc = Object.create(RegionDomainService.prototype);
+  Object.assign(svc, {
+    logger: { log: jest.fn(), warn: jest.fn(), error: jest.fn() },
+    db: {
+      civicsBlock: {
+        findMany: jest.fn().mockResolvedValue(dbRows),
+      },
+    },
+  });
+  return svc;
+}
+
+// ── sanitizeCivicsUrl ─────────────────────────────────────────────────────────
+
+describe('sanitizeCivicsUrl', () => {
+  const svc = buildSvc();
+
+  it('passes through https URLs', () => {
+    expect(svc.sanitizeCivicsUrl('https://example.gov/contact')).toBe(
+      'https://example.gov/contact',
+    );
+  });
+
+  it('passes through http URLs', () => {
+    expect(svc.sanitizeCivicsUrl('http://example.gov/contact')).toBe(
+      'http://example.gov/contact',
+    );
+  });
+
+  it('blocks javascript: URLs', () => {
+    expect(svc.sanitizeCivicsUrl('javascript:alert(1)')).toBeUndefined();
+  });
+
+  it('blocks javascript: URLs with encoding tricks', () => {
+    expect(svc.sanitizeCivicsUrl('javascript\t:alert(1)')).toBeUndefined();
+    expect(svc.sanitizeCivicsUrl(' javascript:alert(1)')).toBeUndefined();
+  });
+
+  it('blocks data: URLs', () => {
+    expect(
+      svc.sanitizeCivicsUrl('data:text/html,<script>alert(1)</script>'),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(svc.sanitizeCivicsUrl(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for malformed URLs', () => {
+    expect(svc.sanitizeCivicsUrl('not a url')).toBeUndefined();
+  });
+});
+
+// ── normalizeCivicText ────────────────────────────────────────────────────────
+
+describe('normalizeCivicText', () => {
+  const svc = buildSvc();
+
+  it('returns verbatim/plainLanguage/sourceUrl from a proper CivicText object', () => {
+    const result = svc.normalizeCivicText(
+      {
+        verbatim: 'Original',
+        plainLanguage: 'Plain',
+        sourceUrl: 'https://x.gov',
+      },
+      SRC,
+    );
+    expect(result).toEqual({
+      verbatim: 'Original',
+      plainLanguage: 'Plain',
+      sourceUrl: 'https://x.gov',
+    });
+  });
+
+  it('uses verbatim as plainLanguage fallback when plainLanguage is missing', () => {
+    const result = svc.normalizeCivicText({ verbatim: 'Original' }, SRC);
+    expect(result.plainLanguage).toBe('Original');
+    expect(result.sourceUrl).toBe(SRC);
+  });
+
+  it('uses fallbackSourceUrl when sourceUrl is missing from object', () => {
+    const result = svc.normalizeCivicText(
+      { verbatim: 'V', plainLanguage: 'P' },
+      SRC,
+    );
+    expect(result.sourceUrl).toBe(SRC);
+  });
+
+  it('normalises a plain string to verbatim=plainLanguage=string', () => {
+    const result = svc.normalizeCivicText('Introduction', SRC);
+    expect(result).toEqual({
+      verbatim: 'Introduction',
+      plainLanguage: 'Introduction',
+      sourceUrl: SRC,
+    });
+  });
+
+  it('normalises null to empty strings and does not throw', () => {
+    const result = svc.normalizeCivicText(null, SRC);
+    expect(result.verbatim).toBe('');
+    expect(result.plainLanguage).toBe('');
+  });
+
+  it('normalises undefined to empty strings', () => {
+    const result = svc.normalizeCivicText(undefined, SRC);
+    expect(result.verbatim).toBe('');
+  });
+
+  it('logs a warning and returns empty strings for an array value', () => {
+    const result = svc.normalizeCivicText(['bad'], SRC);
+    expect(result.verbatim).toBe('');
+    expect(svc.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('array'),
+    );
+  });
+
+  it('logs a warning and returns empty strings for a boolean value', () => {
+    const result = svc.normalizeCivicText(true, SRC);
+    expect(result.verbatim).toBe('');
+    expect(svc.logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('boolean'),
+    );
+  });
+});
+
+// ── getCivicsData ─────────────────────────────────────────────────────────────
+
+describe('getCivicsData', () => {
+  it('returns null when no rows exist for the region', async () => {
+    const svc = buildSvc([]);
+    expect(await svc.getCivicsData('california')).toBeNull();
+  });
+
+  it('returns null when all rows have empty arrays and no sessionScheme', async () => {
+    const svc = buildSvc([
+      {
+        sourceUrl: SRC,
+        chambers: [],
+        measureTypes: [],
+        lifecycleStages: [],
+        glossary: [],
+        sessionScheme: null,
+      },
+    ]);
+    expect(await svc.getCivicsData('california')).toBeNull();
+  });
+
+  it('merges glossary entries from a single row', async () => {
+    const svc = buildSvc([
+      {
+        sourceUrl: SRC,
+        chambers: null,
+        measureTypes: null,
+        lifecycleStages: null,
+        sessionScheme: null,
+        glossary: [
+          {
+            term: 'Engrossed',
+            slug: 'engrossed',
+            definition: { verbatim: 'V', plainLanguage: 'P', sourceUrl: SRC },
+            relatedTerms: [],
+          },
+        ],
+      },
+    ]);
+    const result = await svc.getCivicsData('california');
+    expect(result).not.toBeNull();
+    expect(result!.glossary).toHaveLength(1);
+    expect(result!.glossary[0].slug).toBe('engrossed');
+  });
+
+  it('deduplicates glossary entries by slug across rows (first wins)', async () => {
+    const svc = buildSvc([
+      {
+        sourceUrl: SRC,
+        chambers: null,
+        measureTypes: null,
+        lifecycleStages: null,
+        sessionScheme: null,
+        glossary: [
+          {
+            slug: 'engrossed',
+            term: 'Engrossed',
+            definition: {
+              verbatim: 'First',
+              plainLanguage: 'First',
+              sourceUrl: SRC,
+            },
+            relatedTerms: [],
+          },
+        ],
+      },
+      {
+        sourceUrl: 'https://example.gov/other',
+        chambers: null,
+        measureTypes: null,
+        lifecycleStages: null,
+        sessionScheme: null,
+        glossary: [
+          {
+            slug: 'engrossed',
+            term: 'Engrossed',
+            definition: {
+              verbatim: 'Second',
+              plainLanguage: 'Second',
+              sourceUrl: SRC,
+            },
+            relatedTerms: [],
+          },
+        ],
+      },
+    ]);
+    const result = await svc.getCivicsData('california');
+    expect(result!.glossary).toHaveLength(1);
+    expect(result!.glossary[0].definition.verbatim).toBe('First');
+  });
+
+  it('deduplicates measureTypes by code across rows', async () => {
+    const svc = buildSvc([
+      {
+        sourceUrl: SRC,
+        chambers: null,
+        lifecycleStages: null,
+        glossary: null,
+        sessionScheme: null,
+        measureTypes: [
+          {
+            code: 'AB',
+            name: 'Assembly Bill',
+            chamber: 'Assembly',
+            votingThreshold: 'majority',
+            reachesGovernor: true,
+            purpose: 'A bill.',
+            lifecycleStageIds: [],
+          },
+        ],
+      },
+      {
+        sourceUrl: 'https://example.gov/other',
+        chambers: null,
+        lifecycleStages: null,
+        glossary: null,
+        sessionScheme: null,
+        measureTypes: [
+          {
+            code: 'AB',
+            name: 'Assembly Bill (dup)',
+            chamber: 'Assembly',
+            votingThreshold: 'majority',
+            reachesGovernor: true,
+            purpose: 'A bill.',
+            lifecycleStageIds: [],
+          },
+        ],
+      },
+    ]);
+    const result = await svc.getCivicsData('california');
+    expect(result!.measureTypes).toHaveLength(1);
+    expect(result!.measureTypes[0].name).toBe('Assembly Bill');
+  });
+
+  it('first non-null sessionScheme wins across rows', async () => {
+    const svc = buildSvc([
+      {
+        sourceUrl: SRC,
+        chambers: null,
+        measureTypes: null,
+        lifecycleStages: null,
+        glossary: [{ slug: 'x', term: 'X', definition: 'X', relatedTerms: [] }],
+        sessionScheme: {
+          cadence: 'annual',
+          namingPattern: '{year}',
+          description: 'First',
+        },
+      },
+      {
+        sourceUrl: 'https://example.gov/b',
+        chambers: null,
+        measureTypes: null,
+        lifecycleStages: null,
+        glossary: null,
+        sessionScheme: {
+          cadence: 'biennial',
+          namingPattern: '{y1}-{y2}',
+          description: 'Second',
+        },
+      },
+    ]);
+    const result = await svc.getCivicsData('california');
+    expect(result!.sessionScheme?.cadence).toBe('annual');
+  });
+
+  it('normalises plain-string lifecycle stage name to CivicText', async () => {
+    const svc = buildSvc([
+      {
+        sourceUrl: SRC,
+        chambers: null,
+        measureTypes: null,
+        glossary: null,
+        sessionScheme: null,
+        lifecycleStages: [
+          {
+            id: 'introduction',
+            name: 'Introduction',
+            shortDescription: 'The bill is introduced.',
+            statusStringPatterns: [],
+          },
+        ],
+      },
+    ]);
+    const result = await svc.getCivicsData('california');
+    const stage = result!.lifecycleStages[0];
+    expect(stage.name.verbatim).toBe('Introduction');
+    expect(stage.name.plainLanguage).toBe('Introduction');
+    expect(stage.shortDescription.verbatim).toBe('The bill is introduced.');
+  });
+
+  it('uses safe array fallback when leadershipRoles is not an array', async () => {
+    const svc = buildSvc([
+      {
+        sourceUrl: SRC,
+        measureTypes: null,
+        lifecycleStages: null,
+        glossary: null,
+        sessionScheme: null,
+        chambers: [
+          {
+            name: 'Assembly',
+            abbreviation: 'A',
+            size: 80,
+            termYears: 2,
+            leadershipRoles: 'Speaker',
+            description: 'The lower house.',
+          },
+        ],
+      },
+    ]);
+    const result = await svc.getCivicsData('california');
+    expect(result!.chambers[0].leadershipRoles).toEqual([]);
+  });
+
+  it('strips javascript: URLs from citizenAction.url (XSS prevention)', async () => {
+    const svc = buildSvc([
+      {
+        sourceUrl: SRC,
+        chambers: null,
+        measureTypes: null,
+        glossary: null,
+        sessionScheme: null,
+        lifecycleStages: [
+          {
+            id: 'intro',
+            name: 'Introduction',
+            shortDescription: 'Introduced.',
+            statusStringPatterns: [],
+            citizenAction: {
+              verb: 'learn',
+              label: 'Read the bill',
+              urgency: 'passive',
+              url: 'javascript:alert(document.cookie)',
+            },
+          },
+        ],
+      },
+    ]);
+    const result = await svc.getCivicsData('california');
+    expect(result!.lifecycleStages[0].citizenAction?.url).toBeUndefined();
+  });
+
+  it('preserves https: citizenAction URLs', async () => {
+    const svc = buildSvc([
+      {
+        sourceUrl: SRC,
+        chambers: null,
+        measureTypes: null,
+        glossary: null,
+        sessionScheme: null,
+        lifecycleStages: [
+          {
+            id: 'intro',
+            name: 'Introduction',
+            shortDescription: 'Introduced.',
+            statusStringPatterns: [],
+            citizenAction: {
+              verb: 'contact',
+              label: 'Contact your rep',
+              urgency: 'active',
+              url: 'https://example.gov/contact',
+            },
+          },
+        ],
+      },
+    ]);
+    const result = await svc.getCivicsData('california');
+    expect(result!.lifecycleStages[0].citizenAction?.url).toBe(
+      'https://example.gov/contact',
+    );
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/models/region-info.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/region-info.model.ts
@@ -1,5 +1,150 @@
 import { ObjectType, Field, registerEnumType } from '@nestjs/graphql';
 
+// ── Civics GQL types ─────────────────────────────────────────────────────────
+
+@ObjectType('CivicText')
+export class CivicTextModel {
+  @Field()
+  verbatim!: string;
+
+  @Field()
+  plainLanguage!: string;
+
+  @Field()
+  sourceUrl!: string;
+}
+
+@ObjectType('CivicsChamber')
+export class ChamberModel {
+  @Field()
+  name!: string;
+
+  @Field()
+  abbreviation!: string;
+
+  @Field()
+  size!: number;
+
+  @Field()
+  termYears!: number;
+
+  @Field(() => [String])
+  leadershipRoles!: string[];
+
+  @Field(() => CivicTextModel)
+  description!: CivicTextModel;
+}
+
+@ObjectType('CitizenAction')
+export class CitizenActionModel {
+  @Field()
+  verb!: string;
+
+  @Field(() => CivicTextModel)
+  label!: CivicTextModel;
+
+  @Field({ nullable: true })
+  url?: string;
+
+  @Field()
+  urgency!: string;
+}
+
+@ObjectType('CivicsLifecycleStage')
+export class LifecycleStageModel {
+  @Field()
+  id!: string;
+
+  @Field(() => CivicTextModel)
+  name!: CivicTextModel;
+
+  @Field(() => CivicTextModel)
+  shortDescription!: CivicTextModel;
+
+  @Field(() => CivicTextModel, { nullable: true })
+  longDescription?: CivicTextModel;
+
+  @Field(() => [String])
+  statusStringPatterns!: string[];
+
+  @Field(() => CitizenActionModel, { nullable: true })
+  citizenAction?: CitizenActionModel;
+}
+
+@ObjectType('CivicsMeasureType')
+export class MeasureTypeModel {
+  @Field()
+  code!: string;
+
+  @Field()
+  name!: string;
+
+  @Field()
+  chamber!: string;
+
+  @Field()
+  votingThreshold!: string;
+
+  @Field()
+  reachesGovernor!: boolean;
+
+  @Field(() => CivicTextModel)
+  purpose!: CivicTextModel;
+
+  @Field(() => [String])
+  lifecycleStageIds!: string[];
+}
+
+@ObjectType('CivicsGlossaryEntry')
+export class GlossaryEntryModel {
+  @Field()
+  term!: string;
+
+  @Field()
+  slug!: string;
+
+  @Field(() => CivicTextModel)
+  definition!: CivicTextModel;
+
+  @Field(() => CivicTextModel, { nullable: true })
+  longDefinition?: CivicTextModel;
+
+  @Field(() => [String])
+  relatedTerms!: string[];
+}
+
+@ObjectType('CivicsSessionScheme')
+export class SessionSchemeModel {
+  @Field()
+  cadence!: string;
+
+  @Field()
+  namingPattern!: string;
+
+  @Field(() => CivicTextModel)
+  description!: CivicTextModel;
+}
+
+@ObjectType('CivicsBlock')
+export class CivicsBlockModel {
+  @Field(() => [ChamberModel])
+  chambers!: ChamberModel[];
+
+  @Field(() => [MeasureTypeModel])
+  measureTypes!: MeasureTypeModel[];
+
+  @Field(() => [LifecycleStageModel])
+  lifecycleStages!: LifecycleStageModel[];
+
+  @Field(() => SessionSchemeModel, { nullable: true })
+  sessionScheme?: SessionSchemeModel;
+
+  @Field(() => [GlossaryEntryModel])
+  glossary!: GlossaryEntryModel[];
+}
+
+// ── DataType enum ─────────────────────────────────────────────────────────────
+
 /**
  * Data types enum for GraphQL
  */
@@ -38,6 +183,9 @@ export class RegionInfoModel {
 
   @Field(() => [DataTypeGQL])
   supportedDataTypes!: DataTypeGQL[];
+
+  @Field(() => CivicsBlockModel, { nullable: true })
+  civics?: CivicsBlockModel;
 }
 
 /**

--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -158,13 +158,17 @@ describe('RegionResolver', () => {
   });
 
   describe('regionInfo', () => {
-    it('should return region info', async () => {
+    it('should return region info with civics merged in', async () => {
       regionService.getRegionInfo.mockReturnValue(mockRegionInfo);
+      (regionService.getCivicsData as jest.Mock).mockResolvedValue(null);
 
       const result = await resolver.regionInfo();
 
-      expect(result).toEqual(mockRegionInfo);
+      expect(result).toEqual({ ...mockRegionInfo, civics: undefined });
       expect(regionService.getRegionInfo).toHaveBeenCalled();
+      expect(regionService.getCivicsData).toHaveBeenCalledWith(
+        mockRegionInfo.id,
+      );
     });
   });
 

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -67,12 +67,14 @@ export class RegionResolver {
   constructor(private readonly regionService: RegionDomainService) {}
 
   /**
-   * Get region information
+   * Get region information, including merged civics data for the active region.
    */
   @Public()
   @Query(() => RegionInfoModel)
   async regionInfo(): Promise<RegionInfoModel> {
-    return this.regionService.getRegionInfo();
+    const info = this.regionService.getRegionInfo();
+    const civics = await this.regionService.getCivicsData(info.id);
+    return { ...info, civics: civics ?? undefined };
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -68,7 +68,11 @@ interface DataFetcher {
   fetchMeetingMinutes?(): Promise<MinutesWithActions[]>;
 }
 import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
-import { RegionInfoModel, DataTypeGQL } from './models/region-info.model';
+import {
+  RegionInfoModel,
+  DataTypeGQL,
+  CivicsBlockModel,
+} from './models/region-info.model';
 import {
   PaginatedPropositions,
   PropositionModel,
@@ -634,6 +638,211 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       supportedDataTypes: supportedTypes.map(
         (t) => t as unknown as DataTypeGQL,
       ),
+    };
+  }
+
+  /**
+   * Allow only https: and http: URLs from LLM-extracted civics data.
+   * Rejects javascript:, data:, and any other protocol to prevent XSS
+   * when the URL is rendered in an <a href> on the public civics hub.
+   */
+  private sanitizeCivicsUrl(raw: string | undefined): string | undefined {
+    if (!raw) return undefined;
+    try {
+      const parsed = new URL(raw);
+      return parsed.protocol === 'https:' || parsed.protocol === 'http:'
+        ? raw
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Normalise a field that should be CivicText but may have been stored by
+   * an older extraction as a plain string. Falls back to empty strings so
+   * the GraphQL non-null contract is never violated.
+   */
+  private normalizeCivicText(
+    value: unknown,
+    fallbackSourceUrl: string,
+  ): CivicsBlockModel['glossary'][number]['definition'] {
+    if (
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      'verbatim' in value
+    ) {
+      const v = value as Record<string, unknown>;
+      return {
+        verbatim: String(v['verbatim'] ?? ''),
+        plainLanguage: String(v['plainLanguage'] ?? v['verbatim'] ?? ''),
+        sourceUrl: String(v['sourceUrl'] ?? fallbackSourceUrl),
+      };
+    }
+    if (typeof value !== 'string' && value !== null && value !== undefined) {
+      this.logger.warn(
+        `normalizeCivicText: unexpected type "${Array.isArray(value) ? 'array' : typeof value}" from ${fallbackSourceUrl}`,
+      );
+    }
+    const text = typeof value === 'string' ? value : '';
+    return {
+      verbatim: text,
+      plainLanguage: text,
+      sourceUrl: fallbackSourceUrl,
+    };
+  }
+
+  /**
+   * Merge all civics_blocks rows for a region into a single CivicsBlockModel.
+   * Normalises CivicText fields that the LLM may have stored as plain strings.
+   * Deduplicates by stable key (code/id/slug); first non-null wins for scalars.
+   */
+  async getCivicsData(regionId: string): Promise<CivicsBlockModel | null> {
+    const rows = await this.db.civicsBlock.findMany({
+      where: { regionId },
+      orderBy: { extractedAt: 'desc' },
+    });
+
+    if (rows.length === 0) return null;
+
+    const chambers = new Map<string, CivicsBlockModel['chambers'][number]>();
+    const measureTypes = new Map<
+      string,
+      CivicsBlockModel['measureTypes'][number]
+    >();
+    const lifecycleStages = new Map<
+      string,
+      CivicsBlockModel['lifecycleStages'][number]
+    >();
+    const glossary = new Map<string, CivicsBlockModel['glossary'][number]>();
+    let sessionScheme: CivicsBlockModel['sessionScheme'] | null = null;
+
+    for (const row of rows) {
+      const src = row.sourceUrl;
+      const rawC = row.chambers as Record<string, unknown>[] | null;
+      const rawM = row.measureTypes as Record<string, unknown>[] | null;
+      const rawL = row.lifecycleStages as Record<string, unknown>[] | null;
+      const rawG = row.glossary as Record<string, unknown>[] | null;
+      const rawS = row.sessionScheme as Record<string, unknown> | null;
+
+      if (rawC) {
+        for (const ch of rawC) {
+          const name = String(ch['name'] ?? '');
+          if (!name || chambers.has(name)) continue;
+          chambers.set(name, {
+            name,
+            abbreviation: String(ch['abbreviation'] ?? ''),
+            size: Number(ch['size'] ?? 0),
+            termYears: Number(ch['termYears'] ?? 0),
+            leadershipRoles: Array.isArray(ch['leadershipRoles'])
+              ? (ch['leadershipRoles'] as string[])
+              : [],
+            description: this.normalizeCivicText(ch['description'], src),
+          });
+        }
+      }
+
+      if (rawM) {
+        for (const mt of rawM) {
+          const code = String(mt['code'] ?? '');
+          if (!code || measureTypes.has(code)) continue;
+          measureTypes.set(code, {
+            code,
+            name: String(mt['name'] ?? ''),
+            chamber: String(mt['chamber'] ?? ''),
+            votingThreshold: String(mt['votingThreshold'] ?? 'majority'),
+            reachesGovernor: Boolean(mt['reachesGovernor']),
+            purpose: this.normalizeCivicText(mt['purpose'], src),
+            lifecycleStageIds: Array.isArray(mt['lifecycleStageIds'])
+              ? (mt['lifecycleStageIds'] as string[])
+              : [],
+          });
+        }
+      }
+
+      if (rawL) {
+        for (const ls of rawL) {
+          const id = String(ls['id'] ?? '');
+          if (!id || lifecycleStages.has(id)) continue;
+          const rawAction = ls['citizenAction'] as Record<
+            string,
+            unknown
+          > | null;
+          const citizenAction = rawAction
+            ? {
+                verb: String(rawAction['verb'] ?? 'learn'),
+                label: this.normalizeCivicText(rawAction['label'], src),
+                url: this.sanitizeCivicsUrl(
+                  (rawAction['url'] as string | undefined) ??
+                    (rawAction['sourceUrl'] as string | undefined),
+                ),
+                urgency: String(rawAction['urgency'] ?? 'passive') as
+                  | 'active'
+                  | 'passive'
+                  | 'none',
+              }
+            : undefined;
+          lifecycleStages.set(id, {
+            id,
+            name: this.normalizeCivicText(ls['name'], src),
+            shortDescription: this.normalizeCivicText(
+              ls['shortDescription'],
+              src,
+            ),
+            longDescription: ls['longDescription']
+              ? this.normalizeCivicText(ls['longDescription'], src)
+              : undefined,
+            statusStringPatterns: Array.isArray(ls['statusStringPatterns'])
+              ? (ls['statusStringPatterns'] as string[])
+              : [],
+            citizenAction,
+          });
+        }
+      }
+
+      if (rawG) {
+        for (const ge of rawG) {
+          const slug = String(ge['slug'] ?? '');
+          if (!slug || glossary.has(slug)) continue;
+          glossary.set(slug, {
+            term: String(ge['term'] ?? ''),
+            slug,
+            definition: this.normalizeCivicText(ge['definition'], src),
+            longDefinition: ge['longDefinition']
+              ? this.normalizeCivicText(ge['longDefinition'], src)
+              : undefined,
+            relatedTerms: Array.isArray(ge['relatedTerms'])
+              ? (ge['relatedTerms'] as string[])
+              : [],
+          });
+        }
+      }
+
+      if (rawS && !sessionScheme) {
+        sessionScheme = {
+          cadence: String(rawS['cadence'] ?? 'annual'),
+          namingPattern: String(rawS['namingPattern'] ?? ''),
+          description: this.normalizeCivicText(rawS['description'], src),
+        };
+      }
+    }
+
+    if (
+      chambers.size === 0 &&
+      measureTypes.size === 0 &&
+      lifecycleStages.size === 0 &&
+      glossary.size === 0
+    ) {
+      return null;
+    }
+
+    return {
+      chambers: Array.from(chambers.values()),
+      measureTypes: Array.from(measureTypes.values()),
+      lifecycleStages: Array.from(lifecycleStages.values()),
+      sessionScheme: sessionScheme ?? undefined,
+      glossary: Array.from(glossary.values()),
     };
   }
 

--- a/apps/frontend/Dockerfile
+++ b/apps/frontend/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 
 COPY apps/frontend/package.json ./
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --lockfile=false --ignore-workspace
 
@@ -45,7 +45,7 @@ ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL
 ENV NEXT_PUBLIC_HMAC_CLIENT_ID=$NEXT_PUBLIC_HMAC_CLIENT_ID
 ENV NEXT_PUBLIC_HMAC_SECRET=$NEXT_PUBLIC_HMAC_SECRET
 
-RUN corepack enable
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 RUN pnpm build
 
 # Production image, copy all the files and run next

--- a/apps/frontend/__tests__/components/civics/CitizenActionCallout.test.tsx
+++ b/apps/frontend/__tests__/components/civics/CitizenActionCallout.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { CitizenActionCallout } from "@/components/civics/CitizenActionCallout";
+import type { CitizenAction } from "@/lib/graphql/region";
+
+const makeAction = (overrides: Partial<CitizenAction> = {}): CitizenAction => ({
+  verb: "contact",
+  label: {
+    verbatim: "Contact your representative",
+    plainLanguage: "Contact your representative",
+    sourceUrl: "https://example.gov",
+  },
+  urgency: "active",
+  url: "https://example.gov/contact",
+  ...overrides,
+});
+
+describe("CitizenActionCallout", () => {
+  it("renders nothing when action is null", () => {
+    const { container } = render(<CitizenActionCallout action={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when action is undefined", () => {
+    const { container } = render(<CitizenActionCallout action={undefined} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when urgency is 'none'", () => {
+    const { container } = render(
+      <CitizenActionCallout action={makeAction({ urgency: "none" })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a link when url is provided", () => {
+    render(<CitizenActionCallout action={makeAction()} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "https://example.gov/contact");
+    expect(link).toHaveTextContent("Contact your representative");
+  });
+
+  it("renders a div (not a link) when no url", () => {
+    render(
+      <CitizenActionCallout
+        action={makeAction({ url: undefined, urgency: "passive" })}
+      />,
+    );
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("Contact your representative")).toBeInTheDocument();
+  });
+
+  it("applies orange styling for active urgency", () => {
+    render(<CitizenActionCallout action={makeAction({ urgency: "active" })} />);
+    const el =
+      screen.getByRole("link").parentElement ?? screen.getByRole("link");
+    // Orange class is present somewhere in the rendered output
+    expect(
+      document.querySelector(".text-orange-800, .bg-orange-50"),
+    ).toBeInTheDocument();
+  });
+
+  it("applies gray styling for passive urgency", () => {
+    render(
+      <CitizenActionCallout
+        action={makeAction({ urgency: "passive", url: undefined })}
+      />,
+    );
+    expect(
+      document.querySelector(".text-gray-600, .bg-gray-50"),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/components/civics/CivicTerm.test.tsx
+++ b/apps/frontend/__tests__/components/civics/CivicTerm.test.tsx
@@ -1,0 +1,142 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { CivicTerm } from "@/components/civics/CivicTerm";
+import type {
+  CivicsGlossaryEntry,
+  CivicsMeasureType,
+} from "@/lib/graphql/region";
+
+const makeGlossaryEntry = (
+  overrides: Partial<CivicsGlossaryEntry> = {},
+): CivicsGlossaryEntry => ({
+  term: "Engrossed",
+  slug: "engrossed",
+  definition: {
+    verbatim: "A bill passed by one chamber.",
+    plainLanguage: "A bill passed by one chamber in plain language.",
+    sourceUrl: "https://example.gov",
+  },
+  relatedTerms: [],
+  ...overrides,
+});
+
+const makeMeasureType = (
+  overrides: Partial<CivicsMeasureType> = {},
+): CivicsMeasureType => ({
+  code: "AB",
+  name: "Assembly Bill",
+  chamber: "Assembly",
+  votingThreshold: "majority",
+  reachesGovernor: true,
+  purpose: {
+    verbatim: "A draft of a proposed law.",
+    plainLanguage: "A draft of a proposed law for the Assembly.",
+    sourceUrl: "https://example.gov",
+  },
+  lifecycleStageIds: [],
+  ...overrides,
+});
+
+// Mock useCivics
+const mockCivicsContext = {
+  civics: null,
+  glossaryMap: new Map<string, CivicsGlossaryEntry>(),
+  glossaryByTerm: new Map<string, CivicsGlossaryEntry>(),
+  measureTypeByCode: new Map<string, CivicsMeasureType>(),
+  loading: false,
+};
+
+jest.mock("@/components/civics/CivicsContext", () => ({
+  useCivics: () => mockCivicsContext,
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+beforeEach(() => {
+  mockCivicsContext.glossaryMap = new Map();
+  mockCivicsContext.glossaryByTerm = new Map();
+  mockCivicsContext.measureTypeByCode = new Map();
+  mockCivicsContext.loading = false;
+});
+
+describe("CivicTerm", () => {
+  it("renders children unchanged when term is not in glossary or measure types", () => {
+    render(<CivicTerm term="unknown-term">Some text</CivicTerm>);
+    expect(screen.getByText("Some text")).toBeInTheDocument();
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
+  it("renders children during loading without tooltip", () => {
+    mockCivicsContext.loading = true;
+    render(<CivicTerm term="unknown">Loading state</CivicTerm>);
+    expect(screen.getByText("Loading state")).toBeInTheDocument();
+  });
+
+  it("shows tooltip when term is found by slug", () => {
+    const entry = makeGlossaryEntry();
+    mockCivicsContext.glossaryMap.set("engrossed", entry);
+    render(<CivicTerm term="engrossed">Engrossed</CivicTerm>);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "A bill passed by one chamber in plain language.",
+    );
+  });
+
+  it("shows tooltip when term is found by lowercase term text", () => {
+    const entry = makeGlossaryEntry();
+    mockCivicsContext.glossaryByTerm.set("engrossed", entry);
+    render(<CivicTerm term="Engrossed">Engrossed</CivicTerm>);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+  });
+
+  it("shows tooltip with measure type purpose when code matches", () => {
+    const mt = makeMeasureType();
+    mockCivicsContext.measureTypeByCode.set("AB", mt);
+    render(<CivicTerm term="AB">AB 1234</CivicTerm>);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "A draft of a proposed law for the Assembly.",
+    );
+  });
+
+  it("prefers glossary entry over measure type code", () => {
+    const entry = makeGlossaryEntry({ term: "AB", slug: "ab" });
+    mockCivicsContext.glossaryByTerm.set("ab", entry);
+    const mt = makeMeasureType();
+    mockCivicsContext.measureTypeByCode.set("AB", mt);
+    render(<CivicTerm term="AB">AB</CivicTerm>);
+    // Glossary definition should win
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "A bill passed by one chamber in plain language.",
+    );
+  });
+
+  it("includes Learn more link for glossary entries", () => {
+    const entry = makeGlossaryEntry();
+    mockCivicsContext.glossaryMap.set("engrossed", entry);
+    render(<CivicTerm term="engrossed">Engrossed</CivicTerm>);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/region/how-it-works#term-engrossed");
+  });
+
+  it("does not include Learn more link for measure type lookups", () => {
+    const mt = makeMeasureType();
+    mockCivicsContext.measureTypeByCode.set("AB", mt);
+    render(<CivicTerm term="AB">AB</CivicTerm>);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/components/civics/GlossaryList.test.tsx
+++ b/apps/frontend/__tests__/components/civics/GlossaryList.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { GlossaryList } from "@/components/civics/GlossaryList";
+import type { CivicsGlossaryEntry } from "@/lib/graphql/region";
+
+const mockGlossaryByTerm = new Map<string, CivicsGlossaryEntry>();
+
+jest.mock("@/components/civics/CivicsContext", () => ({
+  useCivics: () => ({ glossaryByTerm: mockGlossaryByTerm }),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts?.query ? `No terms match "${opts.query}".` : key,
+  }),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+const makeEntry = (
+  term: string,
+  slug: string,
+  overrides: Partial<CivicsGlossaryEntry> = {},
+): CivicsGlossaryEntry => ({
+  term,
+  slug,
+  definition: {
+    verbatim: `${term} verbatim definition`,
+    plainLanguage: `${term} plain definition`,
+    sourceUrl: "https://example.gov",
+  },
+  relatedTerms: [],
+  ...overrides,
+});
+
+const ENTRIES: CivicsGlossaryEntry[] = [
+  makeEntry("Engrossed", "engrossed"),
+  makeEntry("Committee", "committee"),
+  makeEntry("Chaptered", "chaptered"),
+];
+
+beforeEach(() => {
+  mockGlossaryByTerm.clear();
+  ENTRIES.forEach((e) => mockGlossaryByTerm.set(e.term.toLowerCase(), e));
+});
+
+describe("GlossaryList", () => {
+  it("renders all entries when query is empty", () => {
+    render(<GlossaryList entries={ENTRIES} />);
+    expect(screen.getByText("Engrossed")).toBeInTheDocument();
+    expect(screen.getByText("Committee")).toBeInTheDocument();
+    expect(screen.getByText("Chaptered")).toBeInTheDocument();
+  });
+
+  it("filters entries by term (case-insensitive)", async () => {
+    render(<GlossaryList entries={ENTRIES} />);
+    await userEvent.type(screen.getByRole("searchbox"), "engr");
+    expect(screen.getByText("Engrossed")).toBeInTheDocument();
+    expect(screen.queryByText("Committee")).not.toBeInTheDocument();
+  });
+
+  it("filters entries by definition text", async () => {
+    render(<GlossaryList entries={ENTRIES} />);
+    await userEvent.type(screen.getByRole("searchbox"), "chaptered plain");
+    expect(screen.getByText("Chaptered")).toBeInTheDocument();
+    expect(screen.queryByText("Engrossed")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no entries match", async () => {
+    render(<GlossaryList entries={ENTRIES} />);
+    await userEvent.type(screen.getByRole("searchbox"), "zzznomatch");
+    expect(screen.getByText(/No terms match/)).toBeInTheDocument();
+  });
+
+  it("gives each entry the correct anchor id matching its slug", () => {
+    render(<GlossaryList entries={ENTRIES} />);
+    expect(document.getElementById("term-engrossed")).toBeInTheDocument();
+    expect(document.getElementById("term-committee")).toBeInTheDocument();
+  });
+
+  it("uses real slug from glossaryByTerm for related term links", () => {
+    const entryWithRelated = makeEntry("Engrossed", "engrossed", {
+      relatedTerms: ["Committee"],
+    });
+    render(<GlossaryList entries={[entryWithRelated]} />);
+    const link = screen.getByRole("link", { name: "Committee" });
+    // glossaryByTerm has "committee" → slug "committee"
+    expect(link).toHaveAttribute("href", "#term-committee");
+  });
+
+  it("falls back to derived slug when term not in glossaryByTerm", () => {
+    const entryWithRelated = makeEntry("Engrossed", "engrossed", {
+      relatedTerms: ["Unknown Term"],
+    });
+    render(<GlossaryList entries={[entryWithRelated]} />);
+    const link = screen.getByRole("link", { name: "Unknown Term" });
+    expect(link).toHaveAttribute("href", "#term-unknown-term");
+  });
+});

--- a/apps/frontend/__tests__/components/civics/LifecycleProgressBar.test.tsx
+++ b/apps/frontend/__tests__/components/civics/LifecycleProgressBar.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { LifecycleProgressBar } from "@/components/civics/LifecycleProgressBar";
+import type { CivicsLifecycleStage } from "@/lib/graphql/region";
+
+const makeStage = (id: string, name: string): CivicsLifecycleStage => ({
+  id,
+  name: {
+    verbatim: name,
+    plainLanguage: name,
+    sourceUrl: "https://example.gov",
+  },
+  shortDescription: {
+    verbatim: `${name} short description`,
+    plainLanguage: `${name} short description`,
+    sourceUrl: "https://example.gov",
+  },
+  longDescription: {
+    verbatim: `${name} long description`,
+    plainLanguage: `${name} long description`,
+    sourceUrl: "https://example.gov",
+  },
+  statusStringPatterns: [],
+  citizenAction: undefined,
+});
+
+const STAGES: CivicsLifecycleStage[] = [
+  makeStage("introduction", "Introduction"),
+  makeStage("committee", "In Committee"),
+  makeStage("floor-vote", "Floor Vote"),
+];
+
+describe("LifecycleProgressBar", () => {
+  it("renders nothing when stages array is empty", () => {
+    const { container } = render(
+      <LifecycleProgressBar stages={[]} currentStageId={null} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders all stage names", () => {
+    render(<LifecycleProgressBar stages={STAGES} currentStageId={null} />);
+    expect(screen.getByText("Introduction")).toBeInTheDocument();
+    expect(screen.getByText("In Committee")).toBeInTheDocument();
+    expect(screen.getByText("Floor Vote")).toBeInTheDocument();
+  });
+
+  it("marks current stage with aria-current='step'", () => {
+    render(<LifecycleProgressBar stages={STAGES} currentStageId="committee" />);
+    const items = screen.getAllByRole("listitem");
+    const currentItem = items.find(
+      (el) => el.getAttribute("aria-current") === "step",
+    );
+    expect(currentItem).toBeInTheDocument();
+  });
+
+  it("does not set aria-current in abstract mode (currentStageId=null)", () => {
+    render(<LifecycleProgressBar stages={STAGES} currentStageId={null} />);
+    const withAriaStep = document.querySelectorAll('[aria-current="step"]');
+    expect(withAriaStep).toHaveLength(0);
+  });
+
+  it("clicking a stage dot expands the detail panel", async () => {
+    render(<LifecycleProgressBar stages={STAGES} currentStageId={null} />);
+    const buttons = screen.getAllByRole("button");
+    // First button is the first stage dot
+    await userEvent.click(buttons[0]);
+    expect(
+      screen.getByText("Introduction short description"),
+    ).toBeInTheDocument();
+  });
+
+  it("clicking the same stage again collapses the detail panel", async () => {
+    render(<LifecycleProgressBar stages={STAGES} currentStageId={null} />);
+    const buttons = screen.getAllByRole("button");
+    await userEvent.click(buttons[0]);
+    expect(
+      screen.getByText("Introduction short description"),
+    ).toBeInTheDocument();
+    await userEvent.click(buttons[0]);
+    expect(
+      screen.queryByText("Introduction short description"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("close button (✕) dismisses the detail panel", async () => {
+    render(<LifecycleProgressBar stages={STAGES} currentStageId={null} />);
+    await userEvent.click(screen.getAllByRole("button")[0]);
+    const closeBtn = screen.getByRole("button", { name: /close/i });
+    await userEvent.click(closeBtn);
+    expect(
+      screen.queryByText("Introduction short description"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows longDescription in detail panel when available", async () => {
+    render(<LifecycleProgressBar stages={STAGES} currentStageId={null} />);
+    await userEvent.click(screen.getAllByRole("button")[0]);
+    expect(
+      screen.getByText("Introduction long description"),
+    ).toBeInTheDocument();
+  });
+
+  it("stage label span does not have onClick (keyboard accessibility guard)", () => {
+    render(<LifecycleProgressBar stages={STAGES} currentStageId={null} />);
+    // The aria-hidden spans should not receive click events — only buttons should
+    const hiddenSpans = document.querySelectorAll('[aria-hidden="true"]');
+    hiddenSpans.forEach((span) => {
+      expect(span).not.toHaveAttribute("role", "button");
+    });
+  });
+});

--- a/apps/frontend/app/region/how-it-works/page.tsx
+++ b/apps/frontend/app/region/how-it-works/page.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { useCivics } from "@/components/civics/CivicsContext";
+import { MeasureTypeTable } from "@/components/civics/MeasureTypeTable";
+import { GlossaryList } from "@/components/civics/GlossaryList";
+import { HowABillBecomesLaw } from "@/components/civics/HowABillBecomesLaw";
+
+export default function HowItWorksPage() {
+  const { t } = useTranslation("civics");
+  const { civics, loading } = useCivics();
+
+  if (loading) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-8">
+        <div className="animate-pulse space-y-4">
+          <div className="h-8 w-64 rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-4 w-96 rounded bg-gray-200 dark:bg-gray-700" />
+          <div className="h-48 rounded bg-gray-200 dark:bg-gray-700" />
+        </div>
+      </main>
+    );
+  }
+
+  if (
+    !civics ||
+    (civics.measureTypes.length === 0 && civics.glossary.length === 0)
+  ) {
+    return (
+      <main className="mx-auto max-w-4xl px-4 py-8">
+        <p className="text-gray-500 dark:text-gray-400">{t("hub.noData")}</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8">
+      {/* Page header */}
+      <header className="mb-10">
+        <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100">
+          {t("hub.title")}
+        </h1>
+        {civics.sessionScheme && (
+          <p className="mt-2 text-gray-600 dark:text-gray-400">
+            {civics.sessionScheme.description.plainLanguage}
+          </p>
+        )}
+      </header>
+
+      {/* Measure type comparison table */}
+      {civics.measureTypes.length > 0 && (
+        <section aria-labelledby="measure-types-heading" className="mb-12">
+          <h2
+            id="measure-types-heading"
+            className="mb-1 text-xl font-semibold text-gray-900 dark:text-gray-100"
+          >
+            {t("measureTypes.title")}
+          </h2>
+          <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+            {t("measureTypes.description", { regionName: "California" })}
+          </p>
+          <MeasureTypeTable
+            measureTypes={civics.measureTypes}
+            lifecycleStages={civics.lifecycleStages}
+          />
+        </section>
+      )}
+
+      {/* How a bill becomes law */}
+      {civics.lifecycleStages.length > 0 && civics.measureTypes.length > 0 && (
+        <section aria-labelledby="lifecycle-heading" className="mb-12">
+          <h2
+            id="lifecycle-heading"
+            className="mb-1 text-xl font-semibold text-gray-900 dark:text-gray-100"
+          >
+            {t("lifecycle.title")}
+          </h2>
+          <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+            {t("lifecycle.abstractMode")}
+          </p>
+          <HowABillBecomesLaw
+            measureTypes={civics.measureTypes}
+            lifecycleStages={civics.lifecycleStages}
+          />
+        </section>
+      )}
+
+      {/* Glossary */}
+      {civics.glossary.length > 0 && (
+        <section aria-labelledby="glossary-heading">
+          <h2
+            id="glossary-heading"
+            className="mb-1 text-xl font-semibold text-gray-900 dark:text-gray-100"
+          >
+            {t("glossary.title")}
+          </h2>
+          <p className="mb-4 text-sm text-gray-500 dark:text-gray-400">
+            {civics.glossary.length} terms
+          </p>
+          <GlossaryList entries={civics.glossary} />
+        </section>
+      )}
+    </main>
+  );
+}

--- a/apps/frontend/app/region/layout.tsx
+++ b/apps/frontend/app/region/layout.tsx
@@ -2,6 +2,7 @@
 
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { Header } from "@/components/Header";
+import { CivicsProvider } from "@/components/civics/CivicsContext";
 
 export default function RegionLayout({
   children,
@@ -11,7 +12,7 @@ export default function RegionLayout({
   return (
     <ProtectedRoute>
       <Header />
-      {children}
+      <CivicsProvider>{children}</CivicsProvider>
     </ProtectedRoute>
   );
 }

--- a/apps/frontend/app/region/legislative-committees/[id]/page.tsx
+++ b/apps/frontend/app/region/legislative-committees/[id]/page.tsx
@@ -23,6 +23,7 @@ import { PartyBadge } from "@/components/region/PartyBadge";
 import { CommitteeActivityStats } from "@/components/region/CommitteeActivityStats";
 import { CommitteeActivityFeed } from "@/components/region/CommitteeActivityFeed";
 import { ActivitySummary } from "@/components/region/ActivitySummary";
+import { CivicTerm } from "@/components/civics/CivicTerm";
 import { formatDate } from "@/lib/format";
 
 const LAYERS = [
@@ -407,6 +408,8 @@ export default function LegislativeCommitteeDetailPage() {
         <div className="flex flex-wrap items-center gap-3">
           <ChamberBadge chamber={committee.chamber} />
           <span className="text-sm text-[#4d4d4d]">
+            <CivicTerm term="committee">Committee</CivicTerm>
+            {" · "}
             {committee.memberCount}{" "}
             {committee.memberCount === 1 ? "member" : "members"}
           </span>

--- a/apps/frontend/app/region/page.tsx
+++ b/apps/frontend/app/region/page.tsx
@@ -325,6 +325,26 @@ export default function RegionPage() {
         })}
       </div>
 
+      {/* Civics Hub */}
+      <div className="mt-8">
+        <Link
+          href="/region/how-it-works"
+          className="flex items-center justify-between rounded-xl border border-blue-100 bg-blue-50 px-6 py-4 hover:bg-blue-100 transition-colors dark:border-blue-900 dark:bg-blue-900/20 dark:hover:bg-blue-900/30"
+        >
+          <div>
+            <h2 className="text-base font-semibold text-blue-800 dark:text-blue-300">
+              How your government works →
+            </h2>
+            <p className="mt-0.5 text-sm text-blue-600 dark:text-blue-400">
+              Measure types, glossary, and the legislative process explained
+            </p>
+          </div>
+          <span aria-hidden="true" className="text-2xl">
+            🏛️
+          </span>
+        </Link>
+      </div>
+
       {/* Data Sources */}
       {regionInfo?.dataSourceUrls && regionInfo.dataSourceUrls.length > 0 && (
         <div className="mt-12 pt-8 border-t border-gray-100">

--- a/apps/frontend/app/region/propositions/[id]/page.tsx
+++ b/apps/frontend/app/region/propositions/[id]/page.tsx
@@ -26,6 +26,7 @@ import { YesNoOutcomeCard } from "@/components/region/YesNoOutcomeCard";
 import { ClaimAttribution } from "@/components/region/ClaimAttribution";
 import { SegmentedFullText } from "@/components/region/SegmentedFullText";
 import { PropositionFundingSection } from "@/components/region/PropositionFundingSection";
+import { CivicTerm } from "@/components/civics/CivicTerm";
 import { formatDate } from "@/lib/format";
 
 const STATUS_STYLES: Record<
@@ -505,7 +506,9 @@ export default function PropositionDetailPage() {
       {/* Persistent Header */}
       <div className="mb-6">
         <p className="text-xs font-bold uppercase tracking-[1px] text-[#595959] mb-2">
-          {proposition.externalId}
+          <CivicTerm term={proposition.externalId.replace(/\d+$/, "").trim()}>
+            {proposition.externalId}
+          </CivicTerm>
         </p>
         <h1 className="text-2xl font-extrabold text-[#222222] leading-tight mb-3">
           {proposition.title}

--- a/apps/frontend/app/region/representatives/[id]/page.tsx
+++ b/apps/frontend/app/region/representatives/[id]/page.tsx
@@ -26,6 +26,7 @@ import { LayerNav } from "@/components/region/LayerNav";
 import { ActivityStats } from "@/components/region/ActivityStats";
 import { ActivityFeed } from "@/components/region/ActivityFeed";
 import { ActivitySummary } from "@/components/region/ActivitySummary";
+import { CivicTerm } from "@/components/civics/CivicTerm";
 
 const LAYERS = [
   { n: 1, label: "Who They Are" },
@@ -710,7 +711,7 @@ function PersistentHeader({
           <div className="flex flex-wrap items-center gap-2.5 mb-2.5">
             <PartyBadge party={rep.party} size="md" />
             <span className="text-sm text-[#4d4d4d] font-medium">
-              {rep.chamber}
+              <CivicTerm term={rep.chamber}>{rep.chamber}</CivicTerm>
             </span>
             <span className="text-sm text-[#4d4d4d]">
               District {rep.district}

--- a/apps/frontend/components/civics/CitizenActionCallout.tsx
+++ b/apps/frontend/components/civics/CitizenActionCallout.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import type { CitizenAction } from "@/lib/graphql/region";
+
+interface CitizenActionCalloutProps {
+  action: CitizenAction | null | undefined;
+}
+
+const verbIcons: Record<string, string> = {
+  comment: "💬",
+  attend: "📅",
+  contact: "✉️",
+  monitor: "👁",
+  vote: "🗳",
+  learn: "📖",
+};
+
+/**
+ * Displays the citizen-action CTA for the current lifecycle stage.
+ * Active urgency: orange styling, prominent button.
+ * Passive urgency: subdued gray, informational.
+ * None: renders nothing.
+ */
+export function CitizenActionCallout({ action }: CitizenActionCalloutProps) {
+  if (!action || action.urgency === "none") return null;
+
+  const isActive = action.urgency === "active";
+  const icon = verbIcons[action.verb] ?? "➡️";
+
+  const content = (
+    <>
+      <span aria-hidden="true" className="text-lg">
+        {icon}
+      </span>
+      <span className="font-medium">{action.label.plainLanguage}</span>
+    </>
+  );
+
+  const baseClass = [
+    "flex items-center gap-2 rounded-lg px-4 py-3 text-sm transition-colors",
+    isActive
+      ? "bg-orange-50 text-orange-800 border border-orange-200 hover:bg-orange-100 dark:bg-orange-900/20 dark:text-orange-300 dark:border-orange-800"
+      : "bg-gray-50 text-gray-600 border border-gray-200 dark:bg-gray-800/50 dark:text-gray-400 dark:border-gray-700",
+  ].join(" ");
+
+  // Defense-in-depth: only render the link if the URL is http(s).
+  // The primary sanitization happens in the backend getCivicsData service,
+  // but we guard here too in case of a schema change or direct API call.
+  const safeUrl =
+    action.url &&
+    (action.url.startsWith("https://") || action.url.startsWith("http://"))
+      ? action.url
+      : null;
+
+  if (safeUrl) {
+    return (
+      <a
+        href={safeUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={baseClass}
+        aria-label={`${action.label.plainLanguage} — opens in new tab`}
+      >
+        {content}
+        <span aria-hidden="true" className="ml-auto text-xs opacity-60">
+          ↗
+        </span>
+      </a>
+    );
+  }
+
+  return <div className={baseClass}>{content}</div>;
+}

--- a/apps/frontend/components/civics/CivicTerm.tsx
+++ b/apps/frontend/components/civics/CivicTerm.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useId } from "react";
+import { useTranslation } from "react-i18next";
+import Link from "next/link";
+import { useCivics } from "./CivicsContext";
+
+interface CivicTermProps {
+  /**
+   * Slug, lowercase term text, or measure-type code (e.g. "AB") used to
+   * look up the definition. Lookup order: slug → term → measure-type code.
+   */
+  term: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps civic-vocabulary text in an accessible tooltip sourced from the
+ * region glossary or measure-type definitions. Renders children unchanged
+ * when the term is not found — never produces a broken state.
+ *
+ * Keyboard: tooltip opens on focus, closes on blur/Escape.
+ */
+export function CivicTerm({ term, children }: CivicTermProps) {
+  const { t } = useTranslation("civics");
+  const { glossaryMap, glossaryByTerm, measureTypeByCode, loading } =
+    useCivics();
+  const descId = useId();
+
+  // 1. Try glossary by slug
+  const glossaryEntry =
+    glossaryMap.get(term) ?? glossaryByTerm.get(term.toLowerCase()) ?? null;
+
+  // 2. Fall back to measure type by code (e.g. "AB", "SB", "ACA")
+  const measureType = !glossaryEntry
+    ? (measureTypeByCode.get(term.toUpperCase()) ?? null)
+    : null;
+
+  const hasMatch = Boolean(glossaryEntry ?? measureType);
+
+  // No match and not loading: render children unchanged.
+  if (!loading && !hasMatch) {
+    return <>{children}</>;
+  }
+
+  const shortDef =
+    glossaryEntry?.definition.plainLanguage ??
+    measureType?.purpose.plainLanguage ??
+    t("tooltip.loading");
+
+  const displayTerm =
+    glossaryEntry?.term ?? measureType?.name ?? String(children);
+
+  const learnMoreSlug = glossaryEntry?.slug ?? null;
+
+  return (
+    <span className="civic-term group relative inline-block">
+      <span
+        tabIndex={0}
+        aria-describedby={hasMatch ? descId : undefined}
+        className="cursor-help border-b border-dashed border-current underline-offset-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded-sm"
+      >
+        {children}
+      </span>
+
+      {hasMatch && (
+        <span
+          role="tooltip"
+          id={descId}
+          className={[
+            "pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-64 -translate-x-1/2",
+            "rounded-lg border border-gray-200 bg-white px-3 py-2 shadow-lg",
+            "text-sm text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100",
+            "opacity-0 transition-opacity duration-150",
+            "group-hover:pointer-events-auto group-hover:opacity-100",
+            "group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+          ].join(" ")}
+        >
+          <span className="block font-semibold">{displayTerm}</span>
+          <span className="mt-1 block leading-snug text-gray-600 dark:text-gray-300">
+            {shortDef}
+          </span>
+          {learnMoreSlug && (
+            <Link
+              href={`/region/how-it-works#term-${learnMoreSlug}`}
+              className="mt-2 block text-xs font-medium text-blue-600 hover:underline dark:text-blue-400"
+              tabIndex={0}
+            >
+              {t("tooltip.learnMore")} →
+            </Link>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/apps/frontend/components/civics/CivicsContext.tsx
+++ b/apps/frontend/components/civics/CivicsContext.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_REGION_INFO,
+  type CivicsBlock,
+  type CivicsGlossaryEntry,
+  type CivicsMeasureType,
+} from "@/lib/graphql/region";
+
+interface RegionInfoData {
+  regionInfo: { civics?: CivicsBlock };
+}
+
+interface CivicsContextValue {
+  civics: CivicsBlock | null;
+  /** Slug → GlossaryEntry lookup map. O(1) per tooltip lookup. */
+  glossaryMap: Map<string, CivicsGlossaryEntry>;
+  /** Term (lowercase) → GlossaryEntry lookup map. */
+  glossaryByTerm: Map<string, CivicsGlossaryEntry>;
+  /** Measure type code (e.g. "AB") → MeasureType. For CivicTerm on externalIds. */
+  measureTypeByCode: Map<string, CivicsMeasureType>;
+  loading: boolean;
+}
+
+const CivicsContext = createContext<CivicsContextValue>({
+  civics: null,
+  glossaryMap: new Map(),
+  glossaryByTerm: new Map(),
+  measureTypeByCode: new Map(),
+  loading: false,
+});
+
+export function CivicsProvider({ children }: { children: ReactNode }) {
+  const { data, loading } = useQuery<RegionInfoData>(GET_REGION_INFO);
+  const civics = data?.regionInfo?.civics ?? null;
+
+  const glossaryMap = useMemo(() => {
+    const map = new Map<string, CivicsGlossaryEntry>();
+    if (civics) for (const entry of civics.glossary) map.set(entry.slug, entry);
+    return map;
+  }, [civics]);
+
+  const glossaryByTerm = useMemo(() => {
+    const map = new Map<string, CivicsGlossaryEntry>();
+    if (civics)
+      for (const entry of civics.glossary)
+        map.set(entry.term.toLowerCase(), entry);
+    return map;
+  }, [civics]);
+
+  const measureTypeByCode = useMemo(() => {
+    const map = new Map<string, CivicsMeasureType>();
+    if (civics) for (const mt of civics.measureTypes) map.set(mt.code, mt);
+    return map;
+  }, [civics]);
+
+  const value = useMemo(
+    () => ({ civics, glossaryMap, glossaryByTerm, measureTypeByCode, loading }),
+    [civics, glossaryMap, glossaryByTerm, measureTypeByCode, loading],
+  );
+
+  return (
+    <CivicsContext.Provider value={value}>{children}</CivicsContext.Provider>
+  );
+}
+
+export function useCivics() {
+  return useContext(CivicsContext);
+}

--- a/apps/frontend/components/civics/GlossaryList.tsx
+++ b/apps/frontend/components/civics/GlossaryList.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState, useId } from "react";
+import { useTranslation } from "react-i18next";
+import Link from "next/link";
+import type { CivicsGlossaryEntry } from "@/lib/graphql/region";
+import { useCivics } from "./CivicsContext";
+
+interface GlossaryListProps {
+  entries: CivicsGlossaryEntry[];
+}
+
+/**
+ * Searchable glossary list for the /region/how-it-works hub.
+ *
+ * Each entry has an anchor id="term-{slug}" matching the deep-link target
+ * from <CivicTerm> "Learn more" links. scroll-margin-top clears sticky header.
+ *
+ * Accessibility: search input is labelled, results region announces count
+ * changes to screen readers via aria-live.
+ */
+export function GlossaryList({ entries }: GlossaryListProps) {
+  const { t } = useTranslation("civics");
+  const [query, setQuery] = useState("");
+  const searchId = useId();
+  const resultsId = useId();
+
+  const filtered =
+    query.trim().length === 0
+      ? entries
+      : entries.filter(
+          (e) =>
+            e.term.toLowerCase().includes(query.toLowerCase()) ||
+            e.definition.plainLanguage
+              .toLowerCase()
+              .includes(query.toLowerCase()),
+        );
+
+  return (
+    <div className="space-y-4">
+      {/* Search input */}
+      <div className="relative">
+        <label htmlFor={searchId} className="sr-only">
+          {t("glossary.searchPlaceholder")}
+        </label>
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+        >
+          🔍
+        </span>
+        <input
+          id={searchId}
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder={t("glossary.searchPlaceholder")}
+          aria-controls={resultsId}
+          className="w-full rounded-lg border border-gray-300 py-2 pl-10 pr-4 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        />
+      </div>
+
+      {/* Results */}
+      <div
+        id={resultsId}
+        role="region"
+        aria-label={t("glossary.title")}
+        aria-live="polite"
+        className="space-y-6"
+      >
+        {filtered.length === 0 ? (
+          <p className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+            {t("glossary.noResults", { query })}
+          </p>
+        ) : (
+          filtered.map((entry) => (
+            <GlossaryEntry key={entry.slug} entry={entry} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+function GlossaryEntry({ entry }: { entry: CivicsGlossaryEntry }) {
+  const { t } = useTranslation("civics");
+  const { glossaryByTerm } = useCivics();
+  const [expanded, setExpanded] = useState(false);
+  const longDefId = useId();
+
+  return (
+    <section
+      id={`term-${entry.slug}`}
+      aria-labelledby={`term-heading-${entry.slug}`}
+      className="scroll-mt-20 border-b border-gray-100 pb-4 last:border-0 dark:border-gray-800"
+    >
+      <h3
+        id={`term-heading-${entry.slug}`}
+        className="text-base font-semibold text-gray-900 dark:text-gray-100"
+      >
+        {entry.term}
+      </h3>
+
+      <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+        {entry.definition.plainLanguage}
+      </p>
+
+      {/* Long definition expandable */}
+      {entry.longDefinition && (
+        <div className="mt-2">
+          <button
+            type="button"
+            aria-expanded={expanded}
+            aria-controls={longDefId}
+            onClick={() => setExpanded((v) => !v)}
+            className="text-xs font-medium text-blue-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-400"
+          >
+            {expanded ? "▲" : "▼"} {t("glossary.longDefinitionLabel")}
+          </button>
+          {expanded && (
+            <p
+              id={longDefId}
+              className="mt-2 text-sm leading-relaxed text-gray-500 dark:text-gray-400"
+            >
+              {entry.longDefinition.plainLanguage}
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Related terms — look up real slug via glossaryByTerm */}
+      {entry.relatedTerms.length > 0 && (
+        <div className="mt-2 flex flex-wrap items-center gap-1.5">
+          <span className="text-xs text-gray-400">
+            {t("glossary.relatedTerms")}:
+          </span>
+          {entry.relatedTerms.map((rt) => {
+            const slug =
+              glossaryByTerm.get(rt.toLowerCase())?.slug ??
+              rt.toLowerCase().replace(/\s+/g, "-");
+            return (
+              <Link
+                key={rt}
+                href={`#term-${slug}`}
+                className="rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
+                {rt}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/frontend/components/civics/HowABillBecomesLaw.tsx
+++ b/apps/frontend/components/civics/HowABillBecomesLaw.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState, useId } from "react";
+import { useTranslation } from "react-i18next";
+import type {
+  CivicsMeasureType,
+  CivicsLifecycleStage,
+} from "@/lib/graphql/region";
+import { LifecycleProgressBar } from "./LifecycleProgressBar";
+
+interface HowABillBecomesLawProps {
+  measureTypes: CivicsMeasureType[];
+  lifecycleStages: CivicsLifecycleStage[];
+}
+
+/**
+ * Abstract lifecycle diagram for the civics hub.
+ * Shows the full stage sequence for the selected measure type with no
+ * bill-specific current stage (LifecycleProgressBar in abstract mode).
+ * Measure type selector covers all types returned by the region.
+ */
+export function HowABillBecomesLaw({
+  measureTypes,
+  lifecycleStages,
+}: HowABillBecomesLawProps) {
+  const { t } = useTranslation("civics");
+  const selectId = useId();
+
+  const [selectedCode, setSelectedCode] = useState(measureTypes[0]?.code ?? "");
+
+  const stageMap = new Map(lifecycleStages.map((s) => [s.id, s]));
+  const selectedType = measureTypes.find((mt) => mt.code === selectedCode);
+  const stages = (selectedType?.lifecycleStageIds ?? [])
+    .map((id) => stageMap.get(id))
+    .filter(Boolean) as CivicsLifecycleStage[];
+
+  if (measureTypes.length === 0) return null;
+
+  return (
+    <div className="space-y-4">
+      {/* Measure type selector */}
+      <div className="flex flex-wrap items-center gap-3">
+        <label
+          htmlFor={selectId}
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {t("lifecycle.measureTypeLabel")}
+        </label>
+        <select
+          id={selectId}
+          value={selectedCode}
+          onChange={(e) => setSelectedCode(e.target.value)}
+          className="rounded-lg border border-gray-300 px-3 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+        >
+          {measureTypes.map((mt) => (
+            <option key={mt.code} value={mt.code}>
+              {mt.code} — {mt.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Abstract hint */}
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        {t("lifecycle.abstractMode")}
+      </p>
+
+      {/* Progress bar in abstract mode */}
+      {stages.length > 0 ? (
+        <LifecycleProgressBar stages={stages} currentStageId={null} />
+      ) : (
+        <p className="py-4 text-center text-sm text-gray-400">
+          {t("hub.noData")}
+        </p>
+      )}
+
+      {/* Selected type purpose */}
+      {selectedType && (
+        <p className="mt-2 rounded-lg bg-gray-50 p-3 text-sm text-gray-600 dark:bg-gray-800/50 dark:text-gray-400">
+          {selectedType.purpose.plainLanguage}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/civics/LifecycleProgressBar.tsx
+++ b/apps/frontend/components/civics/LifecycleProgressBar.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { useState } from "react";
+import type { CivicsLifecycleStage, CitizenAction } from "@/lib/graphql/region";
+
+interface LifecycleProgressBarProps {
+  stages: CivicsLifecycleStage[];
+  /**
+   * The `id` of the current stage. Pass `null` for "abstract" mode
+   * (used on the how-it-works hub) where no stage is highlighted.
+   */
+  currentStageId: string | null;
+}
+
+const urgencyColors: Record<CitizenAction["urgency"], string> = {
+  active:
+    "bg-orange-50 border-orange-200 text-orange-800 dark:bg-orange-900/20 dark:border-orange-800 dark:text-orange-300",
+  passive:
+    "bg-gray-50 border-gray-200 text-gray-600 dark:bg-gray-800/50 dark:border-gray-700 dark:text-gray-400",
+  none: "hidden",
+};
+
+/**
+ * Horizontal step indicator for a bill's lifecycle.
+ *
+ * In bill-detail mode: completed stages dimmed, current highlighted, future outlined.
+ * In abstract mode (currentStageId === null): all stages shown equally.
+ * Clicking a stage dot expands a detail panel below the bar.
+ */
+export function LifecycleProgressBar({
+  stages,
+  currentStageId,
+}: LifecycleProgressBarProps) {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  if (stages.length === 0) return null;
+
+  const currentIdx = currentStageId
+    ? stages.findIndex((s) => s.id === currentStageId)
+    : -1;
+
+  const selectedStage = stages.find((s) => s.id === selectedId) ?? null;
+
+  return (
+    <div className="space-y-4">
+      <nav aria-label="Bill lifecycle stages">
+        <ol
+          role="list"
+          className="flex items-start gap-1 overflow-x-auto pb-1 text-xs"
+        >
+          {stages.map((stage, idx) => {
+            const isCompleted = currentIdx >= 0 && idx < currentIdx;
+            const isCurrent = idx === currentIdx;
+            const isAbstract = currentStageId === null;
+            const isSelected = selectedId === stage.id;
+
+            return (
+              <li
+                key={stage.id}
+                role="listitem"
+                aria-current={isCurrent ? "step" : undefined}
+                className="group relative flex min-w-[4rem] flex-1 flex-col items-center"
+              >
+                {/* Connector line */}
+                {idx < stages.length - 1 && (
+                  <span
+                    aria-hidden="true"
+                    className={[
+                      "absolute left-1/2 top-3 h-0.5 w-full",
+                      isCompleted
+                        ? "bg-blue-500"
+                        : "bg-gray-200 dark:bg-gray-700",
+                    ].join(" ")}
+                  />
+                )}
+
+                {/* Step dot — click to select */}
+                <button
+                  type="button"
+                  tabIndex={0}
+                  onClick={() =>
+                    setSelectedId((prev) =>
+                      prev === stage.id ? null : stage.id,
+                    )
+                  }
+                  aria-pressed={isSelected}
+                  aria-label={`${stage.name.plainLanguage}: ${stage.shortDescription.plainLanguage}`}
+                  className={[
+                    "relative z-10 flex h-6 w-6 items-center justify-center rounded-full border-2 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1",
+                    isSelected
+                      ? "scale-110 border-blue-700 bg-blue-700 shadow-md"
+                      : isAbstract
+                        ? "border-gray-400 bg-white hover:border-blue-400 dark:border-gray-500 dark:bg-gray-800"
+                        : isCompleted
+                          ? "border-blue-500 bg-blue-500"
+                          : isCurrent
+                            ? "border-blue-600 bg-blue-600 ring-2 ring-blue-300"
+                            : "border-gray-300 bg-white hover:border-blue-400 dark:border-gray-600 dark:bg-gray-900",
+                  ].join(" ")}
+                >
+                  {isCompleted && !isSelected && (
+                    <svg
+                      aria-hidden="true"
+                      className="h-3 w-3 text-white"
+                      fill="currentColor"
+                      viewBox="0 0 20 20"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  )}
+                  {isSelected && (
+                    <span
+                      aria-hidden="true"
+                      className="h-2 w-2 rounded-full bg-white"
+                    />
+                  )}
+                </button>
+
+                {/* Stage label — click handled by button above; span is display only */}
+                <span
+                  aria-hidden="true"
+                  className={[
+                    "mt-1 max-w-[5rem] text-center leading-tight",
+                    isSelected
+                      ? "font-semibold text-blue-700 dark:text-blue-400"
+                      : isCompleted
+                        ? "text-gray-400 dark:text-gray-500"
+                        : isCurrent
+                          ? "font-semibold text-blue-700 dark:text-blue-400"
+                          : "text-gray-500 dark:text-gray-400",
+                  ].join(" ")}
+                >
+                  {stage.name.plainLanguage}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
+
+      {/* Expanded detail panel for selected stage */}
+      {selectedStage && (
+        <div className="rounded-lg border border-blue-100 bg-blue-50 p-4 dark:border-blue-900/50 dark:bg-blue-900/10">
+          <div className="flex items-start justify-between gap-2">
+            <h4 className="font-semibold text-blue-900 dark:text-blue-200">
+              {selectedStage.name.plainLanguage}
+            </h4>
+            <button
+              type="button"
+              onClick={() => setSelectedId(null)}
+              aria-label="Close stage detail"
+              className="text-blue-400 hover:text-blue-600 dark:hover:text-blue-300"
+            >
+              ✕
+            </button>
+          </div>
+
+          <p className="mt-1 text-sm text-blue-800 dark:text-blue-300">
+            {selectedStage.shortDescription.plainLanguage}
+          </p>
+
+          {selectedStage.longDescription && (
+            <p className="mt-2 text-sm leading-relaxed text-gray-600 dark:text-gray-400">
+              {selectedStage.longDescription.plainLanguage}
+            </p>
+          )}
+
+          {selectedStage.citizenAction &&
+            selectedStage.citizenAction.urgency !== "none" && (
+              <div
+                className={[
+                  "mt-3 flex items-center gap-2 rounded-md border px-3 py-2 text-sm",
+                  urgencyColors[selectedStage.citizenAction.urgency],
+                ].join(" ")}
+              >
+                <span aria-hidden="true" className="font-medium">
+                  {selectedStage.citizenAction.verb === "comment" && "💬"}
+                  {selectedStage.citizenAction.verb === "attend" && "📅"}
+                  {selectedStage.citizenAction.verb === "contact" && "✉️"}
+                  {selectedStage.citizenAction.verb === "monitor" && "👁"}
+                  {selectedStage.citizenAction.verb === "vote" && "🗳"}
+                  {selectedStage.citizenAction.verb === "learn" && "📖"}
+                </span>
+                {/* Defense-in-depth: only allow http(s) URLs (primary guard is in backend) */}
+                {selectedStage.citizenAction.url &&
+                (selectedStage.citizenAction.url.startsWith("https://") ||
+                  selectedStage.citizenAction.url.startsWith("http://")) ? (
+                  <a
+                    href={selectedStage.citizenAction.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-medium underline"
+                  >
+                    {selectedStage.citizenAction.label.plainLanguage}
+                  </a>
+                ) : (
+                  <span>{selectedStage.citizenAction.label.plainLanguage}</span>
+                )}
+              </div>
+            )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/civics/MeasureTypeTable.tsx
+++ b/apps/frontend/components/civics/MeasureTypeTable.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import type {
+  CivicsMeasureType,
+  CivicsLifecycleStage,
+} from "@/lib/graphql/region";
+
+interface MeasureTypeTableProps {
+  measureTypes: CivicsMeasureType[];
+  lifecycleStages: CivicsLifecycleStage[];
+}
+
+/**
+ * Comparison grid showing all measure types for the region.
+ * Lifecycle stages column opens a portal popover so it isn't clipped
+ * by the table's overflow-x-auto container.
+ * Mobile: horizontally scrollable, first column sticky.
+ */
+export function MeasureTypeTable({
+  measureTypes,
+  lifecycleStages,
+}: MeasureTypeTableProps) {
+  const { t } = useTranslation("civics");
+  const stageMap = new Map(lifecycleStages.map((s) => [s.id, s]));
+
+  if (measureTypes.length === 0) return null;
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+      <table className="min-w-full divide-y divide-gray-200 text-sm dark:divide-gray-700">
+        <caption className="sr-only">{t("measureTypes.title")}</caption>
+        <thead className="bg-gray-50 dark:bg-gray-800">
+          <tr>
+            <th
+              scope="col"
+              className="sticky left-0 bg-gray-50 px-4 py-3 text-left font-semibold text-gray-900 dark:bg-gray-800 dark:text-gray-100"
+            >
+              {t("measureTypes.columns.code")}
+            </th>
+            <th
+              scope="col"
+              className="px-4 py-3 text-left font-semibold text-gray-900 dark:text-gray-100"
+            >
+              {t("measureTypes.columns.name")}
+            </th>
+            <th
+              scope="col"
+              className="px-4 py-3 text-left font-semibold text-gray-900 dark:text-gray-100"
+            >
+              {t("measureTypes.columns.chamber")}
+            </th>
+            <th
+              scope="col"
+              className="px-4 py-3 text-left font-semibold text-gray-900 dark:text-gray-100"
+            >
+              {t("measureTypes.columns.votingThreshold")}
+            </th>
+            <th
+              scope="col"
+              className="px-4 py-3 text-center font-semibold text-gray-900 dark:text-gray-100"
+            >
+              {t("measureTypes.columns.reachesGovernor")}
+            </th>
+            <th
+              scope="col"
+              className="px-4 py-3 text-left font-semibold text-gray-900 dark:text-gray-100"
+            >
+              {t("measureTypes.columns.lifecycleStages")}
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100 bg-white dark:divide-gray-800 dark:bg-gray-900">
+          {measureTypes.map((mt) => (
+            <MeasureTypeRow
+              key={mt.code}
+              measureType={mt}
+              stageMap={stageMap}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function MeasureTypeRow({
+  measureType: mt,
+  stageMap,
+}: {
+  measureType: CivicsMeasureType;
+  stageMap: Map<string, CivicsLifecycleStage>;
+}) {
+  const { t } = useTranslation("civics");
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [popoverPos, setPopoverPos] = useState({ top: 0, left: 0 });
+  const btnRef = useRef<HTMLButtonElement>(null);
+
+  const stages = mt.lifecycleStageIds
+    .map((id) => stageMap.get(id))
+    .filter(Boolean) as CivicsLifecycleStage[];
+
+  const threshold = t(`measureTypes.thresholds.${mt.votingThreshold}`, {
+    defaultValue: mt.votingThreshold,
+  });
+
+  const openPopover = useCallback(() => {
+    if (btnRef.current) {
+      const rect = btnRef.current.getBoundingClientRect();
+      // position: fixed — viewport-relative, won't drift on scroll
+      setPopoverPos({ top: rect.bottom + 4, left: rect.left });
+    }
+    setPopoverOpen(true);
+  }, []);
+
+  // Close on outside click or Escape
+  useEffect(() => {
+    if (!popoverOpen) return;
+    const close = (e: MouseEvent | KeyboardEvent) => {
+      if (e instanceof KeyboardEvent && e.key !== "Escape") return;
+      if (e instanceof MouseEvent && btnRef.current?.contains(e.target as Node))
+        return;
+      setPopoverOpen(false);
+    };
+    document.addEventListener("mousedown", close);
+    document.addEventListener("keydown", close);
+    return () => {
+      document.removeEventListener("mousedown", close);
+      document.removeEventListener("keydown", close);
+    };
+  }, [popoverOpen]);
+
+  return (
+    <tr className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+      <td className="sticky left-0 bg-white px-4 py-3 font-mono font-semibold text-blue-700 dark:bg-gray-900 dark:text-blue-400">
+        {mt.code}
+      </td>
+      <td className="px-4 py-3 text-gray-800 dark:text-gray-200">
+        <span title={mt.purpose.plainLanguage} className="cursor-help">
+          {mt.name}
+        </span>
+      </td>
+      <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+        {mt.chamber}
+      </td>
+      <td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+        {threshold}
+      </td>
+      <td className="px-4 py-3 text-center">
+        {mt.reachesGovernor ? (
+          <span
+            aria-label={t("measureTypes.yes")}
+            className="text-green-600 dark:text-green-400"
+          >
+            ✓
+          </span>
+        ) : (
+          <span aria-label={t("measureTypes.no")} className="text-gray-400">
+            ✗
+          </span>
+        )}
+      </td>
+      <td className="px-4 py-3">
+        {stages.length > 0 ? (
+          <>
+            <button
+              ref={btnRef}
+              type="button"
+              aria-expanded={popoverOpen}
+              aria-haspopup="listbox"
+              onClick={() =>
+                popoverOpen ? setPopoverOpen(false) : openPopover()
+              }
+              className="rounded bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700 hover:bg-blue-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:bg-blue-900/30 dark:text-blue-300"
+            >
+              {t("measureTypes.stagesPopover", { count: stages.length })}
+            </button>
+            {popoverOpen &&
+              createPortal(
+                <div
+                  role="list"
+                  aria-label={`${mt.name} stages`}
+                  style={{
+                    position: "fixed",
+                    top: popoverPos.top,
+                    left: popoverPos.left,
+                    zIndex: 9999,
+                  }}
+                  className="w-64 rounded-lg border border-gray-200 bg-white py-2 shadow-xl dark:border-gray-700 dark:bg-gray-900"
+                >
+                  <p className="px-3 pb-1 text-xs font-semibold text-gray-500 dark:text-gray-400">
+                    {mt.name} — stages
+                  </p>
+                  {stages.map((s, i) => (
+                    <div
+                      key={s.id}
+                      role="listitem"
+                      className="px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300"
+                    >
+                      <span className="mr-1.5 text-gray-400">{i + 1}.</span>
+                      {s.name.plainLanguage}
+                    </div>
+                  ))}
+                </div>,
+                document.body,
+              )}
+          </>
+        ) : (
+          <span className="text-xs text-gray-400">—</span>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -9,7 +9,75 @@ export type DataType =
   | "PROPOSITIONS"
   | "MEETINGS"
   | "REPRESENTATIVES"
-  | "CAMPAIGN_FINANCE";
+  | "CAMPAIGN_FINANCE"
+  | "CIVICS";
+
+// ── Civics types ──────────────────────────────────────────────────────────────
+
+export interface CivicText {
+  verbatim: string;
+  plainLanguage: string;
+  sourceUrl: string;
+}
+
+export interface CivicsChamber {
+  name: string;
+  abbreviation: string;
+  size: number;
+  termYears: number;
+  leadershipRoles: string[];
+  description: CivicText;
+}
+
+export interface CitizenAction {
+  verb: string;
+  label: CivicText;
+  url?: string;
+  urgency: "active" | "passive" | "none";
+}
+
+export interface CivicsLifecycleStage {
+  id: string;
+  name: CivicText;
+  shortDescription: CivicText;
+  longDescription?: CivicText;
+  statusStringPatterns: string[];
+  citizenAction?: CitizenAction;
+}
+
+export interface CivicsMeasureType {
+  code: string;
+  name: string;
+  chamber: string;
+  votingThreshold: string;
+  reachesGovernor: boolean;
+  purpose: CivicText;
+  lifecycleStageIds: string[];
+}
+
+export interface CivicsGlossaryEntry {
+  term: string;
+  slug: string;
+  definition: CivicText;
+  longDefinition?: CivicText;
+  relatedTerms: string[];
+}
+
+export interface CivicsSessionScheme {
+  cadence: string;
+  namingPattern: string;
+  description: CivicText;
+}
+
+export interface CivicsBlock {
+  chambers: CivicsChamber[];
+  measureTypes: CivicsMeasureType[];
+  lifecycleStages: CivicsLifecycleStage[];
+  sessionScheme?: CivicsSessionScheme;
+  glossary: CivicsGlossaryEntry[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 
 export interface RegionInfo {
   id: string;
@@ -18,6 +86,7 @@ export interface RegionInfo {
   timezone: string;
   dataSourceUrls?: string[];
   supportedDataTypes: DataType[];
+  civics?: CivicsBlock;
 }
 
 /**
@@ -516,7 +585,16 @@ export interface SyncDataTypeVars {
 // Queries
 // ============================================
 
+const CIVIC_TEXT_FIELDS = gql`
+  fragment CivicTextFields on CivicText {
+    verbatim
+    plainLanguage
+    sourceUrl
+  }
+`;
+
 export const GET_REGION_INFO = gql`
+  ${CIVIC_TEXT_FIELDS}
   query GetRegionInfo {
     regionInfo {
       id
@@ -525,6 +603,68 @@ export const GET_REGION_INFO = gql`
       timezone
       dataSourceUrls
       supportedDataTypes
+      civics {
+        chambers {
+          name
+          abbreviation
+          size
+          termYears
+          leadershipRoles
+          description {
+            ...CivicTextFields
+          }
+        }
+        measureTypes {
+          code
+          name
+          chamber
+          votingThreshold
+          reachesGovernor
+          purpose {
+            ...CivicTextFields
+          }
+          lifecycleStageIds
+        }
+        lifecycleStages {
+          id
+          name {
+            ...CivicTextFields
+          }
+          shortDescription {
+            ...CivicTextFields
+          }
+          longDescription {
+            ...CivicTextFields
+          }
+          statusStringPatterns
+          citizenAction {
+            verb
+            label {
+              ...CivicTextFields
+            }
+            url
+            urgency
+          }
+        }
+        sessionScheme {
+          cadence
+          namingPattern
+          description {
+            ...CivicTextFields
+          }
+        }
+        glossary {
+          term
+          slug
+          definition {
+            ...CivicTextFields
+          }
+          longDefinition {
+            ...CivicTextFields
+          }
+          relatedTerms
+        }
+      }
     }
   }
 `;

--- a/apps/frontend/lib/i18n/index.ts
+++ b/apps/frontend/lib/i18n/index.ts
@@ -6,11 +6,13 @@ import enSettings from "@/locales/en/settings.json";
 import enOnboarding from "@/locales/en/onboarding.json";
 import enPetition from "@/locales/en/petition.json";
 import enLanding from "@/locales/en/landing.json";
+import enCivics from "@/locales/en/civics.json";
 import esCommon from "@/locales/es/common.json";
 import esSettings from "@/locales/es/settings.json";
 import esOnboarding from "@/locales/es/onboarding.json";
 import esPetition from "@/locales/es/petition.json";
 import esLanding from "@/locales/es/landing.json";
+import esCivics from "@/locales/es/civics.json";
 
 export const defaultNS = "common";
 export const supportedLanguages = ["en", "es"] as const;
@@ -23,6 +25,7 @@ export const resources = {
     onboarding: enOnboarding,
     petition: enPetition,
     landing: enLanding,
+    civics: enCivics,
   },
   es: {
     common: esCommon,
@@ -30,6 +33,7 @@ export const resources = {
     onboarding: esOnboarding,
     petition: esPetition,
     landing: esLanding,
+    civics: esCivics,
   },
 } as const;
 

--- a/apps/frontend/locales/en/civics.json
+++ b/apps/frontend/locales/en/civics.json
@@ -1,0 +1,45 @@
+{
+  "tooltip": {
+    "learnMore": "Learn more",
+    "loading": "Loading definition…"
+  },
+  "glossary": {
+    "title": "Civic Glossary",
+    "searchPlaceholder": "Search terms…",
+    "noResults": "No terms match \"{{query}}\".",
+    "relatedTerms": "Related terms",
+    "longDefinitionLabel": "Full definition"
+  },
+  "measureTypes": {
+    "title": "Measure Types",
+    "description": "How different types of legislation work in {{regionName}}",
+    "columns": {
+      "code": "Code",
+      "name": "Name",
+      "chamber": "Chamber",
+      "votingThreshold": "Voting threshold",
+      "reachesGovernor": "Goes to Governor",
+      "lifecycleStages": "Stages"
+    },
+    "yes": "Yes",
+    "no": "No",
+    "stagesPopover": "{{count}} stages",
+    "thresholds": {
+      "majority": "Majority",
+      "two-thirds": "2/3",
+      "three-fifths": "3/5",
+      "unanimous": "Unanimous"
+    }
+  },
+  "lifecycle": {
+    "title": "How a Bill Becomes Law",
+    "description": "The path a {{measureType}} takes through the legislature",
+    "measureTypeLabel": "Select measure type",
+    "abstractMode": "Follow the stages a bill passes through from introduction to final action."
+  },
+  "hub": {
+    "title": "How Your Government Works",
+    "subtitle": "A plain-language guide to {{regionName}}'s legislative process",
+    "noData": "Civics data is still being indexed. Check back soon."
+  }
+}

--- a/apps/frontend/locales/es/civics.json
+++ b/apps/frontend/locales/es/civics.json
@@ -1,0 +1,45 @@
+{
+  "tooltip": {
+    "learnMore": "Más información",
+    "loading": "Cargando definición…"
+  },
+  "glossary": {
+    "title": "Glosario cívico",
+    "searchPlaceholder": "Buscar términos…",
+    "noResults": "Ningún término coincide con \"{{query}}\".",
+    "relatedTerms": "Términos relacionados",
+    "longDefinitionLabel": "Definición completa"
+  },
+  "measureTypes": {
+    "title": "Tipos de medidas",
+    "description": "Cómo funcionan los diferentes tipos de legislación en {{regionName}}",
+    "columns": {
+      "code": "Código",
+      "name": "Nombre",
+      "chamber": "Cámara",
+      "votingThreshold": "Umbral de votación",
+      "reachesGovernor": "Va al Gobernador",
+      "lifecycleStages": "Etapas"
+    },
+    "yes": "Sí",
+    "no": "No",
+    "stagesPopover": "{{count}} etapas",
+    "thresholds": {
+      "majority": "Mayoría",
+      "two-thirds": "2/3",
+      "three-fifths": "3/5",
+      "unanimous": "Unánime"
+    }
+  },
+  "lifecycle": {
+    "title": "Cómo se convierte en ley un proyecto",
+    "description": "El camino que recorre {{measureType}} por la legislatura",
+    "measureTypeLabel": "Seleccionar tipo de medida",
+    "abstractMode": "Siga las etapas por las que pasa un proyecto desde su presentación hasta la acción final."
+  },
+  "hub": {
+    "title": "Cómo funciona su gobierno",
+    "subtitle": "Una guía en lenguaje sencillo del proceso legislativo de {{regionName}}",
+    "noData": "Los datos cívicos aún se están indexando. Vuelva pronto."
+  }
+}

--- a/packages/relationaldb-provider/prisma/migrations/20260509000001_add_civics_blocks_extracted_at_index/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260509000001_add_civics_blocks_extracted_at_index/migration.sql
@@ -1,0 +1,7 @@
+-- getCivicsData() queries WHERE region_id = ? ORDER BY extracted_at DESC.
+-- The existing region_id index covers the filter; this composite index
+-- also covers the sort so Postgres can avoid a sequential sort on the
+-- filtered set as civics_blocks grows.
+
+CREATE INDEX "civics_blocks_region_id_extracted_at_idx"
+    ON "civics_blocks"("region_id", "extracted_at" DESC);

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -932,6 +932,7 @@ model CivicsBlock {
 
   @@unique([regionId, sourceUrl])
   @@index([regionId])
+  @@index([regionId, extractedAt])
   @@map("civics_blocks")
 }
 


### PR DESCRIPTION
## Summary

Closes #678, #679, #680.

Delivers the citizen-facing civics literacy UI on top of the `CivicsBlock` data synced in #669/#681. Citizens can now explore how their legislature works — chambers, measure types, the full bill lifecycle, and a searchable glossary — directly from the region page.

**Backend**
- `getCivicsData(regionId)`: queries all `civics_blocks` rows for a region, merges and deduplicates them (first-wins by slug/code/id), normalizes mixed LLM output (plain strings vs. `CivicText` objects) via `normalizeCivicText()`
- `sanitizeCivicsUrl()`: allow-lists `https:`/`http:` only, blocking `javascript:`, `data:`, and any other protocol — prevents XSS from LLM-extracted citizenAction URLs
- Eight new `@ObjectType` classes with explicit GQL names matching frontend fragment types (`CivicText`, `CivicsBlock`, `CivicsChamber`, `CivicsLifecycleStage`, `CivicsMeasureType`, `CivicsGlossaryEntry`, `CivicsSessionScheme`, `CitizenAction`)
- Composite index `(region_id, extracted_at DESC)` on `civics_blocks` for efficient per-region queries
- 25 unit tests covering merge logic, normalization edge cases, and the `javascript:` URL block

**Frontend**
- `CivicsContext`: eagerly loaded in region layout; exposes `glossaryMap` (slug → entry), `glossaryByTerm` (lowercase → entry), `measureTypeByCode` (code → MeasureType)
- `CivicTerm`: accessible inline tooltip with 3-path lookup (slug → lowercase term → measure type code); missing terms render children unchanged
- `LifecycleProgressBar`: horizontal step indicator with click-to-expand detail panel; abstract mode (`currentStageId={null}`) for the how-it-works hub; XSS guard on `citizenAction.url` (defense-in-depth)
- `CitizenActionCallout`: urgency-styled CTA; only renders `<a>` when URL passes `https:`/`http:` check
- `MeasureTypeTable`: `createPortal`-based popover that escapes `overflow-x-auto` container without position drift
- `GlossaryList`: related-term links look up actual slugs via `CivicsContext` (avoids dead links when LLM slug ≠ term name)
- `HowABillBecomesLaw`: full measure-type selector + abstract lifecycle view
- `/region/how-it-works` hub page: MeasureTypeTable + HowABillBecomesLaw + GlossaryList with loading skeleton and "still being indexed" empty state
- "How your government works →" nav card on `/region` page
- `civics` i18n namespace wired for en + es (22 UI chrome strings; translation copy deferred post-MVP)
- Dockerfile: pin `pnpm@10.33.0` via corepack to prevent corepack downloading v11 (incompatible with Node 20)
- 32 frontend component tests across `CivicTerm`, `LifecycleProgressBar`, `CitizenActionCallout`, `GlossaryList`

## How to test

**Backend**
```bash
# Start the region service
cd apps/backend && pnpm start:region

# Sync civics data for a region (requires prompt-service + Ollama running)
curl -X POST http://localhost:3004/graphql \
  -H 'Content-Type: application/json' \
  -d '{"query":"mutation { syncRegionData(regionId:\"california\", dataTypes:[CIVICS]) { success message } }"}'

# Query the merged civics data
curl -X POST http://localhost:3004/graphql \
  -H 'Content-Type: application/json' \
  -d '{"query":"{ regionInfo(id:\"california\") { civics { chambers { name } measureTypes { code name } lifecycleStages { id name { plainLanguage } } glossary { term slug } } } }"}'
```

**Frontend**
```bash
cd apps/frontend && pnpm dev  # :3200
```
1. Navigate to `/region` — confirm "How your government works" nav card is present
2. Navigate to `/region/how-it-works`:
   - Measure Types table loads with stage popover (click "Stages" — popover should not be clipped)
   - "How a Bill Becomes Law" — change measure type in dropdown, click lifecycle dots to expand detail
   - Glossary — related term links resolve correctly
3. On `/region/propositions/[id]` — hover any `<CivicTerm>` in description text to see tooltip
4. Test with no civics data synced — hub shows "still being indexed" empty state

**Tests**
```bash
pnpm test  # all 1,571 pass
```

## Migration

New Prisma migration applies a composite index — additive, no table changes:
```
packages/relationaldb-provider/prisma/migrations/20260509000001_add_civics_blocks_extracted_at_index/
```

## Checklist

- [x] Lint: 0 errors
- [x] Tests: 1,571 pass / 0 fail
- [x] Build: clean (`/region/how-it-works` renders as static)
- [x] No `console.log` / debug flags / skipped tests
- [x] No hardcoded secrets
- [x] No new dependencies
- [x] GraphQL: additive types only, no gateway changes required
- [x] Security: `javascript:` URL injection blocked server-side + defense-in-depth in components
- [x] WCAG: `aria-label`, `aria-pressed`, `aria-current="step"`, `aria-live="polite"`, `role="list"` on all new components

🤖 Generated with [Claude Code](https://claude.com/claude-code)