### PR TITLE
feat(region,frontend): per-bill activity timeline + History tab (#666)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -84,7 +84,7 @@
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/queue-provider": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.61",
+    "@opuspopuli/regions": "^1.0.66",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.spec.ts
@@ -27,15 +27,37 @@ interface CommitteeRow {
   externalId: string;
 }
 
+interface BillRow {
+  id: string;
+  billNumber: string;
+  sessionYear: string;
+}
+
+interface PriorAction {
+  date: Date;
+  minutesId: string;
+  billId: string | null;
+  propositionId: string | null;
+  actionType: string;
+  position: string | null;
+  representativeId: string | null;
+}
+
 const buildLinker = (opts: {
   minutes: MinutesRow[];
   reps?: RepRow[];
   propositions?: PropositionRow[];
   committees?: CommitteeRow[];
+  bills?: BillRow[];
+  /** Pre-existing actions to simulate prior journal/history ingestion
+   *  for cross-source dedup tests. */
+  priorActions?: PriorAction[];
 }) => {
   const reps = opts.reps ?? [];
   const propositions = opts.propositions ?? [];
   const committees = opts.committees ?? [];
+  const bills = opts.bills ?? [];
+  const priorActions = opts.priorActions ?? [];
   const persistedActions: any[] = [];
 
   const db = {
@@ -70,8 +92,35 @@ const buildLinker = (opts: {
         for (const r of args.data) persistedActions.push(r);
         return { count: args.data.length };
       }),
+      // Used by cross-source dedup (#666): returns existing actions in
+      // OTHER Minutes for the same date.
+      findMany: jest.fn(async (args: any) => {
+        const targetDate = args?.where?.date?.getTime?.();
+        const excludeMinutesId = args?.where?.minutesId?.not;
+        const billIdsFilter: string[] | undefined = args?.where?.OR?.find(
+          (o: any) => o?.billId,
+        )?.billId?.in;
+        const propIdsFilter: string[] | undefined = args?.where?.OR?.find(
+          (o: any) => o?.propositionId,
+        )?.propositionId?.in;
+        return priorActions.filter((a) => {
+          if (a.minutesId === excludeMinutesId) return false;
+          if (targetDate != null && a.date.getTime() !== targetDate)
+            return false;
+          const billMatch =
+            billIdsFilter && a.billId
+              ? billIdsFilter.includes(a.billId)
+              : false;
+          const propMatch =
+            propIdsFilter && a.propositionId
+              ? propIdsFilter.includes(a.propositionId)
+              : false;
+          return billMatch || propMatch;
+        });
+      }),
     },
     bill: {
+      findMany: jest.fn(async () => bills),
       updateMany: jest.fn(async () => ({ count: 0 })),
     },
     $transaction: jest.fn(async (ops: any[]) => {
@@ -377,5 +426,177 @@ describe('LegislativeActionLinkerService', () => {
     for (const id of ids) {
       expect(id).toMatch(/^ca-2026-04-28-\d{4}$/);
     }
+  });
+
+  describe('per-bill linkage + cross-source dedup (#666)', () => {
+    it('sets billId on actions whose citation matches a Bill row', async () => {
+      const { linker, persistedActions } = buildLinker({
+        minutes: [
+          {
+            id: 'm-1',
+            externalId: 'ca-2026-04-28',
+            body: 'Assembly',
+            date: new Date('2026-04-28T00:00:00Z'),
+            isActive: true,
+            rawText: FIXTURE_RAWTEXT,
+          },
+        ],
+        bills: [
+          {
+            id: 'bill-ab1897',
+            billNumber: 'AB 1897',
+            sessionYear: '2025-2026',
+          },
+        ],
+      });
+
+      await linker.linkMinutes(['m-1']);
+
+      const ab1897 = persistedActions.filter((a) => a.rawSubject === 'AB 1897');
+      expect(ab1897.length).toBeGreaterThanOrEqual(1);
+      for (const a of ab1897) {
+        expect(a.billId).toBe('bill-ab1897');
+      }
+    });
+
+    it('leaves billId null when no matching Bill exists', async () => {
+      const { linker, persistedActions } = buildLinker({
+        minutes: [
+          {
+            id: 'm-1',
+            externalId: 'ca-2026-04-28',
+            body: 'Assembly',
+            date: new Date('2026-04-28T00:00:00Z'),
+            isActive: true,
+            rawText: FIXTURE_RAWTEXT,
+          },
+        ],
+        // No bills array → no rows match → billId stays null
+      });
+
+      await linker.linkMinutes(['m-1']);
+
+      const ab1897 = persistedActions.filter((a) => a.rawSubject === 'AB 1897');
+      expect(ab1897.length).toBeGreaterThanOrEqual(1);
+      for (const a of ab1897) {
+        expect(a.billId).toBeNull();
+      }
+    });
+
+    it('drops actions already linked to a prior Minutes (cross-source dedup)', async () => {
+      // Simulate the same engrossment action having been recorded earlier
+      // from a daily journal (different minutesId, same date + billId).
+      const { linker, persistedActions } = buildLinker({
+        minutes: [
+          {
+            id: 'm-weekly',
+            externalId: 'ca-weekly-2026-04-28',
+            body: 'Assembly',
+            date: new Date('2026-04-28T00:00:00Z'),
+            isActive: true,
+            rawText: FIXTURE_RAWTEXT,
+          },
+        ],
+        bills: [
+          {
+            id: 'bill-ab1897',
+            billNumber: 'AB 1897',
+            sessionYear: '2025-2026',
+          },
+        ],
+        priorActions: [
+          {
+            date: new Date('2026-04-28T00:00:00Z'),
+            minutesId: 'm-daily-prior',
+            billId: 'bill-ab1897',
+            propositionId: null,
+            actionType: 'engrossment',
+            position: null,
+            representativeId: null,
+          },
+        ],
+      });
+
+      await linker.linkMinutes(['m-weekly']);
+
+      // The engrossment for AB 1897 should NOT have been written this run.
+      const engrossments = persistedActions.filter(
+        (a) => a.actionType === 'engrossment' && a.billId === 'bill-ab1897',
+      );
+      expect(engrossments).toHaveLength(0);
+    });
+
+    it('scopes billId resolution by sessionYear (no cross-session collision)', async () => {
+      // Two bills share billNumber "AB 1897" across different sessions.
+      // The 2026-04-28 Minutes is in the 2025-2026 session, so actions
+      // must resolve to the 2025-2026 bill, NOT the 2023-2024 row.
+      const { linker, persistedActions } = buildLinker({
+        minutes: [
+          {
+            id: 'm-1',
+            externalId: 'ca-2026-04-28',
+            body: 'Assembly',
+            date: new Date('2026-04-28T00:00:00Z'),
+            isActive: true,
+            rawText: FIXTURE_RAWTEXT,
+          },
+        ],
+        bills: [
+          {
+            id: 'bill-ab1897-old',
+            billNumber: 'AB 1897',
+            sessionYear: '2023-2024',
+          },
+          {
+            id: 'bill-ab1897-current',
+            billNumber: 'AB 1897',
+            sessionYear: '2025-2026',
+          },
+        ],
+      });
+
+      await linker.linkMinutes(['m-1']);
+
+      const ab1897 = persistedActions.filter((a) => a.rawSubject === 'AB 1897');
+      expect(ab1897.length).toBeGreaterThanOrEqual(1);
+      for (const a of ab1897) {
+        expect(a.billId).toBe('bill-ab1897-current');
+      }
+    });
+
+    it('resolves billId and propositionId independently on the same action', async () => {
+      // Edge case: a constitutional amendment whose citation matches both
+      // a Bill row (legislative-process record) and a Proposition row
+      // (qualified-for-ballot record). Both FKs should be populated.
+      const { linker, persistedActions } = buildLinker({
+        minutes: [
+          {
+            id: 'm-1',
+            externalId: 'ca-2026-04-28',
+            body: 'Assembly',
+            date: new Date('2026-04-28T00:00:00Z'),
+            isActive: true,
+            rawText: FIXTURE_RAWTEXT,
+          },
+        ],
+        bills: [
+          {
+            id: 'bill-ab1897',
+            billNumber: 'AB 1897',
+            sessionYear: '2025-2026',
+          },
+        ],
+        propositions: [{ id: 'prop-ab1897', externalId: 'AB 1897' }],
+      });
+
+      await linker.linkMinutes(['m-1']);
+
+      const linked = persistedActions.filter((a) => a.rawSubject === 'AB 1897');
+      expect(linked.length).toBeGreaterThanOrEqual(1);
+      for (const a of linked) {
+        expect(a.billId).toBe('bill-ab1897');
+        expect(a.propositionId).toBe('prop-ab1897');
+      }
+    });
   });
 });

--- a/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/legislative-action-linker.service.ts
@@ -27,6 +27,14 @@ interface LinkerCaches {
   repsByLastName: Map<string, Map<string, string[]>>;
   /** canonical proposition externalId (e.g., 'AB 1863') → proposition id. */
   propositionsByExternalId: Map<string, string>;
+  /** Two-level lookup: sessionYear ("2025-2026") → billNumber ("AB 1863")
+   *  → bill id. Session-scoped because billNumber values are reused
+   *  across CA legislative sessions (e.g., `AB 2` exists in 2023-2024
+   *  AND 2025-2026 as distinct rows). Distinct from
+   *  `propositionsByExternalId`: bills are the legislative-process
+   *  records, propositions are the qualified-for-ballot records — a
+   *  citation can resolve to one, both, or neither. See opuspopuli#666. */
+  billsByBillNumber: Map<string, Map<string, string>>;
   /** chamber-scoped normalized committee name → committee id. */
   committeesByExternalId: Map<string, string>;
 }
@@ -35,6 +43,10 @@ interface MinutesContext {
   id: string;
   body: string;
   date: Date;
+  /** CA legislative session ("YYYY-YYYY") derived from {@link date}.
+   *  Computed once per Minutes so bill-citation lookups stay scoped to
+   *  the right session without recomputing on every match. */
+  sessionYear: string;
   externalId: string;
   rawText: string;
   caches: LinkerCaches;
@@ -49,6 +61,7 @@ interface CandidateAction {
   passageEnd: number;
   representativeId?: string;
   propositionId?: string;
+  billId?: string;
   committeeId?: string;
 }
 
@@ -207,6 +220,7 @@ export class LegislativeActionLinkerService {
         id: row.id,
         body: row.body,
         date: row.date,
+        sessionYear: this.deriveSessionYear(row.date),
         externalId: row.externalId,
         rawText: row.rawText,
         caches,
@@ -289,13 +303,16 @@ export class LegislativeActionLinkerService {
   // ============================================
 
   private async loadCaches(): Promise<LinkerCaches> {
-    const [reps, propositions, committees] = await Promise.all([
+    const [reps, propositions, bills, committees] = await Promise.all([
       this.db.representative.findMany({
         where: { deletedAt: null },
         select: { id: true, lastName: true, chamber: true },
       }),
       this.db.proposition.findMany({
         select: { id: true, externalId: true },
+      }),
+      this.db.bill.findMany({
+        select: { id: true, billNumber: true, sessionYear: true },
       }),
       this.db.legislativeCommittee.findMany({
         where: { deletedAt: null },
@@ -323,12 +340,32 @@ export class LegislativeActionLinkerService {
       propositionsByExternalId.set(p.externalId, p.id);
     }
 
+    const billsByBillNumber = new Map<string, Map<string, string>>();
+    for (const b of bills) {
+      // billNumber is "AB 1234" / "SB 99" — same canonical form the
+      // citation extractor produces. Session-scoped so e.g. "AB 2" in
+      // the 2023-2024 session doesn't collide with "AB 2" in 2025-2026.
+      // Single-region today; cross-region collisions would need a
+      // regionId filter (see opuspopuli#731).
+      let inner = billsByBillNumber.get(b.sessionYear);
+      if (!inner) {
+        inner = new Map<string, string>();
+        billsByBillNumber.set(b.sessionYear, inner);
+      }
+      inner.set(b.billNumber, b.id);
+    }
+
     const committeesByExternalId = new Map<string, string>();
     for (const c of committees) {
       committeesByExternalId.set(c.externalId, c.id);
     }
 
-    return { repsByLastName, propositionsByExternalId, committeesByExternalId };
+    return {
+      repsByLastName,
+      propositionsByExternalId,
+      billsByBillNumber,
+      committeesByExternalId,
+    };
   }
 
   // ============================================
@@ -594,6 +631,7 @@ export class LegislativeActionLinkerService {
         blockText,
         blockOffset,
         ctx.caches,
+        ctx.sessionYear,
       )) {
         out.push({
           actionType: 'committee_report',
@@ -608,6 +646,7 @@ export class LegislativeActionLinkerService {
           passageEnd: cite.passageEnd,
           committeeId,
           propositionId: cite.propId,
+          billId: cite.billId,
         });
       }
     }
@@ -637,6 +676,7 @@ export class LegislativeActionLinkerService {
         blockText,
         blockOffset,
         ctx.caches,
+        ctx.sessionYear,
       )) {
         out.push({
           actionType: 'amendment',
@@ -649,6 +689,7 @@ export class LegislativeActionLinkerService {
           passageEnd: cite.passageEnd,
           committeeId,
           propositionId: cite.propId,
+          billId: cite.billId,
         });
       }
     }
@@ -676,7 +717,7 @@ export class LegislativeActionLinkerService {
       // amendment to. Scan backward up to ~600 chars.
       const lookback = Math.max(0, m.index - 600);
       const window = section.text.slice(lookback, m.index);
-      const bills = this.lastBillCitation(window);
+      const bills = this.lastBillCitation(window, ctx.caches, ctx.sessionYear);
 
       out.push({
         actionType: 'amendment',
@@ -691,6 +732,7 @@ export class LegislativeActionLinkerService {
         passageEnd: section.startOffset + m.index + m[0].length,
         committeeId,
         propositionId: bills?.propId,
+        billId: bills?.billId,
       });
     }
     return out;
@@ -723,6 +765,7 @@ export class LegislativeActionLinkerService {
         block.text,
         blockOffset,
         ctx.caches,
+        ctx.sessionYear,
       )) {
         out.push({
           actionType,
@@ -734,6 +777,7 @@ export class LegislativeActionLinkerService {
           passageStart: cite.passageStart,
           passageEnd: cite.passageEnd,
           propositionId: cite.propId,
+          billId: cite.billId,
         });
       }
     }
@@ -759,6 +803,9 @@ export class LegislativeActionLinkerService {
       const propId = canonical
         ? ctx.caches.propositionsByExternalId.get(canonical)
         : undefined;
+      const billId = canonical
+        ? this.resolveBillId(ctx.caches, canonical, ctx.sessionYear)
+        : undefined;
 
       out.push({
         actionType: 'resolution',
@@ -767,6 +814,7 @@ export class LegislativeActionLinkerService {
         passageStart: section.startOffset + m.index,
         passageEnd: section.startOffset + m.index + m[0].length,
         propositionId: propId,
+        billId,
       });
     }
     return out;
@@ -785,9 +833,11 @@ export class LegislativeActionLinkerService {
     blockText: string,
     blockOffset: number,
     caches: LinkerCaches,
+    sessionYear: string,
   ): Array<{
     canonical: string;
     propId: string | undefined;
+    billId: string | undefined;
     passageStart: number;
     passageEnd: number;
   }> {
@@ -795,6 +845,7 @@ export class LegislativeActionLinkerService {
     const results: Array<{
       canonical: string;
       propId: string | undefined;
+      billId: string | undefined;
       passageStart: number;
       passageEnd: number;
     }> = [];
@@ -804,11 +855,34 @@ export class LegislativeActionLinkerService {
       results.push({
         canonical,
         propId: caches.propositionsByExternalId.get(canonical),
+        billId: this.resolveBillId(caches, canonical, sessionYear),
         passageStart: blockOffset + m.index,
         passageEnd: blockOffset + m.index + m[0].length,
       });
     }
     return results;
+  }
+
+  /**
+   * Derive the CA legislative sessionYear ("2025-2026") that contains
+   * the given date. CA sessions are 2-year cycles starting in odd
+   * years — Jan 2025 through Nov 2026 is the "2025-2026" session.
+   * Used to scope bill-citation resolution so we don't mis-link an
+   * action to the same billNumber from a prior session.
+   */
+  private deriveSessionYear(date: Date): string {
+    const y = date.getUTCFullYear();
+    const start = y % 2 === 1 ? y : y - 1;
+    return `${start}-${start + 1}`;
+  }
+
+  /** Session-scoped billNumber → billId lookup. */
+  private resolveBillId(
+    caches: LinkerCaches,
+    canonical: string,
+    sessionYear: string,
+  ): string | undefined {
+    return caches.billsByBillNumber.get(sessionYear)?.get(canonical);
   }
 
   private normalizeBillCitation(
@@ -840,7 +914,9 @@ export class LegislativeActionLinkerService {
 
   private lastBillCitation(
     window: string,
-  ): { canonical: string; propId?: string } | undefined {
+    caches: LinkerCaches,
+    sessionYear: string,
+  ): { canonical: string; propId?: string; billId?: string } | undefined {
     BILL_CITATION_RE.lastIndex = 0;
     let last: RegExpExecArray | null = null;
     let m: RegExpExecArray | null;
@@ -849,7 +925,11 @@ export class LegislativeActionLinkerService {
     }
     if (!last) return undefined;
     const canonical = this.normalizeBillCitation(last[1], last[2], last[3]);
-    return { canonical };
+    return {
+      canonical,
+      propId: caches.propositionsByExternalId.get(canonical),
+      billId: this.resolveBillId(caches, canonical, sessionYear),
+    };
   }
 
   // ============================================
@@ -913,7 +993,13 @@ export class LegislativeActionLinkerService {
       return 0;
     }
 
-    const records = candidates.map((c, i) => ({
+    // Cross-source dedup: the same atomic action can appear in both a
+    // daily journal AND the week's history (opuspopuli#666). Filter out
+    // candidates whose (billId, date, actionType, position, representativeId)
+    // tuple already exists in a *different* Minutes row for this region.
+    const filtered = await this.dedupAgainstPriorMinutes(ctx, candidates);
+
+    const records = filtered.map((c, i) => ({
       externalId: `${ctx.externalId}-${String(i + 1).padStart(4, '0')}`,
       minutesId: ctx.id,
       body: ctx.body,
@@ -921,6 +1007,7 @@ export class LegislativeActionLinkerService {
       actionType: c.actionType,
       representativeId: c.representativeId ?? null,
       propositionId: c.propositionId ?? null,
+      billId: c.billId ?? null,
       committeeId: c.committeeId ?? null,
       position: c.position ?? null,
       text: c.text ?? null,
@@ -935,6 +1022,103 @@ export class LegislativeActionLinkerService {
     ]);
 
     return records.length;
+  }
+
+  /**
+   * Drop candidates that duplicate actions already linked to a different
+   * Minutes row. The same atomic event (e.g. "AB 440 referred to Judiciary
+   * 5/3") appears in both the day-of journal and the week's history; we
+   * want one row, not two.
+   *
+   * Dedup key: (billId|propositionId, date, actionType, position, representativeId).
+   * Actions without a billId/propositionId anchor (e.g. presence rolls)
+   * are bypassed — they're inherently per-Minutes and not duplicated
+   * across sources.
+   */
+  private async dedupAgainstPriorMinutes(
+    ctx: MinutesContext,
+    candidates: CandidateAction[],
+  ): Promise<CandidateAction[]> {
+    const tupleKey = (
+      anchor: string,
+      actionType: string,
+      position?: string | null,
+      representativeId?: string | null,
+    ): string =>
+      `${anchor}|${actionType}|${position ?? ''}|${representativeId ?? ''}`;
+
+    // Collect distinct anchored candidates so we can do ONE Prisma read.
+    const anchored = candidates.filter(
+      (c) => c.billId != null || c.propositionId != null,
+    );
+    if (anchored.length === 0) return candidates;
+
+    const billIds = new Set<string>();
+    const propIds = new Set<string>();
+    for (const c of anchored) {
+      if (c.billId) billIds.add(c.billId);
+      else if (c.propositionId) propIds.add(c.propositionId);
+    }
+
+    const anchorClauses: Array<
+      { billId: { in: string[] } } | { propositionId: { in: string[] } }
+    > = [];
+    if (billIds.size > 0) {
+      anchorClauses.push({ billId: { in: Array.from(billIds) } });
+    }
+    if (propIds.size > 0) {
+      anchorClauses.push({ propositionId: { in: Array.from(propIds) } });
+    }
+
+    const existing = await this.db.legislativeAction.findMany({
+      where: {
+        date: ctx.date,
+        minutesId: { not: ctx.id },
+        OR: anchorClauses,
+      },
+      select: {
+        billId: true,
+        propositionId: true,
+        actionType: true,
+        position: true,
+        representativeId: true,
+      },
+    });
+
+    const seen = new Set<string>();
+    for (const row of existing) {
+      const anchor = row.billId ?? row.propositionId;
+      if (!anchor) continue;
+      seen.add(
+        tupleKey(anchor, row.actionType, row.position, row.representativeId),
+      );
+    }
+
+    let dropped = 0;
+    const out = candidates.filter((c) => {
+      const anchor = c.billId ?? c.propositionId;
+      if (!anchor) return true; // un-anchored events stay (presence rolls, etc.)
+      const key = tupleKey(
+        anchor,
+        c.actionType,
+        c.position,
+        c.representativeId,
+      );
+      if (seen.has(key)) {
+        dropped++;
+        return false;
+      }
+      // Mark intra-batch duplicates too: if two candidates in this single
+      // Minutes share the tuple, keep only the first.
+      seen.add(key);
+      return true;
+    });
+    if (dropped > 0) {
+      this.logger.log(
+        `Linker dedup: dropped ${dropped} duplicate action(s) already present in another Minutes for ${ctx.externalId}`,
+      );
+    }
+    return out;
   }
 
   // ============================================

--- a/apps/backend/src/apps/region/src/domains/models/legislative-action.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/legislative-action.model.ts
@@ -65,6 +65,9 @@ export class LegislativeActionModel {
   propositionId?: string;
 
   @Field(() => ID, { nullable: true })
+  billId?: string;
+
+  @Field(() => ID, { nullable: true })
   committeeId?: string;
 
   @Field(() => ID)

--- a/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
@@ -737,6 +737,57 @@ describe('RegionQueryService — query methods', () => {
     });
   });
 
+  describe('getBillActivity (#666)', () => {
+    it('returns paginated feed scoped by billId', async () => {
+      mockDb.legislativeAction.findMany.mockResolvedValue([
+        {
+          id: 'la-1',
+          externalId: 'ext-1',
+          body: 'Assembly',
+          date: new Date('2026-04-28'),
+          actionType: 'engrossment',
+          position: null,
+          text: 'Ordered to the Senate.',
+          passageStart: 100,
+          passageEnd: 124,
+          rawSubject: 'AB 1897',
+          representativeId: null,
+          propositionId: null,
+          billId: 'bill-ab1897',
+          committeeId: null,
+          minutesId: 'min-1',
+          minutes: { externalId: 'weekly-2026-04-28' },
+        },
+      ] as never);
+      mockDb.legislativeAction.count.mockResolvedValue(1);
+
+      const result = await service.getBillActivity({ billId: 'bill-ab1897' });
+
+      expect(result.total).toBe(1);
+      expect(result.items[0].billId).toBe('bill-ab1897');
+      expect(result.items[0].minutesExternalId).toBe('weekly-2026-04-28');
+    });
+
+    it('scopes the Prisma where clause by billId', async () => {
+      mockDb.legislativeAction.findMany.mockResolvedValue([] as never);
+      mockDb.legislativeAction.count.mockResolvedValue(0);
+
+      await service.getBillActivity({
+        billId: 'bill-ab1897',
+        actionTypes: ['engrossment', 'enrollment'],
+      });
+
+      const findManyCall = mockDb.legislativeAction.findMany.mock
+        .calls[0][0] as {
+        where: Record<string, unknown>;
+      };
+      expect(findManyCall.where.billId).toBe('bill-ab1897');
+      expect(findManyCall.where.actionType).toEqual({
+        in: ['engrossment', 'enrollment'],
+      });
+    });
+  });
+
   describe('getCommittees', () => {
     it('should return paginated committees', async () => {
       const mockItems = [

--- a/apps/backend/src/apps/region/src/domains/region-query.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.ts
@@ -164,6 +164,7 @@ interface LegislativeActionFeedItem {
   rawSubject: string | null;
   representativeId: string | null;
   propositionId: string | null;
+  billId: string | null;
   committeeId: string | null;
   minutesId: string;
   minutesExternalId: string;
@@ -846,6 +847,25 @@ export class RegionQueryService {
     return this.paginateLegislativeActions(where, args.skip, args.take);
   }
 
+  /**
+   * Reverse-chronological feed of LegislativeActions linked to a Bill
+   * via the canonical `billId` FK populated by the linker (issue #666).
+   * Mirrors {@link getCommitteeActivity}; no presence-row filtering
+   * needed (presence actions aren't bill-attributed).
+   */
+  async getBillActivity(args: {
+    billId: string;
+    actionTypes?: string[];
+    skip?: number;
+    take?: number;
+  }): Promise<LegislativeActionFeedPage> {
+    const where = this.buildActionFeedWhere({
+      billId: args.billId,
+      actionTypes: args.actionTypes,
+    });
+    return this.paginateLegislativeActions(where, args.skip, args.take);
+  }
+
   // ─── Legislative committee getters ───────────────────────────────────────────
 
   async listLegislativeCommittees(args: {
@@ -1297,11 +1317,13 @@ export class RegionQueryService {
   private buildActionFeedWhere(args: {
     representativeId?: string;
     committeeId?: string;
+    billId?: string;
     actionTypes?: string[];
   }): Record<string, unknown> {
     const where: Record<string, unknown> = {};
     if (args.representativeId) where.representativeId = args.representativeId;
     if (args.committeeId) where.committeeId = args.committeeId;
+    if (args.billId) where.billId = args.billId;
     if (args.actionTypes?.length) {
       where.actionType = { in: args.actionTypes };
     }
@@ -1345,6 +1367,7 @@ export class RegionQueryService {
     rawSubject: string | null;
     representativeId: string | null;
     propositionId: string | null;
+    billId: string | null;
     committeeId: string | null;
     minutesId: string;
     minutes: { externalId: string };
@@ -1362,6 +1385,7 @@ export class RegionQueryService {
       rawSubject: r.rawSubject,
       representativeId: r.representativeId,
       propositionId: r.propositionId,
+      billId: r.billId,
       committeeId: r.committeeId,
       minutesId: r.minutesId,
       minutesExternalId: r.minutes.externalId,

--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -851,6 +851,7 @@ describe('RegionResolver', () => {
       rawSubject: 'AB 1897',
       representativeId: 'rep-1',
       propositionId: null,
+      billId: null,
       committeeId: 'cmt-1',
       minutesId: 'min-1',
       minutesExternalId: 'california-meetings-2026-04-28',
@@ -991,6 +992,7 @@ describe('RegionResolver', () => {
       rawSubject: 'AB 1897',
       representativeId: null,
       propositionId: null,
+      billId: null,
       committeeId: 'cmt-1',
       minutesId: 'min-1',
       minutesExternalId: 'california-meetings-2026-04-28',
@@ -1035,6 +1037,76 @@ describe('RegionResolver', () => {
       expect(regionService.getCommitteeActivity).toHaveBeenCalledWith({
         committeeId: 'cmt-1',
         actionTypes: ['committee_hearing'],
+        skip: 20,
+        take: 5,
+      });
+    });
+  });
+
+  describe('billActivity (#666)', () => {
+    const mockBillAction = {
+      id: 'la-2',
+      externalId: 'california-weekly-2026-04-28-0007',
+      body: 'Assembly',
+      date: new Date('2026-04-28T00:00:00Z'),
+      actionType: 'engrossment',
+      position: null,
+      text: 'AB 1897 — Ordered to the Senate.',
+      passageStart: 4200,
+      passageEnd: 4280,
+      rawSubject: 'AB 1897',
+      representativeId: null,
+      propositionId: null,
+      billId: 'bill-ab1897',
+      committeeId: null,
+      minutesId: 'min-2',
+      minutesExternalId: 'california-weekly-2026-04-28',
+    };
+
+    it('returns paginated activity feed for the bill', async () => {
+      regionService.getBillActivity.mockResolvedValue({
+        items: [mockBillAction],
+        total: 1,
+        hasMore: false,
+      });
+
+      const result = await resolver.billActivity('bill-ab1897');
+
+      expect(regionService.getBillActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          billId: 'bill-ab1897',
+          skip: 0,
+          take: 10,
+        }),
+      );
+      expect(result.total).toBe(1);
+      expect(result.items[0]).toEqual(
+        expect.objectContaining({
+          id: 'la-2',
+          actionType: 'engrossment',
+          billId: 'bill-ab1897',
+          rawSubject: 'AB 1897',
+        }),
+      );
+    });
+
+    it('forwards actionTypes + pagination args', async () => {
+      regionService.getBillActivity.mockResolvedValue({
+        items: [],
+        total: 0,
+        hasMore: false,
+      });
+
+      await resolver.billActivity(
+        'bill-ab1897',
+        ['engrossment', 'enrollment'],
+        20,
+        5,
+      );
+
+      expect(regionService.getBillActivity).toHaveBeenCalledWith({
+        billId: 'bill-ab1897',
+        actionTypes: ['engrossment', 'enrollment'],
         skip: 20,
         take: 5,
       });

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -449,6 +449,35 @@ export class RegionResolver {
     };
   }
 
+  /**
+   * Reverse-chronological feed of LegislativeActions linked to a Bill
+   * via the canonical `billId` FK (issue #666). Powers the bill detail
+   * page "History" tab — engrossments, enrollments, committee reports
+   * and amendments extracted from Assembly weekly histories + daily
+   * journals.
+   */
+  @Public()
+  @Query(() => PaginatedLegislativeActions)
+  async billActivity(
+    @Args({ name: 'billId', type: () => ID }) billId: string,
+    @Args({ name: 'actionTypes', type: () => [String], nullable: true })
+    actionTypes?: string[],
+    @Args({ name: 'skip', type: () => Int, nullable: true }) skip?: number,
+    @Args({ name: 'take', type: () => Int, nullable: true }) take?: number,
+  ): Promise<PaginatedLegislativeActions> {
+    const result = await this.regionService.getBillActivity({
+      billId,
+      actionTypes,
+      skip: skip ?? 0,
+      take: take ?? 10,
+    });
+    return {
+      items: result.items.map((r) => this.toLegislativeActionModel(r)),
+      total: result.total,
+      hasMore: result.hasMore,
+    };
+  }
+
   private toLegislativeActionModel(r: {
     id: string;
     externalId: string;
@@ -462,6 +491,7 @@ export class RegionResolver {
     rawSubject: string | null;
     representativeId: string | null;
     propositionId: string | null;
+    billId: string | null;
     committeeId: string | null;
     minutesId: string;
     minutesExternalId: string;
@@ -479,6 +509,7 @@ export class RegionResolver {
       rawSubject: r.rawSubject ?? undefined,
       representativeId: r.representativeId ?? undefined,
       propositionId: r.propositionId ?? undefined,
+      billId: r.billId ?? undefined,
       committeeId: r.committeeId ?? undefined,
       minutesId: r.minutesId,
       minutesExternalId: r.minutesExternalId,

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -427,6 +427,15 @@ export class RegionDomainService {
     return this.queryService.getCommitteeActivity(args);
   }
 
+  getBillActivity(args: {
+    billId: string;
+    actionTypes?: string[];
+    skip?: number;
+    take?: number;
+  }) {
+    return this.queryService.getBillActivity(args);
+  }
+
   listLegislativeCommittees(args: {
     skip: number;
     take: number;

--- a/apps/backend/src/apps/region/src/scripts/run-relink-minutes.ts
+++ b/apps/backend/src/apps/region/src/scripts/run-relink-minutes.ts
@@ -8,6 +8,11 @@
  * re-insert), so running it twice in a row is a no-op on the second
  * pass.
  *
+ * Doubles as the backfill path for new linker columns. After deploying
+ * the LegislativeAction.billId migration (opuspopuli#666), run this to
+ * populate `billId` on historical actions — the migration leaves the
+ * column NULL on existing rows and only new linker passes write to it.
+ *
  * Usage (assumes the region container is running):
  *   docker compose -f docker-compose-uat.yml exec region \
  *     node dist/src/apps/region/apps/region/src/scripts/run-relink-minutes.js

--- a/apps/frontend/__tests__/pages/region/bill-detail.test.tsx
+++ b/apps/frontend/__tests__/pages/region/bill-detail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import BillDetailPage from "@/app/region/bills/[id]/page";
 import type {
@@ -177,6 +177,21 @@ describe("BillDetailPage", () => {
       render(<BillDetailPage />);
       expect(screen.getByText("Chaptered")).toBeInTheDocument();
       expect(screen.getByText("Failed")).toBeInTheDocument();
+    });
+  });
+
+  describe("history tab (#666)", () => {
+    it("exposes a History tab in the layer navigation", () => {
+      render(<BillDetailPage />);
+      expect(
+        screen.getByRole("button", { name: /^History$/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders the BillActivityFeed when the History tab is selected", () => {
+      render(<BillDetailPage />);
+      fireEvent.click(screen.getByRole("button", { name: /^History$/ }));
+      expect(screen.getByTestId("bill-activity-feed")).toBeInTheDocument();
     });
   });
 });

--- a/apps/frontend/app/region/bills/[id]/page.tsx
+++ b/apps/frontend/app/region/bills/[id]/page.tsx
@@ -18,14 +18,16 @@ import { LayerNav } from "@/components/region/LayerNav";
 import { ComingSoon } from "@/components/region/ComingSoon";
 import { LifecycleProgressBar } from "@/components/civics/LifecycleProgressBar";
 import { useCivics } from "@/components/civics/CivicsContext";
+import { BillActivityFeed } from "@/components/region/BillActivityFeed";
 import { formatDate } from "@/lib/format";
 import { MEASURE_TYPE_STYLES } from "@/lib/bill-styles";
 import { useState, useMemo } from "react";
 
 const LAYERS = [
   { n: 1, label: "Snapshot" },
-  { n: 2, label: "Votes" },
-  { n: 3, label: "Sources" },
+  { n: 2, label: "History" },
+  { n: 3, label: "Votes" },
+  { n: 4, label: "Sources" },
 ] as const;
 
 const POSITION_STYLES: Record<string, { cls: string; label: string }> = {
@@ -186,7 +188,35 @@ function Snapshot({
         )}
       </div>
 
-      <LayerButton onClick={onNext}>See vote record</LayerButton>
+      <LayerButton onClick={onNext}>See bill history</LayerButton>
+    </div>
+  );
+}
+
+function History({
+  bill,
+  onNext,
+  onBack,
+}: {
+  readonly bill: NonNullable<BillData["bill"]>;
+  readonly onNext: () => void;
+  readonly onBack: () => void;
+}) {
+  return (
+    <div className="animate-layer-enter">
+      <SectionTitle>What has happened to this bill</SectionTitle>
+      <p className="text-sm text-slate-500 mb-4">
+        Committee reports, amendments, and chamber movements extracted from
+        official legislative journals and weekly histories.
+      </p>
+      <BillActivityFeed billId={bill.id} />
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        <LayerButton onClick={onNext}>See vote record</LayerButton>
+        <LayerButton onClick={onBack} variant="secondary">
+          Back to snapshot
+        </LayerButton>
+      </div>
     </div>
   );
 }
@@ -211,7 +241,7 @@ function Votes({
         />
         <div className="mt-6">
           <LayerButton onClick={onBack} variant="secondary">
-            Back to snapshot
+            Back to history
           </LayerButton>
         </div>
       </div>
@@ -268,7 +298,7 @@ function Votes({
       <div className="flex flex-wrap gap-3">
         <LayerButton onClick={onNext}>Sources & deep dive</LayerButton>
         <LayerButton onClick={onBack} variant="secondary">
-          Back to snapshot
+          Back to history
         </LayerButton>
       </div>
     </div>
@@ -462,13 +492,20 @@ export default function BillDetailPage() {
           />
         )}
         {layer === 2 && (
-          <Votes
+          <History
             bill={bill}
             onNext={() => setLayer(3)}
             onBack={() => setLayer(1)}
           />
         )}
-        {layer === 3 && <Sources bill={bill} onBack={() => setLayer(2)} />}
+        {layer === 3 && (
+          <Votes
+            bill={bill}
+            onNext={() => setLayer(4)}
+            onBack={() => setLayer(2)}
+          />
+        )}
+        {layer === 4 && <Sources bill={bill} onBack={() => setLayer(3)} />}
       </div>
     </div>
   );

--- a/apps/frontend/components/region/BillActivityFeed.tsx
+++ b/apps/frontend/components/region/BillActivityFeed.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "@apollo/client/react";
+import {
+  GET_BILL_ACTIVITY,
+  type LegislativeAction,
+  type PaginatedLegislativeActions,
+} from "@/lib/graphql/region";
+import { groupActionsByType, groupBillBatches } from "@/lib/format-action";
+import { ActionCard } from "./ActionCard";
+import { GroupedBillBatch } from "./GroupedBillBatch";
+
+const PAGE_SIZE = 10;
+
+interface Data {
+  billActivity: PaginatedLegislativeActions;
+}
+
+interface Vars {
+  billId: string;
+  actionTypes?: string[];
+  skip?: number;
+  take?: number;
+}
+
+/**
+ * Reverse-chronological feed of LegislativeActions linked to a Bill —
+ * committee_report + engrossment + enrollment + amendment rows
+ * extracted from Assembly weekly histories + daily journals. Mirrors
+ * CommitteeActivityFeed but scoped by billId (issue #666).
+ */
+export function BillActivityFeed({
+  billId,
+  onSeePassage,
+}: {
+  readonly billId: string;
+  readonly onSeePassage?: (actionId: string) => void;
+}) {
+  const [filter, setFilter] = useState<string>("all");
+  const [pageSize, setPageSize] = useState(PAGE_SIZE);
+
+  const actionTypes = filter === "all" ? undefined : [filter];
+
+  const { data, loading, error } = useQuery<Data, Vars>(GET_BILL_ACTIVITY, {
+    variables: { billId, actionTypes, skip: 0, take: pageSize },
+    notifyOnNetworkStatusChange: true,
+  });
+
+  if (loading && !data) {
+    return (
+      <div className="space-y-3" aria-busy="true" aria-live="polite">
+        {Array.from({ length: 3 }, (_, i) => (
+          <div
+            key={`bill-feed-skel-${i.toString()}`}
+            className="h-24 rounded-lg bg-slate-100 animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className="text-sm text-red-600">
+        Couldn&apos;t load bill activity. Try refreshing.
+      </p>
+    );
+  }
+
+  const items: LegislativeAction[] = data?.billActivity?.items ?? [];
+  const total = data?.billActivity?.total ?? 0;
+  const hasMore = data?.billActivity?.hasMore ?? false;
+
+  return (
+    <div data-testid="bill-activity-feed">
+      <div className="flex items-center justify-between mb-3 gap-3 flex-wrap">
+        <p className="text-xs text-[#595959]">
+          Showing {items.length} of {total} record{total === 1 ? "" : "s"}
+        </p>
+        <select
+          value={filter}
+          onChange={(e) => {
+            setFilter(e.target.value);
+            setPageSize(PAGE_SIZE);
+          }}
+          className="text-xs px-2 py-1 rounded border border-slate-300 bg-white text-[#334155] focus:outline-none focus:ring-2 focus:ring-blue-500"
+          aria-label="Filter bill activity by type"
+        >
+          <option value="all">All activity</option>
+          <option value="committee_report">Committee reports</option>
+          <option value="engrossment">Engrossments</option>
+          <option value="enrollment">Enrollments</option>
+          <option value="amendment">Amendments</option>
+        </select>
+      </div>
+
+      {total === 0 ? (
+        <p className="italic text-slate-400 text-sm">
+          No legislative activity has been linked to this bill yet.
+        </p>
+      ) : (
+        groupActionsByType(items).map((group) => (
+          <section key={group.actionType} className="mb-6">
+            <h3 className="text-xs font-bold uppercase tracking-wider text-[#595959] mb-2 flex items-baseline gap-2">
+              <span>{group.label}</span>
+              <span className="text-[10px] font-medium text-slate-400">
+                · {group.items.length} record
+                {group.items.length === 1 ? "" : "s"}
+              </span>
+            </h3>
+            <ul className="space-y-3">
+              {groupBillBatches(group.items).map((entry) => (
+                <li
+                  key={
+                    entry.type === "single"
+                      ? entry.action.id
+                      : `${entry.actionType}-${entry.date}-${entry.actions[0].id}`
+                  }
+                >
+                  {entry.type === "single" ? (
+                    <ActionCard
+                      action={entry.action}
+                      onSeePassage={onSeePassage}
+                    />
+                  ) : (
+                    <GroupedBillBatch
+                      actionType={entry.actionType}
+                      date={entry.date}
+                      verdict={entry.verdict}
+                      actions={entry.actions}
+                      onSeePassage={onSeePassage}
+                    />
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
+      )}
+
+      {hasMore && (
+        <div className="mt-4">
+          <button
+            type="button"
+            onClick={() => setPageSize((p) => p + PAGE_SIZE)}
+            disabled={loading}
+            className="text-sm font-medium text-blue-600 hover:text-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? "Loading…" : "Load more"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/e2e/region.spec.ts
+++ b/apps/frontend/e2e/region.spec.ts
@@ -331,42 +331,77 @@ const mockBillActivity = {
   hasMore: false,
 };
 
-// Returns mock data for a given GraphQL POST body, or null for unknown queries.
-function resolveRegionQueryData(
-  postData: Record<string, unknown> | null,
-): unknown {
-  if (!postData) return null;
-  if (postData.operationName === "GetRepresentative")
-    return { representative: mockRepresentatives.items[0] };
-  if (postData.operationName === "GetBill") return { bill: mockBill };
-  if (postData.operationName === "GetBillActivity")
-    return { billActivity: mockBillActivity };
-  const q = (postData.query as string) ?? "";
-  if (q.includes("regionInfo")) return { regionInfo: mockRegionInfo };
-  if (q.includes("petitionDocumentsForProposition"))
-    return { petitionDocumentsForProposition: [] };
-  if (q.match(/proposition[\s(]/))
-    return {
+// Lookup by GraphQL operationName for the queries that have an explicit
+// `query Foo` declaration in the frontend (Apollo sets operationName).
+const OPERATION_RESPONSES: Record<string, () => unknown> = {
+  GetRepresentative: () => ({ representative: mockRepresentatives.items[0] }),
+  GetBill: () => ({ bill: mockBill }),
+  GetBillActivity: () => ({ billActivity: mockBillActivity }),
+};
+
+// Fallback dispatch table for inline / anonymous queries — first matching
+// predicate wins. Order matters: more-specific predicates come first.
+const QUERY_MATCHERS: Array<[(q: string) => boolean, () => unknown]> = [
+  [(q) => q.includes("regionInfo"), () => ({ regionInfo: mockRegionInfo })],
+  [
+    (q) => q.includes("petitionDocumentsForProposition"),
+    () => ({ petitionDocumentsForProposition: [] }),
+  ],
+  [
+    (q) => /proposition[\s(]/.test(q),
+    () => ({
       proposition: {
         ...mockPropositions.items[0],
         fullText:
           "This proposition would amend the California Constitution to require commercial and industrial properties worth more than $3 million to be reassessed at current market value.",
       },
-    };
-  if (q.includes("propositions")) return { propositions: mockPropositions };
-  if (q.includes("meetings")) return { meetings: mockMeetings };
-  if (q.includes("myAddresses")) return { myAddresses: [] };
-  if (q.includes("representativesByDistricts"))
-    return { representativesByDistricts: [] };
-  if (q.includes("myCountySupervisors")) return { myCountySupervisors: [] };
-  if (q.includes("representatives"))
-    return { representatives: mockRepresentatives };
-  if (q.includes("independentExpenditures"))
-    return { independentExpenditures: mockIndependentExpenditures };
-  if (q.includes("expenditures")) return { expenditures: mockExpenditures };
-  if (q.includes("contributions")) return { contributions: mockContributions };
-  if (q.includes("committees")) return { committees: mockCommittees };
-  return null;
+    }),
+  ],
+  [
+    (q) => q.includes("propositions"),
+    () => ({ propositions: mockPropositions }),
+  ],
+  [(q) => q.includes("meetings"), () => ({ meetings: mockMeetings })],
+  [(q) => q.includes("myAddresses"), () => ({ myAddresses: [] })],
+  [
+    (q) => q.includes("representativesByDistricts"),
+    () => ({ representativesByDistricts: [] }),
+  ],
+  [
+    (q) => q.includes("myCountySupervisors"),
+    () => ({ myCountySupervisors: [] }),
+  ],
+  [
+    (q) => q.includes("representatives"),
+    () => ({ representatives: mockRepresentatives }),
+  ],
+  [
+    (q) => q.includes("independentExpenditures"),
+    () => ({ independentExpenditures: mockIndependentExpenditures }),
+  ],
+  [
+    (q) => q.includes("expenditures"),
+    () => ({ expenditures: mockExpenditures }),
+  ],
+  [
+    (q) => q.includes("contributions"),
+    () => ({ contributions: mockContributions }),
+  ],
+  [(q) => q.includes("committees"), () => ({ committees: mockCommittees })],
+];
+
+// Returns mock data for a given GraphQL POST body, or null for unknown queries.
+function resolveRegionQueryData(
+  postData: Record<string, unknown> | null,
+): unknown {
+  if (!postData) return null;
+  const opName = postData.operationName as string | undefined;
+  if (opName && OPERATION_RESPONSES[opName]) {
+    return OPERATION_RESPONSES[opName]();
+  }
+  const q = (postData.query as string) ?? "";
+  const match = QUERY_MATCHERS.find(([predicate]) => predicate(q));
+  return match ? match[1]() : null;
 }
 
 // Helper function to mock GraphQL API

--- a/apps/frontend/e2e/region.spec.ts
+++ b/apps/frontend/e2e/region.spec.ts
@@ -269,6 +269,68 @@ const mockIndependentExpenditures = {
   hasMore: false,
 };
 
+const mockBill = {
+  id: "bill-ab1897",
+  externalId: "20252026AB1897",
+  billNumber: "AB 1897",
+  sessionYear: "2025-2026",
+  measureTypeCode: "AB",
+  title: "Test bill — placeholder text used by the History-tab e2e",
+  subject: "Testing",
+  status: "In committee",
+  currentStageId: "policy-committee",
+  lastAction: "From committee chair, with author's amendments",
+  lastActionDate: "2026-05-13T00:00:00Z",
+  fiscalImpact: null,
+  fullTextUrl: null,
+  authorId: null,
+  authorName: "Jane Smith",
+  sourceUrl:
+    "https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=ab1897",
+  extractedAt: "2026-05-14T00:00:00Z",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-05-14T00:00:00Z",
+  votes: [
+    {
+      id: "v-1",
+      representativeName: "Aguiar-Curry, Cecilia",
+      representativeId: null,
+      chamber: "Assembly",
+      voteDate: "2026-04-28T00:00:00Z",
+      position: "yes",
+      motionText: "Do pass",
+      sourceUrl:
+        "https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=ab1897",
+    },
+  ],
+  coAuthors: [],
+};
+
+const mockBillActivity = {
+  items: [
+    {
+      id: "la-1",
+      externalId: "california-meetings-2026-04-28-0042",
+      body: "Assembly",
+      date: "2026-04-28T00:00:00Z",
+      actionType: "committee_report",
+      position: null,
+      text: "AB 1897: Do pass.",
+      passageStart: 12347,
+      passageEnd: 12521,
+      rawSubject: "AB 1897",
+      representativeId: null,
+      propositionId: null,
+      billId: "bill-ab1897",
+      committeeId: null,
+      minutesId: "min-1",
+      minutesExternalId: "california-meetings-2026-04-28",
+    },
+  ],
+  total: 1,
+  hasMore: false,
+};
+
 // Returns mock data for a given GraphQL POST body, or null for unknown queries.
 function resolveRegionQueryData(
   postData: Record<string, unknown> | null,
@@ -276,6 +338,9 @@ function resolveRegionQueryData(
   if (!postData) return null;
   if (postData.operationName === "GetRepresentative")
     return { representative: mockRepresentatives.items[0] };
+  if (postData.operationName === "GetBill") return { bill: mockBill };
+  if (postData.operationName === "GetBillActivity")
+    return { billActivity: mockBillActivity };
   const q = (postData.query as string) ?? "";
   if (q.includes("regionInfo")) return { regionInfo: mockRegionInfo };
   if (q.includes("petitionDocumentsForProposition"))
@@ -1726,5 +1791,42 @@ test.describe("Independent Expenditures Page", () => {
 
     await expect(page.getByText("Candidate: Jane Smith")).toBeVisible();
     await expect(page.getByText("Proposition: Proposition X")).toBeVisible();
+  });
+});
+
+test.describe("Bill Detail Page — History tab (#666)", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockRegionGraphQL(page);
+  });
+
+  test("exposes a History tab and renders the activity feed when selected", async ({
+    page,
+  }) => {
+    await page.goto("/region/bills/bill-ab1897");
+
+    await expect(
+      page.getByRole("button", { name: "History", exact: true }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "History", exact: true }).click();
+
+    await expect(
+      page.getByRole("heading", { name: /What has happened to this bill/ }),
+    ).toBeVisible();
+    await expect(page.getByTestId("bill-activity-feed")).toBeVisible();
+    await expect(page.getByText("Showing 1 of 1 record")).toBeVisible();
+  });
+
+  test("filter dropdown narrows the feed by action type", async ({ page }) => {
+    await page.goto("/region/bills/bill-ab1897");
+    await page.getByRole("button", { name: "History", exact: true }).click();
+
+    const filter = page.getByLabel("Filter bill activity by type");
+    await expect(filter).toBeVisible();
+    await filter.selectOption("engrossment");
+    // Mock router returns the same fixture for any filter — assert the
+    // dropdown wiring + persistent feed presence; the value-level filtering
+    // is covered by the backend resolver tests.
+    await expect(page.getByTestId("bill-activity-feed")).toBeVisible();
   });
 });

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -331,6 +331,7 @@ export interface LegislativeAction {
   rawSubject?: string;
   representativeId?: string;
   propositionId?: string;
+  billId?: string;
   committeeId?: string;
   minutesId: string;
   minutesExternalId: string;
@@ -1438,6 +1439,43 @@ export const GET_COMMITTEE_ACTIVITY = gql`
         rawSubject
         representativeId
         propositionId
+        committeeId
+        minutesId
+        minutesExternalId
+      }
+      total
+      hasMore
+    }
+  }
+`;
+
+export const GET_BILL_ACTIVITY = gql`
+  query GetBillActivity(
+    $billId: ID!
+    $actionTypes: [String!]
+    $skip: Int
+    $take: Int
+  ) {
+    billActivity(
+      billId: $billId
+      actionTypes: $actionTypes
+      skip: $skip
+      take: $take
+    ) {
+      items {
+        id
+        externalId
+        body
+        date
+        actionType
+        position
+        text
+        passageStart
+        passageEnd
+        rawSubject
+        representativeId
+        propositionId
+        billId
         committeeId
         minutesId
         minutesExternalId

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.61"
+    "@opuspopuli/regions": "^1.0.66"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/relationaldb-provider/prisma/migrations/20260525000000_legislative_action_bill_id/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260525000000_legislative_action_bill_id/migration.sql
@@ -1,0 +1,13 @@
+-- Per-bill legislative action linkage for opuspopuli#666 (weekly histories).
+-- Additive only: existing rows get NULL; subsequent linker passes will
+-- populate via canonical bill-citation matching against the bills table.
+
+ALTER TABLE "legislative_actions"
+  ADD COLUMN "bill_id" TEXT;
+
+ALTER TABLE "legislative_actions"
+  ADD CONSTRAINT "legislative_actions_bill_id_fkey"
+  FOREIGN KEY ("bill_id") REFERENCES "bills"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+CREATE INDEX "legislative_actions_bill_id_date_idx"
+  ON "legislative_actions"("bill_id", "date" DESC);

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -822,6 +822,11 @@ model LegislativeAction {
   actionType       String    @map("action_type") @db.VarChar(40)
   representativeId String?   @map("representative_id")
   propositionId    String?   @map("proposition_id")
+  /// Optional FK to Bill — resolved by the linker when the action's
+  /// canonical citation (e.g. "AB 1234") matches a row in `bills`. Set
+  /// independently of propositionId: an action can link to one, both,
+  /// or neither. See opuspopuli#666.
+  billId           String?   @map("bill_id")
   committeeId      String?   @map("committee_id")
   /// 'yes' | 'no' | 'abstain' | 'absent' — null for non-vote actions in V1.
   position         String?   @db.VarChar(20)
@@ -848,11 +853,13 @@ model LegislativeAction {
   minutes        Minutes               @relation(fields: [minutesId],        references: [id], onDelete: Cascade)
   representative Representative?       @relation(fields: [representativeId], references: [id], onDelete: SetNull)
   proposition    Proposition?          @relation(fields: [propositionId],    references: [id], onDelete: SetNull)
+  bill           Bill?                 @relation(fields: [billId],           references: [id], onDelete: SetNull)
   committee      LegislativeCommittee? @relation(fields: [committeeId],      references: [id], onDelete: SetNull)
 
   @@index([minutesId])
   @@index([representativeId, date(sort: Desc)])
   @@index([propositionId, date(sort: Desc)])
+  @@index([billId, date(sort: Desc)])
   @@index([committeeId, date(sort: Desc)])
   @@index([body, date(sort: Desc)])
   @@index([actionType])
@@ -1059,6 +1066,7 @@ model Bill {
   coAuthors         BillCoAuthor[]
   committeeReferrals BillCommitteeAssignment[]
   votes             BillVote[]
+  actions           LegislativeAction[]
 
   @@index([regionId, sessionYear])
   @@index([regionId, measureTypeCode])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.61
-        version: 1.0.61
+        specifier: ^1.0.66
+        version: 1.0.66
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -545,7 +545,7 @@ importers:
         version: 16.5.0
       jest:
         specifier: ^30.2.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       jest-axe:
         specifier: ^10.0.0
         version: 10.0.0
@@ -563,7 +563,7 @@ importers:
         version: 4.2.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -606,7 +606,7 @@ importers:
         version: 7.0.11
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -615,7 +615,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -640,10 +640,10 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -686,7 +686,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -695,7 +695,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -726,7 +726,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -735,7 +735,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -778,7 +778,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -787,7 +787,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -812,7 +812,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -821,7 +821,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -849,10 +849,10 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -883,7 +883,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -892,7 +892,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -920,10 +920,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -932,7 +932,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -963,13 +963,13 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -983,8 +983,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.61
-        version: 1.0.61
+        specifier: ^1.0.66
+        version: 1.0.66
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -997,7 +997,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1006,7 +1006,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1034,10 +1034,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       prisma:
         specifier: '5'
         version: 5.22.0
@@ -1049,7 +1049,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1107,7 +1107,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       mupdf:
         specifier: ^1.27.0
         version: 1.27.0
@@ -1119,7 +1119,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1150,7 +1150,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1159,7 +1159,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1196,7 +1196,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1205,7 +1205,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1233,13 +1233,13 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -4992,8 +4992,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.61':
-    resolution: {integrity: sha512-bO96O/aE/ovzut/MCaKZVKhG9601PZ8qlYkr/tlC9ot0TVIBNOkQkZa1H3uam7r3c3G37MIypqx9GnlxZ3dPfw==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.61/0ccc82173961df0130ce9419bfc70d26bee670e6}
+  '@opuspopuli/regions@1.0.66':
+    resolution: {integrity: sha512-0C0ZRh2pIWKCeRX5I2NA5mDrjQgWwUwmGhJeHYI0vS++3QWzQJuAlwR98Kq6Cr2RaBNeZQiUf/xE7Bk3egnoeA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.66/3bf765552b73c9888eba3862c07d9588916e263f}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -11473,15 +11473,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
-  tldts-core@7.1.2:
-    resolution: {integrity: sha512-26EbERPLf5wkNFKW+7egxArSPN1Nqipe/PIe1nvhpNu8HqQeY2pYdOeQk4sAiADv/e03VzHkLY0PPohKv1JMAQ==}
+  tldts-core@7.4.0:
+    resolution: {integrity: sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==}
 
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tldts@7.1.2:
-    resolution: {integrity: sha512-RUX5sQm8bl03ycwQ6nSgJiKw9FZWhA8GBzxX6X1lsG3xKzFIW+lYLLpM30FQbDD6XjTWa/VkF15VxjnAMWYJAQ==}
+  tldts@7.4.0:
+    resolution: {integrity: sha512-yHBe+zVfzNZ3QfTPW/Z6KK1G2t340gFjMHqI/4KKSt/abzYydzuCnpqdaF5gCCABby+9Yfbj59oR5F2Fd5CBzg==}
     hasBin: true
 
   tmpl@1.0.5:
@@ -15040,6 +15040,41 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
+  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 25.8.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.3.0
+      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-haste-map: 30.3.0
+      jest-message-util: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-resolve-dependencies: 30.3.0
+      jest-runner: 30.3.0
+      jest-runtime: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      jest-watcher: 30.3.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.3.0
@@ -15056,6 +15091,76 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
       jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      jest-haste-map: 30.3.0
+      jest-message-util: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-resolve-dependencies: 30.3.0
+      jest-runner: 30.3.0
+      jest-runtime: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      jest-watcher: 30.3.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 25.8.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.3.0
+      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      jest-haste-map: 30.3.0
+      jest-message-util: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-resolve-dependencies: 30.3.0
+      jest-runner: 30.3.0
+      jest-runtime: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      jest-watcher: 30.3.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 25.8.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.3.0
+      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -16896,7 +17001,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.61':
+  '@opuspopuli/regions@1.0.66':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
@@ -21595,34 +21700,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@22.19.15):
+  jest-cli@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.19.15)
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest-cli@30.3.0(@types/node@25.5.0):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -21652,7 +21738,45 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@22.19.15):
+  jest-cli@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-config@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -21679,6 +21803,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.15
+      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21715,6 +21840,38 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.8.0
+      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -21743,6 +21900,102 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.8.0
       ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.8.0
+      ts-node: 10.9.2(@types/node@25.8.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.8.0
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.1
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21867,10 +22120,10 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
+  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       '@jest/globals': 30.3.0
-      jest: 30.3.0(@types/node@22.19.15)
+      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -21881,10 +22134,10 @@ snapshots:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
-  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3):
+  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       '@jest/globals': 30.3.0
-      jest: 30.3.0
+      jest: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -22056,38 +22309,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0:
+  jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@22.19.15):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.19.15)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.5.0):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)
+      jest-cli: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22101,6 +22328,32 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -24802,15 +25055,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
-  tldts-core@7.1.2: {}
+  tldts-core@7.4.0: {}
 
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
 
-  tldts@7.1.2:
+  tldts@7.4.0:
     dependencies:
-      tldts-core: 7.1.2
+      tldts-core: 7.4.0
 
   tmpl@1.0.5: {}
 
@@ -24847,7 +25100,7 @@ snapshots:
 
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.1.2
+      tldts: 7.4.0
 
   tr46@0.0.3: {}
 
@@ -24876,12 +25129,12 @@ snapshots:
 
   ts-graphviz@1.8.2: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@22.19.15)
+      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24916,12 +25169,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.5.0)
+      jest: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24936,12 +25189,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0
+      jest: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24984,6 +25237,25 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.15
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
   ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -25001,6 +25273,44 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.8.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.9.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-tqdm@0.8.6: {}
 

--- a/postman/OpusPopuli.postman_collection.json
+++ b/postman/OpusPopuli.postman_collection.json
@@ -799,6 +799,150 @@
           }
         },
         {
+          "name": "Sync — PROPOSITIONS (Admin)",
+          "description": "Trigger a PROPOSITIONS data sync (qualified ballot measures). Returns a job ID immediately; the worker processes it async. Saves sync_job_id.",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const res = pm.response.json();",
+                  "const job = res.data && res.data.syncRegionData;",
+                  "if (job && job.jobId) {",
+                  "    pm.environment.set('sync_job_id', job.jobId);",
+                  "    console.log('sync_job_id saved:', job.jobId, '— status:', job.status);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $regionId: String) {\n  syncRegionData(dataTypes: $dataTypes, regionId: $regionId) {\n    jobId\n    status\n    triggerSource\n    regionId\n    dataTypes\n    enqueuedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"PROPOSITIONS\"],\n  \"regionId\": \"california\"\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
+          "name": "Sync — MEETINGS (Admin)",
+          "description": "Trigger a MEETINGS data sync (Assembly/Senate daily journals + weekly histories — pdf_archive sources fetch and extract LegislativeActions per #666). Returns a job ID immediately; the worker processes it async. Saves sync_job_id.",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const res = pm.response.json();",
+                  "const job = res.data && res.data.syncRegionData;",
+                  "if (job && job.jobId) {",
+                  "    pm.environment.set('sync_job_id', job.jobId);",
+                  "    console.log('sync_job_id saved:', job.jobId, '— status:', job.status);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $depth: SyncDepth, $regionId: String) {\n  syncRegionData(dataTypes: $dataTypes, depth: $depth, regionId: $regionId) {\n    jobId\n    status\n    triggerSource\n    regionId\n    dataTypes\n    enqueuedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"MEETINGS\"],\n  \"regionId\": \"california\",\n  \"depth\": \"STATE\"\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
+          "name": "Sync — CAMPAIGN_FINANCE (Admin)",
+          "description": "Trigger a CAMPAIGN_FINANCE data sync (committees, contributions, expenditures from CAL-ACCESS). Returns a job ID immediately; the worker processes it async. Saves sync_job_id.",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const res = pm.response.json();",
+                  "const job = res.data && res.data.syncRegionData;",
+                  "if (job && job.jobId) {",
+                  "    pm.environment.set('sync_job_id', job.jobId);",
+                  "    console.log('sync_job_id saved:', job.jobId, '— status:', job.status);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $regionId: String) {\n  syncRegionData(dataTypes: $dataTypes, regionId: $regionId) {\n    jobId\n    status\n    triggerSource\n    regionId\n    dataTypes\n    enqueuedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"CAMPAIGN_FINANCE\"],\n  \"regionId\": \"california\"\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
+          "name": "Sync — BILLS (Admin)",
+          "description": "Trigger a BILLS data sync (legislative bills + status pages from leginfo). Use maxBills to cap the run for smoke testing; omit for full sync. Returns a job ID immediately; saves sync_job_id.",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const res = pm.response.json();",
+                  "const job = res.data && res.data.syncRegionData;",
+                  "if (job && job.jobId) {",
+                  "    pm.environment.set('sync_job_id', job.jobId);",
+                  "    console.log('sync_job_id saved:', job.jobId, '— status:', job.status);",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $regionId: String, $maxBills: Int) {\n  syncRegionData(dataTypes: $dataTypes, regionId: $regionId, maxBills: $maxBills) {\n    jobId\n    status\n    triggerSource\n    regionId\n    dataTypes\n    enqueuedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"BILLS\"],\n  \"regionId\": \"california\",\n  \"maxBills\": 10\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
           "name": "Poll Job Status (by sync_job_id)",
           "description": "Poll the job saved by the last sync mutation. Refresh until status is SUCCEEDED or FAILED.",
           "request": {


### PR DESCRIPTION
Closes #666.

## Summary

- **Backend**: resolve `LegislativeAction` citations to `Bill` rows (new nullable FK), cross-source dedup against prior Minutes, and a new `billActivity` GraphQL query
- **Frontend**: new **History** tab on the bill detail page (`Snapshot → History → Votes → Sources`) rendering the bill's legislative timeline via `BillActivityFeed`
- **Postman**: 4 new per-DataType sync requests (PROPOSITIONS, MEETINGS, CAMPAIGN_FINANCE, BILLS)

## Why

Citizens visiting a bill page could see authorship + current status, but not the **journey** — when it was reported out of committee, what amendments it received, when it engrossed to the other chamber. Assembly publishes a weekly history PDF per session week that captures all of this. This PR teaches the linker to attribute those actions to the bill via the canonical citation (e.g. `AB 1897`), and surfaces them in a new History tab.

## Architecture

### Schema (`packages/relationaldb-provider/prisma/migrations/20260525000000_legislative_action_bill_id`)
- `legislative_actions.bill_id` (nullable FK, `ON DELETE SET NULL`)
- `(bill_id, date DESC)` composite index for the feed query
- Additive only — existing rows get NULL, populated by subsequent linker passes

### Linker (`legislative-action-linker.service.ts`)
- `LinkerCaches.billsByBillNumber` is a **two-level map** keyed `(sessionYear, billNumber)` → `billId`. Bill numbers recur across sessions (e.g. `AB 2` in both 2023-2024 AND 2025-2026), so session-scoping prevents mis-linking
- `MinutesContext.sessionYear` derived once per Minutes via `deriveSessionYear(date)`
- `resolveBillId(caches, canonical, sessionYear)` is the single-source lookup
- New `dedupAgainstPriorMinutes` — drops candidates whose `(billId|propositionId, date, actionType, position, repId)` tuple already exists in another Minutes for the same date. Same atomic event (e.g. an engrossment) often appears in both the daily journal AND the week's history; we want one row, not two

### GraphQL (`region.resolver.ts`)
- New `billActivity(billId, actionTypes, skip, take)` mirrors `committeeActivity`
- `LegislativeActionModel.billId: ID` exposed
- Federation-safe additive

### Frontend (`apps/frontend/components/region/BillActivityFeed.tsx`)
- New component clones the `CommitteeActivityFeed` shell, scoped by `billId` with filter options for `committee_report` / `engrossment` / `enrollment` / `amendment`
- New History layer in `bills/[id]/page.tsx` between Snapshot and Votes

### Postman
Per-DataType sync requests so individual data flows can be exercised without a Custom variant.

## UAT validation evidence

Ran the linker against the real UAT DB (`@opuspopuli/regions@1.0.66`, 10 Assembly Minutes, 1977 bills):

| Metric | Value |
|--------|-------|
| Minutes processed | 10 |
| LegislativeActions created | 777 |
| Actions linked to bills via canonical citation | **130** |
| Bills flagged for status re-check (#689 path still works) | 95 |
| Cross-source duplicates dropped (#666 dedup live-fire) | **1** for `california-meetings-2026-04-30` |
| `billActivity(billId: AB 1579)` | 4-step timeline returned via federation gateway |

Both `pdf_archive` sources (Assembly daily-journals + Assembly weekly-histories) fired through `MinutesIngestHandler`; watermarks already current so no new PDFs ingested, but the path is wired and confirmed in worker logs.

## Backfill

`apps/backend/src/apps/region/src/scripts/run-relink-minutes.ts` (existing script; docstring updated) doubles as the #666 backfill — running it re-links every active Minutes and populates `billId` on historical rows. Idempotent (delete-then-recreate per Minutes within a transaction).

## Test plan

- [x] Backend Jest (`apps/backend`): **467/467** pass — includes 5 new linker tests, 2 query-service tests, 2 resolver tests for `billActivity`
- [x] Frontend Jest: **1241/1241** pass — includes 2 new History-tab unit tests
- [x] Playwright e2e: 2 new tests for the History tab × 6 browser/device profiles = **12/12** pass
- [x] `pnpm lint` (both packages): 0 errors
- [x] `pnpm lint:sonar`: clean (table-driven mock dispatcher in 3rd commit drops cognitive complexity from 17 → 5)
- [x] `pnpm jscpd`: 0 clones
- [x] `pnpm build:region` + `pnpm build:region-worker`: clean
- [x] Migration applied in UAT (db-migrate exit 0; column + FK + index verified via `\d legislative_actions`)
- [x] Linker backfill in UAT: 10 Minutes → 777 actions, 130 linked to bills, 1 dup dropped
- [x] `billActivity` query via federated gateway against real DB: ✅ 4-step AB 1579 timeline
- [x] History tab renders end-to-end in UAT frontend (visually confirmed)

## Commits

1. `0183612` `feat(region): per-bill LegislativeAction.billId + cross-source dedup (#666)`
2. `3c39884` `feat(frontend): bill detail History tab (#666)`
3. `46b8447` `chore(frontend): table-driven mock dispatcher in region e2e (#666)`

## Dependencies

- `@opuspopuli/regions` bumped 1.0.61 → **1.0.66** (brings the Assembly weekly-histories `pdf_archive` source published from `OpusPopuli/opuspopuli-regions#50`)
- No new GPL-licensed dependencies