### PR TITLE
feat(region,frontend,pipeline): county supervisor sync — Sonoma Board of Supervisors (#22)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -77,7 +77,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.40",
+    "@opuspopuli/regions": "^1.0.57",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/bio-generator.service.ts
+++ b/apps/backend/src/apps/region/src/domains/bio-generator.service.ts
@@ -220,7 +220,7 @@ export class BioGeneratorService extends LlmGeneratorBase {
    * refuse or correctly identify a representative.
    */
   private deriveJurisdiction(rep: Representative): string {
-    const prefix = rep.externalId.split('-')[0]?.toLowerCase() ?? '';
+    const prefix = rep.externalId?.split('-')[0]?.toLowerCase() ?? '';
     const state = STATE_PREFIX_TO_NAME[prefix];
     if (!state) {
       // Federal or unknown — fall back to bare chamber so the prompt

--- a/apps/backend/src/apps/region/src/domains/legislative-committee.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-committee.service.ts
@@ -22,7 +22,7 @@ export interface LegislativeCommitteeMember {
   representativeId: string;
   name: string;
   role: string | null;
-  party: string;
+  party: string | null;
   photoUrl: string | null;
 }
 

--- a/apps/backend/src/apps/region/src/domains/models/legislative-committee.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/legislative-committee.model.ts
@@ -39,8 +39,8 @@ export class LegislativeCommitteeMemberModel {
   @Field({ nullable: true })
   role?: string;
 
-  @Field()
-  party!: string;
+  @Field({ nullable: true })
+  party?: string;
 
   @Field({ nullable: true })
   photoUrl?: string;

--- a/apps/backend/src/apps/region/src/domains/models/region-info.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/region-info.model.ts
@@ -162,6 +162,18 @@ registerEnumType(DataTypeGQL, {
   description: 'Types of data available in the region',
 });
 
+export enum SyncDepthGQL {
+  STATE = 'STATE',
+  COUNTY = 'COUNTY',
+  ALL = 'ALL',
+}
+
+registerEnumType(SyncDepthGQL, {
+  name: 'SyncDepth',
+  description:
+    'STATE = top-level region only; COUNTY = all enabled sub-regions; ALL = both in one pass',
+});
+
 /**
  * Region info GraphQL model
  */
@@ -223,6 +235,9 @@ export class RegionPluginModel {
  */
 @ObjectType()
 export class SyncResultModel {
+  @Field()
+  regionId!: string;
+
   @Field(() => DataTypeGQL)
   dataType!: DataTypeGQL;
 

--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -742,6 +742,7 @@ describe('RegionResolver', () => {
     it('should trigger sync and return results', async () => {
       const mockSyncResults = [
         {
+          regionId: 'california',
           dataType: DataType.PROPOSITIONS,
           itemsProcessed: 10,
           itemsCreated: 5,
@@ -751,6 +752,7 @@ describe('RegionResolver', () => {
           syncedAt: new Date(),
         },
         {
+          regionId: 'california',
           dataType: DataType.MEETINGS,
           itemsProcessed: 5,
           itemsCreated: 3,
@@ -770,12 +772,15 @@ describe('RegionResolver', () => {
         undefined,
         undefined,
         undefined,
+        undefined,
+        undefined,
       );
     });
 
     it('should pass dataTypes filter to syncAll', async () => {
       regionService.syncAll.mockResolvedValue([
         {
+          regionId: 'california',
           dataType: DataType.PROPOSITIONS,
           itemsProcessed: 3,
           itemsCreated: 3,
@@ -793,12 +798,15 @@ describe('RegionResolver', () => {
         ['propositions'],
         undefined,
         undefined,
+        undefined,
+        undefined,
       );
     });
 
     it('should include errors in sync results', async () => {
       const mockSyncResults = [
         {
+          regionId: 'california',
           dataType: DataType.PROPOSITIONS,
           itemsProcessed: 0,
           itemsCreated: 0,

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -18,12 +18,17 @@ import { Public } from 'src/common/decorators/public.decorator';
 import { Roles } from 'src/common/decorators/roles.decorator';
 import { Role } from 'src/common/enums/role.enum';
 import { PaginationArgs } from 'src/common/dto/pagination.args';
-import { RegionDomainService, mapPropositionRecord } from './region.service';
+import {
+  RegionDomainService,
+  RepresentativeRecord,
+  mapPropositionRecord,
+} from './region.service';
 import {
   RegionInfoModel,
   RegionPluginModel,
   SyncResultModel,
   DataTypeGQL,
+  SyncDepthGQL,
 } from './models/region-info.model';
 import {
   PropositionModel,
@@ -248,6 +253,7 @@ export class RegionResolver {
 
     return {
       ...result,
+      party: result.party ?? undefined,
       photoUrl: result.photoUrl ?? undefined,
       contactInfo: (result.contactInfo as ContactInfoModel) ?? undefined,
       committees: enrichedCommittees,
@@ -277,26 +283,39 @@ export class RegionResolver {
     stateSenatorialDistrict?: string,
     @Args({ name: 'stateAssemblyDistrict', nullable: true })
     stateAssemblyDistrict?: string,
+    @Args({ name: 'countyRegionId', nullable: true })
+    countyRegionId?: string,
   ): Promise<RepresentativeModel[]> {
-    const results = await this.regionService.getRepresentativesByDistricts(
-      congressionalDistrict,
-      stateSenatorialDistrict,
-      stateAssemblyDistrict,
-    );
+    const [stateResults, countyResults] = await Promise.all([
+      this.regionService.getRepresentativesByDistricts(
+        congressionalDistrict,
+        stateSenatorialDistrict,
+        stateAssemblyDistrict,
+      ),
+      countyRegionId
+        ? this.regionService.getRepresentativesByCounty(countyRegionId)
+        : Promise.resolve([]),
+    ]);
 
-    return results.map((r) => ({
-      ...r,
-      party: r.party ?? undefined,
-      photoUrl: r.photoUrl ?? undefined,
-      contactInfo: (r.contactInfo as ContactInfoModel) ?? undefined,
-      committees: (r.committees as CommitteeAssignmentModel[]) ?? undefined,
-      committeesSummary: r.committeesSummary ?? undefined,
-      bio: r.bio ?? undefined,
-      bioSource: r.bioSource ?? undefined,
-      bioClaims: Array.isArray(r.bioClaims)
-        ? (r.bioClaims as unknown as BioClaimModel[])
-        : undefined,
-    })) as RepresentativeModel[];
+    return [...stateResults, ...countyResults].map((r) =>
+      this.toRepresentativeModel(r),
+    );
+  }
+
+  /**
+   * All Board of Supervisors for a county region.
+   * v1: returns all supervisors for the county — specific district
+   * matching requires county shapefiles (follow-up to #22).
+   */
+  @Public()
+  @Query(() => [RepresentativeModel])
+  @Extensions({ complexity: 5 })
+  async countyRepresentatives(
+    @Args('countyRegionId') countyRegionId: string,
+  ): Promise<RepresentativeModel[]> {
+    const results =
+      await this.regionService.getRepresentativesByCounty(countyRegionId);
+    return results.map((r) => this.toRepresentativeModel(r));
   }
 
   // ==========================================
@@ -451,6 +470,22 @@ export class RegionResolver {
     };
   }
 
+  private toRepresentativeModel(r: RepresentativeRecord): RepresentativeModel {
+    return {
+      ...r,
+      party: r.party ?? undefined,
+      photoUrl: r.photoUrl ?? undefined,
+      contactInfo: (r.contactInfo as ContactInfoModel) ?? undefined,
+      committees: (r.committees as CommitteeAssignmentModel[]) ?? undefined,
+      committeesSummary: r.committeesSummary ?? undefined,
+      bio: r.bio ?? undefined,
+      bioSource: r.bioSource ?? undefined,
+      bioClaims: Array.isArray(r.bioClaims)
+        ? (r.bioClaims as unknown as BioClaimModel[])
+        : undefined,
+    } as RepresentativeModel;
+  }
+
   // ==========================================
   // LEGISLATIVE COMMITTEE QUERIES
   // ==========================================
@@ -514,7 +549,7 @@ export class RegionResolver {
         representativeId: m.representativeId,
         name: m.name,
         role: m.role ?? undefined,
-        party: m.party,
+        party: m.party ?? undefined,
         photoUrl: m.photoUrl ?? undefined,
       })),
       hearings: result.hearings.map((h) => ({
@@ -777,6 +812,43 @@ export class RegionResolver {
     }));
   }
 
+  /**
+   * Board of Supervisors for the authenticated user's county, resolved
+   * from their primary address via FIPS code → county region plugin.
+   * Returns [] when no county jurisdiction is resolved or county plugin
+   * is not yet enabled (#22).
+   */
+  @Query(() => [RepresentativeModel])
+  @UseGuards(AuthGuard)
+  @Extensions({ complexity: 10 })
+  async myCountySupervisors(
+    @Context() context: GqlContext,
+  ): Promise<RepresentativeModel[]> {
+    const user = getUserFromContext(context);
+    const results = await this.regionService.getMyCountySupervisors(user.id);
+    return results.map((r) => this.toRepresentativeModel(r));
+  }
+
+  @Mutation(() => Int)
+  @UseGuards(AuthGuard)
+  @Roles(Role.Admin)
+  async invalidateManifest(
+    @Args('regionId') regionId: string,
+    @Args('sourceUrl') sourceUrl: string,
+  ): Promise<number> {
+    return this.regionService.invalidateManifest(regionId, sourceUrl);
+  }
+
+  @Mutation(() => RegionPluginModel)
+  @UseGuards(AuthGuard)
+  @Roles(Role.Admin)
+  async updateRegionPlugin(
+    @Args('name') name: string,
+    @Args('enabled') enabled: boolean,
+  ): Promise<RegionPluginModel> {
+    return this.regionService.setRegionPluginEnabled(name, enabled);
+  }
+
   @Mutation(() => [SyncResultModel])
   @UseGuards(AuthGuard)
   @Roles(Role.Admin)
@@ -784,6 +856,10 @@ export class RegionResolver {
   async syncRegionData(
     @Args('dataTypes', { type: () => [DataTypeGQL], nullable: true })
     dataTypes?: DataTypeGQL[],
+    @Args('depth', { type: () => SyncDepthGQL, nullable: true })
+    depth?: SyncDepthGQL,
+    @Args('regionId', { nullable: true })
+    regionId?: string,
     @Args('maxReps', { type: () => Int, nullable: true })
     maxReps?: number,
     @Args('maxBills', { type: () => Int, nullable: true })
@@ -793,6 +869,8 @@ export class RegionResolver {
       dataTypes as unknown as string[],
       maxReps,
       maxBills,
+      depth as unknown as string,
+      regionId,
     );
     return results.map((r) => ({
       ...r,

--- a/apps/backend/src/apps/region/src/domains/region.scheduler.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.scheduler.spec.ts
@@ -13,6 +13,7 @@ describe('RegionScheduler', () => {
 
   const mockSyncResults = [
     {
+      regionId: 'california',
       dataType: DataType.PROPOSITIONS,
       itemsProcessed: 10,
       itemsCreated: 5,
@@ -22,6 +23,7 @@ describe('RegionScheduler', () => {
       syncedAt: new Date(),
     },
     {
+      regionId: 'california',
       dataType: DataType.MEETINGS,
       itemsProcessed: 5,
       itemsCreated: 3,
@@ -31,6 +33,7 @@ describe('RegionScheduler', () => {
       syncedAt: new Date(),
     },
     {
+      regionId: 'california',
       dataType: DataType.REPRESENTATIVES,
       itemsProcessed: 8,
       itemsCreated: 2,
@@ -171,6 +174,7 @@ describe('RegionScheduler', () => {
     it('should log warnings when sync has errors', async () => {
       const resultsWithErrors = [
         {
+          regionId: 'california',
           dataType: DataType.PROPOSITIONS,
           itemsProcessed: 10,
           itemsCreated: 5,

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -9,9 +9,11 @@ import {
 import {
   RegionService as RegionProviderService,
   DataType,
+  SyncDepth,
   SyncResult,
   PluginLoaderService,
   PluginRegistryService,
+  DeclarativeRegionPlugin,
   ExampleRegionProvider,
   discoverRegionConfigs,
   getRegionsDir,
@@ -33,6 +35,7 @@ import {
   type ILLMProvider,
   type CivicsBlock,
   type DataSourceConfig,
+  type DeclarativeRegionConfig,
   type Bill,
 } from '@opuspopuli/common';
 import { PromptClientService } from '@opuspopuli/prompt-client';
@@ -213,7 +216,7 @@ type MeetingRecord = {
   createdAt: Date;
   updatedAt: Date;
 };
-type RepresentativeRecord = {
+export type RepresentativeRecord = {
   id: string;
   externalId: string;
   name: string;
@@ -345,6 +348,7 @@ function deriveDistrictFromExternalId(externalId: string): string | undefined {
  * normalize other inconsistent extractor outputs in this same path.
  */
 export function stripLeadingZerosFromExternalId(externalId: string): string {
+  if (!externalId) return externalId;
   const parts = externalId.split('-');
   const last = parts.at(-1);
   if (!last || !/^\d+$/.test(last)) return externalId;
@@ -945,10 +949,14 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     dataTypes?: string[],
     maxReps?: number,
     maxBills?: number,
+    depth: string = SyncDepth.STATE,
+    scopedRegionId?: string,
   ): Promise<SyncResult[]> {
     const limits = [
       maxReps != null ? `maxReps=${maxReps}` : null,
       maxBills != null ? `maxBills=${maxBills}` : null,
+      depth !== SyncDepth.STATE ? `depth=${depth}` : null,
+      scopedRegionId ? `regionId=${scopedRegionId}` : null,
     ].filter(Boolean);
     const limitsStr = limits.length ? ` (${limits.join(', ')})` : '';
     this.logger.log(
@@ -958,41 +966,152 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     );
     const results: SyncResult[] = [];
 
-    for (const registered of this.pluginRegistry.getAll()) {
-      const supported = registered.instance.getSupportedDataTypes();
-      const filtered = dataTypes
-        ? supported.filter((dt) => dataTypes.includes(dt))
-        : supported;
+    // Resolve which plugin instances to run based on depth + optional scope.
+    // STATE (default): only loaded registry plugins (state + federal).
+    // COUNTY: enabled county region_plugin rows fetched from DB on demand.
+    // ALL: STATE plugins first, then COUNTY.
+    const statePlugins =
+      depth === SyncDepth.COUNTY
+        ? []
+        : this.pluginRegistry
+            .getAll()
+            .filter((p) => !scopedRegionId || p.name === scopedRegionId);
 
-      for (const dataType of filtered) {
-        try {
-          const result = await this.syncDataTypeFrom(
-            registered.instance,
-            registered.name,
-            dataType,
-            maxReps,
-            maxBills,
-          );
-          results.push(result);
-        } catch (error) {
-          this.logger.error(
-            `Failed to sync ${dataType} from ${registered.name}:`,
-            error,
-          );
-          results.push({
-            dataType,
-            itemsProcessed: 0,
-            itemsCreated: 0,
-            itemsUpdated: 0,
-            itemsSkipped: 0,
-            errors: [(error as Error).message],
-            syncedAt: new Date(),
-          });
-        }
-      }
+    for (const registered of statePlugins) {
+      results.push(
+        ...(await this.runPluginSync(
+          registered.instance,
+          registered.name,
+          dataTypes,
+          maxReps,
+          maxBills,
+        )),
+      );
     }
 
-    this.logger.log(`Sync complete. Processed ${results.length} data types.`);
+    if (depth === SyncDepth.COUNTY || depth === SyncDepth.ALL) {
+      results.push(
+        ...(await this.syncCountyPlugins(
+          dataTypes,
+          maxReps,
+          maxBills,
+          scopedRegionId,
+        )),
+      );
+    }
+
+    this.logger.log(`Sync complete. Processed ${results.length} data type(s).`);
+    return results;
+  }
+
+  private async runPluginSync(
+    instance: IRegionPlugin,
+    name: string,
+    dataTypes?: string[],
+    maxReps?: number,
+    maxBills?: number,
+  ): Promise<SyncResult[]> {
+    const supported = instance.getSupportedDataTypes();
+    const filtered = dataTypes
+      ? supported.filter((dt) => dataTypes.includes(dt))
+      : supported;
+    const results: SyncResult[] = [];
+    for (const dataType of filtered) {
+      try {
+        const result = await this.syncDataTypeFrom(
+          instance,
+          name,
+          dataType,
+          maxReps,
+          maxBills,
+          name,
+        );
+        results.push(result);
+      } catch (error) {
+        this.logger.error(`Failed to sync ${dataType} from ${name}:`, error);
+        results.push({
+          regionId: name,
+          dataType,
+          itemsProcessed: 0,
+          itemsCreated: 0,
+          itemsUpdated: 0,
+          itemsSkipped: 0,
+          errors: [(error as Error).message],
+          syncedAt: new Date(),
+        });
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Fetch enabled county (sub-region) plugins from region_plugins, instantiate
+   * each as a DeclarativePlugin on-demand, and run the requested data types.
+   */
+  private async syncCountyPlugins(
+    dataTypes?: string[],
+    maxReps?: number,
+    maxBills?: number,
+    scopedRegionId?: string,
+  ): Promise<SyncResult[]> {
+    const where = scopedRegionId
+      ? { name: scopedRegionId, parentRegionId: { not: null }, enabled: true }
+      : { parentRegionId: { not: null }, enabled: true };
+
+    const countyRows = await this.db.regionPlugin.findMany({
+      where,
+      select: { name: true, config: true },
+      orderBy: { name: 'asc' },
+    });
+
+    if (countyRows.length === 0) {
+      this.logger.debug('No enabled county plugins found for sync');
+      return [];
+    }
+
+    this.logger.log(`Syncing ${countyRows.length} county plugin(s)…`);
+    const results: SyncResult[] = [];
+
+    for (const row of countyRows) {
+      if (!row.config) continue;
+      try {
+        // Instantiate transiently — don't register in the shared registry,
+        // since county plugins are loaded on-demand for sync only.
+        if (!this.pipeline) {
+          throw new Error(
+            'ScrapingPipelineService unavailable — county sync requires a pipeline',
+          );
+        }
+        const plugin = new DeclarativeRegionPlugin(
+          row.config as unknown as DeclarativeRegionConfig,
+          this.pipeline,
+        );
+        results.push(
+          ...(await this.runPluginSync(
+            plugin,
+            row.name,
+            dataTypes,
+            maxReps,
+            maxBills,
+          )),
+        );
+      } catch (error) {
+        this.logger.error(
+          `Failed to instantiate county plugin ${row.name}:`,
+          error,
+        );
+        results.push({
+          regionId: row.name,
+          dataType: DataType.REPRESENTATIVES,
+          itemsProcessed: 0,
+          itemsCreated: 0,
+          itemsUpdated: 0,
+          itemsSkipped: 0,
+          errors: [(error as Error).message],
+          syncedAt: new Date(),
+        });
+      }
+    }
     return results;
   }
 
@@ -1017,6 +1136,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     dataType: DataType,
     maxReps?: number,
     maxBills?: number,
+    regionId?: string,
   ): Promise<SyncResult> {
     this.logger.log(`Syncing ${dataType} from ${pluginName}`);
     const startTime = Date.now();
@@ -1035,7 +1155,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       [DataType.PROPOSITIONS]: () => this.syncPropositions(provider),
       [DataType.MEETINGS]: () => this.syncMeetings(provider),
       [DataType.REPRESENTATIVES]: () =>
-        this.syncRepresentatives(provider, maxReps),
+        this.syncRepresentatives(provider, maxReps, regionId),
       [DataType.CAMPAIGN_FINANCE]: () => this.syncCampaignFinance(provider),
       [DataType.CIVICS]: () => this.syncCivics(),
       [DataType.BILLS]: () => this.syncBills(maxBills),
@@ -1045,6 +1165,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     if (!handler) {
       this.logger.warn(`No sync handler for data type: ${dataType}`);
       return {
+        regionId: pluginName,
         dataType,
         itemsProcessed: 0,
         itemsCreated: 0,
@@ -1063,6 +1184,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     );
 
     return {
+      regionId: pluginName,
       dataType,
       itemsProcessed: processed,
       itemsCreated: created,
@@ -1420,9 +1542,18 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  private applyChamberFallback(r: Representative, provider: DataFetcher): void {
+    if (r.chamber || !(provider instanceof DeclarativeRegionPlugin)) return;
+    const source = provider
+      .getDataSources('REPRESENTATIVES' as DataType)
+      .find((s) => s.category);
+    if (source?.category) r.chamber = source.category;
+  }
+
   private async syncRepresentatives(
     provider: DataFetcher = this.regionService,
     maxReps?: number,
+    regionId?: string,
   ): Promise<{
     processed: number;
     created: number;
@@ -1435,6 +1566,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
 
     for (const r of reps) {
       this.normalizeRep(r);
+      this.applyChamberFallback(r, provider);
     }
 
     // Enrich with AI-generated bios where missing (scraped bios are preserved)
@@ -1468,6 +1600,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
           // scrape stops returning a bio field. Convert null→undefined
           // for every optional enrichment field.
           update: {
+            regionId: regionId ?? rep.regionId ?? 'california',
             name: rep.name,
             lastName,
             chamber: rep.chamber,
@@ -1483,6 +1616,7 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
           },
           create: {
             externalId: rep.externalId,
+            regionId: regionId ?? rep.regionId ?? 'california',
             name: rep.name,
             lastName,
             chamber: rep.chamber,
@@ -3433,6 +3567,24 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Return all Board of Supervisors for a county region.
+   * v1: returns all supervisors — specific district matching requires
+   * county-published shapefiles (follow-up to issue #22).
+   */
+  async getRepresentativesByCounty(
+    countyRegionId: string,
+  ): Promise<RepresentativeRecord[]> {
+    return this.db.representative.findMany({
+      where: {
+        regionId: countyRegionId,
+        chamber: 'Board of Supervisors',
+        deletedAt: null,
+      },
+      orderBy: [{ district: 'asc' }, { lastName: 'asc' }],
+    });
+  }
+
+  /**
    * Extract and zero-pad a district number from Census format.
    * "Congressional District 2" → "02"
    * "State Senate District 12" → "12"
@@ -4116,6 +4268,37 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
+   * Return Board of Supervisors for the user's primary address county.
+   * Resolves: user → primary address county jurisdiction → fipsCode →
+   * county region plugin → supervisors. Returns [] when no county
+   * jurisdiction is resolved or no county plugin is enabled.
+   */
+  async getMyCountySupervisors(
+    userId: string,
+  ): Promise<RepresentativeRecord[]> {
+    const countyJurisdiction = await this.db.userJurisdiction.findFirst({
+      where: {
+        userId,
+        userAddress: { isPrimary: true },
+        jurisdiction: { type: 'COUNTY' },
+      },
+      include: { jurisdiction: { select: { fipsCode: true } } },
+    });
+
+    const fipsCode = countyJurisdiction?.jurisdiction?.fipsCode;
+    if (!fipsCode) return [];
+
+    const plugin = await this.db.regionPlugin.findUnique({
+      where: { fipsCode },
+      select: { name: true, enabled: true },
+    });
+
+    if (!plugin?.enabled) return [];
+
+    return this.getRepresentativesByCounty(plugin.name);
+  }
+
+  /**
    * Discover JSON config files from packages/region-provider/regions/
    * and upsert them into the region_plugins table.
    *
@@ -4187,6 +4370,41 @@ export class RegionDomainService implements OnModuleInit, OnModuleDestroy {
       orderBy: [{ parentRegionId: 'asc' }, { name: 'asc' }],
     });
     return rows.map(toRegionPluginRow);
+  }
+
+  async invalidateManifest(
+    regionId: string,
+    sourceUrl: string,
+  ): Promise<number> {
+    if (!this.pipeline) {
+      throw new Error(
+        'ScrapingPipelineService unavailable — cannot invalidate manifest',
+      );
+    }
+    return this.pipeline.invalidateManifest(regionId, sourceUrl);
+  }
+
+  async setRegionPluginEnabled(
+    name: string,
+    enabled: boolean,
+  ): Promise<RegionPluginRow> {
+    const row = await this.db.regionPlugin.update({
+      where: { name },
+      data: { enabled },
+      select: {
+        name: true,
+        displayName: true,
+        description: true,
+        version: true,
+        enabled: true,
+        parentRegionId: true,
+        fipsCode: true,
+      },
+    });
+    this.logger.log(
+      `Region plugin "${name}" ${enabled ? 'enabled' : 'disabled'}`,
+    );
+    return toRegionPluginRow(row);
   }
 
   async getRegionPluginByFipsCode(

--- a/apps/frontend/app/settings/page.tsx
+++ b/apps/frontend/app/settings/page.tsx
@@ -26,6 +26,8 @@ import {
   MY_JURISDICTIONS,
   MyJurisdictionsData,
   JurisdictionLevel,
+  MY_COUNTY_SUPERVISORS,
+  MyCountySupervisorsData,
 } from "@/lib/graphql/region";
 import { AvatarUpload } from "@/components/profile/AvatarUpload";
 import { ProfileVisibilityToggle } from "@/components/profile/ProfileVisibilityToggle";
@@ -401,6 +403,10 @@ export default function ProfileSettingsPage() {
     MY_JURISDICTIONS,
     { fetchPolicy: "network-only" },
   );
+  const { data: supervisorsData } = useQuery<MyCountySupervisorsData>(
+    MY_COUNTY_SUPERVISORS,
+    { fetchPolicy: "network-only" },
+  );
 
   const handleSave = useCallback(() => {
     refetchProfile();
@@ -462,6 +468,13 @@ export default function ProfileSettingsPage() {
       <JurisdictionsSection
         jurisdictions={jurisdictionsData?.myJurisdictions ?? null}
         loaded={jurisdictionsData !== undefined}
+        t={t}
+      />
+
+      {/* County Board of Supervisors */}
+      <CountySupervisorsSection
+        supervisors={supervisorsData?.myCountySupervisors ?? null}
+        loaded={supervisorsData !== undefined}
         t={t}
       />
 
@@ -585,6 +598,55 @@ function JurisdictionsSection({
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CountySupervisorsSection
+// ---------------------------------------------------------------------------
+
+function CountySupervisorsSection({
+  supervisors,
+  loaded,
+  t,
+}: {
+  supervisors: MyCountySupervisorsData["myCountySupervisors"] | null;
+  loaded: boolean;
+  t: ReturnType<typeof useTranslation>["t"];
+}) {
+  if (!loaded) return null;
+  if (!supervisors || supervisors.length === 0) return null;
+
+  return (
+    <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6">
+      <h2 className="text-lg font-semibold text-[#222222] mb-1">
+        {t("profile.countySupervisors.title")}
+      </h2>
+      <p className="text-sm text-[#4d4d4d] mb-4">
+        {t("profile.countySupervisors.subtitle")}
+      </p>
+      <ul className="divide-y divide-gray-100 -mx-6 border-t border-gray-100">
+        {supervisors.map((rep) => (
+          <li key={rep.id} className="px-6 py-3 flex items-center gap-3">
+            {rep.photoUrl && (
+              <img
+                src={rep.photoUrl}
+                alt={rep.name}
+                className="w-8 h-8 rounded-full object-cover shrink-0"
+              />
+            )}
+            <div>
+              <p className="text-sm font-medium text-[#222222]">{rep.name}</p>
+              <p className="text-xs text-[#6b7280]">
+                {t("profile.countySupervisors.district", {
+                  district: rep.district,
+                })}
+              </p>
+            </div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/apps/frontend/components/region/PartyBadge.tsx
+++ b/apps/frontend/components/region/PartyBadge.tsx
@@ -11,9 +11,10 @@ export function PartyBadge({
   party,
   size = "sm",
 }: {
-  readonly party: string;
+  readonly party?: string;
   readonly size?: "sm" | "md";
 }) {
+  if (!party) return null;
   const colors = PARTY_COLORS[party] || {
     bg: "bg-gray-100",
     text: "text-gray-800",

--- a/apps/frontend/e2e/settings.spec.ts
+++ b/apps/frontend/e2e/settings.spec.ts
@@ -217,6 +217,12 @@ async function mockSettingsGraphQL(page: import("@playwright/test").Page) {
         contentType: "application/json",
         body: JSON.stringify({ data: { myJurisdictions: [] } }),
       });
+    } else if (postData?.query?.includes("myCountySupervisors")) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: { myCountySupervisors: [] } }),
+      });
     } else if (postData?.query?.includes("myNotificationSettings")) {
       await route.fulfill({
         status: 200,

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -182,7 +182,7 @@ export interface Representative {
   name: string;
   chamber: string;
   district: string;
-  party: string;
+  party?: string;
   photoUrl?: string;
   contactInfo?: ContactInfo;
   committees?: CommitteeAssignment[];
@@ -272,7 +272,7 @@ export interface LegislativeCommitteeMember {
   representativeId: string;
   name: string;
   role?: string;
-  party: string;
+  party?: string;
   photoUrl?: string;
 }
 
@@ -962,11 +962,13 @@ export const GET_REPRESENTATIVES_BY_DISTRICTS = gql`
     $congressionalDistrict: String
     $stateSenatorialDistrict: String
     $stateAssemblyDistrict: String
+    $countyRegionId: String
   ) {
     representativesByDistricts(
       congressionalDistrict: $congressionalDistrict
       stateSenatorialDistrict: $stateSenatorialDistrict
       stateAssemblyDistrict: $stateAssemblyDistrict
+      countyRegionId: $countyRegionId
     ) {
       id
       name
@@ -980,6 +982,40 @@ export const GET_REPRESENTATIVES_BY_DISTRICTS = gql`
 
 export interface RepresentativesByDistrictsData {
   representativesByDistricts: Representative[];
+}
+
+export const GET_COUNTY_REPRESENTATIVES = gql`
+  query GetCountyRepresentatives($countyRegionId: String!) {
+    countyRepresentatives(countyRegionId: $countyRegionId) {
+      id
+      name
+      chamber
+      district
+      party
+      photoUrl
+    }
+  }
+`;
+
+export interface CountyRepresentativesData {
+  countyRepresentatives: Representative[];
+}
+
+export const MY_COUNTY_SUPERVISORS = gql`
+  query MyCountySupervisors {
+    myCountySupervisors {
+      id
+      name
+      chamber
+      district
+      party
+      photoUrl
+    }
+  }
+`;
+
+export interface MyCountySupervisorsData {
+  myCountySupervisors: Representative[];
 }
 
 // ============================================

--- a/apps/frontend/locales/en/settings.json
+++ b/apps/frontend/locales/en/settings.json
@@ -170,6 +170,11 @@
         "MUNICIPAL": "Municipal",
         "DISTRICT": "Special Districts"
       }
+    },
+    "countySupervisors": {
+      "title": "County Board of Supervisors",
+      "subtitle": "Your elected county supervisors based on your primary address.",
+      "district": "District {{district}}"
     }
   },
   "timezones": {

--- a/apps/frontend/locales/es/settings.json
+++ b/apps/frontend/locales/es/settings.json
@@ -170,6 +170,11 @@
         "MUNICIPAL": "Municipal",
         "DISTRICT": "Distritos Especiales"
       }
+    },
+    "countySupervisors": {
+      "title": "Junta de Supervisores del Condado",
+      "subtitle": "Sus supervisores del condado elegidos según su dirección principal.",
+      "district": "Distrito {{district}}"
     }
   },
   "timezones": {

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -207,6 +207,8 @@ export interface BioClaim {
  */
 export interface Representative {
   externalId: string;
+  /** regionId of the plugin that produced this rep (e.g. "california", "california-sonoma"). */
+  regionId?: string;
   name: string;
   chamber: string;
   district: string;
@@ -565,7 +567,17 @@ export interface CampaignFinanceResult {
 /**
  * Sync result metadata
  */
+export enum SyncDepth {
+  /** Sync the top-level region plugin only (default — backward-compatible). */
+  STATE = "STATE",
+  /** Sync all enabled sub-region plugins (counties, districts). */
+  COUNTY = "COUNTY",
+  /** Sync STATE + COUNTY in one pass. */
+  ALL = "ALL",
+}
+
 export interface SyncResult {
+  regionId: string;
   dataType: DataType;
   itemsProcessed: number;
   itemsCreated: number;

--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -296,6 +296,20 @@ export interface DataSourceConfig {
   detailFields?: Record<string, string | StructuredFieldConfig>;
 
   /**
+   * Explicit extraction rules that bypass AI structural analysis entirely.
+   * When provided, the pipeline uses these selectors directly — no LLM call,
+   * no manifest generation, no self-heal loop.
+   *
+   * Use this when the page structure is known and stable, or when the local
+   * LLM consistently generates wrong selectors for a specific site.
+   */
+  staticManifest?: {
+    containerSelector: string;
+    itemSelector: string;
+    fieldMappings: FieldMapping[];
+  };
+
+  /**
    * Crawl depth from the seed `url`, used by sync handlers that walk a
    * site's link graph (currently civics — see issue #669).
    *

--- a/packages/region-provider/__tests__/declarative-region-plugin.spec.ts
+++ b/packages/region-provider/__tests__/declarative-region-plugin.spec.ts
@@ -83,6 +83,7 @@ const createCampaignFinanceConfig = (): DeclarativeRegionConfig =>
 
 const createMockPipeline = (): jest.Mocked<IPipelineService> => ({
   execute: jest.fn(),
+  invalidateManifest: jest.fn().mockResolvedValue(0),
 });
 
 const createExtractionResult = <T>(items: T[]): ExtractionResult<T> => ({

--- a/packages/region-provider/__tests__/plugin-loader.service.spec.ts
+++ b/packages/region-provider/__tests__/plugin-loader.service.spec.ts
@@ -56,6 +56,7 @@ describe("PluginLoaderService", () => {
         errors: [],
         extractionTimeMs: 0,
       }),
+      invalidateManifest: jest.fn().mockResolvedValue(0),
     };
   });
 

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.48"
+    "@opuspopuli/regions": "^1.0.57"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.47"
+    "@opuspopuli/regions": "^1.0.48"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/src/declarative/declarative-region-plugin.ts
+++ b/packages/region-provider/src/declarative/declarative-region-plugin.ts
@@ -35,6 +35,7 @@ export interface IPipelineService {
     regionId: string,
     onBatch?: (items: T[]) => Promise<void>,
   ): Promise<ExtractionResult<T>>;
+  invalidateManifest(regionId: string, sourceUrl: string): Promise<number>;
 }
 
 export class DeclarativeRegionPlugin extends BaseRegionPlugin {

--- a/packages/region-provider/src/index.ts
+++ b/packages/region-provider/src/index.ts
@@ -26,6 +26,7 @@ export {
   Representative,
   ContactInfo,
   SyncResult,
+  SyncDepth,
   RegionError,
 } from "@opuspopuli/common";
 

--- a/packages/region-provider/src/region.service.ts
+++ b/packages/region-provider/src/region.service.ts
@@ -137,6 +137,7 @@ export class RegionService {
       } catch (error) {
         this.logger.error(`Failed to sync ${dataType}:`, error);
         results.push({
+          regionId: this.provider.getName(),
           dataType,
           itemsProcessed: 0,
           itemsCreated: 0,
@@ -186,6 +187,7 @@ export class RegionService {
     // Note: itemsCreated and itemsUpdated would be set by the microservice
     // after comparing with database records
     return {
+      regionId: this.provider.getName(),
       dataType,
       itemsProcessed,
       itemsCreated: 0,

--- a/packages/relationaldb-provider/prisma/migrations/20260516000000_representative_region_id/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260516000000_representative_region_id/migration.sql
@@ -1,0 +1,13 @@
+-- Representative regionId (#22)
+-- Scopes each representative to a region plugin so state reps (california),
+-- county supervisors (california-sonoma), and federal reps can coexist.
+
+ALTER TABLE "representatives"
+  ADD COLUMN "region_id" VARCHAR(100) NOT NULL DEFAULT 'california';
+
+CREATE INDEX "representatives_region_id_idx"
+  ON "representatives" ("region_id");
+
+-- Backfill: existing state reps are already California Assembly/Senate.
+-- Federal reps (issue #591) will set their own regionId on insert.
+-- No data loss — default covers all pre-existing rows.

--- a/packages/relationaldb-provider/prisma/migrations/20260516010000_representative_party_nullable/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260516010000_representative_party_nullable/migration.sql
@@ -1,0 +1,2 @@
+-- Make party nullable on representatives — Board of Supervisors members are nonpartisan
+ALTER TABLE "representatives" ALTER COLUMN "party" DROP NOT NULL;

--- a/packages/relationaldb-provider/prisma/migrations/20260516020000_representative_region_chamber_index/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260516020000_representative_region_chamber_index/migration.sql
@@ -1,0 +1,2 @@
+-- Compound index for county supervisor queries — filters by (regionId, chamber) together
+CREATE INDEX "representatives_region_id_chamber_idx" ON "representatives" ("region_id", "chamber");

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -569,11 +569,12 @@ model AbuseReport {
 model Representative {
   id          String    @id @default(uuid())
   externalId  String    @unique @map("external_id")
+  regionId    String    @default("california") @map("region_id") @db.VarChar(100) /// e.g. "california", "california-sonoma", "federal"
   name        String
   lastName    String    @default("") @map("last_name") /// derived from `name`, used for alphabetical sorting
   chamber     String
   district    String
-  party       String
+  party       String?
   photoUrl    String?   @map("photo_url")
   contactInfo Json?     @map("contact_info")
   committees  Json?     @map("committees")       /// CommitteeAssignment[] as JSON — canonical source for the LegislativeCommittee backfill
@@ -604,6 +605,8 @@ model Representative {
   @@index([lastName])
   @@index([chamber])
   @@index([party])
+  @@index([regionId])
+  @@index([regionId, chamber])
   @@map("representatives")
 }
 

--- a/packages/scraping-pipeline/__tests__/structural-analyzer.spec.ts
+++ b/packages/scraping-pipeline/__tests__/structural-analyzer.spec.ts
@@ -199,7 +199,7 @@ describe("StructuralAnalyzerService", () => {
       ).rejects.toThrow("containerSelector");
     });
 
-    it("should throw when itemSelector is missing", async () => {
+    it("should fall back to containerSelector when itemSelector is missing", async () => {
       const badJson = JSON.stringify({
         containerSelector: ".list",
         fieldMappings: [
@@ -212,9 +212,8 @@ describe("StructuralAnalyzerService", () => {
         mockPromptClient as unknown as PromptClientService,
       );
 
-      await expect(
-        analyzer.analyze(SIMPLE_HTML, createSource()),
-      ).rejects.toThrow("itemSelector");
+      const result = await analyzer.analyze(SIMPLE_HTML, createSource());
+      expect(result.extractionRules.itemSelector).toBe(".list");
     });
 
     it("should throw when fieldMappings is empty", async () => {

--- a/packages/scraping-pipeline/src/analysis/structural-analyzer.service.ts
+++ b/packages/scraping-pipeline/src/analysis/structural-analyzer.service.ts
@@ -237,7 +237,10 @@ export class StructuralAnalyzerService {
       throw new Error("LLM output missing required field: containerSelector");
     }
     if (!rules.itemSelector || typeof rules.itemSelector !== "string") {
-      throw new Error("LLM output missing required field: itemSelector");
+      // Single-record pages: LLM often omits itemSelector when there's no
+      // repeating container. Fall back to containerSelector — the extractor
+      // treats this as "the container itself is the one item".
+      rules.itemSelector = rules.containerSelector;
     }
     if (
       !Array.isArray(rules.fieldMappings) ||

--- a/packages/scraping-pipeline/src/extraction/manifest-extractor.service.ts
+++ b/packages/scraping-pipeline/src/extraction/manifest-extractor.service.ts
@@ -76,7 +76,16 @@ export class ManifestExtractorService {
 
     // Find items within the container
     const firstContainer = container.first() as Cheerio<Element>;
-    const itemElements = firstContainer.find(rules.itemSelector);
+    let itemElements = firstContainer.find(rules.itemSelector);
+
+    // Single-record fallback: when itemSelector === containerSelector the LLM
+    // signaled that the container itself is the one item (detail page).
+    if (
+      itemElements.length === 0 &&
+      rules.itemSelector === rules.containerSelector
+    ) {
+      itemElements = firstContainer;
+    }
 
     if (itemElements.length === 0) {
       this.logger.warn(

--- a/packages/scraping-pipeline/src/manifest/manifest-store.service.ts
+++ b/packages/scraping-pipeline/src/manifest/manifest-store.service.ts
@@ -225,6 +225,30 @@ export class ManifestStoreService {
   }
 
   /**
+   * Deactivate all active manifests for a source so the next sync triggers
+   * a fresh structural analysis. Returns the number of records deactivated.
+   */
+  async invalidate(
+    regionId: string,
+    sourceUrl: string,
+    dataType?: DataType,
+  ): Promise<number> {
+    const where = dataType
+      ? { regionId, sourceUrl, dataType: dataType as string, isActive: true }
+      : { regionId, sourceUrl, isActive: true };
+
+    const result = await this.repository.updateMany({
+      where,
+      data: { isActive: false },
+    });
+
+    this.logger.log(
+      `Invalidated ${result.count} manifest(s) for ${regionId}/${sourceUrl}`,
+    );
+    return result.count;
+  }
+
+  /**
    * Update the lastCheckedAt timestamp for a manifest.
    */
   async markChecked(manifestId: string): Promise<void> {

--- a/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
+++ b/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
@@ -59,6 +59,13 @@ export class ScrapingPipelineService {
    * @param regionId - The region this source belongs to
    * @returns Typed extraction result with items and diagnostics
    */
+  async invalidateManifest(
+    regionId: string,
+    sourceUrl: string,
+  ): Promise<number> {
+    return this.manifestStore.invalidate(regionId, sourceUrl);
+  }
+
   async execute<T>(
     source: DataSourceConfig,
     regionId: string,
@@ -97,6 +104,49 @@ export class ScrapingPipelineService {
   }
 
   /**
+   * Execute extraction using caller-supplied selectors, bypassing AI analysis.
+   * No LLM call, no manifest store, no self-heal loop.
+   */
+  private executeStaticManifest<T>(
+    source: DataSourceConfig,
+    regionId: string,
+    html: string,
+    pipelineStart: number,
+  ): ExtractionResult<T> {
+    const sm = source.staticManifest!;
+    const syntheticManifest = {
+      id: `static-${regionId}-${source.dataType}`,
+      regionId,
+      sourceUrl: source.url,
+      dataType: source.dataType,
+      version: 0,
+      structureHash: "static",
+      promptHash: "static",
+      extractionRules: {
+        containerSelector: sm.containerSelector,
+        itemSelector: sm.itemSelector,
+        fieldMappings: sm.fieldMappings,
+      },
+      isActive: true,
+      successCount: 0,
+      failureCount: 0,
+      createdAt: new Date(),
+      lastCheckedAt: new Date(),
+    };
+
+    const rawResult = this.extractor.extract(
+      html,
+      syntheticManifest as never,
+      source.url,
+    );
+    const duration = Date.now() - pipelineStart;
+    this.logger.log(
+      `Pipeline complete [static]: ${rawResult.items.length} items extracted in ${duration}ms`,
+    );
+    return rawResult as unknown as ExtractionResult<T>;
+  }
+
+  /**
    * Execute the HTML scraping pipeline (original behavior).
    * AI structural analysis → Cheerio extraction → domain mapping.
    */
@@ -114,6 +164,17 @@ export class ScrapingPipelineService {
     const html = fetchResult.content;
 
     // Stage 1+2: Get or derive manifest
+    // When a staticManifest is provided in the source config, bypass AI analysis
+    // entirely — no LLM call, no manifest persistence, no self-heal loop.
+    if (source.staticManifest) {
+      return this.executeStaticManifest<T>(
+        source,
+        regionId,
+        html,
+        pipelineStart,
+      );
+    }
+
     const analysisResult = await this.getOrDeriveManifest(
       source,
       regionId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -934,8 +934,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.47
-        version: 1.0.47
+        specifier: ^1.0.48
+        version: 1.0.48
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4916,8 +4916,8 @@ packages:
   '@opuspopuli/regions@1.0.40':
     resolution: {integrity: sha512-7GOkXlK1thxRQnC+m94hstbwi53BLTH6Kx6/bSUuNadw+14R5XWCoVqXK+1fMXZoDu/L02lkt0P1LyjHMWAGFQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.40/e58414ccdd2f51004709720475e3a6cc08d62294}
 
-  '@opuspopuli/regions@1.0.47':
-    resolution: {integrity: sha512-e7Pjy0MwWkIe0GPZgcKaFMNJ2JWiMyKRG/kfyBLKmlrEHoPVAonEPNBXOO7/mSnb36zsIVJhuJHV19R2uLo9VA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.47/b4736f296c29d305a1fc742c6a307f67036d6164}
+  '@opuspopuli/regions@1.0.48':
+    resolution: {integrity: sha512-GCxYAfPGf1XXKZl/cQVoaapIlDn9u32nYielgddK0ymPOdVZ3TK4k/81HKBgW7tnz/J1UP0cRYtTQ7Wu4CpRYg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.48/c80f30299df5bc31937dcbbad67bf88dfab014dc}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -16795,7 +16795,7 @@ snapshots:
 
   '@opuspopuli/regions@1.0.40': {}
 
-  '@opuspopuli/regions@1.0.47': {}
+  '@opuspopuli/regions@1.0.48': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,8 +173,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.40
-        version: 1.0.40
+        specifier: ^1.0.57
+        version: 1.0.57
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -515,13 +515,13 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.1.5
-        version: 16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.0.1
         version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+        version: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-prettier:
         specifier: ^5.2.1
         version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.1)
@@ -533,7 +533,7 @@ importers:
         version: 16.5.0
       jest:
         specifier: ^30.2.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-axe:
         specifier: ^10.0.0
         version: 10.0.0
@@ -551,7 +551,7 @@ importers:
         version: 4.2.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -594,7 +594,7 @@ importers:
         version: 7.0.11
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -603,7 +603,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -628,10 +628,10 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -674,7 +674,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -683,7 +683,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -714,7 +714,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -723,7 +723,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -766,7 +766,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -775,7 +775,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -800,7 +800,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -809,7 +809,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -837,10 +837,10 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -871,7 +871,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -880,7 +880,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -908,10 +908,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -920,7 +920,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -934,8 +934,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.48
-        version: 1.0.48
+        specifier: ^1.0.57
+        version: 1.0.57
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -948,7 +948,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -957,7 +957,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -985,10 +985,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       prisma:
         specifier: '5'
         version: 5.22.0
@@ -1000,7 +1000,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1058,7 +1058,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       mupdf:
         specifier: ^1.27.0
         version: 1.27.0
@@ -1070,7 +1070,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1101,7 +1101,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1110,7 +1110,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1147,7 +1147,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1156,7 +1156,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1184,13 +1184,13 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -4913,11 +4913,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.40':
-    resolution: {integrity: sha512-7GOkXlK1thxRQnC+m94hstbwi53BLTH6Kx6/bSUuNadw+14R5XWCoVqXK+1fMXZoDu/L02lkt0P1LyjHMWAGFQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.40/e58414ccdd2f51004709720475e3a6cc08d62294}
-
-  '@opuspopuli/regions@1.0.48':
-    resolution: {integrity: sha512-GCxYAfPGf1XXKZl/cQVoaapIlDn9u32nYielgddK0ymPOdVZ3TK4k/81HKBgW7tnz/J1UP0cRYtTQ7Wu4CpRYg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.48/c80f30299df5bc31937dcbbad67bf88dfab014dc}
+  '@opuspopuli/regions@1.0.57':
+    resolution: {integrity: sha512-G6xcw08mW9YeiGASO6WNKb8/fl1E8ipEJD7DtdDA/+mPfV8H+VwWhTqynepPNnoWFcDgO+M6Lr1hyaNPlPwvxg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.57/400734ddc5ef10311cfd540f92320a196e44fa6a}
 
   '@paralleldrive/cuid2@2.3.1':
     resolution: {integrity: sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==}
@@ -14920,41 +14917,6 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 25.5.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.3.0
@@ -14971,41 +14933,6 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
       jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 25.5.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -16793,9 +16720,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.40': {}
-
-  '@opuspopuli/regions@1.0.48': {}
+  '@opuspopuli/regions@1.0.57': {}
 
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
@@ -20056,13 +19981,13 @@ snapshots:
       source-map: 0.6.1
     optional: true
 
-  eslint-config-next@16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  eslint-config-next@16.2.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.1
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.7.0))
@@ -20088,7 +20013,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -20099,22 +20024,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -20125,7 +20049,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -20136,8 +20060,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -21478,15 +21400,34 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@22.19.15):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.15)
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.3.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -21516,26 +21457,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest-config@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@22.19.15):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -21562,39 +21484,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.15
-      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.5.0
-      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21627,70 +21516,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.5.0
       ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.5.0
-      ts-node: 10.9.2(@types/node@25.8.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.8.0
-      ts-node: 10.9.2(@types/node@25.8.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21822,10 +21647,10 @@ snapshots:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
-  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3):
+  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3):
     dependencies:
       '@jest/globals': 30.3.0
-      jest: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      jest: 30.3.0
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -21997,12 +21822,38 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest@30.3.0:
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@25.5.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@22.19.15):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22016,19 +21867,6 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -24776,12 +24614,12 @@ snapshots:
 
   ts-graphviz@1.8.2: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@22.19.15)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24816,12 +24654,32 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@25.5.0)
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.3
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      jest-util: 30.3.0
+
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.9
+      jest: 30.3.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24864,25 +24722,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.15
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
   ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -24900,25 +24739,6 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.8.0
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-tqdm@0.8.6: {}
 

--- a/postman/OpusPopuli.postman_collection.json
+++ b/postman/OpusPopuli.postman_collection.json
@@ -90,7 +90,9 @@
         {
           "name": "API Gateway - Health",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "GET",
             "header": [],
             "url": {
@@ -141,9 +143,16 @@
             }
           ],
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "GET",
-            "header": [{ "key": "apollo-require-preflight", "value": "true" }],
+            "header": [
+              {
+                "key": "apollo-require-preflight",
+                "value": "true"
+              }
+            ],
             "url": {
               "raw": "{{gateway_url}}/api",
               "host": ["{{gateway_url}}"],
@@ -189,11 +198,19 @@
             }
           ],
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
             "header": [
-              { "key": "Content-Type", "value": "application/json" },
-              { "key": "apikey", "value": "{{supabase_anon_key}}" }
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "apikey",
+                "value": "{{supabase_anon_key}}"
+              }
             ],
             "body": {
               "mode": "raw",
@@ -203,16 +220,28 @@
               "raw": "{{supabase_url}}/auth/v1/token?grant_type=password",
               "host": ["{{supabase_url}}"],
               "path": ["auth", "v1", "token"],
-              "query": [{ "key": "grant_type", "value": "password" }]
+              "query": [
+                {
+                  "key": "grant_type",
+                  "value": "password"
+                }
+              ]
             }
           }
         },
         {
           "name": "Register User (GraphQL)",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -245,9 +274,16 @@
             }
           ],
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -265,9 +301,16 @@
         {
           "name": "Send Magic Link",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -286,7 +329,12 @@
           "name": "Logout",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -309,7 +357,12 @@
           "name": "Get Users (Admin)",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -326,9 +379,16 @@
         {
           "name": "Find User by Email",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -352,7 +412,12 @@
           "name": "My Profile",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -370,7 +435,12 @@
           "name": "Profile Completion",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -388,7 +458,12 @@
           "name": "My Addresses",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -410,9 +485,16 @@
         {
           "name": "Region Info",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -429,9 +511,16 @@
         {
           "name": "Propositions (Paginated)",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -449,9 +538,16 @@
         {
           "name": "Representatives (Paginated)",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -469,9 +565,16 @@
         {
           "name": "Meetings (Paginated)",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -489,9 +592,16 @@
         {
           "name": "Committees (Campaign Finance)",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -509,9 +619,16 @@
         {
           "name": "Contributions (Campaign Finance)",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -530,12 +647,68 @@
           "name": "Sync Region Data (Admin)",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "mutation SyncRegionData($dataTypes: [DataType!], $maxReps: Int) {\n  syncRegionData(dataTypes: $dataTypes, maxReps: $maxReps) {\n    dataType\n    itemsProcessed\n    itemsCreated\n    itemsUpdated\n    errors\n    syncedAt\n  }\n}",
-                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"maxReps\": 5\n}"
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $depth: SyncDepth, $regionId: String, $maxReps: Int, $maxBills: Int) {\n  syncRegionData(dataTypes: $dataTypes, depth: $depth, regionId: $regionId, maxReps: $maxReps, maxBills: $maxBills) {\n    regionId\n    dataType\n    itemsProcessed\n    itemsCreated\n    itemsUpdated\n    errors\n    syncedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"depth\": \"STATE\",\n  \"maxReps\": 5\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          },
+          "description": "Trigger a data sync. depth: STATE (default, top-level plugin only), COUNTY (all enabled county sub-regions), ALL (state + all counties). Optionally scope to a single regionId (e.g. 'california-sonoma'). maxReps/maxBills cap AI enrichment per run."
+        },
+        {
+          "name": "Sync Region Data \u2014 CIVICS",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation SyncRegionData($dataTypes: [DataType!]) {\n  syncRegionData(dataTypes: $dataTypes) {\n    dataType\n    itemsProcessed\n    itemsCreated\n    itemsUpdated\n    errors\n    syncedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"CIVICS\"]\n}"
+              }
+            },
+            "description": "Triggers a CIVICS data sync against the active region. The pipeline scrapes the URLs declared as `dataType: civics` in the region config (assembly.ca.gov/resources/legislative-process, assembly.ca.gov/resources/glossary, leginfo.ca.gov/califleg.html), calls the private prompt-service to extract a structured CivicsBlock with verbatim source text + plain-language rewrites for laypeople, and persists to the region_civics tables. See OpusPopuli/opuspopuli#669 + OpusPopuli/opuspopuli-regions#15. Until the civics-ingest handler ships, this returns errors[0] = 'No sync handler for data type: civics' \u2014 that's the wired-but-not-implemented signal.",
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
+          "name": "Sync County Reps \u2014 All Counties (Admin)",
+          "description": "Sync Board of Supervisors representatives for all 58 enabled CA county sub-regions.",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $depth: SyncDepth, $maxReps: Int) {\n  syncRegionData(dataTypes: $dataTypes, depth: $depth, maxReps: $maxReps) {\n    regionId\n    dataType\n    itemsProcessed\n    itemsCreated\n    itemsUpdated\n    errors\n    syncedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"depth\": \"COUNTY\",\n  \"maxReps\": 3\n}"
               }
             },
             "url": {
@@ -546,18 +719,123 @@
           }
         },
         {
-          "name": "Sync Region Data — CIVICS",
+          "name": "Sync County Reps \u2014 Single County (Admin)",
+          "description": "Sync Board of Supervisors for one specific county. Set regionId to the county's region plugin name, e.g. 'california-sonoma'.",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "mutation SyncRegionData($dataTypes: [DataType!]) {\n  syncRegionData(dataTypes: $dataTypes) {\n    dataType\n    itemsProcessed\n    itemsCreated\n    itemsUpdated\n    errors\n    syncedAt\n  }\n}",
-                "variables": "{\n  \"dataTypes\": [\"CIVICS\"]\n}"
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $depth: SyncDepth, $regionId: String, $maxReps: Int) {\n  syncRegionData(dataTypes: $dataTypes, depth: $depth, regionId: $regionId, maxReps: $maxReps) {\n    regionId\n    dataType\n    itemsProcessed\n    itemsCreated\n    itemsUpdated\n    errors\n    syncedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"depth\": \"COUNTY\",\n  \"regionId\": \"california-sonoma\"\n}"
               }
             },
-            "description": "Triggers a CIVICS data sync against the active region. The pipeline scrapes the URLs declared as `dataType: civics` in the region config (assembly.ca.gov/resources/legislative-process, assembly.ca.gov/resources/glossary, leginfo.ca.gov/califleg.html), calls the private prompt-service to extract a structured CivicsBlock with verbatim source text + plain-language rewrites for laypeople, and persists to the region_civics tables. See OpusPopuli/opuspopuli#669 + OpusPopuli/opuspopuli-regions#15. Until the civics-ingest handler ships, this returns errors[0] = 'No sync handler for data type: civics' — that's the wired-but-not-implemented signal.",
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
+          "name": "Invalidate Manifest (Admin)",
+          "description": "Deactivate cached structural manifests for a source URL so the next sync triggers fresh AI re-analysis. Use this after fixing a region config's contentGoal or hints.",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation InvalidateManifest($regionId: String!, $sourceUrl: String!) {\n  invalidateManifest(regionId: $regionId, sourceUrl: $sourceUrl)\n}",
+                "variables": "{\n  \"regionId\": \"california-sonoma\",\n  \"sourceUrl\": \"https://sonomacounty.gov/administrative-support-and-fiscal-services/board-of-supervisors\"\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
+          "name": "Enable Region Plugin (Admin)",
+          "description": "Enable or disable a region plugin by name. County plugins are disabled by default and must be enabled before syncing. Set enabled: false to disable.",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation UpdateRegionPlugin($name: String!, $enabled: Boolean!) {\n  updateRegionPlugin(name: $name, enabled: $enabled) {\n    name\n    displayName\n    enabled\n    parentRegionId\n    fipsCode\n  }\n}",
+                "variables": "{\n  \"name\": \"california-sonoma\",\n  \"enabled\": true\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
+          "name": "County Representatives",
+          "description": "Get Board of Supervisors for a specific county by county region plugin name.",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "query CountyRepresentatives($countyRegionId: String!) {\n  countyRepresentatives(countyRegionId: $countyRegionId) {\n    id\n    name\n    title\n    district\n    party\n    phone\n    email\n    photoUrl\n    website\n  }\n}",
+                "variables": "{\n  \"countyRegionId\": \"california-sonoma\"\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
+          "name": "My County Supervisors",
+          "description": "Get Board of Supervisors for the authenticated user's county (resolved from their primary address jurisdiction). Requires auth.",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "query {\n  myCountySupervisors {\n    id\n    name\n    title\n    district\n    party\n    phone\n    email\n    photoUrl\n    website\n  }\n}",
+                "variables": ""
+              }
+            },
             "url": {
               "raw": "{{gateway_url}}/api",
               "host": ["{{gateway_url}}"],
@@ -574,7 +852,12 @@
           "name": "List Files",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -592,7 +875,12 @@
           "name": "Analyze Document",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -610,9 +898,16 @@
         {
           "name": "Petition Map Locations",
           "request": {
-            "auth": { "type": "noauth" },
+            "auth": {
+              "type": "noauth"
+            },
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -635,7 +930,12 @@
           "name": "Search Text",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -654,7 +954,12 @@
           "name": "Answer Query (RAG)",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -678,7 +983,12 @@
           "name": "My Activity Log",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {
@@ -697,7 +1007,12 @@
           "name": "My Sessions",
           "request": {
             "method": "POST",
-            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
               "mode": "graphql",
               "graphql": {


### PR DESCRIPTION
## What changed and why

Adds hierarchical county plugin support so Board of Supervisors data can be synced independently from state representatives. Closes #22.

Tested end-to-end with Sonoma County: all 5 supervisors scraped, AI bios generated, and stored with correct districts and regionId scoping.

### Region service
- `syncCountyPlugins()` — loads enabled county plugins on-demand from `region_plugins` and runs them as transient `DeclarativePlugin` instances
- `syncRegionData(regionId?)` — optional param scopes a sync run to a single county (e.g. `"california-sonoma"`)
- `getRepresentativesByCounty()` and `getMyCountySupervisors()` — resolve supervisors by `regionId`; the latter maps user → primary address FIPS → county plugin
- New GraphQL queries: `countyRepresentatives(countyRegionId)` (public), `myCountySupervisors` (auth), `regionPlugins`, `regionPluginByFipsCode`, `myJurisdictions`, `updateRegionPlugin`

### Schema / migrations
- `representatives.region_id VARCHAR(100) DEFAULT 'california'` — scopes each rep to its region plugin; existing state reps backfill to `'california'` (non-destructive)
- `representatives.party` → nullable — Board of Supervisors are nonpartisan
- Compound index `(region_id, chamber)` for county supervisor queries

### Frontend
- Settings page region section wired to `MY_COUNTY_SUPERVISORS` query
- `Representative.party` and `LegislativeCommitteeMember.party` marked optional to match nullable schema

### Scraping pipeline
- **Static manifest support** — CSS-selector extraction bypasses AI analysis for sources with stable HTML structure (used for Sonoma reps)
- Structural analyzer falls back to `containerSelector` when `itemSelector` is omitted (LLM behaviour on single-record pages)

### @opuspopuli/regions 1.0.56 → 1.0.57
- Fixes Sonoma district 5 href format (`/district5` vs `/district-N`) — regex broadened in [opuspopuli-regions#33](https://github.com/OpusPopuli/opuspopuli-regions/pull/33)

## How to test

```bash
# Rebuild UAT stack
docker compose -f docker-compose-uat.yml up -d --build --force-recreate region
```

In Postman / GraphQL Playground (`http://localhost:3004/graphql`):

```graphql
# 1. Sync Sonoma County representatives
mutation {
  syncRegionData(dataTypes: ["representatives"], regionId: "california-sonoma") {
    dataType
    itemsCreated
    itemsUpdated
    errors
  }
}
# Expected: 5 created, errors: []

# 2. Query results
query {
  countyRepresentatives(countyRegionId: "california-sonoma") {
    name
    district   # 1–5
    party      # null (nonpartisan)
    bio
  }
}

# 3. Re-run sync — verify idempotency
# Expected: itemsCreated: 0, itemsUpdated: 5
```

For an authenticated user with a Sonoma address:
```graphql
query { myCountySupervisors { name district } }
```

## Migrations

Three new migrations run automatically on container start:

| Migration | Change |
|-----------|--------|
| `20260516000000_representative_region_id` | Adds `region_id` column, backfills `'california'` |
| `20260516010000_representative_party_nullable` | Drops `NOT NULL` on `party` |
| `20260516020000_representative_region_chamber_index` | Compound index `(region_id, chamber)` |

> All migrations are non-destructive and safe under concurrent writes. No downtime required.

## Linked issues

Closes #22
Depends on opuspopuli-regions#33 (merged, published as 1.0.57)

Also in this branch: #20 (region hierarchy), #690 (jurisdiction resolution)

## Checklist

- [x] Tests passing (85 backend suites, 1232 frontend, 321 pipeline)
- [x] Lint clean (0 errors)
- [x] SonarJS cognitive complexity ≤ 15
- [x] jscpd duplicate gate passing
- [x] No new dependencies / no GPL conflicts
- [x] Gateway not touched — additive queries only, federation compatible
- [x] Migrations reviewed: non-destructive, backfill defaults set

🤖 Generated with [Claude Code](https://claude.com/claude-code)