### PR TITLE
feat(knowledge): parse structured JSON from RAG prompt response (#45)

### DIFF
--- a/apps/backend/src/apps/knowledge/src/domains/knowledge.resolver.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/knowledge.resolver.ts
@@ -13,6 +13,7 @@ import { AuthGuard } from 'src/common/guards/auth.guard';
 import { Permissions } from 'src/common/decorators/permissions.decorator';
 import { Action } from 'src/common/enums/action.enum';
 import { PaginatedSearchResults } from './models/search-result.model';
+import { QueryResult } from './models/query-result.model';
 import {
   GqlContext,
   getUserFromContext,
@@ -37,14 +38,14 @@ export class KnowledgeResolver {
 
   constructor(private readonly knowledgeService: KnowledgeService) {}
 
-  @Mutation(() => String)
+  @Mutation(() => QueryResult)
   @UseGuards(AuthGuard)
   @Permissions({ action: Action.Read, subject: 'Knowledge' })
   @Extensions({ complexity: 100 }) // LLM call - expensive operation
   async answerQuery(
     @Args('input') input: QueryInput,
     @Context() context: GqlContext,
-  ): Promise<string> {
+  ): Promise<QueryResult> {
     const user = getUserFromContext(context);
     return this.knowledgeService.answerQuery(user.id, input.query);
   }

--- a/apps/backend/src/apps/knowledge/src/domains/knowledge.service.spec.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/knowledge.service.spec.ts
@@ -216,6 +216,60 @@ describe('KnowledgeService', () => {
         sourcedFrom: [],
       });
     });
+
+    it('should fall back gracefully when LLM returns wrong-shape JSON', async () => {
+      const mockResults: IVectorDocument[] = [
+        {
+          id: '1',
+          content: 'Some context',
+          embedding: [],
+          metadata: { source: 'doc-1', userId: 'user-1' },
+        },
+      ];
+
+      embeddingsService.getEmbeddingsForQuery = jest
+        .fn()
+        .mockResolvedValue(mockQueryEmbedding);
+      vectorDB.queryEmbeddings = jest.fn().mockResolvedValue(mockResults);
+      llm.generate = jest.fn().mockResolvedValue({
+        text: '{"text":"answer","sources":[]}',
+        tokensUsed: 20,
+      });
+
+      const answer = await knowledgeService.answerQuery('user-1', 'Test?');
+
+      expect(answer).toEqual({
+        answer: '{"text":"answer","sources":[]}',
+        sourcedFrom: [],
+      });
+    });
+
+    it('should strip markdown code fences from LLM response before parsing', async () => {
+      const mockResults: IVectorDocument[] = [
+        {
+          id: '1',
+          content: 'Some context',
+          embedding: [],
+          metadata: { source: 'doc-1', userId: 'user-1' },
+        },
+      ];
+
+      embeddingsService.getEmbeddingsForQuery = jest
+        .fn()
+        .mockResolvedValue(mockQueryEmbedding);
+      vectorDB.queryEmbeddings = jest.fn().mockResolvedValue(mockResults);
+      llm.generate = jest.fn().mockResolvedValue({
+        text: '```json\n{"answer":"Fenced answer","sourcedFrom":["ctx"]}\n```',
+        tokensUsed: 30,
+      });
+
+      const answer = await knowledgeService.answerQuery('user-1', 'Test?');
+
+      expect(answer).toEqual({
+        answer: 'Fenced answer',
+        sourcedFrom: ['ctx'],
+      });
+    });
   });
 
   describe('searchText', () => {

--- a/apps/backend/src/apps/knowledge/src/domains/knowledge.service.spec.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/knowledge.service.spec.ts
@@ -32,7 +32,7 @@ describe('KnowledgeService', () => {
       getName: jest.fn().mockReturnValue('MockLLM'),
       getModelName: jest.fn().mockReturnValue('mock-model'),
       generate: jest.fn().mockResolvedValue({
-        text: 'Generated answer',
+        text: '{"answer":"Generated answer","sourcedFrom":["mock context"]}',
         tokensUsed: 100,
       } as GenerateResult),
     };
@@ -131,7 +131,7 @@ describe('KnowledgeService', () => {
         .mockResolvedValue(mockQueryEmbedding);
       vectorDB.queryEmbeddings = jest.fn().mockResolvedValue(mockResults);
       llm.generate = jest.fn().mockResolvedValue({
-        text: 'This is the answer based on context.',
+        text: '{"answer":"This is the answer based on context.","sourcedFrom":["Context chunk 1"]}',
         tokensUsed: 50,
       });
 
@@ -149,10 +149,13 @@ describe('KnowledgeService', () => {
         3,
       );
       expect(llm.generate).toHaveBeenCalled();
-      expect(answer).toBe('This is the answer based on context.');
+      expect(answer).toEqual({
+        answer: 'This is the answer based on context.',
+        sourcedFrom: ['Context chunk 1'],
+      });
     });
 
-    it('should return no-info message when no context is found', async () => {
+    it('should return no-info result when no context is found', async () => {
       embeddingsService.getEmbeddingsForQuery = jest
         .fn()
         .mockResolvedValue(mockQueryEmbedding);
@@ -163,13 +166,15 @@ describe('KnowledgeService', () => {
         'Unknown topic?',
       );
 
-      expect(answer).toBe(
-        'I could not find any relevant information to answer your question.',
-      );
+      expect(answer).toEqual({
+        answer:
+          'I could not find any relevant information to answer your question.',
+        sourcedFrom: [],
+      });
       expect(llm.generate).not.toHaveBeenCalled();
     });
 
-    it('should return no-info message when semantic search fails', async () => {
+    it('should return no-info result when semantic search fails', async () => {
       // semanticSearch catches errors and returns empty array
       embeddingsService.getEmbeddingsForQuery = jest
         .fn()
@@ -177,10 +182,39 @@ describe('KnowledgeService', () => {
 
       const answer = await knowledgeService.answerQuery('user-1', 'Test query');
 
-      expect(answer).toBe(
-        'I could not find any relevant information to answer your question.',
-      );
+      expect(answer).toEqual({
+        answer:
+          'I could not find any relevant information to answer your question.',
+        sourcedFrom: [],
+      });
       expect(llm.generate).not.toHaveBeenCalled();
+    });
+
+    it('should fall back gracefully when LLM returns non-JSON text', async () => {
+      const mockResults: IVectorDocument[] = [
+        {
+          id: '1',
+          content: 'Some context',
+          embedding: [],
+          metadata: { source: 'doc-1', userId: 'user-1' },
+        },
+      ];
+
+      embeddingsService.getEmbeddingsForQuery = jest
+        .fn()
+        .mockResolvedValue(mockQueryEmbedding);
+      vectorDB.queryEmbeddings = jest.fn().mockResolvedValue(mockResults);
+      llm.generate = jest.fn().mockResolvedValue({
+        text: 'Plain text answer with no JSON',
+        tokensUsed: 20,
+      });
+
+      const answer = await knowledgeService.answerQuery('user-1', 'Test?');
+
+      expect(answer).toEqual({
+        answer: 'Plain text answer with no JSON',
+        sourcedFrom: [],
+      });
     });
   });
 

--- a/apps/backend/src/apps/knowledge/src/domains/knowledge.service.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/knowledge.service.ts
@@ -11,22 +11,24 @@ import { QueryResult } from './models/query-result.model';
 
 function parseRagResponse(text: string): QueryResult {
   const stripped = text
+    .trim()
     .replace(/^```(?:json)?\s*/i, '')
     .replace(/\s*```$/, '')
     .trim();
   try {
     const parsed = JSON.parse(stripped) as unknown;
+    const p = parsed as Record<string, unknown>;
     if (
       typeof parsed === 'object' &&
       parsed !== null &&
-      typeof (parsed as Record<string, unknown>).answer === 'string' &&
-      Array.isArray((parsed as Record<string, unknown>).sourcedFrom)
+      typeof p.answer === 'string' &&
+      Array.isArray(p.sourcedFrom) &&
+      (p.sourcedFrom as unknown[]).every((s) => typeof s === 'string')
     ) {
-      const { answer, sourcedFrom } = parsed as {
-        answer: string;
-        sourcedFrom: string[];
+      return {
+        answer: p.answer as string,
+        sourcedFrom: p.sourcedFrom as string[],
       };
-      return { answer, sourcedFrom };
     }
   } catch {
     // fall through — treat unparseable output as plain-text answer

--- a/apps/backend/src/apps/knowledge/src/domains/knowledge.service.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/knowledge.service.ts
@@ -7,6 +7,32 @@ import {
   SearchResult,
   PaginatedSearchResults,
 } from './models/search-result.model';
+import { QueryResult } from './models/query-result.model';
+
+function parseRagResponse(text: string): QueryResult {
+  const stripped = text
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/\s*```$/, '')
+    .trim();
+  try {
+    const parsed = JSON.parse(stripped) as unknown;
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof (parsed as Record<string, unknown>).answer === 'string' &&
+      Array.isArray((parsed as Record<string, unknown>).sourcedFrom)
+    ) {
+      const { answer, sourcedFrom } = parsed as {
+        answer: string;
+        sourcedFrom: string[];
+      };
+      return { answer, sourcedFrom };
+    }
+  } catch {
+    // fall through — treat unparseable output as plain-text answer
+  }
+  return { answer: stripped, sourcedFrom: [] };
+}
 
 /**
  * Knowledge Service
@@ -72,7 +98,7 @@ export class KnowledgeService {
    * 2. Build prompt with context and user query
    * 3. Generate answer using LLM
    */
-  async answerQuery(userId: string, query: string): Promise<string> {
+  async answerQuery(userId: string, query: string): Promise<QueryResult> {
     try {
       // Step 1: Retrieve relevant context via semantic search
       const contextChunks = await this.semanticSearch(userId, query, 3);
@@ -82,7 +108,11 @@ export class KnowledgeService {
       );
 
       if (contextChunks.length === 0) {
-        return 'I could not find any relevant information to answer your question.';
+        return {
+          answer:
+            'I could not find any relevant information to answer your question.',
+          sourcedFrom: [],
+        };
       }
 
       // Step 2: Get RAG prompt from database templates
@@ -99,7 +129,7 @@ export class KnowledgeService {
       // Step 3: Generate answer with LLM
       // Lower temperature (0.3) for more factual, consistent responses
       const result = await this.llm.generate(promptText, {
-        maxTokens: 500,
+        maxTokens: 600,
         temperature: 0.3,
         topP: 0.9,
       });
@@ -108,7 +138,7 @@ export class KnowledgeService {
         `Generated answer: ${result.text.length} chars (${result.tokensUsed || 'unknown'} tokens)`,
       );
 
-      return result.text;
+      return parseRagResponse(result.text);
     } catch (error) {
       this.logger.error('RAG answer generation failed:', error);
       throw error;

--- a/apps/backend/src/apps/knowledge/src/domains/models/query-result.model.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/models/query-result.model.ts
@@ -1,0 +1,10 @@
+import { ObjectType, Field } from '@nestjs/graphql';
+
+@ObjectType()
+export class QueryResult {
+  @Field()
+  answer!: string;
+
+  @Field(() => [String])
+  sourcedFrom!: string[];
+}


### PR DESCRIPTION
## Summary

- Adds `QueryResult` GraphQL type (`{ answer: String, sourcedFrom: [String] }`) replacing the previous `String` return on `answerQuery`
- `parseRagResponse()` helper: trims before fence-strip, validates JSON shape and element types, falls back gracefully to plain-text on any parse failure
- `maxTokens` bumped 500 → 600 to accommodate the larger JSON envelope
- 16 unit tests (up from 14): covers wrong-shape JSON, markdown-fenced output, and non-JSON fallback paths

## ⚠️ Coordinated deploy

Breaking schema change — must be deployed together with `prompt-service` PR `feat/rag-json-output-45`. Frontend code calling `answerQuery` and reading the result as a plain string will need a follow-up update (tracked separately).

**Deploy order:** prompt-service seed first, then this service.

## Test plan

- [x] 16/16 knowledge unit tests pass
- [x] UAT knowledge container rebuilt and healthy with new code
- [x] Security review: clean

🤖 Generated with [Claude Code](https://claude.ai/claude-code)