### PR TITLE
feat(region): enqueue cron and startup syncs via BullMQ (#653)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/region.scheduler.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.scheduler.spec.ts
@@ -3,44 +3,37 @@ import { ConfigService } from '@nestjs/config';
 import { createMock } from '@golevelup/ts-jest';
 
 import { RegionScheduler } from './region.scheduler';
-import { RegionDomainService } from './region.service';
-import { DataType } from '@opuspopuli/region-provider';
+import { PipelineJobService } from './pipeline-job.service';
+import { QueueService, TRIGGER_SOURCE } from '@opuspopuli/queue-provider';
 
 describe('RegionScheduler', () => {
   let scheduler: RegionScheduler;
-  let regionService: jest.Mocked<RegionDomainService>;
+  let queueService: jest.Mocked<QueueService>;
+  let pipelineJobService: jest.Mocked<PipelineJobService>;
 
-  const mockSyncResults = [
-    {
-      regionId: 'california',
-      dataType: DataType.PROPOSITIONS,
-      itemsProcessed: 10,
-      itemsCreated: 5,
-      itemsUpdated: 5,
-      itemsSkipped: 0,
-      errors: [],
-      syncedAt: new Date(),
-    },
-  ];
+  const defaultEnv: Record<string, string> = {
+    REGION_SYNC_ENABLED: 'true',
+    REGION_SYNC_CRON_VIA_QUEUE: 'false',
+    REGION_SYNC_RUN_ON_STARTUP: 'false',
+  };
 
-  function buildModule(configOverrides: Record<string, unknown> = {}) {
-    const mockRegionService = createMock<RegionDomainService>();
-    mockRegionService.syncAll.mockResolvedValue(mockSyncResults);
+  function buildModule(envOverrides: Record<string, string> = {}) {
+    const env = { ...defaultEnv, ...envOverrides };
+
+    const mockQueueService = createMock<QueueService>();
+    mockQueueService.enqueue.mockResolvedValue('mock-bullmq-id');
+
+    const mockPipelineJobService = createMock<PipelineJobService>();
+    mockPipelineJobService.create.mockResolvedValue({ id: 'mock-job-id' });
 
     const mockConfigService = createMock<ConfigService>();
-    mockConfigService.get.mockImplementation((key: string) => {
-      const defaults: Record<string, unknown> = {
-        'region.syncEnabled': true,
-        'region.syncCronViaQueue': false,
-        'region.syncRunOnStartup': false,
-      };
-      return configOverrides[key] ?? defaults[key] ?? undefined;
-    });
+    mockConfigService.get.mockImplementation((key: string) => env[key]);
 
     return Test.createTestingModule({
       providers: [
         RegionScheduler,
-        { provide: RegionDomainService, useValue: mockRegionService },
+        { provide: QueueService, useValue: mockQueueService },
+        { provide: PipelineJobService, useValue: mockPipelineJobService },
         { provide: ConfigService, useValue: mockConfigService },
       ],
     }).compile();
@@ -49,7 +42,8 @@ describe('RegionScheduler', () => {
   beforeEach(async () => {
     const module: TestingModule = await buildModule();
     scheduler = module.get<RegionScheduler>(RegionScheduler);
-    regionService = module.get(RegionDomainService);
+    queueService = module.get(QueueService);
+    pipelineJobService = module.get(PipelineJobService);
   });
 
   it('should be defined', () => {
@@ -57,67 +51,124 @@ describe('RegionScheduler', () => {
   });
 
   describe('onModuleInit', () => {
-    it('does not sync by default (REGION_SYNC_RUN_ON_STARTUP defaults to false)', async () => {
+    it('does not enqueue by default (REGION_SYNC_RUN_ON_STARTUP defaults to false)', async () => {
       await scheduler.onModuleInit();
-      expect(regionService.syncAll).not.toHaveBeenCalled();
+      expect(queueService.enqueue).not.toHaveBeenCalled();
     });
 
-    it('syncs when REGION_SYNC_RUN_ON_STARTUP=true', async () => {
-      const module = await buildModule({ 'region.syncRunOnStartup': true });
+    it('enqueues a startup job when REGION_SYNC_RUN_ON_STARTUP=true', async () => {
+      const module = await buildModule({ REGION_SYNC_RUN_ON_STARTUP: 'true' });
       const s = module.get<RegionScheduler>(RegionScheduler);
-      const rs = module.get(
-        RegionDomainService,
-      ) as jest.Mocked<RegionDomainService>;
+      const q = module.get(QueueService) as jest.Mocked<QueueService>;
+      const p = module.get(
+        PipelineJobService,
+      ) as jest.Mocked<PipelineJobService>;
 
       await s.onModuleInit();
 
-      expect(rs.syncAll).toHaveBeenCalled();
+      expect(p.create).toHaveBeenCalledWith(
+        expect.objectContaining({ triggerSource: TRIGGER_SOURCE.STARTUP }),
+      );
+      expect(q.enqueue).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ triggerSource: TRIGGER_SOURCE.STARTUP }),
+        expect.any(Object),
+      );
     });
 
-    it('handles errors gracefully on startup', async () => {
-      const module = await buildModule({ 'region.syncRunOnStartup': true });
+    it('skips when syncCronViaQueue=true (worker owns startup)', async () => {
+      const module = await buildModule({
+        REGION_SYNC_RUN_ON_STARTUP: 'true',
+        REGION_SYNC_CRON_VIA_QUEUE: 'true',
+      });
       const s = module.get<RegionScheduler>(RegionScheduler);
-      const rs = module.get(
-        RegionDomainService,
-      ) as jest.Mocked<RegionDomainService>;
-      rs.syncAll.mockRejectedValue(new Error('Startup sync failed'));
+      const q = module.get(QueueService) as jest.Mocked<QueueService>;
+
+      await s.onModuleInit();
+
+      expect(q.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('creates the DB record before enqueuing', async () => {
+      const callOrder: string[] = [];
+      const module = await buildModule({ REGION_SYNC_RUN_ON_STARTUP: 'true' });
+      const s = module.get<RegionScheduler>(RegionScheduler);
+      const q = module.get(QueueService) as jest.Mocked<QueueService>;
+      const p = module.get(
+        PipelineJobService,
+      ) as jest.Mocked<PipelineJobService>;
+
+      p.create.mockImplementation(async (_input) => {
+        callOrder.push('create');
+        return { id: 'job-id' };
+      });
+      q.enqueue.mockImplementation(async () => {
+        callOrder.push('enqueue');
+        return 'bullmq-id';
+      });
+
+      await s.onModuleInit();
+
+      expect(callOrder).toEqual(['create', 'enqueue']);
+    });
+
+    it('handles create failure gracefully on startup', async () => {
+      const module = await buildModule({ REGION_SYNC_RUN_ON_STARTUP: 'true' });
+      const s = module.get<RegionScheduler>(RegionScheduler);
+      const p = module.get(
+        PipelineJobService,
+      ) as jest.Mocked<PipelineJobService>;
+      p.create.mockRejectedValue(new Error('DB unavailable'));
+
+      await expect(s.onModuleInit()).resolves.not.toThrow();
+    });
+
+    it('handles enqueue errors gracefully on startup', async () => {
+      const module = await buildModule({ REGION_SYNC_RUN_ON_STARTUP: 'true' });
+      const s = module.get<RegionScheduler>(RegionScheduler);
+      const q = module.get(QueueService) as jest.Mocked<QueueService>;
+      q.enqueue.mockRejectedValue(new Error('Redis unavailable'));
 
       await expect(s.onModuleInit()).resolves.not.toThrow();
     });
   });
 
   describe('handleScheduledSync', () => {
-    it('runs sync when syncEnabled=true and syncCronViaQueue=false', async () => {
+    it('enqueues a cron job when syncEnabled=true and syncCronViaQueue=false', async () => {
       await scheduler.handleScheduledSync();
-      expect(regionService.syncAll).toHaveBeenCalled();
+
+      expect(pipelineJobService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ triggerSource: TRIGGER_SOURCE.CRON }),
+      );
+      expect(queueService.enqueue).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ triggerSource: TRIGGER_SOURCE.CRON }),
+        expect.any(Object),
+      );
     });
 
     it('skips when syncEnabled=false', async () => {
-      const module = await buildModule({ 'region.syncEnabled': false });
+      const module = await buildModule({ REGION_SYNC_ENABLED: 'false' });
       const s = module.get<RegionScheduler>(RegionScheduler);
-      const rs = module.get(
-        RegionDomainService,
-      ) as jest.Mocked<RegionDomainService>;
+      const q = module.get(QueueService) as jest.Mocked<QueueService>;
 
       await s.handleScheduledSync();
 
-      expect(rs.syncAll).not.toHaveBeenCalled();
+      expect(q.enqueue).not.toHaveBeenCalled();
     });
 
-    it('skips when REGION_SYNC_CRON_VIA_QUEUE=true (worker owns the schedule)', async () => {
-      const module = await buildModule({ 'region.syncCronViaQueue': true });
+    it('skips when syncCronViaQueue=true (worker owns the schedule)', async () => {
+      const module = await buildModule({ REGION_SYNC_CRON_VIA_QUEUE: 'true' });
       const s = module.get<RegionScheduler>(RegionScheduler);
-      const rs = module.get(
-        RegionDomainService,
-      ) as jest.Mocked<RegionDomainService>;
+      const q = module.get(QueueService) as jest.Mocked<QueueService>;
 
       await s.handleScheduledSync();
 
-      expect(rs.syncAll).not.toHaveBeenCalled();
+      expect(q.enqueue).not.toHaveBeenCalled();
     });
 
-    it('handles sync errors gracefully', async () => {
-      regionService.syncAll.mockRejectedValue(new Error('Network error'));
+    it('handles enqueue errors gracefully', async () => {
+      queueService.enqueue.mockRejectedValue(new Error('Redis unavailable'));
       await expect(scheduler.handleScheduledSync()).resolves.not.toThrow();
     });
   });

--- a/apps/backend/src/apps/region/src/domains/region.scheduler.ts
+++ b/apps/backend/src/apps/region/src/domains/region.scheduler.ts
@@ -1,15 +1,27 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
-import { RegionDomainService } from './region.service';
+import {
+  QueueService,
+  REGION_SYNC_QUEUE,
+  TRIGGER_SOURCE,
+} from '@opuspopuli/queue-provider';
+import type {
+  RegionSyncJobData,
+  TriggerSource,
+} from '@opuspopuli/queue-provider';
+import { randomUUID } from 'crypto';
+import { PipelineJobService } from './pipeline-job.service';
 
 /**
- * Region Scheduler (legacy cron path)
+ * Region Scheduler
  *
- * Retained for rollout safety behind REGION_SYNC_CRON_VIA_QUEUE=false.
+ * Fires the daily 2 AM cron from the region service side. Enqueues a
+ * region-sync job onto the BullMQ queue for retry/backoff/observability.
+ *
  * When REGION_SYNC_CRON_VIA_QUEUE=true the worker's RegionSyncScheduler
- * owns the daily repeatable job and this class becomes inert.
- * Cleanup PR: delete this file and remove from RegionDomainModule.
+ * registers a BullMQ repeatable job directly — this class returns early
+ * to avoid double-enqueue.
  */
 @Injectable()
 export class RegionScheduler {
@@ -21,28 +33,26 @@ export class RegionScheduler {
   private readonly syncRunOnStartup: boolean;
 
   constructor(
-    private readonly regionService: RegionDomainService,
+    private readonly queueService: QueueService,
+    private readonly pipelineJobService: PipelineJobService,
     private readonly configService: ConfigService,
   ) {
-    this.syncEnabled = this.configService.get('region.syncEnabled') !== false;
+    this.syncEnabled =
+      this.configService.get<string>('REGION_SYNC_ENABLED') !== 'false';
     this.syncCronViaQueue =
-      this.configService.get<boolean>('region.syncCronViaQueue') === true;
+      this.configService.get<string>('REGION_SYNC_CRON_VIA_QUEUE') === 'true';
     this.syncRunOnStartup =
-      this.configService.get<boolean>('region.syncRunOnStartup') === true;
+      this.configService.get<string>('REGION_SYNC_RUN_ON_STARTUP') === 'true';
   }
 
   async onModuleInit() {
-    if (!this.syncRunOnStartup) {
+    if (!this.syncRunOnStartup || this.syncCronViaQueue) {
       return;
     }
     this.logger.log(
-      'Running initial data sync on startup (REGION_SYNC_RUN_ON_STARTUP=true)',
+      'Enqueueing startup sync (REGION_SYNC_RUN_ON_STARTUP=true)',
     );
-    try {
-      await this.syncData();
-    } catch (error) {
-      this.logger.error('Startup sync failed:', error);
-    }
+    await this.enqueueSync(TRIGGER_SOURCE.STARTUP);
   }
 
   @Cron(CronExpression.EVERY_DAY_AT_2AM)
@@ -50,28 +60,29 @@ export class RegionScheduler {
     if (!this.syncEnabled || this.syncCronViaQueue) {
       return;
     }
-    this.logger.log('Running scheduled data sync');
-    await this.syncData();
+    this.logger.log('Enqueueing scheduled cron sync');
+    await this.enqueueSync(TRIGGER_SOURCE.CRON);
   }
 
-  private async syncData() {
+  private async enqueueSync(triggerSource: TriggerSource) {
     try {
-      const results = await this.regionService.syncAll();
-      const summary = results
-        .map(
-          (r) =>
-            `${r.dataType}: ${r.itemsProcessed} processed (${r.itemsCreated} new, ${r.itemsUpdated} updated)`,
-        )
-        .join(', ');
-      this.logger.log(`Sync complete: ${summary}`);
-      const errors = results.flatMap((r) => r.errors);
-      if (errors.length > 0) {
-        this.logger.warn(
-          `Sync had ${errors.length} errors: ${errors.join(', ')}`,
-        );
-      }
+      const jobId = randomUUID();
+      const row = await this.pipelineJobService.create({
+        bullmqJobId: jobId,
+        triggerSource,
+      });
+      await this.queueService.enqueue<RegionSyncJobData>(
+        REGION_SYNC_QUEUE,
+        { pipelineJobId: row.id, triggerSource },
+        { jobId },
+      );
+      this.logger.log(
+        `Region sync enqueued (jobId=${jobId}, trigger=${triggerSource})`,
+      );
     } catch (error) {
-      this.logger.error('Scheduled sync failed:', error);
+      this.logger.error(
+        `Failed to enqueue ${triggerSource} sync: ${(error as Error).message}`,
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary

Removes the last inline \`syncAll()\` call from the region service. \`RegionScheduler\` previously called \`regionService.syncAll()\` directly inside \`handleScheduledSync()\` (and \`onModuleInit\` for startup). Both paths now create a \`pipeline_jobs\` row and enqueue to the \`region-sync\` BullMQ queue — giving them retry/backoff, observability via \`recentRegionSyncJobs\`, and Prometheus queue metrics with no changes to callers.

**Coordination with the worker**: When \`REGION_SYNC_CRON_VIA_QUEUE=true\` (set in prod/UAT), the worker's \`RegionSyncScheduler\` already owns the BullMQ repeatable job. \`RegionScheduler\` returns early on both the cron and startup paths to avoid double-enqueue. The flag remains as the coordination mechanism; the direct \`syncAll()\` path is now gone entirely.

**Config access**: uses \`configService.get<string>('FLAT_ENV_VAR_NAME')\` rather than \`registerAs\` dot-notation, which returns \`undefined\` in some NestJS module scopes.

## What changed

- \`region.scheduler.ts\` — replaced \`RegionDomainService\` injection with \`QueueService\` + \`PipelineJobService\`; \`syncData()\` private method removed; \`enqueueSync(triggerSource)\` creates a DB record then enqueues; startup path now also guards on \`syncCronViaQueue\` to avoid double-fire
- \`region.scheduler.spec.ts\` — mocks updated to \`QueueService\`/\`PipelineJobService\`; new tests: create-before-enqueue ordering, \`create\` failure handling, \`syncCronViaQueue\` guard on startup

## How to test

Set \`REGION_SYNC_CRON_VIA_QUEUE=false\` and \`REGION_SYNC_RUN_ON_STARTUP=true\`, then start the region service. You should see:

\`\`\`
[RegionScheduler] Enqueueing startup sync (REGION_SYNC_RUN_ON_STARTUP=true)
[QueueService] Enqueued job <uuid> on region-sync
[RegionScheduler] Region sync enqueued (jobId=<uuid>, trigger=startup)
\`\`\`

And a new \`pipeline_jobs\` row appears with \`trigger_source=startup\`. The region-worker picks it up and processes it normally.

**Double-enqueue guard**: set \`REGION_SYNC_CRON_VIA_QUEUE=true\` + \`REGION_SYNC_RUN_ON_STARTUP=true\` — confirm no job is enqueued from the region service (worker owns it).

## Linked issues

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)