### PR TITLE
feat(pipeline,region): auto-requeue sync after manifest analysis and harden job lifecycle (#718)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ playwright/.cache/
 # macOS
 .DS_Store
 
-# Claude Code per-project state (plans, tool results, etc.)
-.claude/CALIFORNIA_SCRAPING_TEST_PLAN.md
+# Claude Code per-project state (worktrees, tool results, local settings)
+# settings.json (team config) can be force-added if needed: git add -f .claude/settings.json
+.claude/
 tmp/

--- a/apps/backend/src/apps/region/src/domains/models/pipeline-job.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/pipeline-job.model.ts
@@ -18,6 +18,7 @@ export enum SyncTriggerSource {
   MANUAL = 'MANUAL',
   CRON = 'CRON',
   STARTUP = 'STARTUP',
+  MANIFEST_READY = 'MANIFEST_READY',
 }
 
 registerEnumType(SyncJobStatus, {

--- a/apps/backend/src/apps/region/src/domains/pipeline-job.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/pipeline-job.service.spec.ts
@@ -1,0 +1,56 @@
+import { PipelineJobService } from './pipeline-job.service';
+import { JOB_STATUS } from '@opuspopuli/queue-provider';
+
+function buildMockPrisma() {
+  return {
+    pipelineJob: {
+      create: jest.fn(),
+      update: jest.fn(),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      findUnique: jest.fn(),
+      findMany: jest.fn(),
+    },
+  };
+}
+
+describe('PipelineJobService', () => {
+  describe('markRunning', () => {
+    it('issues an updateMany that excludes SUCCEEDED records', async () => {
+      const prisma = buildMockPrisma();
+      const svc = new PipelineJobService(prisma as never);
+
+      await svc.markRunning('job-1', 'bullmq-1');
+
+      expect(prisma.pipelineJob.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'job-1', status: { not: JOB_STATUS.SUCCEEDED } },
+        }),
+      );
+    });
+
+    it('does not overwrite a SUCCEEDED record when BullMQ retries a stalled job', async () => {
+      const prisma = buildMockPrisma();
+      // Simulate Prisma returning count:0 when the where-clause excludes the row
+      prisma.pipelineJob.updateMany.mockResolvedValue({ count: 0 });
+
+      const svc = new PipelineJobService(prisma as never);
+      // Should resolve without throwing even when no rows are updated
+      await expect(
+        svc.markRunning('job-1', 'bullmq-2'),
+      ).resolves.toBeUndefined();
+    });
+
+    it('increments attempts on each call for legitimate retries', async () => {
+      const prisma = buildMockPrisma();
+      const svc = new PipelineJobService(prisma as never);
+
+      await svc.markRunning('job-1', 'bullmq-1');
+
+      expect(prisma.pipelineJob.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ attempts: { increment: 1 } }),
+        }),
+      );
+    });
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/pipeline-job.service.ts
+++ b/apps/backend/src/apps/region/src/domains/pipeline-job.service.ts
@@ -43,8 +43,11 @@ export class PipelineJobService {
   }
 
   async markRunning(id: string, bullmqJobId: string): Promise<void> {
-    await this.prisma.pipelineJob.update({
-      where: { id },
+    // Skip if already SUCCEEDED — BullMQ can re-enqueue a stalled job even
+    // after the original attempt finished, and we must not overwrite the
+    // completed record's startedAt/finishedAt (which would cause negative elapsedMs).
+    await this.prisma.pipelineJob.updateMany({
+      where: { id, status: { not: JOB_STATUS.SUCCEEDED } },
       data: {
         status: JOB_STATUS.RUNNING,
         bullmqJobId,

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
@@ -169,7 +169,7 @@ describe('RegionSyncService', () => {
       unloadPlugin: jest.fn().mockResolvedValue(undefined),
     };
 
-    mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+    mockDb.regionPlugin.findMany.mockResolvedValue([]);
     mockDb.regionPlugin.findUnique.mockResolvedValue(null);
     mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
 
@@ -554,7 +554,7 @@ describe('RegionSyncService — federal placeholder resolution', () => {
       },
     };
 
-    mockDb.regionPlugin.findFirst.mockResolvedValue(localConfig as never);
+    mockDb.regionPlugin.findMany.mockResolvedValue([localConfig] as never);
     mockDb.regionPlugin.findUnique.mockResolvedValue(federalConfig as never);
     mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
 
@@ -637,7 +637,7 @@ describe('RegionSyncService — federal placeholder resolution', () => {
       },
     };
 
-    mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+    mockDb.regionPlugin.findMany.mockResolvedValue([]);
     mockDb.regionPlugin.findUnique.mockResolvedValue(federalConfig as never);
     mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
 
@@ -771,7 +771,7 @@ describe('RegionSyncService — campaign finance sync', () => {
       unloadPlugin: jest.fn().mockResolvedValue(undefined),
     };
 
-    mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+    mockDb.regionPlugin.findMany.mockResolvedValue([]);
     mockDb.regionPlugin.findUnique.mockResolvedValue(null);
     mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
 
@@ -962,7 +962,7 @@ describe('RegionSyncService — cache invalidation and batch transactions', () =
       unloadPlugin: jest.fn().mockResolvedValue(undefined),
     };
 
-    mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+    mockDb.regionPlugin.findMany.mockResolvedValue([]);
     mockDb.regionPlugin.findUnique.mockResolvedValue(null);
     mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
 
@@ -1269,7 +1269,7 @@ describe('RegionSyncService — proposition analysis wiring', () => {
     } = {},
   ) {
     const mockDb = createMockDbService();
-    mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+    mockDb.regionPlugin.findMany.mockResolvedValue([]);
     mockDb.regionPlugin.findUnique.mockResolvedValue(null);
     mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
     mockDb.proposition.findMany.mockResolvedValue([]);
@@ -1384,7 +1384,7 @@ describe('RegionSyncService — proposition analysis wiring', () => {
   describe('regeneratePropositionAnalysis when analyzer is not provided', () => {
     it('returns false when the optional dependency is absent', async () => {
       const mockDb = createMockDbService();
-      mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+      mockDb.regionPlugin.findMany.mockResolvedValue([]);
       mockDb.regionPlugin.findUnique.mockResolvedValue(null);
       mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
 
@@ -1503,7 +1503,7 @@ describe('RegionSyncService — proposition finance wiring', () => {
     } = {},
   ) {
     const mockDb = createMockDbService();
-    mockDb.regionPlugin.findFirst.mockResolvedValue(null);
+    mockDb.regionPlugin.findMany.mockResolvedValue([]);
     mockDb.regionPlugin.findUnique.mockResolvedValue(null);
     mockDb.regionPlugin.upsert.mockResolvedValue({} as never);
     mockDb.proposition.findMany.mockResolvedValue([]);

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -109,6 +109,8 @@ interface DataFetcher {
     pipelineJobId?: string,
   ): Promise<CampaignFinanceResult>;
   fetchMeetingMinutes?(): Promise<MinutesWithActions[]>;
+  getName?(): string;
+  getDataSources?(dataType?: DataType): DataSourceConfig[];
 }
 
 type PrismaModelDelegate = {
@@ -124,6 +126,17 @@ type CommitteeRecord = {
   externalId: string;
   id: string;
 };
+
+// State-level rows (parentRegionId IS NULL) sort before county rows so the
+// primary plugin is always a state plugin when one is available.
+function comparePluginRows(
+  a: { name: string; parentRegionId: string | null },
+  b: { name: string; parentRegionId: string | null },
+): number {
+  if (!a.parentRegionId && b.parentRegionId) return -1;
+  if (a.parentRegionId && !b.parentRegionId) return 1;
+  return a.name.localeCompare(b.name);
+}
 
 /**
  * RegionSyncService — owns all data-synchronisation logic extracted from
@@ -210,86 +223,22 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     await this.resolveApiKeysFromVault();
     await this.syncRegionConfigs();
 
-    const localConfigRow = await this.db.regionPlugin.findFirst({
+    const allLocalConfigRows = await this.db.regionPlugin.findMany({
       where: { enabled: true, name: { not: 'federal' } },
     });
+    // State-level plugins (parentRegionId IS NULL) first so the primary plugin
+    // is always a state plugin when one is available.
+    allLocalConfigRows.sort(comparePluginRows);
+    const localConfigRow =
+      allLocalConfigRows.find((r) => !r.parentRegionId) ??
+      allLocalConfigRows[0];
 
-    const localConfigData = localConfigRow?.config as
-      | Record<string, unknown>
-      | undefined;
-    const stateCode = localConfigData?.stateCode as string | undefined;
+    const stateCode = (
+      localConfigRow?.config as Record<string, unknown> | undefined
+    )?.stateCode as string | undefined;
 
-    const variables: Record<string, string> = {};
-    if (stateCode) {
-      variables['stateCode'] = stateCode;
-    }
-
-    // 1. ALWAYS load federal
-    try {
-      const federalConfig = await this.db.regionPlugin.findUnique({
-        where: { name: 'federal' },
-      });
-
-      if (federalConfig) {
-        let config = federalConfig.config as Record<string, unknown>;
-
-        if (Object.keys(variables).length > 0) {
-          config = resolveConfigPlaceholders(config, variables);
-          this.logger.log(
-            `Resolved federal config placeholders (stateCode="${stateCode}")`,
-          );
-        } else {
-          this.logger.warn(
-            'No local region stateCode available — federal config placeholders will not be resolved',
-          );
-        }
-
-        this.logger.log('Loading federal plugin');
-        await this.pluginLoader.loadFederalPlugin(config, this.pipeline);
-      } else {
-        this.logger.warn(
-          'Federal region config not found in database — FEC data will not be available',
-        );
-      }
-    } catch (error) {
-      this.logger.error(
-        `Failed to load federal plugin: ${(error as Error).message}`,
-      );
-    }
-
-    // 2. Load the enabled LOCAL plugin
-    try {
-      const localConfig = localConfigRow;
-
-      if (localConfig) {
-        this.logger.log(
-          `Loading local declarative region plugin "${localConfig.name}"`,
-        );
-        await this.pluginLoader.loadPlugin(
-          {
-            name: localConfig.name,
-            config: localConfig.config as Record<string, unknown> | undefined,
-          },
-          this.pipeline,
-        );
-      } else {
-        this.logger.warn(
-          'No enabled local region plugin found in database, falling back to ExampleRegionProvider',
-        );
-        await this.pluginRegistry.registerLocal(
-          'example',
-          this.createFallbackPlugin(),
-        );
-      }
-    } catch (error) {
-      this.logger.error(
-        `Failed to load local region plugin, falling back to ExampleRegionProvider: ${(error as Error).message}`,
-      );
-      await this.pluginRegistry.registerLocal(
-        'example',
-        this.createFallbackPlugin(),
-      );
-    }
+    await this.initFederalPlugin(stateCode);
+    await this.initLocalPlugins(allLocalConfigRows);
 
     const localPlugin = this.pluginRegistry.getLocal();
     if (!localPlugin) {
@@ -302,7 +251,7 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     const info = this.regionService.getRegionInfo();
     this.pluginRegionName = info.name;
 
-    const pluginCfg = localConfigRow?.config as
+    const pluginCfg = localConfigRow?.config as unknown as
       | DeclarativeRegionConfig
       | undefined;
     this.pluginNormalizeDistrict =
@@ -314,6 +263,85 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
       `RegionSyncService initialized — local: ${this.regionService.getProviderName()} (${info.name}), ` +
         `federal: ${this.pluginRegistry.getFederal() ? 'loaded' : 'not loaded'}`,
     );
+  }
+
+  private async initFederalPlugin(
+    stateCode: string | undefined,
+  ): Promise<void> {
+    try {
+      const federalConfig = await this.db.regionPlugin.findUnique({
+        where: { name: 'federal' },
+      });
+      if (!federalConfig) {
+        this.logger.warn(
+          'Federal region config not found in database — FEC data will not be available',
+        );
+        return;
+      }
+
+      let config = federalConfig.config as Record<string, unknown>;
+      if (stateCode) {
+        config = resolveConfigPlaceholders(config, { stateCode });
+        this.logger.log(
+          `Resolved federal config placeholders (stateCode="${stateCode}")`,
+        );
+      } else {
+        this.logger.warn(
+          'No local region stateCode available — federal config placeholders will not be resolved',
+        );
+      }
+
+      this.logger.log('Loading federal plugin');
+      await this.pluginLoader.loadFederalPlugin(config, this.pipeline);
+    } catch (error) {
+      this.logger.error(
+        `Failed to load federal plugin: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  private async initLocalPlugins(
+    rows: { name: string; config: unknown; parentRegionId: string | null }[],
+  ): Promise<void> {
+    if (rows.length === 0) {
+      this.logger.warn(
+        'No enabled local region plugins found in database, falling back to ExampleRegionProvider',
+      );
+      await this.pluginRegistry.registerLocal(
+        'example',
+        this.createFallbackPlugin(),
+      );
+      return;
+    }
+
+    for (const row of rows) {
+      try {
+        this.logger.log(
+          `Loading local declarative region plugin "${row.name}"`,
+        );
+        await this.pluginLoader.loadPlugin(
+          {
+            name: row.name,
+            config: row.config as Record<string, unknown> | undefined,
+          },
+          this.pipeline,
+        );
+      } catch (error) {
+        this.logger.error(
+          `Failed to load plugin "${row.name}": ${(error as Error).message}`,
+        );
+      }
+    }
+
+    if (!this.pluginRegistry.hasActive()) {
+      this.logger.warn(
+        'All local plugins failed to load, falling back to ExampleRegionProvider',
+      );
+      await this.pluginRegistry.registerLocal(
+        'example',
+        this.createFallbackPlugin(),
+      );
+    }
   }
 
   private createFallbackPlugin(): IRegionPlugin {
@@ -467,7 +495,6 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
             config: file.config as unknown as Prisma.InputJsonValue,
           },
         });
-        this.logger.log(`Synced region config "${file.name}" v${file.version}`);
       }
 
       if (configs.length > 0) {
@@ -689,8 +716,8 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
         this.syncRepresentatives(provider, maxReps, regionId),
       [DataType.CAMPAIGN_FINANCE]: () =>
         this.syncCampaignFinance(provider, pipelineJobId),
-      [DataType.CIVICS]: () => this.syncCivics(),
-      [DataType.BILLS]: () => this.syncBills(maxBills),
+      [DataType.CIVICS]: () => this.syncCivics(provider),
+      [DataType.BILLS]: () => this.syncBills(maxBills, provider),
     };
 
     const handler = syncHandlers[dataType];
@@ -1211,7 +1238,7 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     };
   }
 
-  private async syncCivics(): Promise<{
+  private async syncCivics(plugin: DataFetcher): Promise<{
     processed: number;
     created: number;
     updated: number;
@@ -1223,7 +1250,6 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
       return { processed: 0, created: 0, updated: 0 };
     }
 
-    const plugin = this.pluginRegistry.getLocal();
     if (!plugin?.getDataSources) {
       this.logger.warn(
         'Region plugin does not expose getDataSources(); skipping civics sync',
@@ -1247,7 +1273,7 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
       }),
     );
 
-    const regionId = plugin.getName();
+    const regionId = plugin.getName?.() ?? 'unknown';
     let processed = 0;
     let created = 0;
     let updated = 0;
@@ -1270,7 +1296,10 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
 
   // ─── Bills sync ───────────────────────────────────────────────────────────────
 
-  private async syncBills(maxBills?: number): Promise<{
+  private async syncBills(
+    maxBills: number | undefined,
+    plugin: DataFetcher,
+  ): Promise<{
     processed: number;
     created: number;
     updated: number;
@@ -1281,7 +1310,6 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
       return { processed: 0, created: 0, updated: 0, skipped: 0 };
     }
 
-    const plugin = this.pluginRegistry.getLocal();
     if (!plugin?.getDataSources) {
       this.logger.warn(
         'Region plugin does not expose getDataSources(); skipping bills sync',
@@ -1305,7 +1333,7 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
       }),
     );
 
-    const regionId = plugin.getName();
+    const regionId = plugin.getName?.() ?? 'unknown';
     const repIndex = await this.buildRepNameIndex(regionId);
     const committeeIndex = await this.buildCommitteeNameIndex();
     const stagePatterns = await this.buildStagePatterns(regionId);

--- a/apps/backend/src/apps/workers/region-worker/src/region-sync.processor.ts
+++ b/apps/backend/src/apps/workers/region-worker/src/region-sync.processor.ts
@@ -82,13 +82,15 @@ export class RegionSyncProcessor
       'Processing region-sync job',
     );
 
-    // Cron-fired repeatable jobs have no pre-created DB record — create one now.
+    // Cron and manifest-ready jobs have no pre-created DB record — create one now.
     const effectiveJobId =
       pipelineJobId ??
       (
         await this.pipelineJobService.create({
           bullmqJobId: job.id as string,
           triggerSource: triggerSource ?? TRIGGER_SOURCE.CRON,
+          regionId,
+          dataTypes,
         })
       ).id;
 

--- a/apps/backend/src/apps/workers/structural-analysis-worker/src/structural-analysis.processor.spec.ts
+++ b/apps/backend/src/apps/workers/structural-analysis-worker/src/structural-analysis.processor.spec.ts
@@ -1,0 +1,74 @@
+import { StructuralAnalysisProcessor } from './structural-analysis.processor';
+
+function buildProcessor(
+  overrides: Record<string, unknown> = {},
+): StructuralAnalysisProcessor {
+  const svc = Object.create(
+    StructuralAnalysisProcessor.prototype,
+  ) as StructuralAnalysisProcessor;
+  Object.assign(svc, {
+    logger: {
+      log: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+    pipeline: {},
+    jobService: {},
+    queueService: { enqueue: jest.fn().mockResolvedValue(undefined) },
+    connection: {},
+    config: { get: jest.fn() },
+    worker: undefined,
+    ...overrides,
+  });
+  return svc;
+}
+
+describe('StructuralAnalysisProcessor', () => {
+  describe('enqueueFollowUpSync', () => {
+    it('enqueues a region-sync job with a deterministic deduplication jobId', async () => {
+      const queueService = { enqueue: jest.fn().mockResolvedValue(undefined) };
+      const svc = buildProcessor({ queueService });
+
+      // Access private method via prototype
+      await (
+        svc as unknown as Record<string, (...args: unknown[]) => Promise<void>>
+      ).enqueueFollowUpSync('california', 'BILLS');
+
+      expect(queueService.enqueue).toHaveBeenCalledWith(
+        'region-sync',
+        expect.objectContaining({
+          regionId: 'california',
+          dataTypes: ['BILLS'],
+        }),
+        { jobId: 'manifest-ready:california:BILLS' },
+      );
+    });
+
+    it('logs a warning and does not throw when enqueue fails', async () => {
+      const queueService = {
+        enqueue: jest.fn().mockRejectedValue(new Error('Redis unavailable')),
+      };
+      const logger = {
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+      };
+      const svc = buildProcessor({ queueService, logger });
+
+      await expect(
+        (
+          svc as unknown as Record<
+            string,
+            (...args: unknown[]) => Promise<void>
+          >
+        ).enqueueFollowUpSync('california', 'BILLS'),
+      ).resolves.toBeUndefined();
+
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to enqueue follow-up sync'),
+      );
+    });
+  });
+});

--- a/apps/backend/src/apps/workers/structural-analysis-worker/src/structural-analysis.processor.ts
+++ b/apps/backend/src/apps/workers/structural-analysis-worker/src/structural-analysis.processor.ts
@@ -10,10 +10,14 @@ import { Job, Worker } from 'bullmq';
 import IORedis from 'ioredis';
 import {
   QUEUE_CONNECTION,
+  REGION_SYNC_QUEUE,
   STRUCTURAL_ANALYSIS_QUEUE,
+  TRIGGER_SOURCE,
+  QueueService,
   createWorker,
 } from '@opuspopuli/queue-provider';
 import type {
+  RegionSyncJobData,
   StructuralAnalysisJobData,
   StructuralAnalysisJobResult,
   AnalysisRequestSource,
@@ -33,6 +37,7 @@ export class StructuralAnalysisProcessor
   constructor(
     private readonly pipeline: ScrapingPipelineService,
     private readonly jobService: StructuralAnalysisJobService,
+    private readonly queueService: QueueService,
     @Inject(QUEUE_CONNECTION) private readonly connection: IORedis,
     private readonly config: ConfigService,
   ) {}
@@ -122,6 +127,8 @@ export class StructuralAnalysisProcessor
         'Structural-analysis job succeeded',
       );
 
+      await this.enqueueFollowUpSync(regionId, dataType);
+
       return { manifestId, manifestVersion, analysisTimeMs };
     } catch (err) {
       const isLastAttempt = job.attemptsMade + 1 >= (job.opts.attempts ?? 1);
@@ -146,6 +153,41 @@ export class StructuralAnalysisProcessor
       );
 
       throw err;
+    }
+  }
+
+  /**
+   * Enqueue a targeted region-sync job after a manifest is written.
+   * Uses a deterministic jobId so BullMQ deduplicates concurrent analyses
+   * for the same (regionId, dataType) — only one follow-up sync is queued.
+   */
+  private async enqueueFollowUpSync(
+    regionId: string,
+    dataType: string,
+  ): Promise<void> {
+    try {
+      // Deterministic jobId deduplicates concurrent analyses for the same
+      // (regionId, dataType) — BullMQ silently skips if already queued/active.
+      const dedupeJobId = `manifest-ready:${regionId}:${dataType}`;
+
+      await this.queueService.enqueue<RegionSyncJobData>(
+        REGION_SYNC_QUEUE,
+        {
+          triggerSource: TRIGGER_SOURCE.MANIFEST_READY,
+          regionId,
+          dataTypes: [dataType],
+        },
+        { jobId: dedupeJobId },
+      );
+
+      this.logger.log(
+        `Enqueued follow-up region-sync for ${regionId}/${dataType} after manifest ready`,
+      );
+    } catch (err) {
+      // Log but don't fail the analysis job — the operator can re-trigger sync manually
+      this.logger.warn(
+        `Failed to enqueue follow-up sync for ${regionId}/${dataType}: ${(err as Error).message}`,
+      );
     }
   }
 }

--- a/docker-compose-uat.yml
+++ b/docker-compose-uat.yml
@@ -285,6 +285,8 @@ services:
       # No automatic scheduling in UAT — trigger via syncRegionData mutation
       REGION_SYNC_CRON_ENABLED: "false"
       REGION_SYNC_RUN_ON_STARTUP: "false"
+      # 1-hour lock for region-sync — representatives bio generation takes ~70 min
+      BULLMQ_QUEUE_REGION_SYNC_LOCK_DURATION_MS: "3600000"
       BIO_GENERATOR_MAX_TOKENS: "1500"
       BIO_GENERATOR_CONCURRENCY: "1"
       BIO_GENERATOR_MAX_REPS: "5"
@@ -328,6 +330,8 @@ services:
       DESCRIPTION: Structural analysis worker (async manifest analysis)
       PORT: 8080
       STRUCTURAL_ANALYSIS_WORKER_PORT: 8080
+      # 10-min lock for structural analysis — LLM manifest analysis can be slow
+      BULLMQ_QUEUE_PIPELINE_STRUCTURAL_ANALYSIS_LOCK_DURATION_MS: "600000"
       LLM_URL: http://host.docker.internal:11434
       LLM_MODEL: qwen3.5:9b
       OLLAMA_REQUEST_TIMEOUT_MS: "600000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -393,7 +393,10 @@ services:
     container_name: opuspopuli-redis
     ports:
       - "6379:6379"
-    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy allkeys-lru
+    # noeviction required by BullMQ — allkeys-lru would evict job data under
+    # memory pressure. Conflicts with cache-as-LRU usage; see #725 for the
+    # production split into dedicated Redis instances.
+    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy noeviction
     volumes:
       - redis-data:/data
     networks:

--- a/packages/queue-provider/src/queue.constants.ts
+++ b/packages/queue-provider/src/queue.constants.ts
@@ -17,6 +17,7 @@ export const TRIGGER_SOURCE = {
   MANUAL: "manual",
   CRON: "cron",
   STARTUP: "startup",
+  MANIFEST_READY: "manifest_ready",
 } as const;
 
 export type TriggerSource =

--- a/packages/queue-provider/src/queue.types.ts
+++ b/packages/queue-provider/src/queue.types.ts
@@ -1,7 +1,7 @@
 import { AnalysisRequestSource, TriggerSource } from "./queue.constants";
 
 export interface RegionSyncJobData {
-  pipelineJobId: string;
+  pipelineJobId?: string;
   triggerSource: TriggerSource;
   regionId?: string;
   dataTypes?: string[];

--- a/packages/queue-provider/src/worker.factory.ts
+++ b/packages/queue-provider/src/worker.factory.ts
@@ -29,10 +29,11 @@ export function createWorker<T>(
   const logger = new Logger(`Worker:${queueName}`);
   const envPrefix = queueName.toUpperCase().replace(/-/g, "_");
 
-  const concurrency = parseInt(
-    process.env[`BULLMQ_QUEUE_${envPrefix}_CONCURRENCY`] ?? "1",
-    10,
-  );
+  const concurrency =
+    Number.parseInt(
+      process.env[`BULLMQ_QUEUE_${envPrefix}_CONCURRENCY`] ?? "1",
+      10,
+    ) || 1;
   const enabled = process.env[`BULLMQ_QUEUE_${envPrefix}_ENABLED`] !== "false";
 
   if (!enabled) {
@@ -41,11 +42,18 @@ export function createWorker<T>(
     );
   }
 
+  const lockDurationMs =
+    Number.parseInt(
+      process.env[`BULLMQ_QUEUE_${envPrefix}_LOCK_DURATION_MS`] ?? "300000",
+      10,
+    ) || 300000;
+
   const workerOpts: WorkerOptions = {
     connection,
     prefix: opts.prefix ?? "bullmq",
     concurrency,
     autorun: enabled,
+    lockDuration: lockDurationMs,
   };
 
   const worker = new Worker<T>(

--- a/packages/region-provider/__tests__/plugin-registry.service.spec.ts
+++ b/packages/region-provider/__tests__/plugin-registry.service.spec.ts
@@ -72,16 +72,31 @@ describe("PluginRegistryService", () => {
       expect(plugin.initialize).toHaveBeenCalledWith(config);
     });
 
-    it("should unregister existing plugin before registering new one", async () => {
+    it("should keep both plugins when registering different names", async () => {
       const plugin1 = createMockPlugin();
       const plugin2 = createMockPlugin();
 
       await registry.register("plugin1", plugin1);
       await registry.register("plugin2", plugin2);
 
+      expect(plugin1.destroy).not.toHaveBeenCalled();
+      expect(registry.getLocal("plugin1")).toBe(plugin1);
+      expect(registry.getLocal("plugin2")).toBe(plugin2);
+      // First registered is still the primary
+      expect(registry.getActive()).toBe(plugin1);
+      expect(registry.getActiveName()).toBe("plugin1");
+    });
+
+    it("should replace existing plugin when registering same name", async () => {
+      const plugin1 = createMockPlugin();
+      const plugin2 = createMockPlugin();
+
+      await registry.register("same-name", plugin1);
+      await registry.register("same-name", plugin2);
+
       expect(plugin1.destroy).toHaveBeenCalled();
       expect(registry.getActive()).toBe(plugin2);
-      expect(registry.getActiveName()).toBe("plugin2");
+      expect(registry.getActiveName()).toBe("same-name");
     });
 
     it("should mark plugin as error if initialize fails", async () => {
@@ -293,6 +308,25 @@ describe("PluginRegistryService", () => {
     it("should return empty array when no plugins registered", () => {
       const all = registry.getAll();
       expect(all).toHaveLength(0);
+    });
+
+    it("should return federal + all local plugins when multiple locals registered", async () => {
+      const federalPlugin = createMockPlugin();
+      const statePlugin = createMockPlugin();
+      const countyPlugin = createMockPlugin();
+
+      await registry.registerFederal("federal", federalPlugin);
+      await registry.registerLocal("california", statePlugin);
+      await registry.registerLocal("california-sonoma", countyPlugin);
+
+      const all = registry.getAll();
+
+      expect(all).toHaveLength(3);
+      expect(all.map((p) => p.name)).toEqual([
+        "federal",
+        "california",
+        "california-sonoma",
+      ]);
     });
   });
 

--- a/packages/region-provider/src/registry/plugin-registry.service.ts
+++ b/packages/region-provider/src/registry/plugin-registry.service.ts
@@ -15,19 +15,21 @@ export interface RegisteredPlugin {
 /**
  * Plugin Registry
  *
- * Manages two plugin slots: federal (always loaded) and local (user-selectable).
- * Federal provides FEC campaign finance data scoped to the local region's state.
- * Local provides civic data (propositions, meetings, representatives) + state-level campaign finance.
+ * Manages a federal slot (always loaded) and multiple local slots (one per
+ * enabled region). Federal provides FEC campaign finance data scoped to the
+ * local region's state. Local plugins provide civic data for each enabled
+ * region — state and county plugins can all be active simultaneously.
  */
 @Injectable()
 export class PluginRegistryService implements OnModuleDestroy {
   private readonly logger = new Logger(PluginRegistryService.name);
   private federalPlugin: RegisteredPlugin | undefined;
-  private localPlugin: RegisteredPlugin | undefined;
+  private readonly localPlugins: Map<string, RegisteredPlugin> = new Map();
 
   /**
-   * Register a local plugin. Replaces any previously registered local plugin.
-   * Backward-compatible alias for registerLocal().
+   * Register a local plugin. If a plugin with the same name is already
+   * registered it is destroyed and replaced. Different names are additive —
+   * both plugins remain active. Backward-compatible alias for registerLocal().
    */
   async register(
     name: string,
@@ -38,16 +40,16 @@ export class PluginRegistryService implements OnModuleDestroy {
   }
 
   /**
-   * Register the local region plugin (e.g., California).
-   * Replaces any previously registered local plugin.
+   * Register a local region plugin. Adds to the pool of active local plugins.
+   * Replaces an existing entry only when the same name is re-registered.
    */
   async registerLocal(
     name: string,
     instance: IRegionPlugin,
     config?: Record<string, unknown>,
   ): Promise<void> {
-    if (this.localPlugin) {
-      await this.unregisterSlot("local");
+    if (this.localPlugins.has(name)) {
+      await this.unregisterLocalByName(name);
     }
 
     this.logger.log(`Registering local plugin: ${name}`);
@@ -55,12 +57,12 @@ export class PluginRegistryService implements OnModuleDestroy {
     try {
       await instance.initialize(config);
 
-      this.localPlugin = {
+      this.localPlugins.set(name, {
         name,
         instance,
         status: "active",
         loadedAt: new Date(),
-      };
+      });
 
       this.logger.log(`Local plugin registered successfully: ${name}`);
     } catch (error) {
@@ -69,13 +71,13 @@ export class PluginRegistryService implements OnModuleDestroy {
         `Failed to initialize local plugin ${name}: ${errorMessage}`,
       );
 
-      this.localPlugin = {
+      this.localPlugins.set(name, {
         name,
         instance,
         status: "error",
         lastError: errorMessage,
         loadedAt: new Date(),
-      };
+      });
 
       throw error;
     }
@@ -125,19 +127,24 @@ export class PluginRegistryService implements OnModuleDestroy {
   }
 
   /**
-   * Unregister and cleanup the local plugin.
-   * Backward-compatible: unregister() only affects the local slot.
+   * Unregister and cleanup all local plugins.
+   * Backward-compatible: unregister() only affects the local slot(s).
    */
   async unregister(): Promise<void> {
     await this.unregisterSlot("local");
   }
 
   /**
-   * Get the local plugin instance, or undefined if none loaded.
+   * Get a local plugin instance by name, or the first active one if no name
+   * is given. Returns undefined when no active local plugin exists.
    */
-  getLocal(): IRegionPlugin | undefined {
-    if (this.localPlugin?.status === "active") {
-      return this.localPlugin.instance;
+  getLocal(name?: string): IRegionPlugin | undefined {
+    if (name) {
+      const entry = this.localPlugins.get(name);
+      return entry?.status === "active" ? entry.instance : undefined;
+    }
+    for (const entry of this.localPlugins.values()) {
+      if (entry.status === "active") return entry.instance;
     }
     return undefined;
   }
@@ -161,32 +168,38 @@ export class PluginRegistryService implements OnModuleDestroy {
   }
 
   /**
-   * Get all registered plugins (federal + local).
-   * Returns only active plugins.
+   * Get all registered plugins (federal + all active locals).
+   * Returns only active plugins, locals in registration order.
    */
   getAll(): RegisteredPlugin[] {
     const plugins: RegisteredPlugin[] = [];
     if (this.federalPlugin?.status === "active") {
       plugins.push(this.federalPlugin);
     }
-    if (this.localPlugin?.status === "active") {
-      plugins.push(this.localPlugin);
+    for (const entry of this.localPlugins.values()) {
+      if (entry.status === "active") plugins.push(entry);
     }
     return plugins;
   }
 
   /**
-   * Get the active local plugin name, or undefined if none loaded.
+   * Get the name of the first active local plugin, or undefined if none loaded.
    */
   getActiveName(): string | undefined {
-    return this.localPlugin?.name;
+    for (const entry of this.localPlugins.values()) {
+      if (entry.status === "active") return entry.name;
+    }
+    return undefined;
   }
 
   /**
-   * Check if a local plugin is registered and active.
+   * Check if at least one local plugin is registered and active.
    */
   hasActive(): boolean {
-    return this.localPlugin?.status === "active";
+    for (const entry of this.localPlugins.values()) {
+      if (entry.status === "active") return true;
+    }
+    return false;
   }
 
   /**
@@ -210,6 +223,8 @@ export class PluginRegistryService implements OnModuleDestroy {
 
   /**
    * Get registry status for diagnostics.
+   * pluginName / pluginStatus reflect the first registered local plugin;
+   * use getAll() to inspect every loaded plugin.
    */
   getStatus(): {
     hasPlugin: boolean;
@@ -220,12 +235,13 @@ export class PluginRegistryService implements OnModuleDestroy {
     federalLoaded: boolean;
     federalName?: string;
   } {
+    const first = [...this.localPlugins.values()][0];
     return {
-      hasPlugin: this.localPlugin !== undefined,
-      pluginName: this.localPlugin?.name,
-      pluginStatus: this.localPlugin?.status,
-      lastError: this.localPlugin?.lastError,
-      loadedAt: this.localPlugin?.loadedAt,
+      hasPlugin: this.localPlugins.size > 0,
+      pluginName: first?.name,
+      pluginStatus: first?.status,
+      lastError: first?.lastError,
+      loadedAt: first?.loadedAt,
       federalLoaded: this.federalPlugin?.status === "active",
       federalName: this.federalPlugin?.name,
     };
@@ -240,27 +256,50 @@ export class PluginRegistryService implements OnModuleDestroy {
   }
 
   /**
-   * Unregister and cleanup a specific plugin slot.
+   * Unregister and cleanup a specific slot. For "local" this destroys all
+   * registered local plugins and clears the map.
    */
   private async unregisterSlot(slot: "federal" | "local"): Promise<void> {
-    const plugin = slot === "federal" ? this.federalPlugin : this.localPlugin;
-    if (!plugin) return;
-
-    this.logger.log(`Unregistering ${slot} plugin: ${plugin.name}`);
-
-    try {
-      await plugin.instance.destroy();
-    } catch (error) {
-      this.logger.error(
-        `Error destroying ${slot} plugin ${plugin.name}:`,
-        error,
-      );
-    }
-
     if (slot === "federal") {
+      if (!this.federalPlugin) return;
+      this.logger.log(
+        `Unregistering federal plugin: ${this.federalPlugin.name}`,
+      );
+      try {
+        await this.federalPlugin.instance.destroy();
+      } catch (error) {
+        this.logger.error(`Error destroying federal plugin:`, error);
+      }
       this.federalPlugin = undefined;
-    } else {
-      this.localPlugin = undefined;
+      return;
     }
+
+    for (const entry of this.localPlugins.values()) {
+      this.logger.log(`Unregistering local plugin: ${entry.name}`);
+      try {
+        await entry.instance.destroy();
+      } catch (error) {
+        this.logger.error(
+          `Error destroying local plugin ${entry.name}:`,
+          error,
+        );
+      }
+    }
+    this.localPlugins.clear();
+  }
+
+  /**
+   * Destroy and remove a single local plugin by name.
+   */
+  private async unregisterLocalByName(name: string): Promise<void> {
+    const entry = this.localPlugins.get(name);
+    if (!entry) return;
+    this.logger.log(`Unregistering local plugin: ${name}`);
+    try {
+      await entry.instance.destroy();
+    } catch (error) {
+      this.logger.error(`Error destroying local plugin ${name}:`, error);
+    }
+    this.localPlugins.delete(name);
   }
 }

--- a/postman/OpusPopuli.postman_collection.json
+++ b/postman/OpusPopuli.postman_collection.json
@@ -643,8 +643,8 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "mutation SyncRegionData($dataTypes: [DataType!], $maxReps: Int) {\n  syncRegionData(dataTypes: $dataTypes, maxReps: $maxReps) {\n    jobId\n    status\n    triggerSource\n    dataTypes\n    enqueuedAt\n  }\n}",
-                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"maxReps\": 1\n}"
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $regionId: String, $maxReps: Int) {\n  syncRegionData(dataTypes: $dataTypes, regionId: $regionId, maxReps: $maxReps) {\n    jobId\n    status\n    triggerSource\n    regionId\n    dataTypes\n    enqueuedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"regionId\": \"california\",\n  \"maxReps\": 1\n}"
               }
             },
             "url": {
@@ -680,7 +680,7 @@
               "mode": "graphql",
               "graphql": {
                 "query": "mutation SyncRegionData($dataTypes: [DataType!], $depth: SyncDepth, $regionId: String, $maxReps: Int, $maxBills: Int) {\n  syncRegionData(dataTypes: $dataTypes, depth: $depth, regionId: $regionId, maxReps: $maxReps, maxBills: $maxBills) {\n    jobId\n    status\n    triggerSource\n    regionId\n    dataTypes\n    enqueuedAt\n  }\n}",
-                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"depth\": \"STATE\",\n  \"maxReps\": 5\n}"
+                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"regionId\": \"california\",\n  \"depth\": \"STATE\",\n  \"maxReps\": 5\n}"
               }
             },
             "url": {
@@ -715,8 +715,8 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "mutation SyncRegionData($dataTypes: [DataType!], $depth: SyncDepth, $maxReps: Int) {\n  syncRegionData(dataTypes: $dataTypes, depth: $depth, maxReps: $maxReps) {\n    jobId\n    status\n    triggerSource\n    dataTypes\n    enqueuedAt\n  }\n}",
-                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"depth\": \"COUNTY\",\n  \"maxReps\": 3\n}"
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $depth: SyncDepth, $regionId: String, $maxReps: Int) {\n  syncRegionData(dataTypes: $dataTypes, depth: $depth, regionId: $regionId, maxReps: $maxReps) {\n    jobId\n    status\n    triggerSource\n    regionId\n    dataTypes\n    enqueuedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"REPRESENTATIVES\"],\n  \"regionId\": \"california\",\n  \"depth\": \"COUNTY\",\n  \"maxReps\": 3\n}"
               }
             },
             "url": {
@@ -787,8 +787,8 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "mutation SyncRegionData($dataTypes: [DataType!]) {\n  syncRegionData(dataTypes: $dataTypes) {\n    jobId\n    status\n    triggerSource\n    dataTypes\n    enqueuedAt\n  }\n}",
-                "variables": "{\n  \"dataTypes\": [\"CIVICS\"]\n}"
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $regionId: String) {\n  syncRegionData(dataTypes: $dataTypes, regionId: $regionId) {\n    jobId\n    status\n    triggerSource\n    regionId\n    dataTypes\n    enqueuedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"CIVICS\"],\n  \"regionId\": \"california\"\n}"
               }
             },
             "url": {


### PR DESCRIPTION
## What changed and why

After structural analysis writes a new manifest, the data sync it unlocked was never re-triggered automatically — the pipeline would silently stall until an operator manually re-ran \`syncRegionData\`. This PR closes that gap and ships several related hardening fixes discovered during end-to-end testing.

### Core feature — closes #718
- \`StructuralAnalysisProcessor\` enqueues a follow-up \`region-sync\` job immediately after \`markSucceeded\`. The job uses a deterministic \`jobId\` (\`manifest-ready:<regionId>:<dataType>\`) so BullMQ deduplicates concurrent analyses for the same region/type.
- \`MANIFEST_READY\` added to \`TRIGGER_SOURCE\` constants and \`SyncTriggerSource\` GQL enum so the auto-triggered job is correctly labelled in pipeline job history.
- \`pipelineJobId\` made optional in \`RegionSyncJobData\` — CRON and MANIFEST_READY jobs no longer need a pre-created DB record. \`RegionSyncProcessor\` creates one on pickup, preventing orphaned records when BullMQ deduplicates.

### Multi-slot plugin registry
- \`PluginRegistryService\` changed from a single \`localPlugin\` slot to a \`Map<string, RegisteredPlugin>\`. All enabled local plugins (state + county) now load simultaneously; previously only the first one loaded, silently dropping \`california-sonoma\` on every init.
- \`region-sync.service.ts\` updated to \`findMany\` + sort (state-level first) and load all rows.

### Job lifecycle hardening
- \`markRunning\` uses \`updateMany\` with \`status != SUCCEEDED\` guard — prevents BullMQ stalled-job retries from overwriting a completed record's \`startedAt\`/\`finishedAt\` (which caused negative \`elapsedMs\`).
- BullMQ lock duration is now env-configurable per queue (\`BULLMQ_QUEUE_<NAME>_LOCK_DURATION_MS\`, default 5 min). UAT sets \`region-sync\` to 1 h to cover ~70-min representative bio runs.
- Redis eviction policy changed to \`noeviction\` (required by BullMQ; \`allkeys-lru\` risks evicting job data). Comment references #725 for the production Redis split.

### Code quality
- \`onModuleInit\` refactored into \`initFederalPlugin\` / \`initLocalPlugins\` helpers — Sonar cognitive complexity 18 → ≤ 15.
- \`comparePluginRows\` extracted as a module-level function.
- \`provider as unknown as IRegionPlugin\` casts removed — \`DataFetcher\` extended with optional \`getName?\` / \`getDataSources?\`.
- \`parseInt\` → \`Number.parseInt\` with NaN fallback guard in \`worker.factory.ts\`.
- \`getStatus()\` uses \`[...map.values()][0]\` instead of \`.next().value\` iterator cast.
- New unit tests: \`markRunning\` SUCCEEDED guard (3 cases), \`enqueueFollowUpSync\` deduplication + error-swallowing (2 cases).

## How to test

1. Trigger \`syncRegionData\` for a data type with no existing structural manifest — expect \`structural-analysis-worker\` to complete analysis then \`region-worker\` to immediately pick up a \`MANIFEST_READY\` job without manual intervention.
2. Check \`pipelineJobs\` — auto-triggered job should show \`triggerSource: MANIFEST_READY\` with correct \`regionId\`/\`dataTypes\`.
3. Run a long sync (representatives + bio generation) past the old 30s lock window — confirm no "could not renew lock" errors.
4. After a successful sync confirm \`elapsedMs > 0\` and \`finishedAt > startedAt\`.
5. Verify both \`california\` and \`california-sonoma\` plugins appear in \`region-worker\` startup logs.

## Linked issues

- Closes #718
- Related: #725 (Redis split — production follow-up, not in scope here)