### PR TITLE
feat(region,pipeline): content-aware BullMQ cadence and region-sync hardening (#651 #693)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -84,7 +84,7 @@
     "@opuspopuli/ocr-provider": "workspace:*",
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.58",
+    "@opuspopuli/regions": "^1.0.60",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/bio-generator.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/bio-generator.service.spec.ts
@@ -70,7 +70,7 @@ describe('BioGeneratorService', () => {
       const built = await buildService(false);
       const reps = [baseRep({ bio: undefined })];
 
-      const result = await built.service.enrichBios(reps);
+      const result = await built.service.enrichBios(reps, undefined);
 
       expect(result).toBe(reps);
       expect(result[0].bio).toBeUndefined();
@@ -97,7 +97,7 @@ describe('BioGeneratorService', () => {
         baseRep({ externalId: 'r3' }),
       ];
 
-      const result = await service.enrichBios(reps);
+      const result = await service.enrichBios(reps, undefined);
 
       expect(llm.generate).toHaveBeenCalledTimes(2);
       expect(result[0].bio).toBe('Existing bio text.');
@@ -112,7 +112,7 @@ describe('BioGeneratorService', () => {
     it('returns early when no reps need bios', async () => {
       const reps = [baseRep({ bio: 'Already has one.' })];
 
-      const result = await service.enrichBios(reps);
+      const result = await service.enrichBios(reps, undefined);
 
       expect(llm.generate).not.toHaveBeenCalled();
       expect(result[0].bioSource).toBe('scraped');
@@ -123,7 +123,7 @@ describe('BioGeneratorService', () => {
         text: '```json\n{"bio": "Fenced bio."}\n```',
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBe('Fenced bio.');
       expect(result[0].bioSource).toBe('ai-generated');
@@ -134,7 +134,7 @@ describe('BioGeneratorService', () => {
         text: '{"bio": ""}',
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBeUndefined();
       expect(result[0].bioSource).toBeUndefined();
@@ -145,7 +145,7 @@ describe('BioGeneratorService', () => {
         text: 'not json at all',
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBeUndefined();
     });
@@ -159,7 +159,7 @@ describe('BioGeneratorService', () => {
         text: truncatedResponse,
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBe(
         'Dawn Addis represents District 30 in the California State Assembly.',
@@ -174,7 +174,7 @@ describe('BioGeneratorService', () => {
         text: malformedResponse,
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBe('Valid bio text.');
     });
@@ -186,7 +186,7 @@ describe('BioGeneratorService', () => {
         text: escapedBio,
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBe('Line one.\nLine two with "quoted" text.');
     });
@@ -198,7 +198,7 @@ describe('BioGeneratorService', () => {
         text: tooShort,
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBeUndefined();
     });
@@ -215,7 +215,7 @@ describe('BioGeneratorService', () => {
         baseRep({ externalId: 'r2' }),
       ];
 
-      const result = await service.enrichBios(reps);
+      const result = await service.enrichBios(reps, undefined);
 
       expect(result[0].bio).toBeUndefined();
       expect(result[1].bio).toBe('Bio for rep 2.');
@@ -235,7 +235,7 @@ describe('BioGeneratorService', () => {
         committees: [{ name: 'Budget', role: 'Chair' }, { name: 'Education' }],
       });
 
-      await service.enrichBios([rep]);
+      await service.enrichBios([rep], 'California');
 
       const firstCall = promptClient.getDocumentAnalysisPrompt.mock.calls[0][0];
       expect(firstCall.documentType).toBe('representative-bio');
@@ -247,10 +247,26 @@ describe('BioGeneratorService', () => {
       expect(firstCall.text).not.toContain('Chair: Budget');
     });
 
+    it('uses county jurisdiction format for county region names', async () => {
+      const rep = baseRep({
+        bio: '',
+        chamber: 'Board of Supervisors',
+        externalId: 'california-sonoma-district-1',
+      });
+
+      await service.enrichBios([rep], 'Sonoma County');
+
+      const firstCall = promptClient.getDocumentAnalysisPrompt.mock.calls[0][0];
+      expect(firstCall.text).toContain(
+        'Jurisdiction: Sonoma County Board of Supervisors',
+      );
+      expect(firstCall.text).not.toContain('State Board');
+    });
+
     it('preserves existing bioSource when already set', async () => {
       const reps = [baseRep({ bio: 'Has bio', bioSource: 'scraped' })];
 
-      const result = await service.enrichBios(reps);
+      const result = await service.enrichBios(reps, undefined);
 
       expect(result[0].bioSource).toBe('scraped');
     });
@@ -277,7 +293,7 @@ describe('BioGeneratorService', () => {
         }),
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBe('Paragraph one.\n\nParagraph two.');
       expect(result[0].bioSource).toBe('ai-generated');
@@ -288,7 +304,7 @@ describe('BioGeneratorService', () => {
         text: 'Here is the biography JSON:\n\n{"bio": "Prose-wrapped bio."}',
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBe('Prose-wrapped bio.');
       expect(result[0].bioSource).toBe('ai-generated');
@@ -299,7 +315,7 @@ describe('BioGeneratorService', () => {
         text: '{"bio": "Bio with trailing text."}\n\nLet me know if you need anything else.',
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBe('Bio with trailing text.');
     });
@@ -309,7 +325,7 @@ describe('BioGeneratorService', () => {
         text: '{"bio": "Reference to {SB-42} passed."}',
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBe('Reference to {SB-42} passed.');
     });
@@ -319,7 +335,7 @@ describe('BioGeneratorService', () => {
         text: JSON.stringify({ bio: 'Just a bio.' }),
       } as Awaited<ReturnType<ILLMProvider['generate']>>);
 
-      const result = await service.enrichBios([baseRep()]);
+      const result = await service.enrichBios([baseRep()], undefined);
 
       expect(result[0].bio).toBe('Just a bio.');
       expect(result[0].bioSource).toBe('ai-generated');
@@ -333,7 +349,7 @@ describe('BioGeneratorService', () => {
         text: JSON.stringify({ bio: 'Bio.' }),
       });
 
-      await built.service.enrichBios([baseRep()]);
+      await built.service.enrichBios([baseRep()], undefined);
 
       expect(built.llm.generate).toHaveBeenCalledWith(
         expect.any(String),
@@ -349,7 +365,7 @@ describe('BioGeneratorService', () => {
         text: JSON.stringify({ bio: 'Bio.' }),
       });
 
-      await built.service.enrichBios([baseRep()]);
+      await built.service.enrichBios([baseRep()], undefined);
 
       expect(built.llm.generate).toHaveBeenCalledWith(
         expect.any(String),
@@ -365,7 +381,7 @@ describe('BioGeneratorService', () => {
         text: JSON.stringify({ bio: 'Bio.' }),
       });
 
-      await built.service.enrichBios([baseRep()]);
+      await built.service.enrichBios([baseRep()], undefined);
 
       expect(built.llm.generate).toHaveBeenCalledWith(
         expect.any(String),
@@ -393,7 +409,7 @@ describe('BioGeneratorService', () => {
         baseRep({ externalId: `r${i}`, name: `Rep ${i}` }),
       );
 
-      await built.service.enrichBios(reps);
+      await built.service.enrichBios(reps, undefined);
 
       expect(peakInFlight).toBe(3);
       expect(built.llm.generate).toHaveBeenCalledTimes(6);
@@ -411,7 +427,7 @@ describe('BioGeneratorService', () => {
         baseRep({ externalId: `r${i}`, name: `Rep ${i}` }),
       );
 
-      const result = await built.service.enrichBios(reps);
+      const result = await built.service.enrichBios(reps, undefined);
 
       expect(built.llm.generate).toHaveBeenCalledTimes(2);
       expect(result[0].bioSource).toBe('ai-generated');
@@ -431,7 +447,7 @@ describe('BioGeneratorService', () => {
         baseRep({ externalId: `r${i}` }),
       );
 
-      await built.service.enrichBios(reps);
+      await built.service.enrichBios(reps, undefined);
 
       expect(built.llm.generate).toHaveBeenCalledTimes(3);
     });
@@ -452,7 +468,7 @@ describe('BioGeneratorService', () => {
         baseRep({ externalId: 'r3', name: 'Rep 3' }),
       ];
 
-      const result = await built.service.enrichBios(reps);
+      const result = await built.service.enrichBios(reps, undefined);
 
       expect(result[0].bio).toBeUndefined();
       expect(result[1].bio).toBe('OK 2.');

--- a/apps/backend/src/apps/region/src/domains/bio-generator.service.ts
+++ b/apps/backend/src/apps/region/src/domains/bio-generator.service.ts
@@ -9,17 +9,6 @@ import { readOptionalPositiveInt, readPositiveInt } from './config-helpers';
 import { LlmGeneratorBase } from './llm-generator.base';
 
 /**
- * Maps the externalId region prefix to a human-readable state name.
- * Extend when a new state comes online. Federal reps use a different
- * prefix ("federal-" or similar); that case falls through to the
- * bare chamber label, and the prompt refuses to use training
- * knowledge if jurisdiction is ambiguous.
- */
-const STATE_PREFIX_TO_NAME: Record<string, string> = {
-  ca: 'California',
-};
-
-/**
  * Generates AI bios for representatives that lack a scraped biography.
  *
  * Uses structured public record data (name, chamber, district, party,
@@ -41,6 +30,7 @@ const STATE_PREFIX_TO_NAME: Record<string, string> = {
 @Injectable()
 export class BioGeneratorService extends LlmGeneratorBase {
   private readonly logger = new Logger(BioGeneratorService.name);
+  private activeRegionName: string | undefined;
   // Field initializers run after super(), so this.config is already set.
   private readonly maxTokens = readPositiveInt(
     this.config,
@@ -69,11 +59,13 @@ export class BioGeneratorService extends LlmGeneratorBase {
    */
   async enrichBios(
     reps: Representative[],
+    regionName: string | undefined,
     maxRepsOverride?: number,
   ): Promise<Representative[]> {
     if (!this.promptClient || !this.llm) {
       return reps;
     }
+    this.activeRegionName = regionName;
 
     const candidates = reps.filter((r) => !r.bio || r.bio.trim() === '');
     const cap = this.resolveCap(maxRepsOverride);
@@ -220,14 +212,17 @@ export class BioGeneratorService extends LlmGeneratorBase {
    * refuse or correctly identify a representative.
    */
   private deriveJurisdiction(rep: Representative): string {
-    const prefix = rep.externalId?.split('-')[0]?.toLowerCase() ?? '';
-    const state = STATE_PREFIX_TO_NAME[prefix];
-    if (!state) {
+    if (!this.activeRegionName) {
       // Federal or unknown — fall back to bare chamber so the prompt
       // can still decide whether to trust training knowledge.
       return rep.chamber;
     }
-    return `${state} State ${rep.chamber}`;
+    // County regions (e.g. "Sonoma County") don't need "State" inserted —
+    // "Sonoma County Board of Supervisors" is already correct.
+    const isCounty = /county/i.test(this.activeRegionName);
+    return isCounty
+      ? `${this.activeRegionName} ${rep.chamber}`
+      : `${this.activeRegionName} State ${rep.chamber}`;
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/models/pipeline-job.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/pipeline-job.model.ts
@@ -1,4 +1,10 @@
-import { ObjectType, Field, ID, registerEnumType } from '@nestjs/graphql';
+import {
+  ObjectType,
+  Field,
+  ID,
+  Float,
+  registerEnumType,
+} from '@nestjs/graphql';
 import { SyncResultModel } from './region-info.model';
 
 export enum SyncJobStatus {
@@ -23,6 +29,18 @@ registerEnumType(SyncTriggerSource, {
   name: 'SyncTriggerSource',
   description: 'What triggered the sync job',
 });
+
+@ObjectType('ScheduledSyncJob')
+export class ScheduledSyncJobModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  pattern!: string;
+
+  @Field(() => Float, { nullable: true })
+  next!: number | null;
+}
 
 @ObjectType('RegionSyncJob')
 export class RegionSyncJobModel {

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -137,6 +137,9 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     timestamp: true,
   });
   private regionService!: RegionProviderService;
+  private pluginRegionName: string | undefined;
+  private pluginNormalizeDistrict = false;
+  private pluginBioNoisePatterns: RegExp[] = [];
 
   constructor(
     private readonly pluginLoader: PluginLoaderService,
@@ -297,6 +300,16 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
 
     this.regionService = new RegionProviderService(localPlugin);
     const info = this.regionService.getRegionInfo();
+    this.pluginRegionName = info.name;
+
+    const pluginCfg = localConfigRow?.config as
+      | DeclarativeRegionConfig
+      | undefined;
+    this.pluginNormalizeDistrict =
+      pluginCfg?.normalizeExternalIdDistrict ?? false;
+    this.pluginBioNoisePatterns = (pluginCfg?.bioNoisePatterns ?? []).map(
+      (p) => new RegExp(p, 'i'),
+    );
     this.logger.log(
       `RegionSyncService initialized — local: ${this.regionService.getProviderName()} (${info.name}), ` +
         `federal: ${this.pluginRegistry.getFederal() ? 'loaded' : 'not loaded'}`,
@@ -349,6 +362,26 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
       orderBy: [{ parentRegionId: 'asc' }, { name: 'asc' }],
     });
     return rows.map(toRegionPluginRow);
+  }
+
+  async getPluginDataSourceConfigs(): Promise<
+    Array<{ regionId: string; sources: DataSourceConfig[] }>
+  > {
+    const rows = await this.db.regionPlugin.findMany({
+      where: { enabled: true },
+      select: { name: true, config: true },
+    });
+    return rows
+      .map((row) => {
+        const cfg = row.config as unknown as
+          | DeclarativeRegionConfig
+          | undefined;
+        return {
+          regionId: row.name,
+          sources: cfg?.dataSources ?? [],
+        };
+      })
+      .filter((entry) => entry.sources.length > 0);
   }
 
   async getRegionPluginByFipsCode(
@@ -930,8 +963,10 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
   }
 
   private normalizeRep(r: Representative): void {
-    r.externalId = stripLeadingZerosFromExternalId(r.externalId);
-    if (r.bio && !isLikelyValidBio(r.bio)) {
+    if (this.pluginNormalizeDistrict) {
+      r.externalId = stripLeadingZerosFromExternalId(r.externalId);
+    }
+    if (r.bio && !isLikelyValidBio(r.bio, this.pluginBioNoisePatterns)) {
       this.logger.warn(
         `Discarding junk bio for ${r.externalId} (${r.bio.length} chars): ${r.bio.slice(0, 60)}…`,
       );
@@ -964,7 +999,7 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     }
 
     if (this.bioGenerator) {
-      await this.bioGenerator.enrichBios(reps, maxReps);
+      await this.bioGenerator.enrichBios(reps, this.pluginRegionName, maxReps);
     }
 
     const result = await this.upsertByExternalId(
@@ -1725,12 +1760,20 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
         select: { id: true },
       });
 
+      const measureTypeCode =
+        raw.measureTypeCode ?? this.inferMeasureTypeCode(raw.billNumber);
+      if (!measureTypeCode) {
+        this.logger.warn(
+          `Bills extraction: cannot determine measureTypeCode for "${raw.billNumber}" at ${sourceUrl}`,
+        );
+        return 'failed';
+      }
+
       const billData = {
         regionId,
         billNumber: raw.billNumber,
         sessionYear: raw.sessionYear ?? sessionYear,
-        measureTypeCode:
-          raw.measureTypeCode ?? this.inferMeasureTypeCode(raw.billNumber),
+        measureTypeCode,
         title: raw.title,
         subject: raw.subject ?? null,
         status: raw.status ?? null,
@@ -1843,12 +1886,12 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     return `${year}${num}`;
   }
 
-  private inferMeasureTypeCode(billNumber: string): string {
+  private inferMeasureTypeCode(billNumber: string): string | null {
     return (
       billNumber
         .replace(/\s*\d+.*$/, '')
         .trim()
-        .toUpperCase() || 'AB'
+        .toUpperCase() || null
     );
   }
 

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -1675,6 +1675,26 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
+  private parseBillJson(
+    candidate: string,
+    sourceUrl: string,
+  ): (Partial<Bill> & { billNumber: string; title: string }) | null {
+    let raw: Partial<Bill>;
+    try {
+      raw = JSON.parse(candidate) as Partial<Bill>;
+    } catch {
+      this.logger.warn(`Bills extraction: JSON parse failed for ${sourceUrl}`);
+      return null;
+    }
+    if (!raw.billNumber || !raw.title) {
+      this.logger.warn(
+        `Bills extraction: missing required fields at ${sourceUrl}`,
+      );
+      return null;
+    }
+    return raw as Partial<Bill> & { billNumber: string; title: string };
+  }
+
   private async extractAndUpsertBillPage(
     regionId: string,
     sourceUrl: string,
@@ -1726,22 +1746,8 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
         return 'failed';
       }
 
-      let raw: Partial<Bill>;
-      try {
-        raw = JSON.parse(candidate) as Partial<Bill>;
-      } catch {
-        this.logger.warn(
-          `Bills extraction: JSON parse failed for ${sourceUrl}`,
-        );
-        return 'failed';
-      }
-
-      if (!raw.billNumber || !raw.title) {
-        this.logger.warn(
-          `Bills extraction: missing required fields at ${sourceUrl}`,
-        );
-        return 'failed';
-      }
+      const raw = this.parseBillJson(candidate, sourceUrl);
+      if (!raw) return 'failed';
 
       const externalId =
         billId ?? raw.externalId ?? this.buildBillExternalId(raw);

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -1743,15 +1743,8 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
         return 'failed';
       }
 
-      const urlBillId = (() => {
-        try {
-          return new URL(sourceUrl).searchParams.get('bill_id') ?? undefined;
-        } catch {
-          return undefined;
-        }
-      })();
       const externalId =
-        urlBillId ?? raw.externalId ?? this.buildBillExternalId(raw);
+        billId ?? raw.externalId ?? this.buildBillExternalId(raw);
       const authorId = raw.authorName
         ? this.resolveRepByName(raw.authorName, repIndex)
         : undefined;

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -30,7 +30,10 @@ import {
   DataTypeGQL,
   SyncDepthGQL,
 } from './models/region-info.model';
-import { RegionSyncJobModel } from './models/pipeline-job.model';
+import {
+  RegionSyncJobModel,
+  ScheduledSyncJobModel,
+} from './models/pipeline-job.model';
 import { PipelineJobService } from './pipeline-job.service';
 import {
   QueueService,
@@ -907,6 +910,13 @@ export class RegionResolver {
     limit: number,
   ): Promise<RegionSyncJobModel[]> {
     return this.pipelineJobService.findRecent(Math.min(limit, 100));
+  }
+
+  @Query(() => [ScheduledSyncJobModel])
+  @UseGuards(AuthGuard)
+  @Roles(Role.Admin)
+  async scheduledSyncJobs(): Promise<ScheduledSyncJobModel[]> {
+    return this.queueService.listSchedulers(REGION_SYNC_QUEUE);
   }
 
   private async enqueueSyncJob(

--- a/apps/backend/src/apps/region/src/domains/region.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.spec.ts
@@ -107,6 +107,25 @@ describe('isLikelyValidBio', () => {
       ),
     ).toBe(true);
   });
+
+  it('rejects bios matching custom plugin noise patterns', () => {
+    const patterns = [/^About Us/i, /Navigation Menu/i];
+    const longJunk =
+      'Navigation Menu Contact Us Events Calendar Links Resources Committees ' +
+      'Meeting Schedule Agendas Minutes Reports Forms Documents Publications'.repeat(
+        2,
+      );
+    expect(isLikelyValidBio(longJunk, patterns)).toBe(false);
+  });
+
+  it('accepts a valid bio when custom patterns are provided and do not match', () => {
+    const patterns = [/^About Us/i];
+    const realBio =
+      'Representative Jane Doe was elected to the State Assembly in 2020. ' +
+      'She serves on the Agriculture and Finance committees and has championed ' +
+      'water conservation legislation throughout her tenure in the legislature.';
+    expect(isLikelyValidBio(realBio, patterns)).toBe(true);
+  });
 });
 
 // ─── stripLeadingZerosFromExternalId ─────────────────────────────────────────

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -13,6 +13,7 @@
  */
 import { Injectable } from '@nestjs/common';
 import { DataType, SyncResult } from '@opuspopuli/region-provider';
+import type { DataSourceConfig } from '@opuspopuli/common';
 import { Prisma } from '@opuspopuli/relationaldb-provider';
 import { CivicsBlockModel } from './models/region-info.model';
 import { RegionInfoModel } from './models/region-info.model';
@@ -108,15 +109,23 @@ export function stripLeadingZerosFromExternalId(externalId: string): string {
   return [...parts.slice(0, -1), normalized].join('-');
 }
 
+const DEFAULT_BIO_NOISE_PATTERNS: RegExp[] = [/^Home\b/i, /Latest News/i];
+
 /**
  * Decide whether a scraped bio string is real content vs junk.
+ * Pass plugin-configured noise patterns to override the defaults.
  */
-export function isLikelyValidBio(bio: string | null | undefined): boolean {
+export function isLikelyValidBio(
+  bio: string | null | undefined,
+  noisePatterns: RegExp[] = DEFAULT_BIO_NOISE_PATTERNS,
+): boolean {
   if (!bio) return false;
   const trimmed = bio.trim();
   if (trimmed.length < 100) return false;
-  if (/^Home\b/i.test(trimmed)) return false;
-  if (/Latest News/i.test(trimmed.slice(0, 100))) return false;
+  const head = trimmed.slice(0, 100);
+  for (const pattern of noisePatterns) {
+    if (pattern.test(trimmed) || pattern.test(head)) return false;
+  }
   return true;
 }
 
@@ -290,6 +299,12 @@ export class RegionDomainService {
 
   getRegionPluginByFipsCode(fipsCode: string): Promise<RegionPluginRow | null> {
     return this.syncService.getRegionPluginByFipsCode(fipsCode);
+  }
+
+  getPluginDataSourceConfigs(): Promise<
+    Array<{ regionId: string; sources: DataSourceConfig[] }>
+  > {
+    return this.syncService.getPluginDataSourceConfigs();
   }
 
   // ─── Query delegation ─────────────────────────────────────────────────────

--- a/apps/backend/src/apps/workers/region-worker/src/cadence.utils.ts
+++ b/apps/backend/src/apps/workers/region-worker/src/cadence.utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Deterministically offsets the minute field of a cron expression using a
+ * hash of the seed string. Spreads per-source jobs across the hour so they
+ * don't all fire simultaneously.
+ *
+ * Example: staggeredCron('0 2 * * *', 'california-meetings') → '33 2 * * *'
+ */
+export function staggeredCron(baseCron: string, seed: string): string {
+  const offset = [...seed].reduce((n, c) => n + c.charCodeAt(0), 0) % 60;
+  const parts = baseCron.split(' ');
+  parts[0] = String(offset);
+  return parts.join(' ');
+}

--- a/apps/backend/src/apps/workers/region-worker/src/region-sync.scheduler.spec.ts
+++ b/apps/backend/src/apps/workers/region-worker/src/region-sync.scheduler.spec.ts
@@ -4,26 +4,34 @@ import { createMock } from '@golevelup/ts-jest';
 import { RegionSyncScheduler } from './region-sync.scheduler';
 import { QueueService } from '@opuspopuli/queue-provider';
 import { PipelineJobService } from 'src/apps/region/src/domains/pipeline-job.service';
+import { RegionDomainService } from 'src/apps/region/src/domains/region.service';
+import { staggeredCron } from './cadence.utils';
 
 describe('RegionSyncScheduler', () => {
   let scheduler: RegionSyncScheduler;
   let queueService: jest.Mocked<QueueService>;
+  let regionService: jest.Mocked<RegionDomainService>;
 
   function buildModule(env: Record<string, string> = {}) {
     Object.assign(process.env, env);
 
     const mockQueue = createMock<QueueService>();
     const mockJobs = createMock<PipelineJobService>();
+    const mockRegion = createMock<RegionDomainService>();
 
     mockQueue.upsertScheduler.mockResolvedValue(undefined);
     mockQueue.enqueue.mockResolvedValue('bullmq-job-1');
+    mockQueue.listSchedulers.mockResolvedValue([]);
+    mockQueue.removeScheduler.mockResolvedValue(undefined);
     mockJobs.create.mockResolvedValue({ id: 'job-uuid' });
+    mockRegion.getPluginDataSourceConfigs.mockResolvedValue([]);
 
     return Test.createTestingModule({
       providers: [
         RegionSyncScheduler,
         { provide: QueueService, useValue: mockQueue },
         { provide: PipelineJobService, useValue: mockJobs },
+        { provide: RegionDomainService, useValue: mockRegion },
       ],
     }).compile();
   }
@@ -35,6 +43,7 @@ describe('RegionSyncScheduler', () => {
     const module: TestingModule = await buildModule();
     scheduler = module.get<RegionSyncScheduler>(RegionSyncScheduler);
     queueService = module.get(QueueService);
+    regionService = module.get(RegionDomainService);
   });
 
   afterEach(() => {
@@ -47,7 +56,7 @@ describe('RegionSyncScheduler', () => {
   });
 
   describe('onApplicationBootstrap', () => {
-    it('upserts the daily-cron scheduler when REGION_SYNC_CRON_ENABLED=true', async () => {
+    it('falls back to daily-cron when no sources have syncCadence', async () => {
       await scheduler.onApplicationBootstrap();
 
       expect(queueService.upsertScheduler).toHaveBeenCalledWith(
@@ -55,6 +64,147 @@ describe('RegionSyncScheduler', () => {
         'daily-cron',
         '0 2 * * *',
         expect.objectContaining({ triggerSource: 'cron' }),
+      );
+    });
+
+    it('registers per-source schedulers when syncCadence is configured', async () => {
+      regionService.getPluginDataSourceConfigs.mockResolvedValueOnce([
+        {
+          regionId: 'california',
+          sources: [
+            {
+              url: 'https://example.com',
+              dataType: 'meetings' as never,
+              contentGoal: 'meetings',
+              syncCadence: '0 2 * * *',
+            },
+            {
+              url: 'https://example.com/props',
+              dataType: 'propositions' as never,
+              contentGoal: 'props',
+              syncCadence: '0 2 * * 0',
+            },
+          ],
+        },
+      ]);
+
+      await scheduler.onApplicationBootstrap();
+
+      const meetingsCron = staggeredCron('0 2 * * *', 'california-meetings');
+      const propsCron = staggeredCron('0 2 * * 0', 'california-propositions');
+
+      expect(queueService.upsertScheduler).toHaveBeenCalledWith(
+        'region-sync',
+        'california-meetings-cron',
+        meetingsCron,
+        expect.objectContaining({
+          triggerSource: 'cron',
+          regionId: 'california',
+          dataTypes: ['meetings'],
+        }),
+      );
+      expect(queueService.upsertScheduler).toHaveBeenCalledWith(
+        'region-sync',
+        'california-propositions-cron',
+        propsCron,
+        expect.objectContaining({
+          triggerSource: 'cron',
+          regionId: 'california',
+          dataTypes: ['propositions'],
+        }),
+      );
+    });
+
+    it('skips sources without syncCadence', async () => {
+      regionService.getPluginDataSourceConfigs.mockResolvedValueOnce([
+        {
+          regionId: 'california',
+          sources: [
+            {
+              url: 'https://example.com',
+              dataType: 'meetings' as never,
+              contentGoal: 'meetings',
+              syncCadence: '0 2 * * *',
+            },
+            {
+              url: 'https://example.com/props',
+              dataType: 'propositions' as never,
+              contentGoal: 'props',
+              // no syncCadence
+            },
+          ],
+        },
+      ]);
+
+      await scheduler.onApplicationBootstrap();
+
+      expect(queueService.upsertScheduler).toHaveBeenCalledTimes(1);
+      expect(queueService.upsertScheduler).toHaveBeenCalledWith(
+        'region-sync',
+        'california-meetings-cron',
+        expect.any(String),
+        expect.any(Object),
+      );
+    });
+
+    it('continues registering remaining sources when one upsert fails', async () => {
+      regionService.getPluginDataSourceConfigs.mockResolvedValueOnce([
+        {
+          regionId: 'california',
+          sources: [
+            {
+              url: 'https://example.com/meetings',
+              dataType: 'meetings' as never,
+              contentGoal: 'meetings',
+              syncCadence: '0 2 * * *',
+            },
+            {
+              url: 'https://example.com/props',
+              dataType: 'propositions' as never,
+              contentGoal: 'props',
+              syncCadence: '0 2 * * 0',
+            },
+          ],
+        },
+      ]);
+
+      queueService.upsertScheduler
+        .mockRejectedValueOnce(new Error('Redis unavailable'))
+        .mockResolvedValue(undefined);
+
+      await expect(scheduler.onApplicationBootstrap()).resolves.not.toThrow();
+      expect(queueService.upsertScheduler).toHaveBeenCalledTimes(2);
+    });
+
+    it('removes stale scheduler keys not in the active config', async () => {
+      regionService.getPluginDataSourceConfigs.mockResolvedValueOnce([
+        {
+          regionId: 'california',
+          sources: [
+            {
+              url: 'https://example.com',
+              dataType: 'meetings' as never,
+              contentGoal: 'meetings',
+              syncCadence: '0 2 * * *',
+            },
+          ],
+        },
+      ]);
+
+      queueService.listSchedulers.mockResolvedValueOnce([
+        { id: 'california-meetings-cron', pattern: '33 2 * * *', next: null },
+        { id: 'california-old-data-cron', pattern: '0 3 * * *', next: null },
+      ]);
+
+      await scheduler.onApplicationBootstrap();
+
+      expect(queueService.removeScheduler).toHaveBeenCalledWith(
+        'region-sync',
+        'california-old-data-cron',
+      );
+      expect(queueService.removeScheduler).not.toHaveBeenCalledWith(
+        'region-sync',
+        'california-meetings-cron',
       );
     });
 
@@ -94,5 +244,37 @@ describe('RegionSyncScheduler', () => {
       await scheduler.onApplicationBootstrap();
       expect(queueService.enqueue).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('staggeredCron', () => {
+  it('replaces the minute field with a deterministic offset', () => {
+    const result = staggeredCron('0 2 * * *', 'california-meetings');
+    const parts = result.split(' ');
+    expect(parts).toHaveLength(5);
+    expect(parts[1]).toBe('2');
+    expect(Number(parts[0])).toBeGreaterThanOrEqual(0);
+    expect(Number(parts[0])).toBeLessThan(60);
+  });
+
+  it('produces the same result for the same seed', () => {
+    expect(staggeredCron('0 2 * * *', 'test-seed')).toBe(
+      staggeredCron('0 2 * * *', 'test-seed'),
+    );
+  });
+
+  it('produces different results for different seeds', () => {
+    expect(staggeredCron('0 2 * * *', 'region-a-meetings')).not.toBe(
+      staggeredCron('0 2 * * *', 'region-b-meetings'),
+    );
+  });
+
+  it('preserves all non-minute fields of the base cron', () => {
+    const result = staggeredCron('0 3 1 6 5', 'seed');
+    const parts = result.split(' ');
+    expect(parts[1]).toBe('3');
+    expect(parts[2]).toBe('1');
+    expect(parts[3]).toBe('6');
+    expect(parts[4]).toBe('5');
   });
 });

--- a/apps/backend/src/apps/workers/region-worker/src/region-sync.scheduler.ts
+++ b/apps/backend/src/apps/workers/region-worker/src/region-sync.scheduler.ts
@@ -6,7 +6,9 @@ import {
 } from '@opuspopuli/queue-provider';
 import type { RegionSyncJobData } from '@opuspopuli/queue-provider';
 import { PipelineJobService } from 'src/apps/region/src/domains/pipeline-job.service';
+import { RegionDomainService } from 'src/apps/region/src/domains/region.service';
 import { format } from 'date-fns';
+import { staggeredCron } from './cadence.utils';
 
 const DAILY_CRON = '0 2 * * *';
 
@@ -19,6 +21,7 @@ export class RegionSyncScheduler implements OnApplicationBootstrap {
   constructor(
     private readonly queueService: QueueService,
     private readonly pipelineJobService: PipelineJobService,
+    private readonly regionService: RegionDomainService,
   ) {}
 
   async onApplicationBootstrap() {
@@ -26,6 +29,26 @@ export class RegionSyncScheduler implements OnApplicationBootstrap {
     const runOnStartup = process.env.REGION_SYNC_RUN_ON_STARTUP === 'true';
 
     if (cronEnabled) {
+      await this.registerSchedulers();
+    } else {
+      this.logger.log(
+        'REGION_SYNC_CRON_ENABLED=false — skipping scheduler registration',
+      );
+    }
+
+    if (runOnStartup) {
+      await this.enqueueStartupJob();
+    }
+  }
+
+  private async registerSchedulers(): Promise<void> {
+    const configs = await this.regionService.getPluginDataSourceConfigs();
+
+    const hasCadences = configs.some(({ sources }) =>
+      sources.some((s) => s.syncCadence),
+    );
+
+    if (!hasCadences) {
       await this.queueService.upsertScheduler(
         REGION_SYNC_QUEUE,
         'daily-cron',
@@ -37,14 +60,56 @@ export class RegionSyncScheduler implements OnApplicationBootstrap {
       this.logger.log(
         `Registered daily-cron scheduler on ${REGION_SYNC_QUEUE} (${DAILY_CRON})`,
       );
-    } else {
-      this.logger.log(
-        'REGION_SYNC_CRON_ENABLED=false — skipping scheduler registration',
-      );
+      return;
     }
 
-    if (runOnStartup) {
-      await this.enqueueStartupJob();
+    const registeredKeys = new Set<string>();
+
+    for (const { regionId, sources } of configs) {
+      for (const source of sources) {
+        if (!source.syncCadence) continue;
+
+        const schedulerKey = `${regionId}-${source.dataType}-cron`;
+        const cron = staggeredCron(
+          source.syncCadence,
+          `${regionId}-${source.dataType}`,
+        );
+
+        try {
+          await this.queueService.upsertScheduler(
+            REGION_SYNC_QUEUE,
+            schedulerKey,
+            cron,
+            {
+              triggerSource: TRIGGER_SOURCE.CRON,
+              regionId,
+              dataTypes: [source.dataType as string],
+            } satisfies Partial<RegionSyncJobData>,
+          );
+          registeredKeys.add(schedulerKey);
+          this.logger.log(`Registered scheduler ${schedulerKey} (${cron})`);
+        } catch (err) {
+          this.logger.warn(
+            `Failed to register scheduler ${schedulerKey}: ${(err as Error).message}`,
+          );
+        }
+      }
+    }
+
+    await this.removeStaleSchedulers(registeredKeys);
+  }
+
+  private async removeStaleSchedulers(activeKeys: Set<string>): Promise<void> {
+    const existing = await this.queueService.listSchedulers(REGION_SYNC_QUEUE);
+
+    for (const scheduler of existing) {
+      if (!activeKeys.has(scheduler.id)) {
+        await this.queueService.removeScheduler(
+          REGION_SYNC_QUEUE,
+          scheduler.id,
+        );
+        this.logger.log(`Removed stale scheduler ${scheduler.id}`);
+      }
     }
   }
 

--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -361,6 +361,14 @@ export interface DataSourceConfig {
    * exhausting `crawlMaxPages` before any detail pages can be discovered.
    */
   billDiscovery?: BillDiscoveryConfig;
+
+  /**
+   * 5-field cron expression for how often this source is synced
+   * (e.g. '0 2 * * *' = daily at 2 AM, '0 2 * * 0' = weekly on Sunday).
+   * Omit to inherit the global daily-cron fallback. The worker applies a
+   * deterministic per-source minute offset at registration time.
+   */
+  syncCadence?: string;
 }
 
 /**
@@ -542,6 +550,18 @@ export interface DeclarativeRegionConfig {
   cacheTtlMs?: number;
   /** Request timeout in milliseconds */
   requestTimeoutMs?: number;
+  /**
+   * Strip leading zeros from representative externalId trailing segment
+   * (e.g. ca-assembly-01 → ca-assembly-1). Opt-in; default false.
+   * Set true for regions whose LLM manifests emit zero-padded district numbers.
+   */
+  normalizeExternalIdDistrict?: boolean;
+  /**
+   * Regex pattern strings (case-insensitive) matched against scraped
+   * representative bio text. Bios matching any pattern are discarded as
+   * nav junk. Defaults to no filtering if omitted.
+   */
+  bioNoisePatterns?: string[];
 }
 
 // ============================================

--- a/packages/queue-provider/__tests__/queue.service.spec.ts
+++ b/packages/queue-provider/__tests__/queue.service.spec.ts
@@ -8,6 +8,8 @@ jest.mock("bullmq", () => {
     add: jest.fn().mockResolvedValue(mockJob),
     getJob: jest.fn(),
     upsertJobScheduler: jest.fn().mockResolvedValue(undefined),
+    getJobSchedulers: jest.fn().mockResolvedValue([]),
+    removeJobScheduler: jest.fn().mockResolvedValue(true),
     close: jest.fn().mockResolvedValue(undefined),
   };
   return { Queue: jest.fn(() => mockQueue) };
@@ -66,6 +68,48 @@ describe("QueueService", () => {
         service.upsertScheduler("region-sync", "daily-cron", "0 2 * * *", {
           triggerSource: "cron",
         }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("listSchedulers", () => {
+    it("returns mapped scheduler info from bullmq", async () => {
+      const { Queue } = jest.requireMock("bullmq");
+      const mockQueue = Queue.mock.results[0]?.value ?? Queue();
+      mockQueue.getJobSchedulers.mockResolvedValueOnce([
+        {
+          key: "california-campaign_finance-cron",
+          pattern: "15 2 * * *",
+          next: 1700000000000,
+        },
+        {
+          key: "california-propositions-cron",
+          pattern: "22 2 * * 0",
+          next: null,
+        },
+      ]);
+
+      const result = await service.listSchedulers("region-sync");
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        id: "california-campaign_finance-cron",
+        pattern: "15 2 * * *",
+        next: 1700000000000,
+      });
+      expect(result[1].next).toBeNull();
+    });
+
+    it("returns empty array when no schedulers registered", async () => {
+      const result = await service.listSchedulers("region-sync");
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("removeScheduler", () => {
+    it("delegates to bullmq removeJobScheduler", async () => {
+      await expect(
+        service.removeScheduler("region-sync", "daily-cron"),
       ).resolves.not.toThrow();
     });
   });

--- a/packages/queue-provider/src/index.ts
+++ b/packages/queue-provider/src/index.ts
@@ -24,4 +24,5 @@ export type {
   QueueModuleAsyncOptions,
   EnqueueOptions,
   QueueJobInfo,
+  SchedulerInfo,
 } from "./queue.types";

--- a/packages/queue-provider/src/queue.service.ts
+++ b/packages/queue-provider/src/queue.service.ts
@@ -6,6 +6,7 @@ import {
   EnqueueOptions,
   QueueJobInfo,
   QueueModuleOptions,
+  SchedulerInfo,
 } from "./queue.types";
 
 @Injectable()
@@ -61,6 +62,22 @@ export class QueueService implements OnModuleDestroy {
     this.logger.log(
       `Upserted scheduler ${schedulerId} on ${queueName} (cron: ${cron})`,
     );
+  }
+
+  async listSchedulers(queueName: string): Promise<SchedulerInfo[]> {
+    const queue = this.getQueue(queueName);
+    const schedulers = await queue.getJobSchedulers();
+    return schedulers.map((s) => ({
+      id: s.key,
+      pattern: s.pattern ?? "",
+      next: s.next ?? null,
+    }));
+  }
+
+  async removeScheduler(queueName: string, schedulerId: string): Promise<void> {
+    const queue = this.getQueue(queueName);
+    await queue.removeJobScheduler(schedulerId);
+    this.logger.log(`Removed scheduler ${schedulerId} from ${queueName}`);
   }
 
   async close(): Promise<void> {

--- a/packages/queue-provider/src/queue.types.ts
+++ b/packages/queue-provider/src/queue.types.ts
@@ -63,3 +63,9 @@ export interface QueueJobInfo {
   progress: number;
   failedReason?: string;
 }
+
+export interface SchedulerInfo {
+  id: string;
+  pattern: string;
+  next: number | null;
+}

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.59"
+    "@opuspopuli/regions": "^1.0.60"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.58
-        version: 1.0.58
+        specifier: ^1.0.60
+        version: 1.0.60
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -983,8 +983,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.59
-        version: 1.0.59
+        specifier: ^1.0.60
+        version: 1.0.60
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4993,12 +4993,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.58':
-    resolution: {integrity: sha512-V1raCl6s7fVhSfjX8MhUF+Sr4lm2cIhedm+eBZ7M2VuD0AwijTXttBOXvOwuRlCiMLAs8LqQ6GagvLMvZbb58A==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.58/da47c12a0122afa0da3c1993d33ef5e91442a65b}
-    hasBin: true
-
-  '@opuspopuli/regions@1.0.59':
-    resolution: {integrity: sha512-guPe3lBnoRaFvPEvuSNXJHu5Y7vOOYsdSKKwljK564hiJJfM9uy0UbDGixE/8j4rP6CB1V1iIoumRDqBPriWnw==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.59/63f78d27511e11ba2c7931d15344dd9667117880}
+  '@opuspopuli/regions@1.0.60':
+    resolution: {integrity: sha512-A2ZyfH8F9s4vpkijxcB/HiR5K0l+kQHhAHDsYh6BnXY+63Ae8Jm5JEVhuYwfNxHjzS6MfhgFC/YpANkFRzry4Q==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.60/b4d58f9fe3765ecfd48ea845a58b84341ba17e6e}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -16881,16 +16877,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.58':
-    dependencies:
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      chalk: 5.6.2
-      cheerio: 1.2.0
-      commander: 12.1.0
-      ollama: 0.6.3
-
-  '@opuspopuli/regions@1.0.59':
+  '@opuspopuli/regions@1.0.60':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
@@ -21217,7 +21204,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.16.1)
+      retry-axios: 2.6.0(axios@1.16.1(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -23962,7 +23949,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.16.1):
+  retry-axios@2.6.0(axios@1.16.1(debug@4.4.3)):
     dependencies:
       axios: 1.16.1(debug@4.4.3)
 

--- a/postman/OpusPopuli.postman_collection.json
+++ b/postman/OpusPopuli.postman_collection.json
@@ -837,6 +837,25 @@
               "path": ["api"]
             }
           }
+        },
+        {
+          "name": "Scheduled Sync Jobs (Admin)",
+          "description": "List all BullMQ repeatable job schedulers currently registered on the region-sync queue. Each entry shows the scheduler key (e.g. 'california-meetings-cron'), its staggered cron pattern, and the next scheduled fire time as a Unix epoch millisecond value (null if not yet computed). Requires REGION_SYNC_CRON_ENABLED=true on the region-worker for entries to appear.",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "query {\n  scheduledSyncJobs {\n    id\n    pattern\n    next\n  }\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
         }
       ]
     },


### PR DESCRIPTION
## Summary

- **Content-aware BullMQ scheduler** (#651): `RegionSyncScheduler` now reads `syncCadence` from each data source's plugin config and registers a separate BullMQ repeatable job per `(regionId, dataType)` pair. If no source has a cadence, it falls back to the existing daily cron. Stale scheduler keys are pruned on startup to avoid ghost jobs after config changes.
- **`staggeredCron` utility**: deterministic, seed-based minute offset (char-code hash % 60) spreads per-source jobs evenly across the hour, preventing thundering-herd bursts.
- **Remove CA hardcoding** (#693): `DeclarativeRegionConfig` gains `normalizeExternalIdDistrict` and `bioNoisePatterns` plugin-level flags, removing the last California-specific branches from `region-sync.service.ts` and `bio-generator.service.ts`. Bio jurisdiction for county regions now uses `"Sonoma County Board of Supervisors"` (no erroneous "State" infix).
- **`scheduledSyncJobs` admin query**: new GraphQL query returns the live BullMQ scheduler list (id, cron pattern, next fire time as `Float` to avoid 2038 Int overflow). Requires Admin role.
- **`QueueService`** (`@opuspopuli/queue-provider`): added `listSchedulers()` and `removeScheduler()` methods.
- **`@opuspopuli/regions` bumped to `^1.0.60`**: schema adds `syncCadence`, `normalizeExternalIdDistrict`, and `bioNoisePatterns` fields to the region plugin config type.
- **Cognitive complexity fixes**: `extractAndUpsertBillPage` refactored below the SonarCloud gate (≤ 15) via `parseBillJson` helper extraction and removal of a redundant IIFE.

## How to test

**Unit tests** (no infra needed):
```bash
cd apps/backend && pnpm test
```
All 1 623 tests pass.

**UAT (Docker)**:
1. Rebuild and restart the region + region-worker containers:
   ```bash
   docker compose -f docker-compose-uat.yml build --no-cache region region-worker && \
   docker compose -f docker-compose-uat.yml up -d --force-recreate region region-worker
   ```
2. Verify the scheduler log on startup (with `REGION_SYNC_CRON_ENABLED=true`):
   - If regions have `syncCadence` configured → logs `Registered scheduler california-meetings-cron (33 2 * * *)` per source
   - If none → logs `Registered daily-cron scheduler on region-sync`
3. Query the admin endpoint via Postman → **Pipeline Jobs → Scheduled Sync Jobs (Admin)**:
   ```graphql
   query { scheduledSyncJobs { id pattern next } }
   ```
   Returns `[]` when `REGION_SYNC_CRON_ENABLED=false` (expected for UAT).
4. Trigger a manual sync via **syncRegionData** mutation to confirm the pipeline still runs end-to-end.

**Config-flag test** (with a region that has `syncCadence`):
- Set `syncCadence: "0 2 * * *"` on one data source in `@opuspopuli/regions`, restart worker, confirm per-source scheduler key is registered and stale keys are removed.

## Linked issues

Closes #651
Closes #693

## Checklist

- [x] `pnpm lint` — 0 errors (2 pre-existing `process.env.NODE_ENV` warnings, not in changed files)
- [x] `pnpm test` — 91 suites / 1 623 tests, all passing
- [x] `pnpm build` — clean
- [x] No `console.log`, debug flags, hardcoded secrets, or skipped tests in diff
- [x] No new third-party dependencies (only `@opuspopuli/regions` version bump)
- [x] No AGPL/GPL license conflicts — no new packages added
- [x] API Gateway not modified — `scheduledSyncJobs` subgraph addition picked up by `IntrospectAndCompose` on gateway restart
- [x] SonarCloud cognitive complexity gate satisfied (≤ 15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)