### PR TITLE
fix(users,infra): profile empty-string validation + CA jurisdictions seed

### DIFF
--- a/apps/backend/src/apps/users/src/domains/profile/dto/update-profile.dto.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/dto/update-profile.dto.spec.ts
@@ -1,0 +1,48 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { UpdateProfileDto } from './update-profile.dto';
+
+/**
+ * Regression coverage for the empty-string trap on format-validated
+ * optional fields. `@IsOptional()` only short-circuits on null/undefined;
+ * an unfilled form input that sends `phone: ""` would otherwise fail
+ * the E.164 regex with "Phone must be a valid E.164 format" even though
+ * the user intended no phone at all. See issue #737 follow-up.
+ */
+describe('UpdateProfileDto — empty-string handling', () => {
+  const validateInput = async (input: Record<string, unknown>) => {
+    const dto = plainToInstance(UpdateProfileDto, input);
+    return validate(dto);
+  };
+
+  it.each([
+    ['phone', ''],
+    ['dateOfBirth', ''],
+    ['timezone', ''],
+    ['locale', ''],
+    ['preferredLanguage', ''],
+    ['avatarUrl', ''],
+  ])(
+    'accepts an empty string for optional field %s (treated as not provided)',
+    async (field, value) => {
+      const errors = await validateInput({ [field]: value });
+      expect(errors).toHaveLength(0);
+    },
+  );
+
+  it('still rejects an invalid non-empty phone', async () => {
+    const errors = await validateInput({ phone: 'not-a-number' });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toEqual(
+      expect.objectContaining({
+        matches: 'Phone must be a valid E.164 format',
+      }),
+    );
+  });
+
+  it('accepts a valid E.164 phone', async () => {
+    const errors = await validateInput({ phone: '+14155551234' });
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/apps/backend/src/apps/users/src/domains/profile/dto/update-profile.dto.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/dto/update-profile.dto.ts
@@ -1,4 +1,5 @@
 import { Field, InputType } from '@nestjs/graphql';
+import { Transform } from 'class-transformer';
 import {
   IsOptional,
   IsString,
@@ -19,6 +20,16 @@ import {
   IncomeRange,
   HomeownerStatus,
 } from 'src/common/enums/profile.enum';
+
+/**
+ * Coerces a stray empty string to `undefined` BEFORE validation runs so
+ * `@IsOptional()` (which only short-circuits on null/undefined) can do
+ * its job for format-validated fields. Without this, an unfilled form
+ * input that ships `phone: ""` fails the E.164 regex even though the
+ * user intended "no phone." Apply via `@Transform(emptyToUndefined)`.
+ */
+const emptyToUndefined = ({ value }: { value: unknown }): unknown =>
+  value === '' ? undefined : value;
 
 @InputType()
 export class UpdateProfileDto {
@@ -52,11 +63,13 @@ export class UpdateProfileDto {
   @Field({ nullable: true })
   public preferredName?: string;
 
+  @Transform(emptyToUndefined)
   @IsOptional()
   @IsDateString()
   @Field({ nullable: true })
   public dateOfBirth?: string;
 
+  @Transform(emptyToUndefined)
   @IsOptional()
   @IsString()
   @Matches(/^\+?[1-9]\d{1,14}$/, {
@@ -65,16 +78,19 @@ export class UpdateProfileDto {
   @Field({ nullable: true })
   public phone?: string;
 
+  @Transform(emptyToUndefined)
   @IsOptional()
   @IsTimeZone()
   @Field({ nullable: true })
   public timezone?: string;
 
+  @Transform(emptyToUndefined)
   @IsOptional()
   @IsLocale()
   @Field({ nullable: true })
   public locale?: string;
 
+  @Transform(emptyToUndefined)
   @IsOptional()
   @IsString()
   @Matches(/^(en|es)$/, {
@@ -83,6 +99,7 @@ export class UpdateProfileDto {
   @Field({ nullable: true })
   public preferredLanguage?: string;
 
+  @Transform(emptyToUndefined)
   @IsOptional()
   @IsUrl()
   @MaxLength(500)

--- a/apps/frontend/app/settings/page.tsx
+++ b/apps/frontend/app/settings/page.tsx
@@ -52,6 +52,32 @@ interface ProfileFormProps {
   readonly onSave: () => void;
 }
 
+/**
+ * Pull a human-readable validation message out of an Apollo error.
+ * NestJS class-validator surfaces field-level messages as an array on
+ * `graphQLErrors[0].extensions.originalError.message`. Without this we
+ * end up showing the generic "Bad Request Exception" wrapper, leaving
+ * the user guessing what went wrong.
+ */
+function extractValidationMessage(err: unknown, fallback: string): string {
+  type GraphQLErrorShape = {
+    extensions?: {
+      originalError?: { message?: unknown };
+    };
+  };
+  const graphQLErrors = (err as { graphQLErrors?: GraphQLErrorShape[] })
+    .graphQLErrors;
+  const validationMessages =
+    graphQLErrors?.[0]?.extensions?.originalError?.message;
+  if (Array.isArray(validationMessages) && validationMessages.length > 0) {
+    return validationMessages.join(". ");
+  }
+  if (typeof validationMessages === "string") {
+    return validationMessages;
+  }
+  return err instanceof Error ? err.message : fallback;
+}
+
 function ProfileForm({ profile, onSave }: Readonly<ProfileFormProps>) {
   const { t } = useTranslation("settings");
   const { locale, setLocale } = useLocale();
@@ -162,7 +188,7 @@ function ProfileForm({ profile, onSave }: Readonly<ProfileFormProps>) {
       onSave();
     } catch (err) {
       setSaveError(
-        err instanceof Error ? err.message : t("common:errors.saveFailed"),
+        extractValidationMessage(err, t("common:errors.saveFailed")),
       );
     }
   };

--- a/packages/relationaldb-provider/prisma/migrations/20260525230000_seed_ca_jurisdictions/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260525230000_seed_ca_jurisdictions/migration.sql
@@ -1,0 +1,198 @@
+-- Seed CA-complete jurisdictions for the user's-jurisdiction resolution flow
+-- (opuspopuli#690 / follow-up to PR #737). Without these rows the
+-- `JurisdictionResolutionService.resolveCensusJurisdictions` lookup
+-- returns zero matches and the "My Jurisdictions" UI shows empty for
+-- every CA address.
+--
+-- Names are written in the EXACT format the Census Geocoder API returns
+-- via /geographies/coordinates layers — they are matched
+-- case-insensitively against the strings already stored on
+-- `user_addresses` (county, congressional_district, state_senatorial_district,
+-- state_assembly_district), so any deviation here silently breaks
+-- resolution again.
+--
+-- FIPS codes:
+--   Counties      → canonical state(2) + county(3), e.g. 06097 Sonoma
+--   Assembly      → state(2) + "AD" + district(3),  e.g. 06AD002
+--   Senate        → state(2) + "SD" + district(3),  e.g. 06SD002
+--   Congressional → state(2) + "CD" + district(2),  e.g. 06CD02
+-- The county code is kept canonical because future ETL (TIGER boundary
+-- imports, joins against external Census data) expects 06xxx for
+-- counties. Districts are prefixed because Census GEOIDs for SLDL/SLDU
+-- collide with county FIPS in the 06001–06079 range — sharing a
+-- UNIQUE column means the prefix has to come from us, not Census.
+--
+-- OCD IDs follow https://opencivicdata.readthedocs.io/en/latest/proposals/0002.html
+--
+-- This migration is additive + idempotent: `ON CONFLICT (fips_code) DO NOTHING`
+-- on every row. Safe to re-run after manual edits without overwriting.
+--
+-- Boundaries (PostGIS geography(MultiPolygon, 4326)) are intentionally
+-- left NULL. Loading TIGER/Line shapefiles is a separate concern — the
+-- Census-name resolution path (`resolveCensusJurisdictions`) covers the
+-- user's complaint without them; PostGIS point-in-polygon resolution
+-- (`resolvePostgisJurisdictions`) is purely additive and remains a
+-- follow-up ETL once the user-facing surface is unblocked.
+
+DO $$
+DECLARE
+  ca_state_id TEXT;
+  i INT;
+BEGIN
+  -- ============================================================
+  -- California (state-level)
+  -- ============================================================
+  INSERT INTO jurisdictions (id, fips_code, ocd_id, name, type, level, state_code, parent_id)
+  VALUES (
+    gen_random_uuid()::text,
+    '06',
+    'ocd-division/country:us/state:ca',
+    'California',
+    'STATE',
+    'STATE',
+    'CA',
+    NULL
+  )
+  ON CONFLICT (fips_code) DO NOTHING;
+
+  -- Grab the row (whether we just inserted it or it pre-existed) so
+  -- downstream rows can point parent_id at it.
+  SELECT id INTO ca_state_id FROM jurisdictions WHERE fips_code = '06';
+
+  -- ============================================================
+  -- 80 California State Assembly districts ("Assembly District N")
+  -- Note: Census /geographies/coordinates returns NAME without the
+  -- "State" prefix for lower-chamber districts. Match verbatim.
+  -- ============================================================
+  FOR i IN 1..80 LOOP
+    INSERT INTO jurisdictions (id, fips_code, ocd_id, name, type, level, state_code, parent_id)
+    VALUES (
+      gen_random_uuid()::text,
+      '06AD' || LPAD(i::text, 3, '0'),                     -- "06AD002" for Assembly District 2
+      'ocd-division/country:us/state:ca/sldl:' || i,       -- "sldl" = state legislative district lower
+      'Assembly District ' || i,
+      'STATE_ASSEMBLY_DISTRICT',
+      'DISTRICT',
+      'CA',
+      ca_state_id
+    )
+    ON CONFLICT (fips_code) DO NOTHING;
+  END LOOP;
+
+  -- ============================================================
+  -- 40 California State Senate districts ("State Senate District N")
+  -- Census uses "State Senate District N" verbatim for upper-chamber.
+  -- ============================================================
+  FOR i IN 1..40 LOOP
+    INSERT INTO jurisdictions (id, fips_code, ocd_id, name, type, level, state_code, parent_id)
+    VALUES (
+      gen_random_uuid()::text,
+      '06SD' || LPAD(i::text, 3, '0'),                     -- "06SD002" for State Senate District 2
+      'ocd-division/country:us/state:ca/sldu:' || i,       -- "sldu" = state legislative district upper
+      'State Senate District ' || i,
+      'STATE_SENATE_DISTRICT',
+      'DISTRICT',
+      'CA',
+      ca_state_id
+    )
+    ON CONFLICT (fips_code) DO NOTHING;
+  END LOOP;
+
+  -- ============================================================
+  -- 52 California Congressional districts ("Congressional District N")
+  -- 119th Congress (2025–2027) — CA delegation = 52 seats.
+  -- ============================================================
+  FOR i IN 1..52 LOOP
+    INSERT INTO jurisdictions (id, fips_code, ocd_id, name, type, level, state_code, parent_id)
+    VALUES (
+      gen_random_uuid()::text,
+      '06CD' || LPAD(i::text, 2, '0'),                     -- "06CD02" for Congressional District 2
+      'ocd-division/country:us/state:ca/cd:' || i,
+      'Congressional District ' || i,
+      'CONGRESSIONAL_DISTRICT',
+      'DISTRICT',
+      'CA',
+      ca_state_id
+    )
+    ON CONFLICT (fips_code) DO NOTHING;
+  END LOOP;
+END $$;
+
+-- ============================================================
+-- 58 California counties — alphabetical, with official FIPS county codes.
+-- Format: state FIPS (06) + 3-digit county FIPS. Census NAME field
+-- includes the " County" suffix; match verbatim.
+-- ============================================================
+-- One INSERT with VALUES (...) rather than 58 separate statements,
+-- so a transactional db-migrate failure rolls all-or-nothing.
+INSERT INTO jurisdictions (id, fips_code, ocd_id, name, type, level, state_code, parent_id)
+SELECT
+  gen_random_uuid()::text,
+  '06' || LPAD(county_fips::text, 3, '0'),
+  'ocd-division/country:us/state:ca/county:' || LOWER(REPLACE(REPLACE(county_name, ' County', ''), ' ', '_')),
+  county_name,
+  'COUNTY',
+  'COUNTY',
+  'CA',
+  (SELECT id FROM jurisdictions WHERE fips_code = '06')
+FROM (VALUES
+  (1,   'Alameda County'),
+  (3,   'Alpine County'),
+  (5,   'Amador County'),
+  (7,   'Butte County'),
+  (9,   'Calaveras County'),
+  (11,  'Colusa County'),
+  (13,  'Contra Costa County'),
+  (15,  'Del Norte County'),
+  (17,  'El Dorado County'),
+  (19,  'Fresno County'),
+  (21,  'Glenn County'),
+  (23,  'Humboldt County'),
+  (25,  'Imperial County'),
+  (27,  'Inyo County'),
+  (29,  'Kern County'),
+  (31,  'Kings County'),
+  (33,  'Lake County'),
+  (35,  'Lassen County'),
+  (37,  'Los Angeles County'),
+  (39,  'Madera County'),
+  (41,  'Marin County'),
+  (43,  'Mariposa County'),
+  (45,  'Mendocino County'),
+  (47,  'Merced County'),
+  (49,  'Modoc County'),
+  (51,  'Mono County'),
+  (53,  'Monterey County'),
+  (55,  'Napa County'),
+  (57,  'Nevada County'),
+  (59,  'Orange County'),
+  (61,  'Placer County'),
+  (63,  'Plumas County'),
+  (65,  'Riverside County'),
+  (67,  'Sacramento County'),
+  (69,  'San Benito County'),
+  (71,  'San Bernardino County'),
+  (73,  'San Diego County'),
+  (75,  'San Francisco County'),
+  (77,  'San Joaquin County'),
+  (79,  'San Luis Obispo County'),
+  (81,  'San Mateo County'),
+  (83,  'Santa Barbara County'),
+  (85,  'Santa Clara County'),
+  (87,  'Santa Cruz County'),
+  (89,  'Shasta County'),
+  (91,  'Sierra County'),
+  (93,  'Siskiyou County'),
+  (95,  'Solano County'),
+  (97,  'Sonoma County'),
+  (99,  'Stanislaus County'),
+  (101, 'Sutter County'),
+  (103, 'Tehama County'),
+  (105, 'Trinity County'),
+  (107, 'Tulare County'),
+  (109, 'Tuolumne County'),
+  (111, 'Ventura County'),
+  (113, 'Yolo County'),
+  (115, 'Yuba County')
+) AS counties(county_fips, county_name)
+ON CONFLICT (fips_code) DO NOTHING;


### PR DESCRIPTION
Fixes two user-facing bugs surfaced during fresh-account testing on UAT:

## 1. Profile update fails on empty optional fields

**Symptom:** Editing the profile threw
```
{"errors":[{"message":"Bad Request Exception","extensions":{"originalError":{"message":["Phone must be a valid E.164 format"]}}}]}
```
even when the user wasn't trying to set a phone number. The raw error wasn't surfaced to the UI either — users saw a generic "save failed" toast.

**Cause:** `class-validator`'s `@IsOptional()` only short-circuits on `null`/`undefined`. An unfilled form input ships `phone: ""`, which is neither — so the E.164 regex runs and rejects empty string. Same trap on `dateOfBirth`, `timezone`, `locale`, `preferredLanguage`, `avatarUrl`.

**Fix:** Add `@Transform(emptyToUndefined)` ahead of `@IsOptional()` on the six format-validated optional fields. Frontend catch block now extracts `graphQLErrors[0].extensions.originalError.message` (array) and joins to the red banner, so users see the specific validation error if there is one.

## 2. "My Jurisdictions" empty for every CA address

**Symptom:** A user with a geocoded primary address (lat/lng + district names all populated) still saw zero jurisdictions resolved.

**Cause:** `JurisdictionResolutionService.resolveCensusJurisdictions` looks up `jurisdictions` rows by `(name, type, state_code)`. The `jurisdictions` table was **empty** — never seeded since issue #690 shipped. PostGIS path (`resolvePostgisJurisdictions`) silently fell back because the `boundary` column was also unpopulated.

**Fix:** New migration `20260525230000_seed_ca_jurisdictions` seeds 231 CA rows:

| Type | Count | Name format (matches Census Geocoder verbatim) |
|------|-------|-----------------------------------------------|
| STATE | 1 | `California` |
| STATE_ASSEMBLY_DISTRICT | 80 | `Assembly District N` |
| STATE_SENATE_DISTRICT | 40 | `State Senate District N` |
| CONGRESSIONAL_DISTRICT | 52 | `Congressional District N` (119th Congress) |
| COUNTY | 58 | `<Name> County` |

FIPS codes: counties keep canonical state(2)+county(3) (`06097` Sonoma); districts get a type-prefix (`06AD002`, `06SD002`, `06CD02`) to avoid collision in the shared `UNIQUE (fips_code)` column. OCD IDs follow OCDIDs standard. Migration is fully idempotent (`ON CONFLICT DO NOTHING`).

## Out of scope / deliberate cuts

- **PostGIS boundaries** — `boundary` column left NULL. The Census-string resolution path covers the user-facing issue; loading TIGER/Line shapefiles for `resolvePostgisJurisdictions` (special districts, edge cases) is a follow-up ETL.
- **Other states** — CA only for MVP. NY/TX/etc. follow the same template when needed.
- **Cities + school districts** — schema supports them, but Census Geocoder name formats vary enough that I want real-world validation before seeding ~500 cities + ~1000 school districts.

## Test plan

- [x] **DTO unit tests** — 8 new cases in `update-profile.dto.spec.ts`: empty string accepted for each of the 6 affected fields, invalid non-empty phone still rejected, valid E.164 still accepted
- [x] **Backend Jest** (`src/apps/users`): 390/390 pass
- [x] **Backend lint**: 0 errors
- [x] **Backend build:users**: clean
- [x] **UAT validation — phone fix**: rebuilt + force-recreated `users` container; profile save now works with empty phone (live)
- [x] **UAT validation — jurisdictions seed**: applied migration, 231 rows confirmed via `SELECT COUNT(*) FROM jurisdictions GROUP BY level, type`
- [x] **UAT validation — end-to-end resolution**: ran the resolver's matching logic against the affected user's address; resolved 4 jurisdictions (Sonoma County, Assembly D2, Senate D2, Congressional D2) — exactly the expected set

## Commits

1. `cecc9ef` `fix(users,frontend): accept empty optional profile fields + surface validation errors`
2. `ee0296d` `fix(infra): seed CA jurisdictions so address resolution works`

## Migration impact

- Additive only (new INSERT statements; no schema changes)
- Idempotent (re-runnable)
- ~5ms to apply on fresh DB
- Requires no coordinated app deploy — the resolver code already handles the empty case (logs `debug: No jurisdictions resolved`), and starts working as soon as seed data is present