### PR TITLE
feat(users,region): deep jurisdiction resolution via Census + PostGIS (#690)

### DIFF
--- a/apps/backend/docker/scripts/db-migrate.sh
+++ b/apps/backend/docker/scripts/db-migrate.sh
@@ -16,7 +16,8 @@ PGUSER="${RELATIONAL_DB_USERNAME:-postgres}"
 PGDB="${RELATIONAL_DB_DATABASE:-postgres}"
 
 echo "Running Prisma db:push..."
-npx prisma db push --accept-data-loss
+# --skip-generate: client is already built into the image; avoids OOM in memory-constrained containers
+npx prisma db push --accept-data-loss --skip-generate
 
 # NOTE: local prompt_templates seeding intentionally removed. When the
 # region is configured with PROMPT_SERVICE_URL the prompt-service is the

--- a/apps/backend/src/apps/region/src/domains/models/jurisdiction.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/jurisdiction.model.ts
@@ -1,0 +1,73 @@
+import { Field, ID, ObjectType, registerEnumType } from '@nestjs/graphql';
+
+export enum JurisdictionTypeGQL {
+  STATE = 'STATE',
+  CONGRESSIONAL_DISTRICT = 'CONGRESSIONAL_DISTRICT',
+  STATE_SENATE_DISTRICT = 'STATE_SENATE_DISTRICT',
+  STATE_ASSEMBLY_DISTRICT = 'STATE_ASSEMBLY_DISTRICT',
+  COUNTY = 'COUNTY',
+  CITY = 'CITY',
+  SCHOOL_DISTRICT_UNIFIED = 'SCHOOL_DISTRICT_UNIFIED',
+  SCHOOL_DISTRICT_ELEMENTARY = 'SCHOOL_DISTRICT_ELEMENTARY',
+  SCHOOL_DISTRICT_HIGH = 'SCHOOL_DISTRICT_HIGH',
+  COMMUNITY_COLLEGE_DISTRICT = 'COMMUNITY_COLLEGE_DISTRICT',
+  WATER_DISTRICT = 'WATER_DISTRICT',
+  FIRE_DISTRICT = 'FIRE_DISTRICT',
+  TRANSIT_DISTRICT = 'TRANSIT_DISTRICT',
+  SPECIAL_DISTRICT = 'SPECIAL_DISTRICT',
+}
+
+export enum JurisdictionLevelGQL {
+  FEDERAL = 'FEDERAL',
+  STATE = 'STATE',
+  COUNTY = 'COUNTY',
+  MUNICIPAL = 'MUNICIPAL',
+  DISTRICT = 'DISTRICT',
+}
+
+registerEnumType(JurisdictionTypeGQL, {
+  name: 'JurisdictionType',
+});
+
+registerEnumType(JurisdictionLevelGQL, {
+  name: 'JurisdictionLevel',
+});
+
+@ObjectType()
+export class JurisdictionModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field({ nullable: true })
+  fipsCode?: string;
+
+  @Field({ nullable: true })
+  ocdId?: string;
+
+  @Field()
+  name!: string;
+
+  @Field(() => JurisdictionTypeGQL)
+  type!: JurisdictionTypeGQL;
+
+  @Field(() => JurisdictionLevelGQL)
+  level!: JurisdictionLevelGQL;
+
+  @Field()
+  stateCode!: string;
+
+  @Field(() => JurisdictionModel, { nullable: true })
+  parent?: JurisdictionModel;
+}
+
+@ObjectType()
+export class UserJurisdictionModel {
+  @Field()
+  resolvedBy!: string;
+
+  @Field()
+  resolvedAt!: Date;
+
+  @Field(() => JurisdictionModel)
+  jurisdiction!: JurisdictionModel;
+}

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -1,5 +1,6 @@
 import {
   Args,
+  Context,
   Extensions,
   ID,
   Int,
@@ -8,6 +9,10 @@ import {
   Resolver,
 } from '@nestjs/graphql';
 import { UseGuards } from '@nestjs/common';
+import {
+  GqlContext,
+  getUserFromContext,
+} from 'src/common/utils/graphql-context';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import { Public } from 'src/common/decorators/public.decorator';
 import { Roles } from 'src/common/decorators/roles.decorator';
@@ -57,6 +62,10 @@ import {
   MinutesPassageModel,
 } from './models/legislative-action.model';
 import { BillModel, PaginatedBillsModel } from './models/bill.model';
+import {
+  JurisdictionModel,
+  UserJurisdictionModel,
+} from './models/jurisdiction.model';
 
 /**
  * Region Resolver
@@ -709,6 +718,41 @@ export class RegionResolver {
    * plumbing without a full-roster LLM cycle. When omitted, falls
    * back to the generator env-var caps (or unlimited).
    */
+  // ==========================================
+  // JURISDICTION RESOLUTION (#690)
+  // ==========================================
+
+  /**
+   * Return all civic jurisdictions resolved for the authenticated user's
+   * primary address, grouped by level (legislative → county → municipal → district).
+   */
+  @Query(() => [UserJurisdictionModel])
+  @UseGuards(AuthGuard)
+  @Extensions({ complexity: 10 })
+  async myJurisdictions(
+    @Context() context: GqlContext,
+  ): Promise<UserJurisdictionModel[]> {
+    const user = getUserFromContext(context);
+    const rows = await this.regionService.getJurisdictionsForUser(user.id);
+
+    return rows.map((row) => ({
+      resolvedBy: row.resolvedBy,
+      resolvedAt: row.resolvedAt,
+      jurisdiction: {
+        ...row.jurisdiction,
+        fipsCode: row.jurisdiction.fipsCode ?? undefined,
+        ocdId: row.jurisdiction.ocdId ?? undefined,
+        parent: row.jurisdiction.parent
+          ? {
+              ...row.jurisdiction.parent,
+              fipsCode: row.jurisdiction.parent.fipsCode ?? undefined,
+              ocdId: row.jurisdiction.parent.ocdId ?? undefined,
+            }
+          : undefined,
+      } as JurisdictionModel,
+    }));
+  }
+
   @Mutation(() => [SyncResultModel])
   @UseGuards(AuthGuard)
   @Roles(Role.Admin)

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -104,6 +104,12 @@ import {
 // Type aliases for database query results and generic upsert
 type ExternalIdRecord = { externalId: string };
 
+/** Compiled lifecycle stage pattern used for bill status resolution. */
+interface StagePattern {
+  stageId: string;
+  regex: RegExp;
+}
+
 /**
  * Single row in a paginated LegislativeAction feed (rep + committee
  * activity surfaces share this shape). Issue #665.
@@ -1804,6 +1810,10 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     const repIndex = await this.buildRepNameIndex(regionId);
     const committeeIndex = await this.buildCommitteeNameIndex();
 
+    // Compile civics lifecycle stage patterns once per sync run so every bill
+    // upsert can resolve currentStageId without additional DB hits.
+    const stagePatterns = await this.buildStagePatterns(regionId);
+
     let processed = 0;
     let created = 0;
     let updated = 0;
@@ -1818,12 +1828,19 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
         repIndex,
         committeeIndex,
         syncedExternalIds,
+        stagePatterns,
         maxBills,
       );
       processed += counts.processed;
       created += counts.created;
       updated += counts.updated;
       skippedTotal += counts.skipped;
+    }
+
+    // Backfill currentStageId on existing bills that were skipped this run
+    // (content unchanged) or were written before this logic existed.
+    if (stagePatterns.length > 0) {
+      await this.backfillBillStageIds(regionId, stagePatterns);
     }
 
     await this.pruneStaleBills(regionId, syncedExternalIds, maxBills);
@@ -1838,6 +1855,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     repIndex: Map<string, { id: string; chamber: string }>,
     committeeIndex: Map<string, string>,
     syncedExternalIds: Set<string>,
+    stagePatterns: StagePattern[],
     maxBills?: number,
   ): Promise<{
     processed: number;
@@ -1867,6 +1885,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
         ds,
         repIndex,
         committeeIndex,
+        stagePatterns,
       );
       if (result === 'created') {
         created++;
@@ -1905,6 +1924,77 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     }
 
     return { processed, created, updated, skipped };
+  }
+
+  /**
+   * Compile each stage's statusStringPatterns into RegExp objects.
+   * Patterns are JS regex syntax (no surrounding slashes), matched case-insensitively.
+   * Invalid patterns are logged and skipped rather than crashing the sync.
+   */
+  private async buildStagePatterns(regionId: string): Promise<StagePattern[]> {
+    const civics = await this.getCivicsData(regionId);
+    const patterns: StagePattern[] = [];
+    for (const stage of civics?.lifecycleStages ?? []) {
+      for (const raw of stage.statusStringPatterns) {
+        try {
+          patterns.push({ stageId: stage.id, regex: new RegExp(raw, 'i') });
+        } catch {
+          this.logger.warn(
+            `Invalid status pattern "${raw}" for stage "${stage.id}" in ${regionId} — skipping`,
+          );
+        }
+      }
+    }
+    return patterns;
+  }
+
+  /**
+   * Return the stageId whose first matching pattern covers the given status
+   * string, or null when no pattern matches.
+   */
+  private resolveStageFromStatus(
+    status: string | null | undefined,
+    stagePatterns: StagePattern[],
+  ): string | null {
+    if (!status || stagePatterns.length === 0) return null;
+    return stagePatterns.find((p) => p.regex.test(status))?.stageId ?? null;
+  }
+
+  /**
+   * Backfill currentStageId on bills that already have a status string but
+   * were written before stage matching existed, or were skipped this sync run.
+   */
+  private async backfillBillStageIds(
+    regionId: string,
+    stagePatterns: StagePattern[],
+  ): Promise<void> {
+    const unmatched = await this.db.bill.findMany({
+      where: { regionId, currentStageId: null, status: { not: null } },
+      select: { id: true, status: true },
+    });
+    if (unmatched.length === 0) return;
+
+    const byStage = new Map<string, string[]>();
+    for (const bill of unmatched) {
+      const stageId = this.resolveStageFromStatus(bill.status, stagePatterns);
+      if (!stageId) continue;
+      if (!byStage.has(stageId)) byStage.set(stageId, []);
+      byStage.get(stageId)!.push(bill.id);
+    }
+
+    let filled = 0;
+    for (const [stageId, ids] of byStage) {
+      await this.db.bill.updateMany({
+        where: { id: { in: ids } },
+        data: { currentStageId: stageId },
+      });
+      filled += ids.length;
+    }
+    if (filled > 0) {
+      this.logger.log(
+        `Bills: backfilled currentStageId for ${filled} of ${unmatched.length} bill(s) in ${regionId}`,
+      );
+    }
   }
 
   private async pruneStaleBills(
@@ -2109,6 +2199,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     ds: DataSourceConfig,
     repIndex: Map<string, { id: string; chamber: string }>,
     committeeIndex: Map<string, string>,
+    stagePatterns: StagePattern[],
   ): Promise<'created' | 'updated' | 'skipped' | 'failed'> {
     if (!this.promptClient || !this.llm) return 'failed';
     try {
@@ -2198,7 +2289,9 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
         title: raw.title,
         subject: raw.subject ?? null,
         status: raw.status ?? null,
-        currentStageId: raw.currentStageId ?? null,
+        currentStageId:
+          raw.currentStageId ??
+          this.resolveStageFromStatus(raw.status, stagePatterns),
         lastAction: raw.lastAction ?? null,
         lastActionDate: raw.lastActionDate
           ? new Date(raw.lastActionDate as unknown as string)
@@ -4045,6 +4138,30 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
    * Adapt ExampleRegionProvider (DataFetcher) to IRegionPlugin
    * by adding the required lifecycle methods.
    */
+  // ==========================================
+  // JURISDICTION RESOLUTION (#690)
+  // ==========================================
+
+  async getJurisdictionsForUser(userId: string): Promise<
+    Prisma.UserJurisdictionGetPayload<{
+      include: { jurisdiction: { include: { parent: true } } };
+    }>[]
+  > {
+    return this.db.userJurisdiction.findMany({
+      where: { userId, userAddress: { isPrimary: true } },
+      include: {
+        jurisdiction: {
+          include: { parent: true },
+        },
+      },
+      orderBy: [
+        { jurisdiction: { level: 'asc' } },
+        { jurisdiction: { type: 'asc' } },
+        { jurisdiction: { name: 'asc' } },
+      ],
+    });
+  }
+
   private createFallbackPlugin(): IRegionPlugin {
     const provider = new ExampleRegionProvider();
     return Object.assign(Object.create(provider), {

--- a/apps/backend/src/apps/users/src/domains/profile/geocoding.service.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/geocoding.service.spec.ts
@@ -79,8 +79,80 @@ describe('GeocodingService', () => {
       expect(result!.stateAssemblyDistrict).toBe('Assembly District 6');
       expect(result!.county).toBe('Sacramento County');
       expect(result!.municipality).toBe('Sacramento city');
+      expect(result!.schoolDistrict).toBeUndefined();
       expect(result!.timezone).toBe('America/Los_Angeles');
 
+      jest.restoreAllMocks();
+    });
+
+    it('should extract unified school district when present', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            result: {
+              addressMatches: [
+                {
+                  coordinates: { x: -122.2, y: 37.8 },
+                  matchedAddress: '1000 Broadway, Oakland, CA, 94607',
+                  geographies: {
+                    '119th Congressional Districts': [
+                      { NAME: 'Congressional District 12' },
+                    ],
+                    Counties: [{ NAME: 'Alameda County' }],
+                    'Incorporated Places': [{ NAME: 'Oakland city' }],
+                    'Unified School Districts': [
+                      { NAME: 'Oakland Unified School District' },
+                    ],
+                  },
+                },
+              ],
+            },
+          }),
+      };
+      jest.spyOn(global, 'fetch').mockResolvedValue(mockResponse as Response);
+
+      const result = await service.geocode(
+        '1000 Broadway',
+        'Oakland',
+        'CA',
+        '94607',
+      );
+
+      expect(result!.schoolDistrict).toBe('Oakland Unified School District');
+      jest.restoreAllMocks();
+    });
+
+    it('should fall back to elementary school district when unified is absent', async () => {
+      const mockResponse = {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            result: {
+              addressMatches: [
+                {
+                  coordinates: { x: -121.0, y: 37.5 },
+                  matchedAddress: '1 Main St, Anywhere, CA, 95000',
+                  geographies: {
+                    'Elementary School Districts': [
+                      { NAME: 'Anywhere Elementary District' },
+                    ],
+                  },
+                },
+              ],
+            },
+          }),
+      };
+      jest.spyOn(global, 'fetch').mockResolvedValue(mockResponse as Response);
+
+      const result = await service.geocode(
+        '1 Main St',
+        'Anywhere',
+        'CA',
+        '95000',
+      );
+
+      expect(result!.schoolDistrict).toBe('Anywhere Elementary District');
       jest.restoreAllMocks();
     });
 

--- a/apps/backend/src/apps/users/src/domains/profile/geocoding.service.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/geocoding.service.ts
@@ -13,6 +13,7 @@ export interface GeocodingResult {
   stateAssemblyDistrict?: string;
   county?: string;
   municipality?: string;
+  schoolDistrict?: string;
   timezone?: string;
 }
 
@@ -107,6 +108,11 @@ export class GeocodingService {
           'Incorporated Places',
           'NAME',
         ),
+        schoolDistrict: this.extractFirstMatching(
+          geographies,
+          'School District',
+          'NAME',
+        ),
         timezone: this.deriveTimezone(match.coordinates?.x),
       };
     } catch (error) {
@@ -118,7 +124,7 @@ export class GeocodingService {
   }
 
   /**
-   * Extract a geography name from the Census response.
+   * Extract a geography name from the Census response by exact key.
    */
   private extractGeography(
     geographies: Record<string, unknown[]>,
@@ -126,6 +132,27 @@ export class GeocodingService {
     field: string,
   ): string | undefined {
     const entries = geographies[key] as Record<string, string>[] | undefined;
+    return entries?.[0]?.[field] || undefined;
+  }
+
+  /**
+   * Extract a field from the first geography key whose name contains the given
+   * substring (case-insensitive). Used for layer names that vary by vintage
+   * (e.g. "Unified School Districts", "Elementary School Districts").
+   */
+  private extractFirstMatching(
+    geographies: Record<string, unknown[]>,
+    keySubstring: string,
+    field: string,
+  ): string | undefined {
+    const lower = keySubstring.toLowerCase();
+    const matchingKey = Object.keys(geographies).find((k) =>
+      k.toLowerCase().includes(lower),
+    );
+    if (!matchingKey) return undefined;
+    const entries = geographies[matchingKey] as
+      | Record<string, string>[]
+      | undefined;
     return entries?.[0]?.[field] || undefined;
   }
 

--- a/apps/backend/src/apps/users/src/domains/profile/jurisdiction-resolution.service.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/jurisdiction-resolution.service.spec.ts
@@ -1,0 +1,201 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { JurisdictionResolutionService } from './jurisdiction-resolution.service';
+import {
+  DbService,
+  UserAddress,
+  Jurisdiction,
+} from '@opuspopuli/relationaldb-provider';
+import {
+  createMockDbClient,
+  MockDbClient,
+} from '@opuspopuli/relationaldb-provider/testing';
+
+describe('JurisdictionResolutionService', () => {
+  let service: JurisdictionResolutionService;
+  let mockDb: MockDbClient;
+
+  const mockAddress: Partial<UserAddress> = {
+    id: 'addr-1',
+    userId: 'user-1',
+    congressionalDistrict: 'Congressional District 12',
+    stateSenatorialDistrict: 'State Senate District 9',
+    stateAssemblyDistrict: 'Assembly District 18',
+    county: 'Alameda County',
+    municipality: 'Oakland city',
+    schoolDistrict: 'Oakland Unified School District',
+    state: 'CA',
+  };
+
+  const mockJurisdictions = [
+    { id: 'j-congressional' },
+    { id: 'j-senate' },
+    { id: 'j-assembly' },
+    { id: 'j-county' },
+    { id: 'j-city' },
+    { id: 'j-school' },
+  ] as Jurisdiction[];
+
+  beforeEach(async () => {
+    mockDb = createMockDbClient();
+
+    // replaceJurisdictions wraps DELETE+INSERT in a $transaction; execute the
+    // callback with mockDb as the transaction client so $executeRaw is tracked.
+
+    (mockDb.$transaction as jest.Mock).mockImplementation(
+      async (fn: (tx: typeof mockDb) => Promise<unknown>) => fn(mockDb),
+    );
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        JurisdictionResolutionService,
+        { provide: DbService, useValue: mockDb },
+      ],
+    }).compile();
+
+    service = module.get<JurisdictionResolutionService>(
+      JurisdictionResolutionService,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('resolveForAddress', () => {
+    it('should resolve census and postgis jurisdictions and upsert', async () => {
+      mockDb.userAddress.findUnique.mockResolvedValue(
+        mockAddress as UserAddress,
+      );
+      mockDb.jurisdiction.findMany.mockResolvedValue(mockJurisdictions);
+      mockDb.$queryRaw.mockResolvedValue([
+        {
+          id: 'j-water',
+          name: 'EBMUD',
+          type: 'WATER_DISTRICT',
+          level: 'DISTRICT',
+        },
+      ]);
+      mockDb.$executeRaw.mockResolvedValue(1);
+
+      await service.resolveForAddress('user-1', 'addr-1', 37.8, -122.2);
+
+      expect(mockDb.userAddress.findUnique).toHaveBeenCalledWith({
+        where: { id: 'addr-1' },
+        select: expect.objectContaining({ congressionalDistrict: true }),
+      });
+      expect(mockDb.jurisdiction.findMany).toHaveBeenCalled();
+      expect(mockDb.$queryRaw).toHaveBeenCalled();
+      expect(mockDb.$executeRaw).toHaveBeenCalled();
+    });
+
+    it('should mark census-only results as census_geocoder and postgis-only as postgis', async () => {
+      mockDb.userAddress.findUnique.mockResolvedValue(
+        mockAddress as UserAddress,
+      );
+      mockDb.jurisdiction.findMany.mockResolvedValue([
+        { id: 'j-county' },
+      ] as Jurisdiction[]);
+      // PostGIS returns a different jurisdiction not in census results
+      mockDb.$queryRaw.mockResolvedValue([
+        {
+          id: 'j-fire',
+          name: 'Fire District',
+          type: 'FIRE_DISTRICT',
+          level: 'DISTRICT',
+        },
+      ]);
+      mockDb.$executeRaw.mockResolvedValue(1);
+
+      await service.resolveForAddress('user-1', 'addr-1', 37.8, -122.2);
+
+      // calls[0] = DELETE, calls[1] = INSERT; JSON rows are the second interpolated value
+      const callArgs = mockDb.$executeRaw.mock.calls[1] as unknown[];
+      const jsonPayload = callArgs[1] as string;
+      const rows = JSON.parse(jsonPayload) as {
+        jurisdictionId: string;
+        resolvedBy: string;
+      }[];
+
+      const countyRow = rows.find((r) => r.jurisdictionId === 'j-county');
+      const fireRow = rows.find((r) => r.jurisdictionId === 'j-fire');
+      expect(countyRow?.resolvedBy).toBe('census_geocoder');
+      expect(fireRow?.resolvedBy).toBe('postgis');
+    });
+
+    it('should do nothing when address is not found', async () => {
+      mockDb.userAddress.findUnique.mockResolvedValue(null);
+      mockDb.$queryRaw.mockResolvedValue([]);
+
+      await service.resolveForAddress('user-1', 'addr-missing', 37.8, -122.2);
+
+      expect(mockDb.$executeRaw).not.toHaveBeenCalled();
+    });
+
+    it('should skip upsert when no jurisdictions are resolved', async () => {
+      mockDb.userAddress.findUnique.mockResolvedValue({
+        ...mockAddress,
+        congressionalDistrict: null,
+        stateSenatorialDistrict: null,
+        stateAssemblyDistrict: null,
+        county: null,
+        municipality: null,
+        schoolDistrict: null,
+      } as unknown as UserAddress);
+      mockDb.jurisdiction.findMany.mockResolvedValue([]);
+      mockDb.$queryRaw.mockResolvedValue([]);
+
+      await service.resolveForAddress('user-1', 'addr-1', 37.8, -122.2);
+
+      expect(mockDb.$executeRaw).not.toHaveBeenCalled();
+    });
+
+    it('should proceed with census results when postgis query fails', async () => {
+      mockDb.userAddress.findUnique.mockResolvedValue(
+        mockAddress as UserAddress,
+      );
+      mockDb.jurisdiction.findMany.mockResolvedValue([
+        { id: 'j-county' },
+      ] as Jurisdiction[]);
+      mockDb.$queryRaw.mockRejectedValue(new Error('PostGIS unavailable'));
+      mockDb.$executeRaw.mockResolvedValue(1);
+
+      await expect(
+        service.resolveForAddress('user-1', 'addr-1', 37.8, -122.2),
+      ).resolves.not.toThrow();
+
+      // Should still upsert the census-resolved jurisdiction
+      expect(mockDb.$executeRaw).toHaveBeenCalled();
+    });
+
+    it('should deduplicate when postgis and census return the same jurisdiction', async () => {
+      const sharedId = 'j-county';
+      mockDb.userAddress.findUnique.mockResolvedValue(
+        mockAddress as UserAddress,
+      );
+      mockDb.jurisdiction.findMany.mockResolvedValue([
+        { id: sharedId },
+      ] as Jurisdiction[]);
+      // PostGIS also returns the same jurisdiction — postgis wins on resolvedBy
+      mockDb.$queryRaw.mockResolvedValue([
+        {
+          id: sharedId,
+          name: 'Alameda County',
+          type: 'COUNTY',
+          level: 'COUNTY',
+        },
+      ]);
+      mockDb.$executeRaw.mockResolvedValue(1);
+
+      await service.resolveForAddress('user-1', 'addr-1', 37.8, -122.2);
+
+      // calls[0] = DELETE, calls[1] = INSERT
+      const callArgs = mockDb.$executeRaw.mock.calls[1] as unknown[];
+      const jsonPayload = callArgs[1] as string;
+      const rows = JSON.parse(jsonPayload) as unknown[];
+
+      // Only one row despite both sources returning the same jurisdiction
+      expect(rows).toHaveLength(1);
+      expect((rows[0] as { resolvedBy: string }).resolvedBy).toBe('postgis');
+    });
+  });
+});

--- a/apps/backend/src/apps/users/src/domains/profile/jurisdiction-resolution.service.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/jurisdiction-resolution.service.ts
@@ -1,0 +1,232 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
+
+interface SpatialJurisdictionRow {
+  id: string;
+  name: string;
+  type: string;
+  level: string;
+}
+
+type ResolutionSource = 'census_geocoder' | 'postgis';
+
+/**
+ * Resolves all civic jurisdictions for a geocoded address and persists them
+ * to user_jurisdictions.
+ *
+ * Two resolution sources:
+ *  1. census_geocoder — string district fields already written to UserAddress
+ *     are matched to Jurisdiction rows by name + type.
+ *  2. postgis — point-in-polygon query against loaded boundary geometries,
+ *     catching everything Census doesn't return (special districts, etc.).
+ *
+ * Results are merged, deduplicated, and upserted. Safe to call multiple times
+ * for the same address.
+ */
+@Injectable()
+export class JurisdictionResolutionService {
+  private readonly logger = new Logger(JurisdictionResolutionService.name);
+
+  constructor(private readonly db: DbService) {}
+
+  async resolveForAddress(
+    userId: string,
+    userAddressId: string,
+    lat: number,
+    lng: number,
+  ): Promise<void> {
+    const [censusIds, postgisIds] = await Promise.all([
+      this.resolveCensusJurisdictions(userAddressId),
+      this.resolvePostgisJurisdictions(lat, lng),
+    ]);
+
+    const censusSet = new Map<string, ResolutionSource>(
+      censusIds.map((id) => [id, 'census_geocoder']),
+    );
+    const postgisSet = new Map<string, ResolutionSource>(
+      postgisIds.map((id) => [id, 'postgis']),
+    );
+
+    // Merge: PostGIS wins on resolvedBy if both sources return the same jurisdiction
+    const merged = new Map<string, ResolutionSource>([
+      ...censusSet,
+      ...postgisSet,
+    ]);
+
+    if (merged.size === 0) {
+      this.logger.debug(
+        `No jurisdictions resolved for address ${userAddressId}`,
+      );
+      return;
+    }
+
+    await this.replaceJurisdictions(userId, userAddressId, merged);
+
+    this.logger.log(
+      `Resolved ${merged.size} jurisdictions for address ${userAddressId} ` +
+        `(census: ${censusIds.length}, postgis: ${postgisIds.length})`,
+    );
+  }
+
+  /**
+   * Look up Jurisdiction rows matching the string district fields already
+   * written to the UserAddress record by the Census Geocoder.
+   */
+  private async resolveCensusJurisdictions(
+    userAddressId: string,
+  ): Promise<string[]> {
+    const address = await this.db.userAddress.findUnique({
+      where: { id: userAddressId },
+      select: {
+        congressionalDistrict: true,
+        stateSenatorialDistrict: true,
+        stateAssemblyDistrict: true,
+        county: true,
+        municipality: true,
+        schoolDistrict: true,
+        state: true,
+      },
+    });
+
+    if (!address) return [];
+
+    const candidates = buildCensusCandidates(address);
+    if (candidates.length === 0) return [];
+
+    const found = await this.db.jurisdiction.findMany({
+      where: { OR: candidates },
+      select: { id: true },
+    });
+
+    return found.map((j) => j.id);
+  }
+
+  /**
+   * Point-in-polygon query against loaded boundary geometries.
+   * Returns all jurisdiction ids whose boundary contains (lat, lng).
+   */
+  private async resolvePostgisJurisdictions(
+    lat: number,
+    lng: number,
+  ): Promise<string[]> {
+    try {
+      const rows = await this.db.$queryRaw<SpatialJurisdictionRow[]>`
+        SELECT id, name, type, level
+        FROM jurisdictions
+        WHERE ST_Contains(
+          boundary::geometry,
+          ST_SetSRID(ST_Point(${lng}, ${lat}), 4326)
+        )
+      `;
+      return rows.map((r) => r.id);
+    } catch (err) {
+      // Boundary table may be empty before the ETL script is run
+      this.logger.debug(
+        `PostGIS jurisdiction query skipped: ${(err as Error).message}`,
+      );
+      return [];
+    }
+  }
+
+  private async replaceJurisdictions(
+    userId: string,
+    userAddressId: string,
+    jurisdictions: Map<string, ResolutionSource>,
+  ): Promise<void> {
+    const now = new Date();
+    const rows = Array.from(jurisdictions.entries()).map(
+      ([jurisdictionId, resolvedBy]) => ({
+        id: crypto.randomUUID(),
+        userId,
+        userAddressId,
+        jurisdictionId,
+        resolvedBy,
+        resolvedAt: now,
+      }),
+    );
+
+    // Atomic delete-then-insert: prevents stale accumulation when an address
+    // changes location, and prevents duplicates from concurrent geocoding calls.
+    await this.db.$transaction(async (tx) => {
+      await tx.$executeRaw`
+        DELETE FROM user_jurisdictions WHERE user_address_id = ${userAddressId}
+      `;
+
+      await tx.$executeRaw`
+        INSERT INTO user_jurisdictions
+          (id, user_id, user_address_id, jurisdiction_id, resolved_by, resolved_at)
+        SELECT
+          (elem->>'id')::text,
+          (elem->>'userId')::text,
+          (elem->>'userAddressId')::text,
+          (elem->>'jurisdictionId')::text,
+          (elem->>'resolvedBy')::text,
+          (elem->>'resolvedAt')::timestamptz
+        FROM jsonb_array_elements(${JSON.stringify(rows)}::jsonb) AS elem
+      `;
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (module-private)
+// ---------------------------------------------------------------------------
+
+type CensusAddressFields = {
+  congressionalDistrict: string | null;
+  stateSenatorialDistrict: string | null;
+  stateAssemblyDistrict: string | null;
+  county: string | null;
+  municipality: string | null;
+  schoolDistrict: string | null;
+  state: string;
+};
+
+type JurisdictionWhereInput = Prisma.JurisdictionWhereInput;
+
+/**
+ * Build OR conditions to match Census string values against Jurisdiction rows.
+ * Each entry pairs a district name with its expected JurisdictionType so we
+ * don't accidentally match a city named "Alameda County" to a COUNTY row.
+ */
+function buildCensusCandidates(
+  address: CensusAddressFields,
+): JurisdictionWhereInput[] {
+  const stateCode = address.state?.toUpperCase() ?? '';
+  const candidates: JurisdictionWhereInput[] = [];
+
+  const add = (
+    name: string | null,
+    type: Prisma.EnumJurisdictionTypeFilter | string,
+  ) => {
+    if (name) {
+      candidates.push({
+        name: { equals: name, mode: 'insensitive' },
+        type: type as Prisma.EnumJurisdictionTypeFilter,
+        stateCode,
+      });
+    }
+  };
+
+  add(address.congressionalDistrict, 'CONGRESSIONAL_DISTRICT');
+  add(address.stateSenatorialDistrict, 'STATE_SENATE_DISTRICT');
+  add(address.stateAssemblyDistrict, 'STATE_ASSEMBLY_DISTRICT');
+  add(address.county, 'COUNTY');
+  add(address.municipality, 'CITY');
+
+  if (address.schoolDistrict) {
+    candidates.push({
+      name: { equals: address.schoolDistrict, mode: 'insensitive' },
+      type: {
+        in: [
+          'SCHOOL_DISTRICT_UNIFIED',
+          'SCHOOL_DISTRICT_ELEMENTARY',
+          'SCHOOL_DISTRICT_HIGH',
+        ],
+      },
+      stateCode,
+    });
+  }
+
+  return candidates;
+}

--- a/apps/backend/src/apps/users/src/domains/profile/profile.module.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.module.ts
@@ -6,10 +6,16 @@ import { StorageModule } from '@opuspopuli/storage-provider';
 import { ProfileService } from './profile.service';
 import { ProfileResolver } from './profile.resolver';
 import { GeocodingService } from './geocoding.service';
+import { JurisdictionResolutionService } from './jurisdiction-resolution.service';
 
 @Module({
   imports: [StorageModule],
-  providers: [ProfileService, ProfileResolver, GeocodingService],
+  providers: [
+    ProfileService,
+    ProfileResolver,
+    GeocodingService,
+    JurisdictionResolutionService,
+  ],
   exports: [ProfileService],
 })
 export class ProfileModule {}

--- a/apps/backend/src/apps/users/src/domains/profile/profile.service.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.service.spec.ts
@@ -21,6 +21,7 @@ import { ConsentType, ConsentStatus } from 'src/common/enums/consent.enum';
 import { AddressType } from 'src/common/enums/address.enum';
 import { CreateAddressDto } from './dto/address.dto';
 import { GeocodingService } from './geocoding.service';
+import { JurisdictionResolutionService } from './jurisdiction-resolution.service';
 
 describe('ProfileService', () => {
   let service: ProfileService;
@@ -157,6 +158,12 @@ describe('ProfileService', () => {
         {
           provide: GeocodingService,
           useValue: mockGeocodingService,
+        },
+        {
+          provide: JurisdictionResolutionService,
+          useValue: {
+            resolveForAddress: jest.fn().mockResolvedValue(undefined),
+          },
         },
       ],
     }).compile();
@@ -357,7 +364,12 @@ describe('ProfileService', () => {
 
   describe('setPrimaryAddress', () => {
     it('should set address as primary', async () => {
-      mockDb.userAddress.findFirst.mockResolvedValue(mockAddress);
+      // Verified address with existing jurisdictions — no re-geocode
+      mockDb.userAddress.findFirst.mockResolvedValue({
+        ...mockAddress,
+        isVerified: true,
+        _count: { userJurisdictions: 3 },
+      } as unknown as UserAddress);
       mockDb.userAddress.updateMany.mockResolvedValue({ count: 1 });
       mockDb.userAddress.update.mockResolvedValue({
         ...mockAddress,
@@ -371,6 +383,27 @@ describe('ProfileService', () => {
 
       expect(result.isPrimary).toBe(true);
       expect(mockDb.userAddress.updateMany).toHaveBeenCalled();
+      expect(mockGeocodingService.geocode).not.toHaveBeenCalled();
+    });
+
+    it('should trigger re-geocoding when new primary has no resolved jurisdictions', async () => {
+      mockDb.userAddress.findFirst.mockResolvedValue({
+        ...mockAddress,
+        isVerified: true,
+        _count: { userJurisdictions: 0 },
+      } as unknown as UserAddress);
+      mockDb.userAddress.updateMany.mockResolvedValue({ count: 1 });
+      mockDb.userAddress.update.mockResolvedValue({
+        ...mockAddress,
+        isPrimary: true,
+      });
+      mockGeocodingService.geocode.mockResolvedValue(null);
+
+      await service.setPrimaryAddress(mockUserId, mockAddress.id);
+
+      // geocode is called fire-and-forget; give the microtask queue a tick
+      await Promise.resolve();
+      expect(mockGeocodingService.geocode).toHaveBeenCalled();
     });
 
     it('should throw NotFoundException if address not found', async () => {

--- a/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
@@ -23,6 +23,7 @@ import { UpdateNotificationPreferencesDto } from './dto/notification-preferences
 import { UpdateConsentDto } from './dto/consent.dto';
 import { ProfileCompletionResult } from './models/profile-completion.model';
 import { GeocodingService } from './geocoding.service';
+import { JurisdictionResolutionService } from './jurisdiction-resolution.service';
 
 @Injectable()
 export class ProfileService {
@@ -33,6 +34,7 @@ export class ProfileService {
   constructor(
     private readonly db: DbService,
     private readonly geocodingService: GeocodingService,
+    private readonly jurisdictionResolutionService: JurisdictionResolutionService,
     @Optional()
     @Inject('STORAGE_PROVIDER')
     private readonly storage?: IStorageProvider,
@@ -310,10 +312,26 @@ export class ProfileService {
         stateAssemblyDistrict: result.stateAssemblyDistrict,
         county: result.county,
         municipality: result.municipality,
+        schoolDistrict: result.schoolDistrict,
         isVerified: true,
         geocodedAt: new Date(),
       },
     });
+
+    // Write PostGIS point for spatial jurisdiction resolution
+    await this.db.$executeRaw`
+      UPDATE user_addresses
+      SET point = ST_SetSRID(ST_Point(${result.longitude}, ${result.latitude}), 4326)
+      WHERE id = ${addressId}
+    `;
+
+    // Resolve and persist all civic jurisdictions for this address
+    await this.jurisdictionResolutionService.resolveForAddress(
+      userId,
+      addressId,
+      result.latitude,
+      result.longitude,
+    );
 
     this.logger.log(
       `Geocoded address ${addressId}: ${result.formattedAddress} → ${result.congressionalDistrict}`,
@@ -343,6 +361,7 @@ export class ProfileService {
   ): Promise<DbUserAddress> {
     const address = await this.db.userAddress.findFirst({
       where: { id: addressId, userId },
+      include: { _count: { select: { userJurisdictions: true } } },
     });
 
     if (!address) {
@@ -356,10 +375,21 @@ export class ProfileService {
     });
 
     // Set this one as primary
-    return this.db.userAddress.update({
+    const updated = await this.db.userAddress.update({
       where: { id: address.id },
       data: { isPrimary: true },
     });
+
+    // If this address has never been geocoded or has no resolved jurisdictions,
+    // trigger geocoding now so myJurisdictions reflects the new primary immediately.
+    if (!address.isVerified || address._count.userJurisdictions === 0) {
+      this.geocodeAndUpdate(userId, address.id, {
+        ...address,
+        isPrimary: true,
+      }).catch(() => {});
+    }
+
+    return updated;
   }
 
   // ============================================

--- a/apps/frontend/__tests__/pages/settings/addresses.test.tsx
+++ b/apps/frontend/__tests__/pages/settings/addresses.test.tsx
@@ -166,14 +166,6 @@ describe("AddressesPage", () => {
       expect(screen.getByText("Verified")).toBeInTheDocument();
     });
 
-    it("should show congressional district when available", () => {
-      render(<AddressesPage />);
-
-      expect(
-        screen.getByText("Congressional District: CA-12"),
-      ).toBeInTheDocument();
-    });
-
     it("should show Set Primary button for non-primary addresses", () => {
       render(<AddressesPage />);
 

--- a/apps/frontend/app/settings/addresses/page.tsx
+++ b/apps/frontend/app/settings/addresses/page.tsx
@@ -428,12 +428,6 @@ export default function AddressesPage() {
                   <p className="text-[#4d4d4d]">
                     {address.city}, {address.state} {address.postalCode}
                   </p>
-                  {address.congressionalDistrict && (
-                    <p className="text-sm text-[#4d4d4d] mt-2">
-                      {t("addresses.congressionalDistrict")}:{" "}
-                      {address.congressionalDistrict}
-                    </p>
-                  )}
                 </div>
                 <div className="flex items-center gap-2">
                   {!address.isPrimary && (

--- a/apps/frontend/app/settings/page.tsx
+++ b/apps/frontend/app/settings/page.tsx
@@ -20,7 +20,13 @@ import {
   HomeownerStatus,
 } from "@/lib/graphql/profile";
 import { useLocale } from "@/lib/i18n/context";
+import Link from "next/link";
 import { ProfileCompletionIndicator } from "@/components/profile/ProfileCompletionIndicator";
+import {
+  MY_JURISDICTIONS,
+  MyJurisdictionsData,
+  JurisdictionLevel,
+} from "@/lib/graphql/region";
 import { AvatarUpload } from "@/components/profile/AvatarUpload";
 import { ProfileVisibilityToggle } from "@/components/profile/ProfileVisibilityToggle";
 import { CivicFieldsSection } from "@/components/profile/CivicFieldsSection";
@@ -391,6 +397,10 @@ export default function ProfileSettingsPage() {
     loading: completionLoading,
     refetch: refetchCompletion,
   } = useQuery<MyProfileCompletionData>(GET_MY_PROFILE_COMPLETION);
+  const { data: jurisdictionsData } = useQuery<MyJurisdictionsData>(
+    MY_JURISDICTIONS,
+    { fetchPolicy: "network-only" },
+  );
 
   const handleSave = useCallback(() => {
     refetchProfile();
@@ -448,6 +458,13 @@ export default function ProfileSettingsPage() {
         />
       )}
 
+      {/* Civic Jurisdictions — derived from primary address */}
+      <JurisdictionsSection
+        jurisdictions={jurisdictionsData?.myJurisdictions ?? null}
+        loaded={jurisdictionsData !== undefined}
+        t={t}
+      />
+
       {/* Profile Form */}
       <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
         <div className="mb-8">
@@ -463,6 +480,111 @@ export default function ProfileSettingsPage() {
           onSave={handleSave}
         />
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// JurisdictionsSection
+// ---------------------------------------------------------------------------
+
+// FEDERAL renders when congressional district rows exist in the jurisdictions table.
+// The ETL currently loads CA state/county/city/district data but not congressional
+// boundaries — add a loadCongressionalDistricts() call to load-ca-boundaries.ts
+// to populate FEDERAL rows.
+const LEVEL_ORDER: JurisdictionLevel[] = [
+  "FEDERAL",
+  "STATE",
+  "COUNTY",
+  "MUNICIPAL",
+  "DISTRICT",
+];
+
+function JurisdictionsSection({
+  jurisdictions,
+  loaded,
+  t,
+}: {
+  jurisdictions: MyJurisdictionsData["myJurisdictions"] | null;
+  loaded: boolean;
+  t: ReturnType<typeof useTranslation>["t"];
+}) {
+  if (!loaded) return null; // still fetching — don't flash empty state
+
+  const hasJurisdictions = jurisdictions !== null && jurisdictions.length > 0;
+  const isResolving = jurisdictions !== null && jurisdictions.length === 0;
+
+  const byLevel = new Map<
+    JurisdictionLevel,
+    NonNullable<typeof jurisdictions>
+  >();
+  if (hasJurisdictions) {
+    for (const uj of jurisdictions) {
+      const level = uj.jurisdiction.level;
+      if (!byLevel.has(level)) byLevel.set(level, []);
+      byLevel.get(level)!.push(uj);
+    }
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6">
+      <div className="flex items-baseline justify-between mb-1">
+        <h2 className="text-lg font-semibold text-[#222222]">
+          {t("profile.jurisdictions.title")}
+        </h2>
+        {hasJurisdictions && (
+          <span className="text-xs text-[#6b7280]">
+            {t("profile.jurisdictions.primaryAddressNote")}
+          </span>
+        )}
+      </div>
+      <p className="text-sm text-[#4d4d4d] mb-4">
+        {t("profile.jurisdictions.subtitle")}
+      </p>
+
+      {/* No primary address set — prompt to add one */}
+      {jurisdictions === null && (
+        <p className="text-sm text-[#4d4d4d]">
+          {t("profile.jurisdictions.empty")}{" "}
+          <Link
+            href="/settings/addresses"
+            className="text-[#222222] underline underline-offset-2 hover:no-underline"
+          >
+            {t("profile.jurisdictions.emptyLink")}
+          </Link>{" "}
+          {t("profile.jurisdictions.emptyTail")}
+        </p>
+      )}
+
+      {/* Primary address exists but geocoding hasn't resolved yet */}
+      {isResolving && (
+        <p className="text-sm text-[#4d4d4d] italic">
+          {t("profile.jurisdictions.resolving")}
+        </p>
+      )}
+
+      {/* Resolved jurisdictions grouped by level */}
+      {hasJurisdictions && (
+        <div className="divide-y divide-gray-100 -mx-6 border-t border-gray-100">
+          {LEVEL_ORDER.filter((l) => byLevel.has(l)).map((level) => (
+            <div key={level} className="px-6 py-3">
+              <p className="text-xs font-semibold uppercase tracking-wider text-[#6b7280] mb-2">
+                {t(`profile.jurisdictions.levels.${level}`)}
+              </p>
+              <ul className="space-y-1">
+                {byLevel.get(level)!.map((uj) => (
+                  <li
+                    key={uj.jurisdiction.id}
+                    className="text-sm text-[#222222]"
+                  >
+                    {uj.jurisdiction.name}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/frontend/e2e/settings.spec.ts
+++ b/apps/frontend/e2e/settings.spec.ts
@@ -211,6 +211,12 @@ async function mockSettingsGraphQL(page: import("@playwright/test").Page) {
         contentType: "application/json",
         body: JSON.stringify({ data: mockAddresses }),
       });
+    } else if (postData?.query?.includes("myJurisdictions")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: { myJurisdictions: [] } }),
+      });
     } else if (postData?.query?.includes("myNotificationSettings")) {
       await route.fulfill({
         status: 200,

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -1573,3 +1573,80 @@ export const GET_BILL = gql`
     }
   }
 `;
+
+// ============================================
+// JURISDICTION TYPES & QUERY (#690)
+// ============================================
+
+export type JurisdictionType =
+  | "STATE"
+  | "CONGRESSIONAL_DISTRICT"
+  | "STATE_SENATE_DISTRICT"
+  | "STATE_ASSEMBLY_DISTRICT"
+  | "COUNTY"
+  | "CITY"
+  | "SCHOOL_DISTRICT_UNIFIED"
+  | "SCHOOL_DISTRICT_ELEMENTARY"
+  | "SCHOOL_DISTRICT_HIGH"
+  | "COMMUNITY_COLLEGE_DISTRICT"
+  | "WATER_DISTRICT"
+  | "FIRE_DISTRICT"
+  | "TRANSIT_DISTRICT"
+  | "SPECIAL_DISTRICT";
+
+export type JurisdictionLevel =
+  | "FEDERAL"
+  | "STATE"
+  | "COUNTY"
+  | "MUNICIPAL"
+  | "DISTRICT";
+
+export interface JurisdictionData {
+  id: string;
+  fipsCode?: string;
+  ocdId?: string;
+  name: string;
+  type: JurisdictionType;
+  level: JurisdictionLevel;
+  stateCode: string;
+  parent?: {
+    id: string;
+    name: string;
+    type: JurisdictionType;
+    level: JurisdictionLevel;
+  };
+}
+
+export interface UserJurisdictionData {
+  resolvedBy: string;
+  resolvedAt: string;
+  jurisdiction: JurisdictionData;
+}
+
+export interface MyJurisdictionsData {
+  myJurisdictions: UserJurisdictionData[];
+}
+
+export const MY_JURISDICTIONS = gql`
+  query MyJurisdictions {
+    myJurisdictions {
+      resolvedBy
+      resolvedAt
+      jurisdiction {
+        id
+        fipsCode
+        ocdId
+        name
+        type
+        level
+        stateCode
+        parent {
+          id
+          name
+          type
+          level
+        }
+      }
+    }
+  }
+`;

--- a/apps/frontend/locales/en/settings.json
+++ b/apps/frontend/locales/en/settings.json
@@ -154,6 +154,22 @@
         "other": "Other",
         "prefer_not_to_say": "Prefer not to say"
       }
+    },
+    "jurisdictions": {
+      "title": "Your Civic Jurisdictions",
+      "subtitle": "All governing bodies that represent your primary address",
+      "primaryAddressNote": "Based on your primary address",
+      "empty": "Add a primary address in",
+      "emptyLink": "Addresses",
+      "emptyTail": "to see your civic jurisdictions.",
+      "resolving": "Jurisdictions are being resolved. Check back shortly.",
+      "levels": {
+        "FEDERAL": "Federal",
+        "STATE": "State Legislative",
+        "COUNTY": "County",
+        "MUNICIPAL": "Municipal",
+        "DISTRICT": "Special Districts"
+      }
     }
   },
   "timezones": {
@@ -199,6 +215,39 @@
     "zipCodePlaceholder": "94102",
     "setPrimary": "Set Primary",
     "congressionalDistrict": "Congressional District",
+    "stateSenatorialDistrict": "State Senate District",
+    "stateAssemblyDistrict": "State Assembly District",
+    "county": "County",
+    "municipality": "City / Municipality",
+    "schoolDistrict": "School District",
+    "jurisdictions": {
+      "title": "Your Civic Jurisdictions",
+      "subtitle": "All governing bodies that represent your address",
+      "empty": "Jurisdictions are being resolved. Check back shortly.",
+      "levels": {
+        "FEDERAL": "Federal",
+        "STATE": "State Legislative",
+        "COUNTY": "County",
+        "MUNICIPAL": "Municipal",
+        "DISTRICT": "Special Districts"
+      },
+      "types": {
+        "STATE": "State",
+        "CONGRESSIONAL_DISTRICT": "Congressional District",
+        "STATE_SENATE_DISTRICT": "State Senate District",
+        "STATE_ASSEMBLY_DISTRICT": "State Assembly District",
+        "COUNTY": "County",
+        "CITY": "City",
+        "SCHOOL_DISTRICT_UNIFIED": "Unified School District",
+        "SCHOOL_DISTRICT_ELEMENTARY": "Elementary School District",
+        "SCHOOL_DISTRICT_HIGH": "High School District",
+        "COMMUNITY_COLLEGE_DISTRICT": "Community College District",
+        "WATER_DISTRICT": "Water District",
+        "FIRE_DISTRICT": "Fire District",
+        "TRANSIT_DISTRICT": "Transit District",
+        "SPECIAL_DISTRICT": "Special District"
+      }
+    },
     "deleteConfirm": "Are you sure you want to delete this address?",
     "requiredFields": "Please fill in all required fields",
     "saveError": "Failed to save address"

--- a/apps/frontend/locales/es/settings.json
+++ b/apps/frontend/locales/es/settings.json
@@ -154,6 +154,22 @@
         "other": "Otro",
         "prefer_not_to_say": "Prefiero no decir"
       }
+    },
+    "jurisdictions": {
+      "title": "Tus Jurisdicciones Civicas",
+      "subtitle": "Todos los organos de gobierno que representan tu direccion principal",
+      "primaryAddressNote": "Basado en tu direccion principal",
+      "empty": "Agrega una direccion principal en",
+      "emptyLink": "Direcciones",
+      "emptyTail": "para ver tus jurisdicciones civicas.",
+      "resolving": "Las jurisdicciones se estan resolviendo. Vuelve pronto.",
+      "levels": {
+        "FEDERAL": "Federal",
+        "STATE": "Legislativo Estatal",
+        "COUNTY": "Condado",
+        "MUNICIPAL": "Municipal",
+        "DISTRICT": "Distritos Especiales"
+      }
     }
   },
   "timezones": {
@@ -199,6 +215,39 @@
     "zipCodePlaceholder": "94102",
     "setPrimary": "Establecer como Principal",
     "congressionalDistrict": "Distrito del Congreso",
+    "stateSenatorialDistrict": "Distrito del Senado Estatal",
+    "stateAssemblyDistrict": "Distrito de la Asamblea Estatal",
+    "county": "Condado",
+    "municipality": "Ciudad / Municipio",
+    "schoolDistrict": "Distrito Escolar",
+    "jurisdictions": {
+      "title": "Tus Jurisdicciones Civicas",
+      "subtitle": "Todos los organos de gobierno que representan tu direccion",
+      "empty": "Las jurisdicciones se estan resolviendo. Vuelve pronto.",
+      "levels": {
+        "FEDERAL": "Federal",
+        "STATE": "Legislativo Estatal",
+        "COUNTY": "Condado",
+        "MUNICIPAL": "Municipal",
+        "DISTRICT": "Distritos Especiales"
+      },
+      "types": {
+        "STATE": "Estado",
+        "CONGRESSIONAL_DISTRICT": "Distrito del Congreso",
+        "STATE_SENATE_DISTRICT": "Distrito del Senado Estatal",
+        "STATE_ASSEMBLY_DISTRICT": "Distrito de la Asamblea Estatal",
+        "COUNTY": "Condado",
+        "CITY": "Ciudad",
+        "SCHOOL_DISTRICT_UNIFIED": "Distrito Escolar Unificado",
+        "SCHOOL_DISTRICT_ELEMENTARY": "Distrito Escolar de Primaria",
+        "SCHOOL_DISTRICT_HIGH": "Distrito de Escuela Secundaria",
+        "COMMUNITY_COLLEGE_DISTRICT": "Distrito de Colegio Comunitario",
+        "WATER_DISTRICT": "Distrito de Agua",
+        "FIRE_DISTRICT": "Distrito de Bomberos",
+        "TRANSIT_DISTRICT": "Distrito de Transporte",
+        "SPECIAL_DISTRICT": "Distrito Especial"
+      }
+    },
     "deleteConfirm": "Estas seguro de que quieres eliminar esta direccion?",
     "requiredFields": "Por favor, completa todos los campos requeridos",
     "saveError": "Error al guardar la direccion"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "uat:logs": "docker compose -f docker-compose-uat.yml logs -f",
     "prepare": "husky",
     "lint:sonar": "pnpm -r lint:sonar",
-    "jscpd": "jscpd"
+    "jscpd": "jscpd",
+    "db:load-ca-boundaries": "ts-node scripts/load-ca-boundaries.ts"
   },
   "keywords": [],
   "author": "",

--- a/packages/relationaldb-provider/prisma/migrations/20260513000000_jurisdiction_hierarchy/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260513000000_jurisdiction_hierarchy/migration.sql
@@ -1,0 +1,103 @@
+-- Jurisdiction hierarchy (#690)
+-- Adds typed, FIPS-keyed jurisdiction entities and a junction table linking
+-- users to every jurisdiction they live within, resolved via Census Geocoder
+-- and PostGIS point-in-polygon against loaded boundary geometries.
+
+-- Enums
+CREATE TYPE "JurisdictionType" AS ENUM (
+  'STATE',
+  'CONGRESSIONAL_DISTRICT',
+  'STATE_SENATE_DISTRICT',
+  'STATE_ASSEMBLY_DISTRICT',
+  'COUNTY',
+  'CITY',
+  'SCHOOL_DISTRICT_UNIFIED',
+  'SCHOOL_DISTRICT_ELEMENTARY',
+  'SCHOOL_DISTRICT_HIGH',
+  'COMMUNITY_COLLEGE_DISTRICT',
+  'WATER_DISTRICT',
+  'FIRE_DISTRICT',
+  'TRANSIT_DISTRICT',
+  'SPECIAL_DISTRICT'
+);
+
+CREATE TYPE "JurisdictionLevel" AS ENUM (
+  'FEDERAL',
+  'STATE',
+  'COUNTY',
+  'MUNICIPAL',
+  'DISTRICT'
+);
+
+-- Jurisdiction table
+CREATE TABLE "jurisdictions" (
+  "id"          TEXT        NOT NULL,
+  "fips_code"   VARCHAR(20),
+  "ocd_id"      VARCHAR(255),
+  "name"        VARCHAR(255) NOT NULL,
+  "type"        "JurisdictionType" NOT NULL,
+  "level"       "JurisdictionLevel" NOT NULL,
+  "state_code"  VARCHAR(2)  NOT NULL,
+  "parent_id"   TEXT,
+  "metadata"    JSONB,
+  "created_at"  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "updated_at"  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT "jurisdictions_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "jurisdictions_fips_code_key" UNIQUE ("fips_code"),
+  CONSTRAINT "jurisdictions_ocd_id_key" UNIQUE ("ocd_id"),
+  CONSTRAINT "jurisdictions_parent_id_fkey"
+    FOREIGN KEY ("parent_id") REFERENCES "jurisdictions"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+-- PostGIS geography column for boundary polygons (Prisma Unsupported type)
+ALTER TABLE "jurisdictions"
+  ADD COLUMN "boundary" geography(MultiPolygon, 4326);
+
+-- GIST spatial indexes on jurisdictions
+CREATE INDEX "jurisdictions_boundary_gist_idx"
+  ON "jurisdictions" USING GIST ("boundary");
+
+CREATE INDEX "jurisdictions_type_boundary_idx"
+  ON "jurisdictions" USING GIST ("boundary")
+  WHERE "boundary" IS NOT NULL;
+
+-- Standard indexes
+CREATE INDEX "jurisdictions_type_idx"      ON "jurisdictions" ("type");
+CREATE INDEX "jurisdictions_level_idx"     ON "jurisdictions" ("level");
+CREATE INDEX "jurisdictions_state_code_idx" ON "jurisdictions" ("state_code");
+CREATE INDEX "jurisdictions_parent_id_idx" ON "jurisdictions" ("parent_id");
+
+-- PostGIS point column on user_addresses for fast spatial lookup
+ALTER TABLE "user_addresses"
+  ADD COLUMN "point" geography(Point, 4326);
+
+CREATE INDEX "user_addresses_point_gist_idx"
+  ON "user_addresses" USING GIST ("point");
+
+-- UserJurisdiction junction table
+CREATE TABLE "user_jurisdictions" (
+  "id"              TEXT        NOT NULL,
+  "user_id"         TEXT        NOT NULL,
+  "user_address_id" TEXT        NOT NULL,
+  "jurisdiction_id" TEXT        NOT NULL,
+  "resolved_by"     VARCHAR(50) NOT NULL,
+  "resolved_at"     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT "user_jurisdictions_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "user_jurisdictions_user_address_id_jurisdiction_id_key"
+    UNIQUE ("user_address_id", "jurisdiction_id"),
+  CONSTRAINT "user_jurisdictions_user_id_fkey"
+    FOREIGN KEY ("user_id") REFERENCES "users"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "user_jurisdictions_user_address_id_fkey"
+    FOREIGN KEY ("user_address_id") REFERENCES "user_addresses"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT "user_jurisdictions_jurisdiction_id_fkey"
+    FOREIGN KEY ("jurisdiction_id") REFERENCES "jurisdictions"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "user_jurisdictions_user_id_idx"         ON "user_jurisdictions" ("user_id");
+CREATE INDEX "user_jurisdictions_user_address_id_idx" ON "user_jurisdictions" ("user_address_id");

--- a/packages/relationaldb-provider/prisma/migrations/20260513000000_jurisdiction_hierarchy/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260513000000_jurisdiction_hierarchy/migration.sql
@@ -55,11 +55,9 @@ CREATE TABLE "jurisdictions" (
 ALTER TABLE "jurisdictions"
   ADD COLUMN "boundary" geography(MultiPolygon, 4326);
 
--- GIST spatial indexes on jurisdictions
+-- Partial GIST index on jurisdictions.boundary for point-in-polygon queries
+-- Partial (WHERE boundary IS NOT NULL) is sufficient; ST_Contains never matches null rows.
 CREATE INDEX "jurisdictions_boundary_gist_idx"
-  ON "jurisdictions" USING GIST ("boundary");
-
-CREATE INDEX "jurisdictions_type_boundary_idx"
   ON "jurisdictions" USING GIST ("boundary")
   WHERE "boundary" IS NOT NULL;
 

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -177,6 +177,7 @@ model User {
   emailCorrespondence    EmailCorrespondence[]
   notificationPreference NotificationPreference?
   abuseReports           AbuseReport[]
+  userJurisdictions      UserJurisdiction[]
 
   @@map("users")
 }
@@ -354,6 +355,7 @@ model UserAddress {
   schoolDistrict          String?     @map("school_district") @db.VarChar(100)
   precinctId              String?     @map("precinct_id") @db.VarChar(100)
   pollingPlace            String?     @map("polling_place") @db.VarChar(100)
+  point                   Unsupported("geography(Point, 4326)")?
   civicDataUpdatedAt      DateTime?   @map("civic_data_updated_at") @db.Timestamptz
   isVerified              Boolean     @default(false) @map("is_verified")
   verifiedAt              DateTime?   @map("verified_at") @db.Timestamptz
@@ -361,7 +363,8 @@ model UserAddress {
   createdAt               DateTime    @default(now()) @map("created_at") @db.Timestamptz
   updatedAt               DateTime    @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
-  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user              User               @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userJurisdictions UserJurisdiction[]
 
   @@index([userId])
   @@index([userId, addressType])
@@ -1443,4 +1446,78 @@ model PromptTemplate {
   @@index([category, isActive])
   @@index([name])
   @@map("prompt_templates")
+}
+
+// ============================================
+// JURISDICTION HIERARCHY (#690)
+// ============================================
+
+enum JurisdictionType {
+  STATE
+  CONGRESSIONAL_DISTRICT
+  STATE_SENATE_DISTRICT
+  STATE_ASSEMBLY_DISTRICT
+  COUNTY
+  CITY
+  SCHOOL_DISTRICT_UNIFIED
+  SCHOOL_DISTRICT_ELEMENTARY
+  SCHOOL_DISTRICT_HIGH
+  COMMUNITY_COLLEGE_DISTRICT
+  WATER_DISTRICT
+  FIRE_DISTRICT
+  TRANSIT_DISTRICT
+  SPECIAL_DISTRICT
+}
+
+enum JurisdictionLevel {
+  FEDERAL
+  STATE
+  COUNTY
+  MUNICIPAL
+  DISTRICT
+}
+
+model Jurisdiction {
+  id        String            @id @default(uuid())
+  fipsCode  String?           @unique @map("fips_code") @db.VarChar(20)
+  ocdId     String?           @unique @map("ocd_id") @db.VarChar(255)
+  name      String            @db.VarChar(255)
+  type      JurisdictionType
+  level     JurisdictionLevel
+  stateCode String            @map("state_code") @db.VarChar(2)
+  parentId  String?           @map("parent_id")
+  // boundary geography(MultiPolygon, 4326) added via raw SQL migration — Prisma Unsupported
+  boundary  Unsupported("geography(MultiPolygon, 4326)")?
+  metadata  Json?
+
+  parent            Jurisdiction?      @relation("JurisdictionHierarchy", fields: [parentId], references: [id])
+  children          Jurisdiction[]     @relation("JurisdictionHierarchy")
+  userJurisdictions UserJurisdiction[]
+
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([type])
+  @@index([level])
+  @@index([stateCode])
+  @@index([parentId])
+  @@map("jurisdictions")
+}
+
+model UserJurisdiction {
+  id             String   @id @default(uuid())
+  userId         String   @map("user_id")
+  userAddressId  String   @map("user_address_id")
+  jurisdictionId String   @map("jurisdiction_id")
+  resolvedBy     String   @map("resolved_by") @db.VarChar(50)
+  resolvedAt     DateTime @default(now()) @map("resolved_at") @db.Timestamptz
+
+  user         User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userAddress  UserAddress  @relation(fields: [userAddressId], references: [id], onDelete: Cascade)
+  jurisdiction Jurisdiction @relation(fields: [jurisdictionId], references: [id])
+
+  @@unique([userAddressId, jurisdictionId])
+  @@index([userId])
+  @@index([userAddressId])
+  @@map("user_jurisdictions")
 }

--- a/packages/relationaldb-provider/prisma/spatial-indexes.sql
+++ b/packages/relationaldb-provider/prisma/spatial-indexes.sql
@@ -33,12 +33,18 @@ END $$;
 CREATE INDEX IF NOT EXISTS documents_scan_location_gist_idx
   ON documents USING GIST (scan_location);
 
--- GIST indexes on jurisdictions.boundary for point-in-polygon queries (#690)
--- Enables resolving a user's lat/lng to all containing civic jurisdictions
-CREATE INDEX IF NOT EXISTS jurisdictions_boundary_gist_idx
-  ON jurisdictions USING GIST (boundary);
+-- Geometry columns for jurisdiction resolution (#690)
+-- Added here because Prisma skips Unsupported() columns during db push
+ALTER TABLE jurisdictions
+  ADD COLUMN IF NOT EXISTS boundary geography(MultiPolygon, 4326);
 
-CREATE INDEX IF NOT EXISTS jurisdictions_type_boundary_idx
+ALTER TABLE user_addresses
+  ADD COLUMN IF NOT EXISTS point geography(Point, 4326);
+
+-- Partial GIST index on jurisdictions.boundary for point-in-polygon queries (#690)
+-- Partial (WHERE boundary IS NOT NULL) is all the planner ever needs for ST_Contains;
+-- a non-partial index would waste storage on the ~0 rows with null boundary.
+CREATE INDEX IF NOT EXISTS jurisdictions_boundary_gist_idx
   ON jurisdictions USING GIST (boundary)
   WHERE boundary IS NOT NULL;
 

--- a/packages/relationaldb-provider/prisma/spatial-indexes.sql
+++ b/packages/relationaldb-provider/prisma/spatial-indexes.sql
@@ -33,5 +33,18 @@ END $$;
 CREATE INDEX IF NOT EXISTS documents_scan_location_gist_idx
   ON documents USING GIST (scan_location);
 
+-- GIST indexes on jurisdictions.boundary for point-in-polygon queries (#690)
+-- Enables resolving a user's lat/lng to all containing civic jurisdictions
+CREATE INDEX IF NOT EXISTS jurisdictions_boundary_gist_idx
+  ON jurisdictions USING GIST (boundary);
+
+CREATE INDEX IF NOT EXISTS jurisdictions_type_boundary_idx
+  ON jurisdictions USING GIST (boundary)
+  WHERE boundary IS NOT NULL;
+
+-- GIST index on user_addresses.point for spatial lookups (#690)
+CREATE INDEX IF NOT EXISTS user_addresses_point_gist_idx
+  ON user_addresses USING GIST (point);
+
 -- Log success
 DO $$ BEGIN RAISE NOTICE 'Spatial indexes created successfully'; END $$;

--- a/packages/relationaldb-provider/src/index.ts
+++ b/packages/relationaldb-provider/src/index.ts
@@ -75,6 +75,8 @@ export type {
   PromptTemplate,
   AbuseReport,
   DocumentProposition,
+  Jurisdiction,
+  UserJurisdiction,
 } from "@prisma/client";
 
 // Re-export database enums
@@ -98,6 +100,8 @@ export {
   AbuseReportStatus,
   LinkSource,
   CommitteeMeasurePositionType,
+  JurisdictionType,
+  JurisdictionLevel,
 } from "@prisma/client";
 
 // Test utilities are available from "@opuspopuli/relationaldb-provider/testing"

--- a/scripts/load-ca-boundaries.ts
+++ b/scripts/load-ca-boundaries.ts
@@ -1,0 +1,590 @@
+/**
+ * Load California civic boundary data into the jurisdictions table.
+ *
+ * Sources:
+ *   - US Census TIGER/Line shapefiles (GeoJSON API) for counties, cities,
+ *     school districts, and state legislative districts
+ *   - CA State Geoportal (gis.data.ca.gov) for independent special districts
+ *
+ * Idempotent — uses upsert semantics on fipsCode / ocdId.
+ * Re-run anytime to refresh boundaries from source.
+ *
+ * Usage:
+ *   DATABASE_URL=postgresql://... npx ts-node -e "require('./scripts/load-ca-boundaries')"
+ *   or add to package.json: "db:load-boundaries": "ts-node scripts/load-ca-boundaries.ts"
+ */
+
+import { PrismaClient } from "@opuspopuli/relationaldb-provider";
+import * as fs from "fs";
+import * as path from "path";
+
+const prisma = new PrismaClient();
+
+// OCD-ID prefix for California
+const CA_OCD_PREFIX = "ocd-division/country:us/state:ca";
+const STATE_CODE = "CA";
+
+// Census TIGER GeoJSON API base — returns GeoJSON FeatureCollection
+// See: https://tigerweb.geo.census.gov/tigerwebmain/TIGERweb_geography.html
+const TIGER_BASE =
+  "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb";
+
+// CA FIPS state code
+const CA_STATE_FIPS = "06";
+
+interface TigerFeature {
+  type: "Feature";
+  properties: Record<string, string | number | null>;
+  geometry: {
+    type: string;
+    coordinates: unknown;
+  };
+}
+
+interface TigerResponse {
+  type: "FeatureCollection";
+  features: TigerFeature[];
+}
+
+interface GeoPortalFeature {
+  attributes: Record<string, string | number | null>;
+  geometry?: {
+    rings?: unknown[][];
+    [key: string]: unknown;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fetch helpers
+// ---------------------------------------------------------------------------
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(120_000),
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status} fetching ${url}`);
+  return res.json() as Promise<T>;
+}
+
+/**
+ * Fetch a TIGER/Line layer as GeoJSON FeatureCollection.
+ * Uses the public TIGERweb REST service which returns GeoJSON directly.
+ */
+async function fetchTigerLayer(
+  serviceLayer: string,
+  whereClause: string,
+  outFields: string,
+): Promise<TigerFeature[]> {
+  const params = new URLSearchParams({
+    where: whereClause,
+    outFields,
+    outSR: "4326",
+    f: "geojson",
+    geometryType: "esriGeometryPolygon",
+    returnGeometry: "true",
+  });
+  const url = `${TIGER_BASE}/${serviceLayer}/query?${params}`;
+
+  try {
+    const data = await fetchJson<TigerResponse>(url);
+    return data.features ?? [];
+  } catch (err) {
+    console.warn(
+      `  ⚠ TIGER fetch failed for ${serviceLayer}: ${(err as Error).message}`,
+    );
+    return [];
+  }
+}
+
+/**
+ * Convert a GeoJSON geometry to PostGIS WKT-compatible input via ST_GeomFromGeoJSON.
+ * We pass the geometry as a JSON string for use in a raw SQL call.
+ */
+function geometryJson(geometry: unknown): string {
+  return JSON.stringify(geometry);
+}
+
+// ---------------------------------------------------------------------------
+// Upsert helpers
+// ---------------------------------------------------------------------------
+
+type JurisdictionType =
+  | "STATE"
+  | "CONGRESSIONAL_DISTRICT"
+  | "STATE_SENATE_DISTRICT"
+  | "STATE_ASSEMBLY_DISTRICT"
+  | "COUNTY"
+  | "CITY"
+  | "SCHOOL_DISTRICT_UNIFIED"
+  | "SCHOOL_DISTRICT_ELEMENTARY"
+  | "SCHOOL_DISTRICT_HIGH"
+  | "COMMUNITY_COLLEGE_DISTRICT"
+  | "WATER_DISTRICT"
+  | "FIRE_DISTRICT"
+  | "TRANSIT_DISTRICT"
+  | "SPECIAL_DISTRICT";
+
+type JurisdictionLevel =
+  | "FEDERAL"
+  | "STATE"
+  | "COUNTY"
+  | "MUNICIPAL"
+  | "DISTRICT";
+
+interface JurisdictionPayload {
+  fipsCode?: string;
+  ocdId?: string;
+  name: string;
+  type: JurisdictionType;
+  level: JurisdictionLevel;
+  stateCode: string;
+  parentId?: string;
+  geometry?: unknown;
+}
+
+/**
+ * Upsert a jurisdiction row using Prisma's native atomic upsert, then write
+ * the PostGIS boundary geometry via raw SQL.
+ *
+ * Prisma's upsert requires a single unique key — fipsCode is preferred when
+ * present, otherwise ocdId. Records with neither are skipped (logged as gaps).
+ */
+async function upsertJurisdiction(
+  payload: JurisdictionPayload,
+): Promise<string> {
+  if (!payload.fipsCode && !payload.ocdId) {
+    logGap(payload.name, payload.type, "No fipsCode or ocdId — cannot upsert");
+    return "";
+  }
+
+  const sharedData = {
+    name: payload.name,
+    type: payload.type,
+    level: payload.level,
+    stateCode: payload.stateCode,
+    parentId: payload.parentId ?? null,
+  };
+
+  let record: { id: string };
+
+  if (payload.fipsCode) {
+    record = await prisma.jurisdiction.upsert({
+      where: { fipsCode: payload.fipsCode },
+      create: {
+        ...sharedData,
+        fipsCode: payload.fipsCode,
+        ocdId: payload.ocdId ?? null,
+      },
+      update: sharedData,
+      select: { id: true },
+    });
+  } else {
+    record = await prisma.jurisdiction.upsert({
+      where: { ocdId: payload.ocdId! },
+      create: { ...sharedData, fipsCode: null, ocdId: payload.ocdId! },
+      update: sharedData,
+      select: { id: true },
+    });
+  }
+
+  const id = record.id;
+
+  // Write boundary geometry via raw SQL (Prisma can't emit PostGIS functions)
+  if (payload.geometry) {
+    await prisma.$executeRaw`
+      UPDATE jurisdictions
+      SET boundary = ST_Multi(ST_GeomFromGeoJSON(${geometryJson(payload.geometry)}::text))
+      WHERE id = ${id}
+    `;
+  }
+
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// Gap log
+// ---------------------------------------------------------------------------
+
+const gaps: { name: string; type: string; reason: string }[] = [];
+
+function logGap(name: string, type: string, reason: string) {
+  gaps.push({ name, type, reason });
+}
+
+// ---------------------------------------------------------------------------
+// Loaders
+// ---------------------------------------------------------------------------
+
+async function loadCounties(): Promise<Map<string, string>> {
+  console.log("Loading CA counties...");
+  const features = await fetchTigerLayer(
+    "State_County/MapServer/1",
+    `STATE='${CA_STATE_FIPS}'`,
+    "GEOID,NAME,COUNTY",
+  );
+
+  const countyIdMap = new Map<string, string>(); // COUNTY (3-digit) → jurisdiction id
+
+  for (const f of features) {
+    const p = f.properties;
+    const fipsCode = String(p["GEOID"]);
+    const name = String(p["NAME"]);
+    const ocdId = `${CA_OCD_PREFIX}/county:${name.toLowerCase().replace(/\s+/g, "_")}`;
+
+    const id = await upsertJurisdiction({
+      fipsCode,
+      ocdId,
+      name, // TIGER NAME already includes "County" (e.g., "San Mateo County")
+      type: "COUNTY",
+      level: "COUNTY",
+      stateCode: STATE_CODE,
+      geometry: f.geometry,
+    });
+
+    countyIdMap.set(String(p["COUNTY"]), id);
+  }
+
+  console.log(`  ✓ ${features.length} counties loaded`);
+  return countyIdMap;
+}
+
+async function loadCities(countyIdMap: Map<string, string>): Promise<void> {
+  console.log("Loading CA incorporated places (cities)...");
+  // Fetch in pages — TIGERweb caps at 1000 per request
+  let offset = 0;
+  let count = 0;
+  while (true) {
+    const params = new URLSearchParams({
+      where: `STATE='${CA_STATE_FIPS}'`,
+      outFields: "GEOID,NAME,PLACE,STATE",
+      outSR: "4326",
+      f: "geojson",
+      geometryType: "esriGeometryPolygon",
+      returnGeometry: "true",
+      resultOffset: String(offset),
+      resultRecordCount: "1000",
+    });
+    const url = `${TIGER_BASE}/Places_CouSub_ConCity_SubMCD/MapServer/4/query?${params}`;
+    let features: TigerFeature[] = [];
+    try {
+      const data = await fetchJson<TigerResponse>(url);
+      features = data.features ?? [];
+    } catch {
+      break;
+    }
+    if (features.length === 0) break;
+
+    for (const f of features) {
+      const p = f.properties;
+      const fipsCode = String(p["GEOID"]);
+      const name = String(p["NAME"]);
+      const ocdId = `${CA_OCD_PREFIX}/place:${name.toLowerCase().replace(/[^a-z0-9]/g, "_")}`;
+      // Cities don't have COUNTYFP in this layer — leave parent unset for now
+      await upsertJurisdiction({
+        fipsCode,
+        ocdId,
+        name,
+        type: "CITY",
+        level: "MUNICIPAL",
+        stateCode: STATE_CODE,
+        geometry: f.geometry,
+      });
+      count++;
+    }
+    if (features.length < 1000) break;
+    offset += 1000;
+  }
+  console.log(`  ✓ ${count} cities loaded`);
+  void countyIdMap; // unused for cities in this layer
+}
+
+async function loadStateLegislativeDistricts(): Promise<void> {
+  console.log("Loading CA state legislative districts...");
+
+  // State Senate (upper) — layer 1, district field: SLDU
+  const senateFeatures = await fetchTigerLayer(
+    "Legislative/MapServer/1",
+    `STATE='${CA_STATE_FIPS}'`,
+    "GEOID,NAME,SLDU",
+  );
+
+  for (const f of senateFeatures) {
+    const p = f.properties;
+    const district = String(p["SLDU"]).replace(/^0+/, "");
+    // Prefix to avoid GEOID collision with county FIPS codes (same format)
+    const fipsCode = `sldu-${String(p["GEOID"])}`;
+    const ocdId = `${CA_OCD_PREFIX}/sldu:${district}`;
+
+    await upsertJurisdiction({
+      fipsCode,
+      ocdId,
+      name: `California State Senate District ${district}`,
+      type: "STATE_SENATE_DISTRICT",
+      level: "STATE",
+      stateCode: STATE_CODE,
+      geometry: f.geometry,
+    });
+  }
+
+  // State Assembly (lower) — layer 2, district field: SLDL
+  const assemblyFeatures = await fetchTigerLayer(
+    "Legislative/MapServer/2",
+    `STATE='${CA_STATE_FIPS}'`,
+    "GEOID,NAME,SLDL",
+  );
+
+  for (const f of assemblyFeatures) {
+    const p = f.properties;
+    const district = String(p["SLDL"]).replace(/^0+/, "");
+    // Prefix to avoid GEOID collision with county FIPS codes (same format)
+    const fipsCode = `sldl-${String(p["GEOID"])}`;
+    const ocdId = `${CA_OCD_PREFIX}/sldl:${district}`;
+
+    await upsertJurisdiction({
+      fipsCode,
+      ocdId,
+      name: `California State Assembly District ${district}`,
+      type: "STATE_ASSEMBLY_DISTRICT",
+      level: "STATE",
+      stateCode: STATE_CODE,
+      geometry: f.geometry,
+    });
+  }
+
+  console.log(
+    `  ✓ ${senateFeatures.length} senate + ${assemblyFeatures.length} assembly districts loaded`,
+  );
+}
+
+async function loadSchoolDistricts(): Promise<void> {
+  console.log("Loading CA school districts...");
+
+  const layers = [
+    {
+      layer: "School/MapServer/0",
+      type: "SCHOOL_DISTRICT_UNIFIED" as JurisdictionType,
+      label: "unified",
+    },
+    {
+      layer: "School/MapServer/1",
+      type: "SCHOOL_DISTRICT_HIGH" as JurisdictionType,
+      label: "high school",
+    },
+    {
+      layer: "School/MapServer/2",
+      type: "SCHOOL_DISTRICT_ELEMENTARY" as JurisdictionType,
+      label: "elementary",
+    },
+  ];
+
+  for (const { layer, type, label } of layers) {
+    const features = await fetchTigerLayer(
+      layer,
+      `STATE='${CA_STATE_FIPS}'`,
+      "GEOID,NAME",
+    );
+
+    for (const f of features) {
+      const p = f.properties;
+      const geoid = String(p["GEOID"]);
+      const name = String(p["NAME"]);
+      const ocdId = `${CA_OCD_PREFIX}/school_district:${geoid}`;
+
+      await upsertJurisdiction({
+        fipsCode: geoid,
+        ocdId,
+        name,
+        type,
+        level: "DISTRICT",
+        stateCode: STATE_CODE,
+        geometry: f.geometry,
+      });
+    }
+
+    console.log(`  ✓ ${features.length} ${label} school districts loaded`);
+  }
+}
+
+/**
+ * Paginated fetch from any ArcGIS FeatureServer layer.
+ * Returns all features regardless of the service's maxRecordCount limit.
+ */
+async function fetchArcGISFeatureServer(
+  serviceUrl: string,
+  outFields: string,
+): Promise<TigerFeature[]> {
+  const all: TigerFeature[] = [];
+  let offset = 0;
+  const pageSize = 1000;
+
+  while (true) {
+    const params = new URLSearchParams({
+      where: "1=1",
+      outFields,
+      outSR: "4326",
+      f: "geojson",
+      returnGeometry: "true",
+      resultOffset: String(offset),
+      resultRecordCount: String(pageSize),
+    });
+
+    const url = `${serviceUrl}/query?${params}`;
+    let features: TigerFeature[] = [];
+    try {
+      const data = await fetchJson<TigerResponse>(url);
+      features = data.features ?? [];
+    } catch (err) {
+      console.warn(
+        `  ⚠ FeatureServer fetch failed at offset ${offset}: ${(err as Error).message}`,
+      );
+      break;
+    }
+
+    all.push(...features);
+    if (features.length < pageSize) break;
+    offset += pageSize;
+  }
+
+  return all;
+}
+
+/**
+ * Load CA fire districts from CALFIRE's authoritative FeatureServer.
+ * Source: California_Local_Fire_Districts (CALFIRE ArcGIS Online)
+ * 671 records — all local fire protection districts in the state.
+ */
+async function loadFireDistricts(): Promise<void> {
+  console.log("Loading CA fire districts (CALFIRE)...");
+
+  const FIRE_FS =
+    "https://services1.arcgis.com/jUJYIo9tSA7EHvfZ/arcgis/rest/services/California_Local_Fire_Districts/FeatureServer/0";
+  const features = await fetchArcGISFeatureServer(
+    FIRE_FS,
+    "OBJECTID,Name,County,FDID",
+  );
+
+  let count = 0;
+  for (const f of features) {
+    const p = f.properties;
+    const name = String(p["Name"] ?? "").trim();
+    const fdid = String(p["FDID"] ?? "").trim();
+
+    if (!name) continue;
+
+    // FDID (Fire Department ID from OSFM) is unique per district.
+    // fipsCode is VARCHAR(20) — fall back to objectId if composed key would overflow.
+    const objectId = String(p["OBJECTID"] ?? "");
+    const candidate = fdid ? `ca-fire-${fdid}` : `ca-fire-obj-${objectId}`;
+    const fipsCode =
+      candidate.length <= 20 ? candidate : `ca-fire-obj-${objectId}`;
+
+    if (!f.geometry) {
+      logGap(name, "FIRE_DISTRICT", "No geometry in CALFIRE response");
+      continue;
+    }
+
+    await upsertJurisdiction({
+      fipsCode,
+      name,
+      type: "FIRE_DISTRICT",
+      level: "DISTRICT",
+      stateCode: STATE_CODE,
+      geometry: f.geometry,
+    });
+    count++;
+  }
+
+  console.log(`  ✓ ${count} fire districts loaded`);
+}
+
+/**
+ * Load CA water districts from the CA Department of Water Resources FeatureServer.
+ * Source: i03_WaterDistricts (gis.water.ca.gov)
+ * 4,021 records — all water agencies in the state.
+ */
+async function loadWaterDistricts(): Promise<void> {
+  console.log("Loading CA water districts (DWR)...");
+
+  const WATER_FS =
+    "https://gis.water.ca.gov/arcgis/rest/services/Boundaries/i03_WaterDistricts/FeatureServer/0";
+  const features = await fetchArcGISFeatureServer(
+    WATER_FS,
+    "OBJECTID,AGENCYNAME,AGENCYUNIQUEID",
+  );
+
+  let count = 0;
+  for (const f of features) {
+    const p = f.properties;
+    const name = String(p["AGENCYNAME"] ?? "").trim();
+    const agencyId = String(p["AGENCYUNIQUEID"] ?? "").trim();
+
+    if (!name) continue;
+
+    // fipsCode is VARCHAR(20) — fall back to objectId if AGENCYUNIQUEID would overflow.
+    const objectId = String(p["OBJECTID"] ?? "");
+    const candidate = agencyId
+      ? `ca-water-${agencyId}`
+      : `ca-water-obj-${objectId}`;
+    const fipsCode =
+      candidate.length <= 20 ? candidate : `ca-water-obj-${objectId}`;
+
+    if (!f.geometry) {
+      logGap(name, "WATER_DISTRICT", "No geometry in DWR response");
+      continue;
+    }
+
+    await upsertJurisdiction({
+      fipsCode,
+      name,
+      type: "WATER_DISTRICT",
+      level: "DISTRICT",
+      stateCode: STATE_CODE,
+      geometry: f.geometry,
+    });
+    count++;
+  }
+
+  console.log(`  ✓ ${count} water districts loaded`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log("=== CA Boundary Loader ===\n");
+
+  try {
+    await prisma.$connect();
+
+    const countyIdMap = await loadCounties();
+    await loadCities(countyIdMap);
+    await loadStateLegislativeDistricts();
+    await loadSchoolDistricts();
+    await loadFireDistricts();
+    await loadWaterDistricts();
+
+    if (gaps.length > 0) {
+      const gapPath = path.join(__dirname, "../tmp/boundary-gaps.csv");
+      fs.mkdirSync(path.dirname(gapPath), { recursive: true });
+      const csv = [
+        "name,type,reason",
+        ...gaps.map((g) => `"${g.name}","${g.type}","${g.reason}"`),
+      ].join("\n");
+      fs.writeFileSync(gapPath, csv);
+      console.log(
+        `\n⚠ ${gaps.length} coverage gaps written to tmp/boundary-gaps.csv`,
+      );
+    }
+
+    console.log("\n✅ Boundary load complete");
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/tsconfig.scripts.json
+++ b/scripts/tsconfig.scripts.json
@@ -1,0 +1,29 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "typeRoots": [
+      "../apps/backend/node_modules/@types",
+      "../node_modules/@types"
+    ],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "../dist/scripts",
+    "paths": {
+      "@opuspopuli/relationaldb-provider": [
+        "packages/relationaldb-provider/src/index.ts"
+      ],
+      "@opuspopuli/*": ["packages/*/src/index.ts"],
+      "@prisma/client": [
+        "node_modules/.pnpm/@prisma+client@5.22.0_prisma@5.22.0/node_modules/@prisma/client"
+      ]
+    },
+    "baseUrl": ".."
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["../node_modules"]
+}


### PR DESCRIPTION
## Summary

Resolves a user's primary address to all containing civic jurisdictions — congressional district, state senate/assembly, county, city, school district, fire district, water district — using a two-source pipeline (Census Geocoder string matching + PostGIS point-in-polygon) and surfaces the results on the Profile settings page.

**Why:** Local governance is under-represented in civic tech. Knowing which fire district, water board, and school board a user lives in is foundational to the platform's local engagement roadmap.

## What changed

**Backend — `users` service**
- `GeocodingService`: extracts `schoolDistrict` from Census Geocoder using key substring matching (generalised, not CA-specific)
- `JurisdictionResolutionService` (new): merges Census name-match + PostGIS point-in-polygon results into `user_jurisdictions`; `DELETE` + `INSERT` wrapped in `$transaction` to prevent stale accumulation when an address changes location
- `ProfileService`: writes PostGIS point after geocoding, fires jurisdiction resolution fire-and-forget; `setPrimaryAddress` now re-triggers geocoding when the new primary has no resolved jurisdictions
- `db-migrate.sh`: added `--skip-generate` to avoid OOM in memory-constrained containers (client is pre-built in image)

**Backend — `region` service**
- `getJurisdictionsForUser`: new service method, filters to primary address, orders by level → type → name
- `myJurisdictions` GraphQL query: auth-guarded, complexity 10
- `JurisdictionModel` / `UserJurisdictionModel` / enum types (new)
- `buildStagePatterns` → regex `RegExp.test()` replaces broken exact-string hash-map lookup for bill status → stage resolution (partial fix for #694)
- `backfillBillStageIds`: batched to one `updateMany` per stage (was N+1)

**Database**
- `Jurisdiction` table with `geography(MultiPolygon, 4326)` boundary column
- `UserJurisdiction` junction table (unique on `userAddressId + jurisdictionId`)
- `UserAddress.point geography(Point, 4326)` for spatial lookups
- Partial GIST index `WHERE boundary IS NOT NULL` (replaces redundant non-partial index)

**ETL** (`scripts/load-ca-boundaries.ts`)
- Loads CA counties, cities, state legislative districts, school/fire/water districts from TIGER/Line + ArcGIS FeatureServer; idempotent upsert; fipsCode length guard for VARCHAR(20)
- Run: `pnpm db:load-ca-boundaries`

**Frontend**
- `JurisdictionsSection` on Profile settings page — grouped by level (Federal → State → County → Municipal → District), keyed to primary address
- Addresses page simplified — district string fields removed (superseded by resolved jurisdictions)
- `MY_JURISDICTIONS` GQL query with `fetchPolicy: 'network-only'`
- i18n strings added (EN + ES)

## How to test

1. Bring up UAT stack: `pnpm uat:up`
2. Run ETL to load CA boundaries: `DATABASE_URL=... pnpm db:load-ca-boundaries`
3. Sign in, go to **Settings → Addresses**, add a CA residential address and save
4. Navigate to **Settings → Profile** — "Your Civic Jurisdictions" section should appear below the completion bar within a few seconds (geocoding is async)
5. Change the address to a different location, save — verify old districts are replaced (not accumulated)
6. Set a second address as primary — verify jurisdictions update to reflect the new primary

**GraphQL smoke test:**
```graphql
query { myJurisdictions { resolvedBy jurisdiction { name type level } } }
```

## Notes

- #694 (bill progress bar not highlighting correct stage) remains open — the regex fix is included here but UI rendering may have a separate stage-ID mismatch issue
- `FEDERAL` level in the UI is wired up but will remain empty until `loadCongressionalDistricts()` is added to the ETL

## Linked issues

Closes #690
See also #694

🤖 Generated with [Claude Code](https://claude.com/claude-code)