### PR TITLE
feat(frontend): onboarding polish, sage pills, dark mode, locale toggle

### DIFF
--- a/apps/frontend/__tests__/accessibility/onboarding.a11y.test.tsx
+++ b/apps/frontend/__tests__/accessibility/onboarding.a11y.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * WCAG 2.2 AA accessibility tests for the onboarding flow.
+ *
+ * Renders each of the 9 OnboardingSteps screens and runs jest-axe to catch
+ * structural a11y regressions (labels, button names, heading order,
+ * landmark roles, decorative-svg hiding). Color contrast is NOT covered
+ * here — jest-axe runs in jsdom which does not apply Tailwind's external
+ * stylesheet, so axe's color-contrast rule can't compute the canvas/text
+ * pairs. Contrast verification for the neutral-canvas refactor relies on
+ * the token choices (text-gray-500 on bg-gray-50 ≈ 4.7:1, sage-dark on
+ * white ≈ 5.4:1) and on the manual Docker eyeball pass.
+ */
+
+import { render } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import "@testing-library/jest-dom";
+import { OnboardingSteps } from "@/components/onboarding/OnboardingSteps";
+import { I18nProvider } from "@/lib/i18n/context";
+
+expect.extend(toHaveNoViolations);
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
+const defaultContext = {
+  hasCompletedOnboarding: false,
+  currentStep: 0,
+  totalSteps: 9,
+  nextStep: jest.fn(),
+  prevStep: jest.fn(),
+  skipOnboarding: jest.fn(),
+  completeOnboarding: jest.fn(),
+  resetOnboarding: jest.fn(),
+};
+let mockContext = { ...defaultContext };
+
+jest.mock("@/lib/onboarding-context", () => ({
+  useOnboarding: () => mockContext,
+}));
+
+// WelcomeStep + LanguageToggle (if rendered) consume the toast provider
+// for persistence-failure feedback. Stub it so renders don't crash.
+jest.mock("@/lib/toast", () => ({
+  useToast: () => ({ showToast: jest.fn() }),
+}));
+
+// Steps render under jsdom without a backing GraphQL server. Each query
+// returns an empty/loading-resolved shape so the component renders its
+// post-mount empty state, which is the surface a11y is judged on.
+jest.mock("@apollo/client/react", () => ({
+  useQuery: () => ({
+    data: null,
+    loading: false,
+    error: null,
+    refetch: jest.fn(),
+  }),
+  useMutation: () => [
+    jest.fn().mockResolvedValue({ data: {} }),
+    { loading: false },
+  ],
+  useLazyQuery: () => [jest.fn(), { data: null, loading: false, error: null }],
+}));
+
+const renderStep = (step: number) => {
+  mockContext = { ...defaultContext, currentStep: step };
+  return render(
+    <I18nProvider>
+      <OnboardingSteps />
+    </I18nProvider>,
+  );
+};
+
+const STEPS = [
+  { step: 0, name: "Welcome" },
+  { step: 1, name: "Explore" },
+  { step: 2, name: "Scan" },
+  { step: 3, name: "Analyze" },
+  { step: 4, name: "Track" },
+  { step: 5, name: "Address" },
+  { step: 6, name: "Topics" },
+  { step: 7, name: "LifeContext" },
+  { step: 8, name: "Veteran" },
+] as const;
+
+describe("Onboarding accessibility (WCAG 2.2 AA, structural)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe.each(STEPS)("step $step ($name)", ({ step }) => {
+    it("has no axe violations", async () => {
+      const { container } = renderStep(step);
+      const results = await axe(container);
+      expect(results).toHaveNoViolations();
+    });
+
+    it("hides decorative SVGs from screen readers", () => {
+      const { container } = renderStep(step);
+      const svgs = container.querySelectorAll("svg");
+      svgs.forEach((svg) => {
+        expect(svg).toHaveAttribute("aria-hidden", "true");
+      });
+    });
+  });
+
+  describe("global chrome", () => {
+    it("progressbar exposes valuenow/valuemin/valuemax", () => {
+      const { container } = renderStep(3);
+      const bar = container.querySelector("[role='progressbar']");
+      expect(bar).toHaveAttribute("aria-valuemin", "1");
+      expect(bar).toHaveAttribute("aria-valuemax", "9");
+      expect(bar).toHaveAttribute("aria-valuenow", "4");
+    });
+  });
+});

--- a/apps/frontend/__tests__/components/Header.test.tsx
+++ b/apps/frontend/__tests__/components/Header.test.tsx
@@ -31,6 +31,29 @@ jest.mock("@/lib/auth-context", () => ({
   useAuth: () => mockAuthContextValue,
 }));
 
+// LanguageToggle (mounted by Header) depends on the i18n locale + toast
+// providers and Apollo. The Header tests assert on nav/auth behavior, not
+// on the language toggle — stub these dependencies so the component
+// renders. Toast assertions live in LanguageToggle's own spec.
+jest.mock("@/lib/i18n/context", () => ({
+  useLocale: () => ({ locale: "en", setLocale: jest.fn() }),
+}));
+
+jest.mock("@/lib/toast", () => ({
+  useToast: () => ({ showToast: jest.fn() }),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock("@apollo/client/react", () => ({
+  useMutation: () => [
+    jest.fn().mockResolvedValue({ data: {} }),
+    { loading: false },
+  ],
+}));
+
 describe("Header", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/frontend/__tests__/components/LanguageToggle.test.tsx
+++ b/apps/frontend/__tests__/components/LanguageToggle.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { LanguageToggle } from "@/components/LanguageToggle";
+
+const mockSetLocale = jest.fn();
+let mockLocale: "en" | "es" = "en";
+
+jest.mock("@/lib/i18n/context", () => ({
+  useLocale: () => ({ locale: mockLocale, setLocale: mockSetLocale }),
+}));
+
+const mockShowToast = jest.fn();
+jest.mock("@/lib/toast", () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+jest.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+let mockIsAuthenticated = false;
+jest.mock("@/lib/auth-context", () => ({
+  useAuth: () => ({ isAuthenticated: mockIsAuthenticated }),
+}));
+
+// The mutation tuple swapped per test via assignment so each case can
+// inspect whether the persist call fired or not.
+let mockUpdate = jest.fn().mockResolvedValue({ data: {} });
+jest.mock("@apollo/client/react", () => ({
+  useMutation: () => [mockUpdate, { loading: false }],
+}));
+
+describe("LanguageToggle", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLocale = "en";
+    mockIsAuthenticated = false;
+    mockUpdate = jest.fn().mockResolvedValue({ data: {} });
+  });
+
+  it("renders both language options as a radio group", () => {
+    render(<LanguageToggle />);
+    expect(screen.getByRole("radio", { name: "EN" })).toBeChecked();
+    expect(screen.getByRole("radio", { name: "ES" })).not.toBeChecked();
+  });
+
+  it("flips the locale on selection", async () => {
+    render(<LanguageToggle />);
+    await userEvent.click(screen.getByRole("radio", { name: "ES" }));
+    expect(mockSetLocale).toHaveBeenCalledWith("es");
+  });
+
+  it("does NOT call updateProfile when unauthenticated", async () => {
+    mockIsAuthenticated = false;
+    render(<LanguageToggle />);
+    await userEvent.click(screen.getByRole("radio", { name: "ES" }));
+    expect(mockSetLocale).toHaveBeenCalledWith("es");
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("persists via updateProfile when authenticated", async () => {
+    mockIsAuthenticated = true;
+    render(<LanguageToggle />);
+    await userEvent.click(screen.getByRole("radio", { name: "ES" }));
+    expect(mockUpdate).toHaveBeenCalledWith({
+      variables: { input: { preferredLanguage: "es" } },
+    });
+  });
+
+  it("shows a toast and warns when persistence fails", async () => {
+    mockIsAuthenticated = true;
+    mockUpdate = jest.fn().mockRejectedValue(new Error("network"));
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    render(<LanguageToggle />);
+    await userEvent.click(screen.getByRole("radio", { name: "ES" }));
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        "errors.preferencesNotSaved",
+        "warning",
+      );
+    });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("is a no-op when the active locale is reselected", async () => {
+    mockIsAuthenticated = true;
+    mockLocale = "en";
+    render(<LanguageToggle />);
+    // Clicking the already-active radio shouldn't fire any state changes
+    // or mutations. This guards against re-render churn and an
+    // unnecessary network call.
+    await userEvent.click(screen.getByRole("radio", { name: "EN" }));
+    expect(mockSetLocale).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/__tests__/components/StatusPill.test.tsx
+++ b/apps/frontend/__tests__/components/StatusPill.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { StatusPill, type StatusPillTone } from "@/components/StatusPill";
+
+describe("StatusPill", () => {
+  it("renders the child label", () => {
+    render(<StatusPill tone="sage-filled">Primary</StatusPill>);
+    expect(screen.getByText("Primary")).toBeInTheDocument();
+  });
+
+  // Lock the tone→class mapping. A future rename of a sage token or a
+  // careless edit to TONE_CLASSES would change these assertions; that's
+  // the regression we want to catch. We assert positively on the
+  // expected tokens and on the shared chrome (padding, radius, text
+  // size) so a structural rewrite doesn't slip past either.
+  describe.each<{ tone: StatusPillTone; expectedClasses: string[] }>([
+    {
+      tone: "sage-filled",
+      expectedClasses: [
+        "bg-sage-light/20",
+        "text-sage-darker",
+        "dark:bg-sage-dark/20",
+        "dark:text-sage-light",
+      ],
+    },
+    {
+      tone: "sage-outline",
+      expectedClasses: [
+        "border",
+        "border-sage-dark",
+        "text-sage-dark",
+        "dark:border-sage-light",
+        "dark:text-sage-light",
+      ],
+    },
+    {
+      tone: "warning",
+      expectedClasses: [
+        "bg-yellow-100",
+        "text-yellow-700",
+        "dark:bg-yellow-900/30",
+        "dark:text-yellow-200",
+      ],
+    },
+    {
+      tone: "danger",
+      expectedClasses: [
+        "bg-red-100",
+        "text-red-700",
+        "dark:bg-red-900/30",
+        "dark:text-red-200",
+      ],
+    },
+    {
+      tone: "neutral",
+      expectedClasses: [
+        "bg-gray-100",
+        "text-gray-700",
+        "dark:bg-gray-700",
+        "dark:text-gray-200",
+      ],
+    },
+  ])("tone=$tone", ({ tone, expectedClasses }) => {
+    it("applies the expected token classes", () => {
+      render(<StatusPill tone={tone}>label</StatusPill>);
+      const pill = screen.getByText("label");
+      expectedClasses.forEach((cls) => {
+        expect(pill).toHaveClass(cls);
+      });
+    });
+
+    it("applies the shared chrome (padding, radius, text size)", () => {
+      render(<StatusPill tone={tone}>label</StatusPill>);
+      const pill = screen.getByText("label");
+      expect(pill).toHaveClass(
+        "px-2",
+        "py-0.5",
+        "text-xs",
+        "font-medium",
+        "rounded",
+      );
+    });
+  });
+});

--- a/apps/frontend/__tests__/components/StatusPill.test.tsx
+++ b/apps/frontend/__tests__/components/StatusPill.test.tsx
@@ -28,7 +28,7 @@ describe("StatusPill", () => {
       expectedClasses: [
         "border",
         "border-sage-dark",
-        "text-sage-dark",
+        "text-sage-darker",
         "dark:border-sage-light",
         "dark:text-sage-light",
       ],

--- a/apps/frontend/__tests__/components/onboarding/OnboardingSteps.test.tsx
+++ b/apps/frontend/__tests__/components/onboarding/OnboardingSteps.test.tsx
@@ -42,6 +42,10 @@ jest.mock("@/lib/i18n/context", () => ({
   useLocale: () => ({ locale: "en", setLocale: jest.fn() }),
 }));
 
+jest.mock("@/lib/toast", () => ({
+  useToast: () => ({ showToast: jest.fn() }),
+}));
+
 jest.mock("@apollo/client/react", () => ({
   useMutation: () => [
     jest.fn().mockResolvedValue({ data: {} }),

--- a/apps/frontend/__tests__/components/profile/ProfileCompletionIndicator.test.tsx
+++ b/apps/frontend/__tests__/components/profile/ProfileCompletionIndicator.test.tsx
@@ -103,52 +103,33 @@ describe("ProfileCompletionIndicator", () => {
       expect(progressBar).toBeInTheDocument();
     });
 
-    it("should have green color when complete", () => {
-      const { container } = render(
-        <ProfileCompletionIndicator
-          completion={createCompletion({
-            isComplete: true,
-            percentage: 100,
-          })}
-        />,
-      );
+    it.each([
+      { percentage: 30, isComplete: false, label: "below 50%" },
+      { percentage: 60, isComplete: false, label: "50–74%" },
+      { percentage: 80, isComplete: false, label: "75%+" },
+      { percentage: 100, isComplete: true, label: "100% complete" },
+    ])(
+      "uses a single sage track at $label (percentage=$percentage)",
+      ({ percentage, isComplete }) => {
+        const { container } = render(
+          <ProfileCompletionIndicator
+            completion={createCompletion({ percentage, isComplete })}
+          />,
+        );
 
-      const progressBar = container.querySelector(".bg-green-500");
-      expect(progressBar).toBeInTheDocument();
-    });
-
-    it("should have blue color when 75% or more", () => {
-      const { container } = render(
-        <ProfileCompletionIndicator
-          completion={createCompletion({ percentage: 80 })}
-        />,
-      );
-
-      const progressBar = container.querySelector(".bg-blue-500");
-      expect(progressBar).toBeInTheDocument();
-    });
-
-    it("should have yellow color when 50-74%", () => {
-      const { container } = render(
-        <ProfileCompletionIndicator
-          completion={createCompletion({ percentage: 60 })}
-        />,
-      );
-
-      const progressBar = container.querySelector(".bg-yellow-500");
-      expect(progressBar).toBeInTheDocument();
-    });
-
-    it("should have orange color when below 50%", () => {
-      const { container } = render(
-        <ProfileCompletionIndicator
-          completion={createCompletion({ percentage: 30 })}
-        />,
-      );
-
-      const progressBar = container.querySelector(".bg-orange-500");
-      expect(progressBar).toBeInTheDocument();
-    });
+        // Single sage track replaces the legacy 4-tier color ramp
+        // (green/blue/yellow/orange) — see the design conversation that
+        // landed in this PR. Assert positively on the new class, and
+        // negatively on the old ones so a future regression that
+        // reintroduces tier colors fails loudly here.
+        const progressBar = container.querySelector(".bg-sage-dark");
+        expect(progressBar).toBeInTheDocument();
+        expect(container.querySelector(".bg-green-500")).toBeNull();
+        expect(container.querySelector(".bg-blue-500")).toBeNull();
+        expect(container.querySelector(".bg-yellow-500")).toBeNull();
+        expect(container.querySelector(".bg-orange-500")).toBeNull();
+      },
+    );
   });
 
   describe("core fields status", () => {
@@ -178,7 +159,7 @@ describe("ProfileCompletionIndicator", () => {
       );
 
       const nameBadge = screen.getByText("Name").closest("div");
-      expect(nameBadge).toHaveClass("bg-green-50", "text-green-700");
+      expect(nameBadge).toHaveClass("bg-sage-light/20", "text-sage-darker");
     });
 
     it("should show incomplete styling for incomplete fields", () => {
@@ -272,27 +253,23 @@ describe("ProfileCompletionIndicator", () => {
     });
 
     it("should handle exactly 50% completion", () => {
-      const { container } = render(
+      render(
         <ProfileCompletionIndicator
           completion={createCompletion({ percentage: 50 })}
         />,
       );
 
       expect(screen.getByText("50%")).toBeInTheDocument();
-      const progressBar = container.querySelector(".bg-yellow-500");
-      expect(progressBar).toBeInTheDocument();
     });
 
     it("should handle exactly 75% completion", () => {
-      const { container } = render(
+      render(
         <ProfileCompletionIndicator
           completion={createCompletion({ percentage: 75 })}
         />,
       );
 
       expect(screen.getByText("75%")).toBeInTheDocument();
-      const progressBar = container.querySelector(".bg-blue-500");
-      expect(progressBar).toBeInTheDocument();
     });
   });
 });

--- a/apps/frontend/app/settings/addresses/page.tsx
+++ b/apps/frontend/app/settings/addresses/page.tsx
@@ -19,6 +19,7 @@ import {
   AddressType,
 } from "@/lib/graphql/profile";
 import { SettingsLoadingSkeleton } from "@/components/settings/SettingsLoadingSkeleton";
+import { StatusPill } from "@/components/StatusPill";
 import { US_STATES } from "@/lib/us-states";
 
 // Values are uppercase to match the GraphQL `AddressType` enum's wire format.
@@ -152,8 +153,8 @@ export default function AddressesPage() {
 
   if (error) {
     return (
-      <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
-        <div className="text-center text-red-600">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-8">
+        <div className="text-center text-red-600 dark:text-red-300">
           <p>{t("common:errors.loadFailed")}</p>
         </div>
       </div>
@@ -175,18 +176,20 @@ export default function AddressesPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-8">
         <div className="flex justify-between items-start">
           <div>
-            <h1 className="text-2xl font-bold text-[#222222]">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
               {t("addresses.title")}
             </h1>
-            <p className="text-[#4d4d4d] mt-1">{t("addresses.subtitle")}</p>
+            <p className="text-gray-600 dark:text-gray-300 mt-1">
+              {t("addresses.subtitle")}
+            </p>
           </div>
           {!showForm && (
             <button
               onClick={() => setShowForm(true)}
-              className="px-4 py-2 bg-[#222222] text-white rounded-lg font-medium hover:bg-[#333333] transition-colors"
+              className="px-4 py-2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg font-medium hover:bg-gray-800 dark:hover:bg-white transition-colors"
             >
               {t("addresses.addAddress")}
             </button>
@@ -195,29 +198,34 @@ export default function AddressesPage() {
 
         {/* Add/Edit Form */}
         {showForm && (
-          <form onSubmit={handleSubmit} className="mt-8 border-t pt-8">
-            <h2 className="text-lg font-semibold text-[#222222] mb-6">
+          <form
+            onSubmit={handleSubmit}
+            className="mt-8 border-t border-gray-200 dark:border-gray-700 pt-8"
+          >
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-6">
               {editingId
                 ? t("addresses.editAddress")
                 : t("addresses.addNewAddress")}
             </h2>
 
             {formError && (
-              <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg">
-                <p className="text-sm text-red-600">{formError}</p>
+              <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900 rounded-lg">
+                <p className="text-sm text-red-600 dark:text-red-300">
+                  {formError}
+                </p>
               </div>
             )}
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
-                <label className="block text-sm font-medium text-[#222222] mb-2">
+                <label className="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
                   {t("addresses.addressType")}
                 </label>
                 <select
                   name="addressType"
                   value={formData.addressType}
                   onChange={handleChange}
-                  className="w-full px-4 py-3 rounded-lg border border-gray-200 focus:border-[#222222] focus:ring-1 focus:ring-[#222222] outline-none bg-white"
+                  className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:border-sage-dark focus:ring-1 focus:ring-sage-dark outline-none"
                 >
                   {ADDRESS_TYPES.map((type) => (
                     <option key={type.value} value={type.value}>
@@ -227,7 +235,7 @@ export default function AddressesPage() {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-[#222222] mb-2">
+                <label className="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
                   {t("addresses.label")}
                 </label>
                 <input
@@ -236,13 +244,13 @@ export default function AddressesPage() {
                   value={formData.label}
                   onChange={handleChange}
                   placeholder={t("addresses.labelPlaceholder")}
-                  className="w-full px-4 py-3 rounded-lg border border-gray-200 focus:border-[#222222] focus:ring-1 focus:ring-[#222222] outline-none"
+                  className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:border-sage-dark focus:ring-1 focus:ring-sage-dark outline-none"
                 />
               </div>
             </div>
 
             <div className="mt-6">
-              <label className="block text-sm font-medium text-[#222222] mb-2">
+              <label className="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
                 {t("addresses.streetAddress")} *
               </label>
               <input
@@ -251,13 +259,13 @@ export default function AddressesPage() {
                 value={formData.addressLine1}
                 onChange={handleChange}
                 placeholder={t("addresses.streetAddressPlaceholder")}
-                className="w-full px-4 py-3 rounded-lg border border-gray-200 focus:border-[#222222] focus:ring-1 focus:ring-[#222222] outline-none"
+                className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:border-sage-dark focus:ring-1 focus:ring-sage-dark outline-none"
                 required
               />
             </div>
 
             <div className="mt-4">
-              <label className="block text-sm font-medium text-[#222222] mb-2">
+              <label className="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
                 {t("addresses.aptSuite")}
               </label>
               <input
@@ -266,13 +274,13 @@ export default function AddressesPage() {
                 value={formData.addressLine2}
                 onChange={handleChange}
                 placeholder={t("addresses.aptSuitePlaceholder")}
-                className="w-full px-4 py-3 rounded-lg border border-gray-200 focus:border-[#222222] focus:ring-1 focus:ring-[#222222] outline-none"
+                className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:border-sage-dark focus:ring-1 focus:ring-sage-dark outline-none"
               />
             </div>
 
             <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-6">
               <div className="col-span-2">
-                <label className="block text-sm font-medium text-[#222222] mb-2">
+                <label className="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
                   {t("addresses.city")} *
                 </label>
                 <input
@@ -281,19 +289,19 @@ export default function AddressesPage() {
                   value={formData.city}
                   onChange={handleChange}
                   placeholder={t("addresses.cityPlaceholder")}
-                  className="w-full px-4 py-3 rounded-lg border border-gray-200 focus:border-[#222222] focus:ring-1 focus:ring-[#222222] outline-none"
+                  className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:border-sage-dark focus:ring-1 focus:ring-sage-dark outline-none"
                   required
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-[#222222] mb-2">
+                <label className="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
                   {t("addresses.state")} *
                 </label>
                 <select
                   name="state"
                   value={formData.state}
                   onChange={handleChange}
-                  className="w-full px-4 py-3 rounded-lg border border-gray-200 focus:border-[#222222] focus:ring-1 focus:ring-[#222222] outline-none bg-white"
+                  className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:border-sage-dark focus:ring-1 focus:ring-sage-dark outline-none"
                   required
                 >
                   <option value="">{t("addresses.selectState")}</option>
@@ -305,7 +313,7 @@ export default function AddressesPage() {
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-[#222222] mb-2">
+                <label className="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
                   {t("addresses.zipCode")} *
                 </label>
                 <input
@@ -314,7 +322,7 @@ export default function AddressesPage() {
                   value={formData.postalCode}
                   onChange={handleChange}
                   placeholder={t("addresses.zipCodePlaceholder")}
-                  className="w-full px-4 py-3 rounded-lg border border-gray-200 focus:border-[#222222] focus:ring-1 focus:ring-[#222222] outline-none"
+                  className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:border-sage-dark focus:ring-1 focus:ring-sage-dark outline-none"
                   required
                 />
               </div>
@@ -324,14 +332,14 @@ export default function AddressesPage() {
               <button
                 type="submit"
                 disabled={creating || updating}
-                className="px-6 py-3 bg-[#222222] text-white rounded-lg font-medium hover:bg-[#333333] transition-colors disabled:opacity-50"
+                className="px-6 py-3 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg font-medium hover:bg-gray-800 dark:hover:bg-white transition-colors disabled:opacity-50"
               >
                 {getSubmitButtonText()}
               </button>
               <button
                 type="button"
                 onClick={handleCancel}
-                className="px-6 py-3 border border-gray-200 text-[#4d4d4d] rounded-lg font-medium hover:bg-gray-50 transition-colors"
+                className="px-6 py-3 border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 rounded-lg font-medium hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
               >
                 {t("common:buttons.cancel")}
               </button>
@@ -346,33 +354,33 @@ export default function AddressesPage() {
           {addresses.map((address) => (
             <div
               key={address.id}
-              className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6"
+              className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-6"
             >
               <div className="flex justify-between items-start">
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-2">
-                    <span className="text-sm font-medium text-[#222222] capitalize">
+                    <span className="text-sm font-medium text-gray-900 dark:text-white capitalize">
                       {address.label ||
                         t(
                           `addresses.types.${address.addressType.toLowerCase()}`,
                         )}
                     </span>
                     {address.isPrimary && (
-                      <span className="px-2 py-0.5 text-xs font-medium bg-green-100 text-green-700 rounded">
+                      <StatusPill tone="sage-filled">
                         {t("common:status.primary")}
-                      </span>
+                      </StatusPill>
                     )}
                     {address.isVerified && (
-                      <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700 rounded">
+                      <StatusPill tone="sage-outline">
                         {t("common:status.verified")}
-                      </span>
+                      </StatusPill>
                     )}
                   </div>
-                  <p className="text-[#222222]">
+                  <p className="text-gray-900 dark:text-gray-100">
                     {address.addressLine1}
                     {address.addressLine2 && `, ${address.addressLine2}`}
                   </p>
-                  <p className="text-[#4d4d4d]">
+                  <p className="text-gray-600 dark:text-gray-300">
                     {address.city}, {address.state} {address.postalCode}
                   </p>
                 </div>
@@ -380,14 +388,14 @@ export default function AddressesPage() {
                   {!address.isPrimary && (
                     <button
                       onClick={() => handleSetPrimary(address.id)}
-                      className="text-sm text-[#4d4d4d] hover:text-[#222222] transition-colors"
+                      className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
                     >
                       {t("addresses.setPrimary")}
                     </button>
                   )}
                   <button
                     onClick={() => handleEdit(address)}
-                    className="p-2 text-[#4d4d4d] hover:text-[#222222] transition-colors"
+                    className="p-2 text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
                     aria-label={t("common:buttons.edit")}
                   >
                     <svg
@@ -408,7 +416,7 @@ export default function AddressesPage() {
                   <button
                     onClick={() => handleDelete(address.id)}
                     disabled={deleting}
-                    className="p-2 text-red-500 hover:text-red-700 transition-colors disabled:opacity-50"
+                    className="p-2 text-red-500 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300 transition-colors disabled:opacity-50"
                     aria-label={t("common:buttons.delete")}
                   >
                     <svg
@@ -433,8 +441,8 @@ export default function AddressesPage() {
         </div>
       ) : (
         !showForm && (
-          <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8 text-center">
-            <div className="text-[#4d4d4d]">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-8 text-center">
+            <div className="text-gray-600 dark:text-gray-300">
               <svg
                 className="w-12 h-12 mx-auto mb-4 opacity-50"
                 fill="none"

--- a/apps/frontend/app/settings/privacy/page.tsx
+++ b/apps/frontend/app/settings/privacy/page.tsx
@@ -261,7 +261,7 @@ export default function PrivacyPage() {
               <p className="text-sm font-medium text-sage-darker dark:text-sage-light">
                 {t("privacy.rightsTitle")}
               </p>
-              <p className="text-sm text-sage-dark dark:text-sage-light/90 mt-1">
+              <p className="text-sm text-sage-darker dark:text-sage-light mt-1">
                 {t("privacy.rightsDescription")}
               </p>
             </div>

--- a/apps/frontend/app/settings/privacy/page.tsx
+++ b/apps/frontend/app/settings/privacy/page.tsx
@@ -16,6 +16,14 @@ import {
   ConsentStatus,
 } from "@/lib/graphql/profile";
 import { SettingsLoadingSkeleton } from "@/components/settings/SettingsLoadingSkeleton";
+import { StatusPill, type StatusPillTone } from "@/components/StatusPill";
+
+const STATUS_TONES: Record<ConsentStatus, StatusPillTone> = {
+  granted: "sage-filled",
+  withdrawn: "warning",
+  denied: "danger",
+  pending: "neutral",
+};
 
 interface ConsentItemProps {
   readonly consent: UserConsent | undefined;
@@ -50,53 +58,32 @@ function ConsentItem({
   };
 
   const getStatusBadge = (status?: ConsentStatus) => {
-    switch (status) {
-      case "granted":
-        return (
-          <span className="px-2 py-0.5 text-xs font-medium bg-green-100 text-green-700 rounded">
-            {t("common:status.granted")}
-          </span>
-        );
-      case "withdrawn":
-        return (
-          <span className="px-2 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-700 rounded">
-            {t("common:status.withdrawn")}
-          </span>
-        );
-      case "denied":
-        return (
-          <span className="px-2 py-0.5 text-xs font-medium bg-red-100 text-red-700 rounded">
-            {t("common:status.denied")}
-          </span>
-        );
-      default:
-        return (
-          <span className="px-2 py-0.5 text-xs font-medium bg-gray-100 text-gray-700 rounded">
-            {t("common:status.notSet")}
-          </span>
-        );
-    }
+    const tone = status ? STATUS_TONES[status] : "neutral";
+    const labelKey = status
+      ? `common:status.${status}`
+      : "common:status.notSet";
+    return <StatusPill tone={tone}>{t(labelKey)}</StatusPill>;
   };
 
   return (
-    <div className="flex items-start justify-between py-4 border-b border-gray-100 last:border-0">
+    <div className="flex items-start justify-between py-4 border-b border-gray-100 dark:border-gray-700 last:border-0">
       <div className="flex-1 pr-4">
         <div className="flex items-center gap-2 mb-1">
-          <p className="text-sm font-medium text-[#222222]">
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
             {t(`privacy.consents.${consentType}.title`)}
           </p>
           {required && (
-            <span className="px-2 py-0.5 text-xs font-medium bg-blue-100 text-blue-700 rounded">
+            <StatusPill tone="sage-outline">
               {t("common:status.required")}
-            </span>
+            </StatusPill>
           )}
           {getStatusBadge(consent?.status)}
         </div>
-        <p className="text-sm text-[#4d4d4d]">
+        <p className="text-sm text-gray-600 dark:text-gray-300">
           {t(`privacy.consents.${consentType}.description`)}
         </p>
         {statusDate && (
-          <p className="text-xs text-[#595959] mt-1">
+          <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
             {consent?.status === "granted"
               ? t("privacy.status.grantedOn")
               : t("privacy.status.updatedOn")}{" "}
@@ -111,8 +98,8 @@ function ConsentItem({
             disabled={loading || required}
             className={`px-3 py-1.5 text-sm font-medium rounded-lg transition-colors ${
               required
-                ? "bg-gray-100 text-gray-500 cursor-not-allowed"
-                : "bg-red-50 text-red-700 hover:bg-red-100"
+                ? "bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-not-allowed"
+                : "bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-200 hover:bg-red-100 dark:hover:bg-red-900/50"
             }`}
           >
             {loading ? "..." : t("common:buttons.withdraw")}
@@ -121,7 +108,7 @@ function ConsentItem({
           <button
             onClick={() => onUpdate(consentType, true)}
             disabled={loading}
-            className="px-3 py-1.5 text-sm font-medium bg-[#222222] text-white rounded-lg hover:bg-[#333333] transition-colors disabled:opacity-50"
+            className="px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-800 dark:hover:bg-white transition-colors disabled:opacity-50"
           >
             {loading ? "..." : t("common:buttons.grant")}
           </button>
@@ -232,8 +219,8 @@ export default function PrivacyPage() {
 
   if (error) {
     return (
-      <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
-        <div className="text-center text-red-600">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-8">
+        <div className="text-center text-red-600 dark:text-red-300">
           <p>{t("privacy.loadError")}</p>
         </div>
       </div>
@@ -243,19 +230,21 @@ export default function PrivacyPage() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-8">
         <div className="mb-8">
-          <h1 className="text-2xl font-bold text-[#222222]">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
             {t("privacy.title")}
           </h1>
-          <p className="text-[#4d4d4d] mt-1">{t("privacy.subtitle")}</p>
+          <p className="text-gray-600 dark:text-gray-300 mt-1">
+            {t("privacy.subtitle")}
+          </p>
         </div>
 
         {/* GDPR/CCPA Notice */}
-        <div className="mb-8 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+        <div className="mb-8 p-4 bg-sage-light/10 dark:bg-sage-dark/15 border border-sage-light/30 dark:border-sage-dark/40 rounded-lg">
           <div className="flex items-start gap-3">
             <svg
-              className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0"
+              className="w-5 h-5 text-sage-dark dark:text-sage-light mt-0.5 flex-shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -269,10 +258,10 @@ export default function PrivacyPage() {
               />
             </svg>
             <div>
-              <p className="text-sm font-medium text-blue-800">
+              <p className="text-sm font-medium text-sage-darker dark:text-sage-light">
                 {t("privacy.rightsTitle")}
               </p>
-              <p className="text-sm text-blue-700 mt-1">
+              <p className="text-sm text-sage-dark dark:text-sage-light/90 mt-1">
                 {t("privacy.rightsDescription")}
               </p>
             </div>
@@ -283,14 +272,14 @@ export default function PrivacyPage() {
         {CONSENT_GROUPS.map((group) => (
           <div key={group.groupKey} className="mb-8 last:mb-0">
             <div className="mb-4">
-              <h2 className="text-lg font-semibold text-[#222222]">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
                 {t(`privacy.groups.${group.groupKey}.title`)}
               </h2>
-              <p className="text-sm text-[#4d4d4d]">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
                 {t(`privacy.groups.${group.groupKey}.description`)}
               </p>
             </div>
-            <div className="pl-4 border-l-2 border-gray-100">
+            <div className="pl-4 border-l-2 border-gray-100 dark:border-gray-700">
               {group.items.map((item) => (
                 <ConsentItem
                   key={item.consentType}
@@ -307,25 +296,25 @@ export default function PrivacyPage() {
       </div>
 
       {/* Data Export Section */}
-      <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
-        <h2 className="text-lg font-semibold text-[#222222] mb-6">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-8">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-6">
           {t("privacy.dataManagement.title")}
         </h2>
 
         <div className="space-y-4">
-          <div className="flex items-center justify-between py-4 border-b border-gray-100">
+          <div className="flex items-center justify-between py-4 border-b border-gray-100 dark:border-gray-700">
             <div>
-              <p className="text-sm font-medium text-[#222222]">
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
                 {t("privacy.dataManagement.exportTitle")}
               </p>
-              <p className="text-sm text-[#4d4d4d]">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
                 {t("privacy.dataManagement.exportDesc")}
               </p>
             </div>
             <button
               onClick={handleExportData}
               disabled={exporting}
-              className="px-4 py-2 text-sm font-medium border border-gray-200 text-[#222222] rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+              className="px-4 py-2 text-sm font-medium border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
             >
               {exporting ? "..." : t("privacy.dataManagement.exportButton")}
             </button>
@@ -333,14 +322,14 @@ export default function PrivacyPage() {
 
           <div className="flex items-center justify-between py-4">
             <div>
-              <p className="text-sm font-medium text-[#222222]">
+              <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
                 {t("privacy.dataManagement.deleteTitle")}
               </p>
-              <p className="text-sm text-[#4d4d4d]">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
                 {t("privacy.dataManagement.deleteDesc")}
               </p>
             </div>
-            <button className="px-4 py-2 text-sm font-medium bg-red-50 text-red-700 rounded-lg hover:bg-red-100 transition-colors">
+            <button className="px-4 py-2 text-sm font-medium bg-red-50 dark:bg-red-900/30 text-red-700 dark:text-red-200 rounded-lg hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors">
               {t("privacy.dataManagement.deleteButton")}
             </button>
           </div>

--- a/apps/frontend/app/settings/security/page.tsx
+++ b/apps/frontend/app/settings/security/page.tsx
@@ -380,7 +380,7 @@ export default function SecurityPage() {
                   <p className="text-sm font-medium text-sage-darker dark:text-sage-light">
                     {t("security.passkeys.whyTitle")}
                   </p>
-                  <ul className="text-sm text-sage-dark dark:text-sage-light/90 mt-1 space-y-1">
+                  <ul className="text-sm text-sage-darker dark:text-sage-light mt-1 space-y-1">
                     <li>• {t("security.passkeys.benefit1")}</li>
                     <li>• {t("security.passkeys.benefit2")}</li>
                     <li>• {t("security.passkeys.benefit3")}</li>

--- a/apps/frontend/app/settings/security/page.tsx
+++ b/apps/frontend/app/settings/security/page.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useAuth } from "@/lib/auth-context";
 import { usePasskey } from "@/lib/hooks/usePasskey";
 import { AUTH_FULL_OPTIONS } from "@/lib/features";
+import { StatusPill } from "@/components/StatusPill";
 
 interface Session {
   id: string;
@@ -216,13 +217,15 @@ export default function SecurityPage() {
   return (
     <div className="space-y-6">
       {/* Passkeys Section */}
-      <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-8">
         <div className="flex justify-between items-start mb-6">
           <div>
-            <h1 className="text-2xl font-bold text-[#222222]">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
               {t("security.title")}
             </h1>
-            <p className="text-[#4d4d4d] mt-1">{t("security.subtitle")}</p>
+            <p className="text-gray-600 dark:text-gray-300 mt-1">
+              {t("security.subtitle")}
+            </p>
           </div>
         </div>
 
@@ -231,17 +234,17 @@ export default function SecurityPage() {
           <div className="mb-8">
             <div className="flex items-center justify-between mb-4">
               <div>
-                <h2 className="text-lg font-semibold text-[#222222]">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
                   {t("security.passkeys.title")}
                 </h2>
-                <p className="text-sm text-[#4d4d4d]">
+                <p className="text-sm text-gray-600 dark:text-gray-300">
                   {t("security.passkeys.description")}
                 </p>
               </div>
               <button
                 onClick={() => setShowAddModal(true)}
                 disabled={!supportsPasskeys || passkeyActionLoading}
-                className="px-4 py-2 bg-[#222222] text-white rounded-lg font-medium hover:bg-[#333333] transition-colors disabled:opacity-50"
+                className="px-4 py-2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg font-medium hover:bg-gray-800 dark:hover:bg-white transition-colors disabled:opacity-50"
               >
                 {t("security.passkeys.addButton")}
               </button>
@@ -249,22 +252,22 @@ export default function SecurityPage() {
 
             {/* Error display */}
             {passkeyError && (
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+              <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900 rounded-lg text-red-700 dark:text-red-200 text-sm">
                 {passkeyError}
               </div>
             )}
 
             {/* Not supported warning */}
             {!supportsPasskeys && (
-              <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg text-yellow-700 text-sm">
+              <div className="mb-4 p-3 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-900 rounded-lg text-yellow-700 dark:text-yellow-200 text-sm">
                 {t("security.passkeys.notSupported")}
               </div>
             )}
 
             {passkeysLoading && (
               <div className="text-center py-8">
-                <div className="animate-spin w-8 h-8 border-2 border-[#222222] border-t-transparent rounded-full mx-auto" />
-                <p className="text-[#4d4d4d] mt-2">
+                <div className="animate-spin w-8 h-8 border-2 border-gray-900 dark:border-gray-100 border-t-transparent rounded-full mx-auto" />
+                <p className="text-gray-600 dark:text-gray-300 mt-2">
                   {t("common:status.loading")}
                 </p>
               </div>
@@ -275,25 +278,25 @@ export default function SecurityPage() {
                 {passkeys.map((passkey) => (
                   <div
                     key={passkey.id}
-                    className="flex items-center justify-between p-4 border border-gray-200 rounded-lg"
+                    className="flex items-center justify-between p-4 border border-gray-200 dark:border-gray-700 rounded-lg"
                   >
                     <div className="flex items-center gap-4">
-                      <div className="p-2 bg-gray-100 rounded-lg text-[#4d4d4d]">
+                      <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg text-gray-600 dark:text-gray-300">
                         <PasskeyIcon />
                       </div>
                       <div>
-                        <p className="font-medium text-[#222222]">
+                        <p className="font-medium text-gray-900 dark:text-gray-100">
                           {passkey.friendlyName ||
                             t("security.passkeys.unnamed")}
                         </p>
-                        <p className="text-sm text-[#4d4d4d]">
+                        <p className="text-sm text-gray-600 dark:text-gray-300">
                           {passkey.deviceType ||
                             t("security.passkeys.unknownDevice")}{" "}
                           • {t("security.passkeys.created")}:{" "}
                           {formatDate(passkey.createdAt)}
                         </p>
                         {passkey.lastUsedAt && (
-                          <p className="text-xs text-[#4b5563]">
+                          <p className="text-xs text-gray-500 dark:text-gray-400">
                             {t("security.passkeys.lastUsed")}:{" "}
                             {formatDate(passkey.lastUsedAt)}
                           </p>
@@ -305,13 +308,13 @@ export default function SecurityPage() {
                         <button
                           onClick={() => handleDeletePasskey(passkey.id)}
                           disabled={passkeyActionLoading}
-                          className="text-sm text-red-600 font-medium hover:text-red-700 transition-colors disabled:opacity-50"
+                          className="text-sm text-red-600 dark:text-red-400 font-medium hover:text-red-700 dark:hover:text-red-300 transition-colors disabled:opacity-50"
                         >
                           {t("common:buttons.confirm")}
                         </button>
                         <button
                           onClick={() => setDeleteConfirmId(null)}
-                          className="text-sm text-[#4d4d4d] hover:text-[#222222] transition-colors"
+                          className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
                         >
                           {t("common:buttons.cancel")}
                         </button>
@@ -319,7 +322,7 @@ export default function SecurityPage() {
                     ) : (
                       <button
                         onClick={() => setDeleteConfirmId(passkey.id)}
-                        className="text-sm text-red-700 hover:text-red-800 transition-colors"
+                        className="text-sm text-red-700 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 transition-colors"
                       >
                         {t("common:buttons.remove")}
                       </button>
@@ -330,8 +333,8 @@ export default function SecurityPage() {
             )}
 
             {!passkeysLoading && passkeys.length === 0 && (
-              <div className="text-center py-8 border border-dashed border-gray-200 rounded-lg">
-                <div className="text-[#4d4d4d] mb-4">
+              <div className="text-center py-8 border border-dashed border-gray-200 dark:border-gray-700 rounded-lg">
+                <div className="text-gray-600 dark:text-gray-300 mb-4">
                   <svg
                     className="w-12 h-12 mx-auto opacity-50"
                     fill="none"
@@ -347,20 +350,20 @@ export default function SecurityPage() {
                     />
                   </svg>
                 </div>
-                <p className="text-[#222222] font-medium">
+                <p className="text-gray-900 dark:text-gray-100 font-medium">
                   {t("security.passkeys.empty")}
                 </p>
-                <p className="text-sm text-[#4d4d4d] mt-1">
+                <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">
                   {t("security.passkeys.emptyHint")}
                 </p>
               </div>
             )}
 
             {/* Passkey Benefits */}
-            <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+            <div className="mt-4 p-4 bg-sage-light/10 dark:bg-sage-dark/15 border border-sage-light/30 dark:border-sage-dark/40 rounded-lg">
               <div className="flex items-start gap-3">
                 <svg
-                  className="w-5 h-5 text-blue-600 mt-0.5 flex-shrink-0"
+                  className="w-5 h-5 text-sage-dark dark:text-sage-light mt-0.5 flex-shrink-0"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -374,10 +377,10 @@ export default function SecurityPage() {
                   />
                 </svg>
                 <div>
-                  <p className="text-sm font-medium text-blue-800">
+                  <p className="text-sm font-medium text-sage-darker dark:text-sage-light">
                     {t("security.passkeys.whyTitle")}
                   </p>
-                  <ul className="text-sm text-blue-700 mt-1 space-y-1">
+                  <ul className="text-sm text-sage-dark dark:text-sage-light/90 mt-1 space-y-1">
                     <li>• {t("security.passkeys.benefit1")}</li>
                     <li>• {t("security.passkeys.benefit2")}</li>
                     <li>• {t("security.passkeys.benefit3")}</li>
@@ -393,16 +396,16 @@ export default function SecurityPage() {
         <div>
           <div className="flex items-center justify-between mb-4">
             <div>
-              <h2 className="text-lg font-semibold text-[#222222]">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
                 {t("security.sessions.title")}
               </h2>
-              <p className="text-sm text-[#4d4d4d]">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
                 {t("security.sessions.description")}
               </p>
             </div>
             <button
               onClick={handleSignOutAllSessions}
-              className="text-sm text-red-700 hover:text-red-800 transition-colors"
+              className="text-sm text-red-700 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 transition-colors"
             >
               {t("security.sessions.signOutAll")}
             </button>
@@ -410,39 +413,39 @@ export default function SecurityPage() {
 
           <div className="space-y-3">
             {/* Current Session */}
-            <div className="flex items-center justify-between p-4 border rounded-lg border-green-200 bg-green-50">
+            <div className="flex items-center justify-between p-4 border rounded-lg border-sage-light/30 bg-sage-light/10 dark:border-sage-dark/40 dark:bg-sage-dark/15">
               <div className="flex items-center gap-4">
-                <div className="p-2 rounded-lg bg-green-100 text-green-600">
+                <div className="p-2 rounded-lg bg-sage-light/20 text-sage-dark dark:bg-sage-dark/30 dark:text-sage-light">
                   <DeviceIcon type={currentSession.deviceType} />
                 </div>
                 <div>
                   <div className="flex items-center gap-2">
-                    <p className="font-medium text-[#222222]">
+                    <p className="font-medium text-gray-900 dark:text-gray-100">
                       {currentSession.deviceName}
                     </p>
-                    <span className="px-2 py-0.5 text-xs font-medium bg-green-100 text-green-700 rounded">
+                    <StatusPill tone="sage-filled">
                       {t("common:status.current")}
-                    </span>
+                    </StatusPill>
                   </div>
-                  <p className="text-sm text-[#4d4d4d]">
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
                     {currentSession.browser}
                   </p>
-                  <p className="text-xs text-[#374151]">
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
                     {currentSession.lastActivity}
                   </p>
                 </div>
               </div>
               <button
                 onClick={handleSignOut}
-                className="text-sm text-red-700 hover:text-red-800 transition-colors"
+                className="text-sm text-red-700 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300 transition-colors"
               >
                 {t("security.sessions.signOut")}
               </button>
             </div>
 
             {/* Info about other sessions */}
-            <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
-              <p className="text-sm text-[#4d4d4d]">
+            <div className="p-4 bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
                 {t("security.sessions.otherSessionsNote")}
               </p>
             </div>
@@ -452,17 +455,17 @@ export default function SecurityPage() {
 
       {/* Two-Factor Authentication — hidden in launch mode */}
       {AUTH_FULL_OPTIONS && (
-        <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
-          <h2 className="text-lg font-semibold text-[#222222] mb-2">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-8">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
             {t("security.twoFactor.title")}
           </h2>
-          <p className="text-[#4d4d4d] text-sm mb-6">
+          <p className="text-gray-600 dark:text-gray-300 text-sm mb-6">
             {t("security.twoFactor.description")}
           </p>
 
-          <div className="flex items-center justify-between py-4 border-b border-gray-100">
+          <div className="flex items-center justify-between py-4 border-b border-gray-100 dark:border-gray-700">
             <div className="flex items-center gap-4">
-              <div className="p-2 bg-gray-100 rounded-lg text-[#4d4d4d]">
+              <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg text-gray-600 dark:text-gray-300">
                 <svg
                   className="w-6 h-6"
                   fill="none"
@@ -479,22 +482,22 @@ export default function SecurityPage() {
                 </svg>
               </div>
               <div>
-                <p className="font-medium text-[#222222]">
+                <p className="font-medium text-gray-900 dark:text-gray-100">
                   {t("security.twoFactor.authenticator.title")}
                 </p>
-                <p className="text-sm text-[#4d4d4d]">
+                <p className="text-sm text-gray-600 dark:text-gray-300">
                   {t("security.twoFactor.authenticator.description")}
                 </p>
               </div>
             </div>
-            <button className="px-4 py-2 text-sm font-medium border border-gray-200 text-[#222222] rounded-lg hover:bg-gray-50 transition-colors">
+            <button className="px-4 py-2 text-sm font-medium border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
               {t("security.twoFactor.authenticator.setupButton")}
             </button>
           </div>
 
           <div className="flex items-center justify-between py-4">
             <div className="flex items-center gap-4">
-              <div className="p-2 bg-gray-100 rounded-lg text-[#4d4d4d]">
+              <div className="p-2 bg-gray-100 dark:bg-gray-700 rounded-lg text-gray-600 dark:text-gray-300">
                 <svg
                   className="w-6 h-6"
                   fill="none"
@@ -511,17 +514,17 @@ export default function SecurityPage() {
                 </svg>
               </div>
               <div>
-                <p className="font-medium text-[#222222]">
+                <p className="font-medium text-gray-900 dark:text-gray-100">
                   {t("security.twoFactor.recovery.title")}
                 </p>
-                <p className="text-sm text-[#4d4d4d]">
+                <p className="text-sm text-gray-600 dark:text-gray-300">
                   {t("security.twoFactor.recovery.description")}
                 </p>
               </div>
             </div>
             <button
               disabled
-              className="px-4 py-2 text-sm font-medium border border-gray-200 text-gray-400 rounded-lg cursor-not-allowed"
+              className="px-4 py-2 text-sm font-medium border border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500 rounded-lg cursor-not-allowed"
             >
               {t("security.twoFactor.recovery.generateButton")}
             </button>
@@ -531,24 +534,24 @@ export default function SecurityPage() {
 
       {/* Password Section (Legacy) — hidden in launch mode */}
       {AUTH_FULL_OPTIONS && (
-        <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-8">
-          <h2 className="text-lg font-semibold text-[#222222] mb-2">
+        <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-8">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
             {t("security.password.title")}
           </h2>
-          <p className="text-[#4d4d4d] text-sm mb-6">
+          <p className="text-gray-600 dark:text-gray-300 text-sm mb-6">
             {t("security.password.description")}
           </p>
 
           <div className="flex items-center justify-between py-4">
             <div>
-              <p className="font-medium text-[#222222]">
+              <p className="font-medium text-gray-900 dark:text-gray-100">
                 {t("security.password.changeTitle")}
               </p>
-              <p className="text-sm text-[#4d4d4d]">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
                 {t("security.password.changeDescription")}
               </p>
             </div>
-            <button className="px-4 py-2 text-sm font-medium border border-gray-200 text-[#222222] rounded-lg hover:bg-gray-50 transition-colors">
+            <button className="px-4 py-2 text-sm font-medium border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
               {t("security.password.changeButton")}
             </button>
           </div>
@@ -558,18 +561,18 @@ export default function SecurityPage() {
       {/* Add Passkey Modal — only reachable when AUTH_FULL_OPTIONS=true */}
       {AUTH_FULL_OPTIONS && showAddModal && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-xl shadow-xl max-w-md w-full mx-4 p-6">
-            <h3 className="text-xl font-semibold text-[#222222] mb-2">
+          <div className="bg-white dark:bg-gray-800 rounded-xl shadow-xl max-w-md w-full mx-4 p-6">
+            <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
               {t("security.passkeys.addTitle")}
             </h3>
-            <p className="text-[#4d4d4d] text-sm mb-6">
+            <p className="text-gray-600 dark:text-gray-300 text-sm mb-6">
               {t("security.passkeys.addDescription")}
             </p>
 
             <div className="mb-6">
               <label
                 htmlFor="friendlyName"
-                className="block text-sm font-medium text-[#222222] mb-2"
+                className="block text-sm font-medium text-gray-900 dark:text-gray-100 mb-2"
               >
                 {t("security.passkeys.friendlyNameLabel")}
               </label>
@@ -579,15 +582,15 @@ export default function SecurityPage() {
                 value={friendlyName}
                 onChange={(e) => setFriendlyName(e.target.value)}
                 placeholder={t("security.passkeys.friendlyNamePlaceholder")}
-                className="w-full px-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#222222] focus:border-transparent"
+                className="w-full px-4 py-2 border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 rounded-lg focus:outline-none focus:ring-2 focus:ring-sage-dark focus:border-transparent"
               />
-              <p className="text-xs text-[#4d4d4d] mt-1">
+              <p className="text-xs text-gray-600 dark:text-gray-300 mt-1">
                 {t("security.passkeys.friendlyNameHint")}
               </p>
             </div>
 
             {passkeyError && (
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">
+              <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900 rounded-lg text-red-700 dark:text-red-200 text-sm">
                 {passkeyError}
               </div>
             )}
@@ -600,14 +603,14 @@ export default function SecurityPage() {
                   clearError();
                 }}
                 disabled={passkeyActionLoading}
-                className="px-4 py-2 text-sm font-medium text-[#4d4d4d] hover:text-[#222222] transition-colors"
+                className="px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
               >
                 {t("common:buttons.cancel")}
               </button>
               <button
                 onClick={handleAddPasskey}
                 disabled={passkeyActionLoading}
-                className="px-4 py-2 bg-[#222222] text-white rounded-lg font-medium hover:bg-[#333333] transition-colors disabled:opacity-50 flex items-center gap-2"
+                className="px-4 py-2 bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg font-medium hover:bg-gray-800 dark:hover:bg-white transition-colors disabled:opacity-50 flex items-center gap-2"
               >
                 {passkeyActionLoading && (
                   <div className="animate-spin w-4 h-4 border-2 border-white border-t-transparent rounded-full" />

--- a/apps/frontend/components/Header.tsx
+++ b/apps/frontend/components/Header.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useAuth } from "@/lib/auth-context";
+import { LanguageToggle } from "@/components/LanguageToggle";
 
 export function Header() {
   const { user, isAuthenticated, isLoading } = useAuth();
@@ -148,6 +149,7 @@ export function Header() {
 
         {/* Desktop nav */}
         <nav className="hidden md:flex items-center gap-4">
+          <LanguageToggle />
           {renderDesktopNav()}
         </nav>
 
@@ -201,6 +203,9 @@ export function Header() {
           className="md:hidden border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 animate-layer-enter"
         >
           <div className="max-w-6xl mx-auto px-8 py-4 flex flex-col gap-3">
+            <div className="flex items-center justify-end">
+              <LanguageToggle />
+            </div>
             {renderMobileNav()}
           </div>
         </nav>

--- a/apps/frontend/components/LanguageToggle.tsx
+++ b/apps/frontend/components/LanguageToggle.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useId } from "react";
+import { useMutation } from "@apollo/client/react";
+import { useAuth } from "@/lib/auth-context";
+import { useLocale } from "@/lib/i18n/context";
+import { useToast } from "@/lib/toast";
+import { useTranslation } from "react-i18next";
+import {
+  UPDATE_MY_PROFILE,
+  type SupportedLanguage,
+  type UpdateMyProfileData,
+  type UpdateProfileInput,
+} from "@/lib/graphql/profile";
+
+// Two-letter codes intentionally — they're language-agnostic, fit the
+// header's tight space, and don't require translating their own labels.
+// The sr-only legend below ("Language") is intentionally not translated
+// for the same reason WelcomeStep keeps it minimal: screen readers run
+// in the user's preferred locale, so a single neutral word reads well
+// in either UI language without an i18n round-trip.
+const LANGUAGES: { code: SupportedLanguage; label: string }[] = [
+  { code: "en", label: "EN" },
+  { code: "es", label: "ES" },
+];
+
+export function LanguageToggle() {
+  const { locale, setLocale } = useLocale();
+  const { isAuthenticated } = useAuth();
+  const { showToast } = useToast();
+  const { t } = useTranslation("common");
+  const groupName = useId();
+  const [updateProfile] = useMutation<
+    UpdateMyProfileData,
+    { input: UpdateProfileInput }
+  >(UPDATE_MY_PROFILE);
+
+  const handleSelect = (code: SupportedLanguage) => {
+    if (code === locale) return;
+    setLocale(code);
+    // Persist only when authenticated. The UI has already flipped via
+    // setLocale; a failed write just means the preference reverts next
+    // session, and the toast tells the user.
+    if (!isAuthenticated) return;
+    updateProfile({
+      variables: { input: { preferredLanguage: code } },
+    }).catch((err: unknown) => {
+      console.warn("Failed to persist preferred language", err);
+      showToast(t("errors.preferencesNotSaved"), "warning");
+    });
+  };
+
+  return (
+    <fieldset className="inline-flex bg-gray-100 dark:bg-gray-800 rounded-full p-0.5 border border-gray-200 dark:border-gray-700">
+      <legend className="sr-only">{t("languageLegend")}</legend>
+      {LANGUAGES.map(({ code, label }) => {
+        const active = code === locale;
+        return (
+          <label
+            key={code}
+            className={[
+              "px-2.5 py-1 rounded-full text-xs font-semibold cursor-pointer transition-colors",
+              "focus-within:ring-2 focus-within:ring-sage-dark",
+              active
+                ? "bg-sage-dark text-white"
+                : "text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white",
+            ].join(" ")}
+          >
+            <input
+              type="radio"
+              name={groupName}
+              value={code}
+              checked={active}
+              onChange={() => handleSelect(code)}
+              className="sr-only"
+            />
+            {label}
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/apps/frontend/components/StatusPill.tsx
+++ b/apps/frontend/components/StatusPill.tsx
@@ -20,7 +20,7 @@ const TONE_CLASSES: Record<StatusPillTone, string> = {
   "sage-filled":
     "bg-sage-light/20 text-sage-darker dark:bg-sage-dark/20 dark:text-sage-light",
   "sage-outline":
-    "border border-sage-dark text-sage-dark dark:border-sage-light dark:text-sage-light",
+    "border border-sage-dark text-sage-darker dark:border-sage-light dark:text-sage-light",
   warning:
     "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200",
   danger: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-200",

--- a/apps/frontend/components/StatusPill.tsx
+++ b/apps/frontend/components/StatusPill.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+
+export type StatusPillTone =
+  | "sage-filled"
+  | "sage-outline"
+  | "warning"
+  | "danger"
+  | "neutral";
+
+interface StatusPillProps {
+  readonly tone: StatusPillTone;
+  readonly children: ReactNode;
+}
+
+// Token-driven status pill — sage tones map to brand, warning/danger/neutral
+// preserve the conventional traffic-light semantics for transitional/negative/
+// informational states. Lookup table dispatch keeps cognitive complexity at
+// 1 regardless of how many tones get added.
+const TONE_CLASSES: Record<StatusPillTone, string> = {
+  "sage-filled":
+    "bg-sage-light/20 text-sage-darker dark:bg-sage-dark/20 dark:text-sage-light",
+  "sage-outline":
+    "border border-sage-dark text-sage-dark dark:border-sage-light dark:text-sage-light",
+  warning:
+    "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-200",
+  danger: "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-200",
+  neutral: "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200",
+};
+
+export function StatusPill({ tone, children }: StatusPillProps) {
+  return (
+    <span
+      className={`px-2 py-0.5 text-xs font-medium rounded ${TONE_CLASSES[tone]}`}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/frontend/components/onboarding/ChipPicker.tsx
+++ b/apps/frontend/components/onboarding/ChipPicker.tsx
@@ -42,12 +42,12 @@ const colsClass: Record<2 | 3 | 4, string> = {
 
 function chipStateClassFor(blocked: boolean, selected: boolean): string {
   if (blocked) {
-    return "bg-white/5 text-white/40 border-white/10 cursor-not-allowed";
+    return "bg-gray-100 dark:bg-gray-800/50 text-gray-400 border-gray-200 dark:border-gray-700 cursor-not-allowed";
   }
   if (selected) {
-    return "bg-white text-[#2D4A3C] border-white cursor-pointer";
+    return "bg-sage-dark text-white border-sage-dark cursor-pointer";
   }
-  return "bg-white/10 text-white border-white/30 hover:bg-white/15 cursor-pointer";
+  return "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 cursor-pointer";
 }
 
 export function ChipPicker(props: Props) {
@@ -82,7 +82,7 @@ export function ChipPicker(props: Props) {
 
   return (
     <fieldset className="w-full">
-      <legend className="block text-white/90 font-medium mb-3 text-sm">
+      <legend className="block text-gray-800 dark:text-gray-100 font-medium mb-3 text-sm">
         {groupLabel}
       </legend>
       <div className={`grid ${colsClass[columns]} gap-2`}>
@@ -100,7 +100,7 @@ export function ChipPicker(props: Props) {
                 "flex items-center justify-center text-center",
                 "px-3 py-2.5 rounded-xl border",
                 "text-sm font-medium transition-colors",
-                "focus-within:ring-2 focus-within:ring-white focus-within:ring-offset-2 focus-within:ring-offset-transparent",
+                "focus-within:ring-2 focus-within:ring-sage-dark focus-within:ring-offset-2 focus-within:ring-offset-gray-50 dark:focus-within:ring-offset-gray-900",
                 chipStateClass,
               ].join(" ")}
             >

--- a/apps/frontend/components/onboarding/OnboardingSteps.tsx
+++ b/apps/frontend/components/onboarding/OnboardingSteps.tsx
@@ -63,11 +63,11 @@ export function OnboardingSteps() {
   const stepOwnsAction = DATA_STEP_INDICES.has(currentStep);
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-[#5A7A6A] to-[#2D4A3C] flex flex-col">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
       <div className="absolute top-4 right-4 z-10">
         <button
           onClick={handleSkip}
-          className="text-white/70 hover:text-white text-sm transition-colors px-3 py-1"
+          className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white text-sm transition-colors px-3 py-1"
         >
           {t("skip")}
         </button>
@@ -85,7 +85,9 @@ export function OnboardingSteps() {
           <div
             key={i}
             className={`w-2 h-2 rounded-full transition-colors ${
-              i === currentStep ? "bg-white" : "bg-white/30"
+              i === currentStep
+                ? "bg-sage-dark"
+                : "bg-gray-300 dark:bg-gray-600"
             }`}
             aria-hidden="true"
           />
@@ -100,7 +102,7 @@ export function OnboardingSteps() {
         <button
           onClick={prevStep}
           disabled={currentStep === 0}
-          className="px-6 py-3 text-white/70 hover:text-white disabled:opacity-0 transition-all"
+          className="px-6 py-3 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white disabled:opacity-0 transition-all"
         >
           {t("back")}
         </button>
@@ -108,11 +110,7 @@ export function OnboardingSteps() {
         {!stepOwnsAction && (
           <button
             onClick={advance}
-            className={
-              isLastStep
-                ? "px-8 py-3 bg-white text-[#5A7A6A] rounded-full font-semibold hover:bg-white/90 transition-colors"
-                : "px-8 py-3 bg-white/20 text-white rounded-full font-semibold hover:bg-white/30 transition-colors"
-            }
+            className="px-8 py-3 bg-sage-dark hover:bg-sage-darker text-white rounded-full font-semibold transition-colors"
           >
             {isLastStep ? t("getStarted") : t("next")}
           </button>

--- a/apps/frontend/components/onboarding/StepFooter.tsx
+++ b/apps/frontend/components/onboarding/StepFooter.tsx
@@ -36,7 +36,7 @@ export function StepFooter({
         type="button"
         onClick={onSkip}
         disabled={loading}
-        className="text-white/70 hover:text-white text-sm px-3 py-2 disabled:opacity-50"
+        className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white text-sm px-3 py-2 disabled:opacity-50"
       >
         {t("skipStep")}
       </button>
@@ -44,7 +44,7 @@ export function StepFooter({
         type="button"
         onClick={onSubmit}
         disabled={loading}
-        className="px-8 py-3 bg-white text-[#2D4A3C] rounded-full font-semibold hover:bg-white/90 transition-colors disabled:opacity-50"
+        className="px-8 py-3 bg-sage-dark hover:bg-sage-darker text-white rounded-full font-semibold transition-colors disabled:opacity-50"
       >
         {t(primaryLabelKey)}
       </button>

--- a/apps/frontend/components/onboarding/steps/AddressStep.tsx
+++ b/apps/frontend/components/onboarding/steps/AddressStep.tsx
@@ -172,9 +172,13 @@ export function AddressStep({ onComplete, isLastStep }: AddressStepProps) {
   };
 
   return (
-    <div className="w-full max-w-md text-white">
-      <h2 className="text-2xl font-bold mb-2">{t("address.title")}</h2>
-      <p className="text-white/80 text-sm mb-6">{t("address.subtitle")}</p>
+    <div className="w-full max-w-md">
+      <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">
+        {t("address.title")}
+      </h2>
+      <p className="text-gray-600 dark:text-gray-300 text-sm mb-6">
+        {t("address.subtitle")}
+      </p>
 
       <form
         onSubmit={(e) => {
@@ -194,7 +198,7 @@ export function AddressStep({ onComplete, isLastStep }: AddressStepProps) {
             placeholder={t("address.fields.line1")}
             value={form.addressLine1}
             onChange={update("addressLine1")}
-            className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/30 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-white"
+            className="w-full px-4 py-3 rounded-xl bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-sage-dark"
           />
         </div>
         <div>
@@ -208,7 +212,7 @@ export function AddressStep({ onComplete, isLastStep }: AddressStepProps) {
             placeholder={t("address.fields.city")}
             value={form.city}
             onChange={update("city")}
-            className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/30 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-white"
+            className="w-full px-4 py-3 rounded-xl bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-sage-dark"
           />
         </div>
         <div className="grid grid-cols-2 gap-3">
@@ -221,13 +225,11 @@ export function AddressStep({ onComplete, isLastStep }: AddressStepProps) {
               autoComplete="address-level1"
               value={form.state}
               onChange={update("state")}
-              className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/30 text-white focus:outline-none focus:ring-2 focus:ring-white"
+              className="w-full px-4 py-3 rounded-xl bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-sage-dark"
             >
-              <option value="" className="text-gray-700">
-                {t("address.fields.statePlaceholder")}
-              </option>
+              <option value="">{t("address.fields.statePlaceholder")}</option>
               {US_STATES.map((s) => (
-                <option key={s} value={s} className="text-gray-700">
+                <option key={s} value={s}>
                   {s}
                 </option>
               ))}
@@ -246,13 +248,16 @@ export function AddressStep({ onComplete, isLastStep }: AddressStepProps) {
               placeholder={t("address.fields.postalCode")}
               value={form.postalCode}
               onChange={update("postalCode")}
-              className="w-full px-4 py-3 rounded-xl bg-white/10 border border-white/30 text-white placeholder-white/50 focus:outline-none focus:ring-2 focus:ring-white"
+              className="w-full px-4 py-3 rounded-xl bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-sage-dark"
             />
           </div>
         </div>
 
         {error && (
-          <p role="alert" className="text-red-200 text-sm pt-1">
+          <p
+            role="alert"
+            className="text-red-600 dark:text-red-400 text-sm pt-1"
+          >
             {error}
           </p>
         )}

--- a/apps/frontend/components/onboarding/steps/AnalyzeStep.tsx
+++ b/apps/frontend/components/onboarding/steps/AnalyzeStep.tsx
@@ -6,8 +6,8 @@ export function AnalyzeStep() {
   const { t } = useTranslation("onboarding");
 
   return (
-    <div className="text-center text-white max-w-md">
-      <div className="w-20 h-20 bg-white/20 rounded-2xl mx-auto mb-8 flex items-center justify-center">
+    <div className="text-center max-w-md">
+      <div className="w-20 h-20 bg-sage-light/30 dark:bg-sage-dark/20 text-sage-dark dark:text-sage-light rounded-2xl mx-auto mb-8 flex items-center justify-center">
         <svg
           className="w-10 h-10"
           fill="none"
@@ -24,8 +24,12 @@ export function AnalyzeStep() {
         </svg>
       </div>
 
-      <h2 className="text-2xl font-bold mb-4">{t("analyze.title")}</h2>
-      <p className="text-white/80">{t("analyze.description")}</p>
+      <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-white">
+        {t("analyze.title")}
+      </h2>
+      <p className="text-gray-600 dark:text-gray-300">
+        {t("analyze.description")}
+      </p>
     </div>
   );
 }

--- a/apps/frontend/components/onboarding/steps/ExploreStep.tsx
+++ b/apps/frontend/components/onboarding/steps/ExploreStep.tsx
@@ -6,8 +6,8 @@ export function ExploreStep() {
   const { t } = useTranslation("onboarding");
 
   return (
-    <div className="text-center text-white max-w-md">
-      <div className="w-20 h-20 bg-white/20 rounded-2xl mx-auto mb-8 flex items-center justify-center">
+    <div className="text-center max-w-md">
+      <div className="w-20 h-20 bg-sage-light/30 dark:bg-sage-dark/20 text-sage-dark dark:text-sage-light rounded-2xl mx-auto mb-8 flex items-center justify-center">
         <svg
           className="w-10 h-10"
           fill="none"
@@ -24,23 +24,27 @@ export function ExploreStep() {
         </svg>
       </div>
 
-      <h2 className="text-2xl font-bold mb-4">{t("explore.title")}</h2>
-      <p className="text-white/80 mb-8">{t("explore.description")}</p>
+      <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-white">
+        {t("explore.title")}
+      </h2>
+      <p className="text-gray-600 dark:text-gray-300 mb-8">
+        {t("explore.description")}
+      </p>
 
       <div className="grid grid-cols-2 gap-3">
-        <div className="bg-white/10 rounded-xl p-3 text-sm">
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-3 text-sm text-gray-800 dark:text-gray-200">
           <div className="text-lg mb-1">📋</div>
           <p className="font-medium">{t("explore.features.propositions")}</p>
         </div>
-        <div className="bg-white/10 rounded-xl p-3 text-sm">
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-3 text-sm text-gray-800 dark:text-gray-200">
           <div className="text-lg mb-1">👥</div>
           <p className="font-medium">{t("explore.features.representatives")}</p>
         </div>
-        <div className="bg-white/10 rounded-xl p-3 text-sm">
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-3 text-sm text-gray-800 dark:text-gray-200">
           <div className="text-lg mb-1">🏛️</div>
           <p className="font-medium">{t("explore.features.meetings")}</p>
         </div>
-        <div className="bg-white/10 rounded-xl p-3 text-sm">
+        <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-3 text-sm text-gray-800 dark:text-gray-200">
           <div className="text-lg mb-1">💰</div>
           <p className="font-medium">{t("explore.features.campaignFinance")}</p>
         </div>

--- a/apps/frontend/components/onboarding/steps/LifeContextStep.tsx
+++ b/apps/frontend/components/onboarding/steps/LifeContextStep.tsx
@@ -180,9 +180,13 @@ export function LifeContextStep({
   };
 
   return (
-    <div className="w-full max-w-lg text-white">
-      <h2 className="text-2xl font-bold mb-2">{t("lifeContext.title")}</h2>
-      <p className="text-white/80 text-sm mb-6">{t("lifeContext.subtitle")}</p>
+    <div className="w-full max-w-lg">
+      <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">
+        {t("lifeContext.title")}
+      </h2>
+      <p className="text-gray-600 dark:text-gray-300 text-sm mb-6">
+        {t("lifeContext.subtitle")}
+      </p>
 
       <div className="space-y-5 max-h-[55vh] overflow-y-auto pr-1">
         <ChipPicker
@@ -272,7 +276,7 @@ export function LifeContextStep({
       </div>
 
       {error && (
-        <p role="alert" className="text-red-200 text-sm pt-3">
+        <p role="alert" className="text-red-600 dark:text-red-400 text-sm pt-3">
           {error}
         </p>
       )}

--- a/apps/frontend/components/onboarding/steps/ScanStep.tsx
+++ b/apps/frontend/components/onboarding/steps/ScanStep.tsx
@@ -6,8 +6,8 @@ export function ScanStep() {
   const { t } = useTranslation("onboarding");
 
   return (
-    <div className="text-center text-white max-w-md">
-      <div className="w-20 h-20 bg-white/20 rounded-2xl mx-auto mb-8 flex items-center justify-center">
+    <div className="text-center max-w-md">
+      <div className="w-20 h-20 bg-sage-light/30 dark:bg-sage-dark/20 text-sage-dark dark:text-sage-light rounded-2xl mx-auto mb-8 flex items-center justify-center">
         <svg
           className="w-10 h-10"
           fill="none"
@@ -30,10 +30,14 @@ export function ScanStep() {
         </svg>
       </div>
 
-      <h2 className="text-2xl font-bold mb-4">{t("scan.title")}</h2>
-      <p className="text-white/80 mb-6">{t("scan.description")}</p>
+      <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-white">
+        {t("scan.title")}
+      </h2>
+      <p className="text-gray-600 dark:text-gray-300 mb-6">
+        {t("scan.description")}
+      </p>
 
-      <div className="bg-white/10 rounded-xl p-4 text-sm text-white/70">
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 text-sm text-gray-600 dark:text-gray-300">
         <p>{t("scan.permissionNote")}</p>
       </div>
     </div>

--- a/apps/frontend/components/onboarding/steps/TopicsStep.tsx
+++ b/apps/frontend/components/onboarding/steps/TopicsStep.tsx
@@ -126,16 +126,23 @@ export function TopicsStep({ onComplete, isLastStep }: TopicsStepProps) {
   };
 
   return (
-    <div className="w-full max-w-md text-white">
-      <h2 className="text-2xl font-bold mb-2">{t("topics.title")}</h2>
-      <p className="text-white/80 text-sm mb-3">{t("topics.subtitle")}</p>
-      <div className="bg-white/5 border border-white/10 rounded-lg p-3 mb-3 text-xs text-white/70">
-        <span className="font-medium text-white/85">
+    <div className="w-full max-w-md">
+      <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">
+        {t("topics.title")}
+      </h2>
+      <p className="text-gray-600 dark:text-gray-300 text-sm mb-3">
+        {t("topics.subtitle")}
+      </p>
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg p-3 mb-3 text-xs text-gray-600 dark:text-gray-300">
+        <span className="font-medium text-gray-800 dark:text-gray-100">
           {t("topics.reasonHeading")}{" "}
         </span>
         {t("topics.reasonBody")}
       </div>
-      <p aria-live="polite" className="text-white/60 text-xs mb-5">
+      <p
+        aria-live="polite"
+        className="text-gray-500 dark:text-gray-400 text-xs mb-5"
+      >
         {t("topics.counter", { count: selected.length, max: MAX_TOPICS })}
       </p>
 
@@ -153,7 +160,7 @@ export function TopicsStep({ onComplete, isLastStep }: TopicsStepProps) {
       />
 
       {error && (
-        <p role="alert" className="text-red-200 text-sm pt-3">
+        <p role="alert" className="text-red-600 dark:text-red-400 text-sm pt-3">
           {error}
         </p>
       )}

--- a/apps/frontend/components/onboarding/steps/TrackStep.tsx
+++ b/apps/frontend/components/onboarding/steps/TrackStep.tsx
@@ -6,8 +6,8 @@ export function TrackStep() {
   const { t } = useTranslation("onboarding");
 
   return (
-    <div className="text-center text-white max-w-md">
-      <div className="w-20 h-20 bg-white/20 rounded-2xl mx-auto mb-8 flex items-center justify-center">
+    <div className="text-center max-w-md">
+      <div className="w-20 h-20 bg-sage-light/30 dark:bg-sage-dark/20 text-sage-dark dark:text-sage-light rounded-2xl mx-auto mb-8 flex items-center justify-center">
         <svg
           className="w-10 h-10"
           fill="none"
@@ -24,8 +24,12 @@ export function TrackStep() {
         </svg>
       </div>
 
-      <h2 className="text-2xl font-bold mb-4">{t("track.title")}</h2>
-      <p className="text-white/80">{t("track.description")}</p>
+      <h2 className="text-2xl font-bold mb-4 text-gray-900 dark:text-white">
+        {t("track.title")}
+      </h2>
+      <p className="text-gray-600 dark:text-gray-300">
+        {t("track.description")}
+      </p>
     </div>
   );
 }

--- a/apps/frontend/components/onboarding/steps/VeteranStep.tsx
+++ b/apps/frontend/components/onboarding/steps/VeteranStep.tsx
@@ -113,12 +113,16 @@ export function VeteranStep({ onComplete, isLastStep }: VeteranStepProps) {
   };
 
   return (
-    <div className="w-full max-w-md text-white">
-      <h2 className="text-2xl font-bold mb-2">{t("veteran.title")}</h2>
-      <p className="text-white/80 text-sm mb-4">{t("veteran.subtitle")}</p>
+    <div className="w-full max-w-md">
+      <h2 className="text-2xl font-bold mb-2 text-gray-900 dark:text-white">
+        {t("veteran.title")}
+      </h2>
+      <p className="text-gray-600 dark:text-gray-300 text-sm mb-4">
+        {t("veteran.subtitle")}
+      </p>
 
-      <div className="bg-white/10 border border-white/20 rounded-xl p-4 mb-5 text-sm">
-        <div className="flex items-center gap-2 mb-2 font-medium">
+      <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 mb-5 text-sm">
+        <div className="flex items-center gap-2 mb-2 font-medium text-sage-dark dark:text-sage-light">
           <svg
             className="w-4 h-4"
             fill="none"
@@ -135,17 +139,19 @@ export function VeteranStep({ onComplete, isLastStep }: VeteranStepProps) {
           </svg>
           {t("veteran.disclosure.encryptedBadge")}
         </div>
-        <p className="text-white/80">{t("veteran.disclosure.whyWeAsk")}</p>
+        <p className="text-gray-600 dark:text-gray-300">
+          {t("veteran.disclosure.whyWeAsk")}
+        </p>
       </div>
 
       <label
         className={[
           "flex items-center justify-between gap-3",
           "px-4 py-3 rounded-xl border transition-colors",
-          "focus-within:ring-2 focus-within:ring-white",
+          "focus-within:ring-2 focus-within:ring-sage-dark",
           veteranChipChecked && !noFieldsMode
-            ? "bg-white text-[#2D4A3C] border-white"
-            : "bg-white/10 text-white border-white/30 hover:bg-white/15",
+            ? "bg-sage-dark text-white border-sage-dark"
+            : "bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-200 border-gray-300 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700",
           veteranChipDisabled
             ? "opacity-60 cursor-not-allowed"
             : "cursor-pointer",
@@ -166,8 +172,8 @@ export function VeteranStep({ onComplete, isLastStep }: VeteranStepProps) {
           aria-hidden="true"
           className={`w-5 h-5 rounded border-2 flex items-center justify-center ${
             veteranChipChecked && !noFieldsMode
-              ? "bg-[#2D4A3C] border-[#2D4A3C]"
-              : "border-white/60"
+              ? "border-white"
+              : "border-gray-400 dark:border-gray-500"
           }`}
         >
           {veteranChipChecked && !noFieldsMode && (
@@ -188,12 +194,12 @@ export function VeteranStep({ onComplete, isLastStep }: VeteranStepProps) {
         </span>
       </label>
       {veteranLocked && (
-        <p className="text-white/60 text-xs mt-1 px-1">
+        <p className="text-gray-500 dark:text-gray-400 text-xs mt-1 px-1">
           {t("veteran.lockedNote")}
         </p>
       )}
 
-      <label className="flex items-center justify-between gap-3 mt-3 px-1 cursor-pointer text-sm text-white/80">
+      <label className="flex items-center justify-between gap-3 mt-3 px-1 cursor-pointer text-sm text-gray-600 dark:text-gray-300">
         <span>{t("veteran.noFieldsToggle")}</span>
         <input
           type="checkbox"
@@ -203,12 +209,12 @@ export function VeteranStep({ onComplete, isLastStep }: VeteranStepProps) {
             if (e.target.checked) setIsVeteran(false);
             setError(null);
           }}
-          className="w-4 h-4 accent-white"
+          className="w-4 h-4 accent-sage-dark"
         />
       </label>
 
       {error && (
-        <p role="alert" className="text-red-200 text-sm pt-3">
+        <p role="alert" className="text-red-600 dark:text-red-400 text-sm pt-3">
           {error}
         </p>
       )}

--- a/apps/frontend/components/onboarding/steps/VeteranStep.tsx
+++ b/apps/frontend/components/onboarding/steps/VeteranStep.tsx
@@ -122,7 +122,7 @@ export function VeteranStep({ onComplete, isLastStep }: VeteranStepProps) {
       </p>
 
       <div className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 mb-5 text-sm">
-        <div className="flex items-center gap-2 mb-2 font-medium text-sage-dark dark:text-sage-light">
+        <div className="flex items-center gap-2 mb-2 font-medium text-sage-darker dark:text-sage-light">
           <svg
             className="w-4 h-4"
             fill="none"

--- a/apps/frontend/components/onboarding/steps/WelcomeStep.tsx
+++ b/apps/frontend/components/onboarding/steps/WelcomeStep.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useId } from "react";
 import { useTranslation } from "react-i18next";
 import { useMutation } from "@apollo/client/react";
 import { useLocale } from "@/lib/i18n/context";
+import { useToast } from "@/lib/toast";
 import {
   UPDATE_MY_PROFILE,
   type SupportedLanguage,
@@ -17,7 +19,10 @@ const LANGUAGES: { code: SupportedLanguage; labelKey: string }[] = [
 
 export function WelcomeStep() {
   const { t } = useTranslation("onboarding");
+  const { t: tc } = useTranslation("common");
   const { locale, setLocale } = useLocale();
+  const { showToast } = useToast();
+  const groupName = useId();
   const [updateProfile] = useMutation<
     UpdateMyProfileData,
     { input: UpdateProfileInput }
@@ -26,28 +31,31 @@ export function WelcomeStep() {
   const handleLocale = (code: SupportedLanguage) => {
     if (code === locale) return;
     setLocale(code);
-    // Fire-and-forget persistence. Client-side setLocale already
-    // updated the UI; a failed mutation must not block onboarding. If
-    // the persist fails the locale lives client-side only and reverts
-    // on next visit — log so the inconsistency is debuggable rather
-    // than silent.
+    // Fire-and-forget persistence. Client-side setLocale already updated
+    // the UI; a failed mutation must not block onboarding. Toast surfaces
+    // the inconsistency to the user; warn so it's debuggable in dev.
     updateProfile({ variables: { input: { preferredLanguage: code } } }).catch(
       (err: unknown) => {
         console.warn("Failed to persist preferred language", err);
+        showToast(tc("errors.preferencesNotSaved"), "warning");
       },
     );
   };
 
   return (
-    <div className="text-center text-white max-w-md">
-      <div className="w-24 h-24 bg-white/20 rounded-3xl mx-auto mb-8 flex items-center justify-center">
+    <div className="text-center max-w-md">
+      <div className="w-24 h-24 bg-sage-dark text-white rounded-3xl mx-auto mb-8 flex items-center justify-center shadow-md">
         <span className="text-4xl font-bold">O</span>
       </div>
 
-      <h1 className="text-3xl font-bold mb-4">{t("welcome.title")}</h1>
-      <p className="text-white/80 text-lg mb-8">{t("welcome.subtitle")}</p>
+      <h1 className="text-3xl font-bold mb-4 text-gray-900 dark:text-white">
+        {t("welcome.title")}
+      </h1>
+      <p className="text-gray-600 dark:text-gray-300 text-lg mb-8">
+        {t("welcome.subtitle")}
+      </p>
 
-      <fieldset className="inline-flex bg-white/10 rounded-full p-1 border border-white/20">
+      <fieldset className="inline-flex bg-white dark:bg-gray-800 rounded-full p-1 border border-gray-300 dark:border-gray-700">
         <legend className="sr-only">{t("welcome.languageLegend")}</legend>
         {LANGUAGES.map(({ code, labelKey }) => {
           const active = code === locale;
@@ -56,15 +64,15 @@ export function WelcomeStep() {
               key={code}
               className={[
                 "px-4 py-1.5 rounded-full text-sm font-medium cursor-pointer transition-colors",
-                "focus-within:ring-2 focus-within:ring-white",
+                "focus-within:ring-2 focus-within:ring-sage-dark",
                 active
-                  ? "bg-white text-[#2D4A3C]"
-                  : "text-white/80 hover:text-white",
+                  ? "bg-sage-dark text-white"
+                  : "text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white",
               ].join(" ")}
             >
               <input
                 type="radio"
-                name="onboarding-locale"
+                name={groupName}
                 value={code}
                 checked={active}
                 onChange={() => handleLocale(code)}

--- a/apps/frontend/components/profile/ProfileCompletionIndicator.tsx
+++ b/apps/frontend/components/profile/ProfileCompletionIndicator.tsx
@@ -21,7 +21,7 @@ export function ProfileCompletionIndicator({
             {t("profile.completion.title", "Profile Completion")}
           </h3>
           {isComplete && (
-            <p className="text-sm text-sage-dark dark:text-sage-light mt-1">
+            <p className="text-sm text-sage-darker dark:text-sage-light mt-1">
               {t("profile.completion.complete", "Your profile is complete!")}
             </p>
           )}

--- a/apps/frontend/components/profile/ProfileCompletionIndicator.tsx
+++ b/apps/frontend/components/profile/ProfileCompletionIndicator.tsx
@@ -13,38 +13,30 @@ export function ProfileCompletionIndicator({
   const { t } = useTranslation("settings");
   const { percentage, isComplete, suggestedNextSteps } = completion;
 
-  // Determine progress bar color based on completion
-  const getProgressColor = () => {
-    if (isComplete) return "bg-green-500";
-    if (percentage >= 75) return "bg-blue-500";
-    if (percentage >= 50) return "bg-yellow-500";
-    return "bg-orange-500";
-  };
-
   return (
-    <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-6 mb-6">
+    <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-6 mb-6">
       <div className="flex items-center justify-between mb-4">
         <div>
-          <h3 className="text-lg font-semibold text-[#222222]">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
             {t("profile.completion.title", "Profile Completion")}
           </h3>
           {isComplete && (
-            <p className="text-sm text-green-600 mt-1">
+            <p className="text-sm text-sage-dark dark:text-sage-light mt-1">
               {t("profile.completion.complete", "Your profile is complete!")}
             </p>
           )}
         </div>
         <div className="text-right">
-          <span className="text-3xl font-bold text-[#222222]">
+          <span className="text-3xl font-bold text-gray-900 dark:text-white">
             {percentage}%
           </span>
         </div>
       </div>
 
       {/* Progress Bar */}
-      <div className="h-3 bg-gray-200 rounded-full overflow-hidden mb-4">
+      <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded-full overflow-hidden mb-4">
         <div
-          className={`h-full transition-all duration-500 ease-out ${getProgressColor()}`}
+          className="h-full bg-sage-dark transition-all duration-500 ease-out"
           style={{ width: `${percentage}%` }}
         />
       </div>
@@ -75,17 +67,17 @@ export function ProfileCompletionIndicator({
 
       {/* Suggested Next Steps */}
       {!isComplete && suggestedNextSteps.length > 0 && (
-        <div className="border-t border-gray-100 pt-4">
-          <p className="text-sm font-medium text-[#4d4d4d] mb-2">
+        <div className="border-t border-gray-100 dark:border-gray-700 pt-4">
+          <p className="text-sm font-medium text-gray-600 dark:text-gray-300 mb-2">
             {t("profile.completion.nextSteps", "Suggested next steps:")}
           </p>
           <ul className="space-y-2">
             {suggestedNextSteps.map((step, idx) => (
               <li
                 key={idx}
-                className="text-sm text-[#222222] flex items-start gap-2"
+                className="text-sm text-gray-900 dark:text-gray-100 flex items-start gap-2"
               >
-                <span className="w-1.5 h-1.5 bg-blue-500 rounded-full mt-1.5 flex-shrink-0" />
+                <span className="w-1.5 h-1.5 bg-sage-dark rounded-full mt-1.5 flex-shrink-0" />
                 {step}
               </li>
             ))}
@@ -105,7 +97,9 @@ function StatusBadge({ label, complete }: StatusBadgeProps) {
   return (
     <div
       className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm ${
-        complete ? "bg-green-50 text-green-700" : "bg-gray-50 text-gray-500"
+        complete
+          ? "bg-sage-light/20 text-sage-darker dark:bg-sage-dark/20 dark:text-sage-light"
+          : "bg-gray-50 text-gray-500 dark:bg-gray-900 dark:text-gray-400"
       }`}
     >
       {complete ? (

--- a/apps/frontend/components/settings/SettingsShellLayout.tsx
+++ b/apps/frontend/components/settings/SettingsShellLayout.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useTranslation } from "react-i18next";
 import { ProtectedRoute } from "@/components/ProtectedRoute";
 import { Footer } from "@/components/Footer";
+import { LanguageToggle } from "@/components/LanguageToggle";
 import { useAuth } from "@/lib/auth-context";
 
 /**
@@ -169,8 +170,8 @@ export function SettingsShellLayout({
 
   return (
     <ProtectedRoute>
-      <div className="min-h-screen bg-[#FFFFFF]">
-        <header className="bg-white border-b border-gray-200">
+      <div className="min-h-screen bg-white dark:bg-gray-900">
+        <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex justify-between items-center h-16">
               <Link
@@ -183,12 +184,15 @@ export function SettingsShellLayout({
                   className="h-8"
                 />
               </Link>
-              <Link
-                href="/region"
-                className="text-sm text-[#4d4d4d] hover:text-[#222222] transition-colors"
-              >
-                {t("common:navigation.backToApp")}
-              </Link>
+              <div className="flex items-center gap-4">
+                <LanguageToggle />
+                <Link
+                  href="/region"
+                  className="text-sm text-gray-600 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors"
+                >
+                  {t("common:navigation.backToApp")}
+                </Link>
+              </div>
             </div>
           </div>
         </header>
@@ -196,8 +200,8 @@ export function SettingsShellLayout({
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <div className="flex gap-8">
             <nav className="w-64 flex-shrink-0">
-              <div className="bg-white rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] p-2">
-                <h2 className="px-4 py-2 text-xs font-semibold text-[#4d4d4d] uppercase tracking-wider">
+              <div className="bg-white dark:bg-gray-800 rounded-xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 p-2">
+                <h2 className="px-4 py-2 text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wider">
                   {t("nav.settings")}
                 </h2>
                 <ul className="space-y-1">
@@ -207,8 +211,8 @@ export function SettingsShellLayout({
                         href={item.href}
                         className={`flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors ${
                           isActive(item.href)
-                            ? "bg-[#222222] text-white"
-                            : "text-[#4d4d4d] hover:bg-gray-100 hover:text-[#222222]"
+                            ? "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900"
+                            : "text-gray-600 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white"
                         }`}
                       >
                         {item.icon}
@@ -217,10 +221,10 @@ export function SettingsShellLayout({
                     </li>
                   ))}
                 </ul>
-                <div className="mt-2 pt-2 border-t border-gray-100">
+                <div className="mt-2 pt-2 border-t border-gray-100 dark:border-gray-700">
                   <button
                     onClick={logout}
-                    className="flex items-center gap-3 w-full px-4 py-2.5 rounded-lg text-sm font-medium text-red-600 hover:bg-red-50 hover:text-red-700 transition-colors"
+                    className="flex items-center gap-3 w-full px-4 py-2.5 rounded-lg text-sm font-medium text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-900/20 dark:hover:text-red-300 transition-colors"
                   >
                     <svg
                       className="w-5 h-5"

--- a/apps/frontend/locales/en/common.json
+++ b/apps/frontend/locales/en/common.json
@@ -17,8 +17,10 @@
   "errors": {
     "generic": "Something went wrong. Please try again.",
     "loadFailed": "Failed to load data. Please try again.",
-    "saveFailed": "Failed to save. Please try again."
+    "saveFailed": "Failed to save. Please try again.",
+    "preferencesNotSaved": "We couldn't save your preference — it'll reset next session."
   },
+  "languageLegend": "Language",
   "status": {
     "success": "Success!",
     "primary": "Primary",
@@ -28,6 +30,7 @@
     "granted": "Granted",
     "withdrawn": "Withdrawn",
     "denied": "Denied",
+    "pending": "Pending",
     "notSet": "Not Set",
     "loading": "Loading..."
   },

--- a/apps/frontend/locales/es/common.json
+++ b/apps/frontend/locales/es/common.json
@@ -17,8 +17,10 @@
   "errors": {
     "generic": "Algo salio mal. Por favor, intentalo de nuevo.",
     "loadFailed": "Error al cargar los datos. Por favor, intentalo de nuevo.",
-    "saveFailed": "Error al guardar. Por favor, intentalo de nuevo."
+    "saveFailed": "Error al guardar. Por favor, intentalo de nuevo.",
+    "preferencesNotSaved": "No pudimos guardar tu preferencia — se restablecerá en la próxima sesión."
   },
+  "languageLegend": "Idioma",
   "status": {
     "success": "Exito!",
     "primary": "Principal",
@@ -28,6 +30,7 @@
     "granted": "Concedido",
     "withdrawn": "Retirado",
     "denied": "Denegado",
+    "pending": "Pendiente",
     "notSet": "No establecido",
     "loading": "Cargando..."
   },


### PR DESCRIPTION
## What changed and why

- **Neutral-canvas onboarding** — flips from the dark-sage gradient that lived only on `/onboarding` to `bg-gray-50 / dark:bg-gray-900`, matching every other screen in the app. Sage moves to its brand-accent role: chips, progress dots, primary CTA, the Welcome hero "O", form focus rings.
- **`<StatusPill tone="..." />`** — new typed primitive in `components/StatusPill.tsx`. Five tones (`sage-filled`, `sage-outline`, `warning`, `danger`, `neutral`). Replaces 8 inline pill-class duplicates across Addresses (Primary, Verified), Privacy (granted/withdrawn/denied/notSet/required consents), Security (Current session), and ProfileCompletionIndicator status badges. Lookup-table dispatch keeps cognitive complexity at 1; expanding tones doesn't grow the cyclomatic count.
- **`<LanguageToggle />`** — new EN/ES toggle in `components/LanguageToggle.tsx`, wired into both `Header.tsx` (public pages, desktop + mobile nav) and `SettingsShellLayout.tsx` (settings sidebar chrome). Auth-gated persistence via existing `UPDATE_MY_PROFILE`; unauthenticated users get a client-side-only switch. Toast on persistence failure. Fixes a real UX bug: previously, the only post-onboarding locale switcher was buried in the Profile settings form, leaving Spanish-locale users stuck.
- **Dark-mode coverage** — full pass on `ProfileCompletionIndicator`, `addresses/page.tsx`, `privacy/page.tsx`, `security/page.tsx`, and `SettingsShellLayout.tsx`. Onboarding was already dark-aware from the canvas refactor.
- **Sage coherence on consent statuses** — Privacy page consent badges now use brand sage for granted; yellow stays for the cautionary `withdrawn` state; red stays for `denied` (semantic). Added `pending` to `common:status.*` in both en/es locale files (was missing and would have rendered a raw key).
- **`<VeteranStep />`** checkmark cleanup — selected chip drops the inverse white-square-on-sage in favor of a single transparent border + white checkmark. Cleaner visual layer count.
- **New a11y test** — `__tests__/accessibility/onboarding.a11y.test.tsx` runs jest-axe across all 9 onboarding steps + the progressbar global chrome. Onboarding had zero a11y coverage before. (Note: jest-axe under jsdom can't compute Tailwind color contrast — that's noted in the test header; the token math and the manual eyeball pass cover contrast.)
- **Test updates** — `ProfileCompletionIndicator.test.tsx` swaps four tier-color tests for a single parameterized "single sage track" assertion that *also* negatively asserts the old `green-500/blue-500/yellow-500/orange-500` classes are gone, so a future regression that reintroduces tiers fails loudly here. Direct unit tests for `StatusPill` and `LanguageToggle` lock the typed tone enum and the auth-gated persistence behavior.

## How to test

- [ ] Walk the onboarding flow start-to-finish (`pnpm dev`, register a fresh user) — neutral canvas with sage accents should read coherent across all 9 steps
- [ ] Toggle OS dark mode mid-flow on any settings page (`/settings`, `/settings/addresses`, `/settings/privacy`, `/settings/security`) — both modes readable, no broken white-on-white or invisible-dark-button states
- [ ] On `/region`, switch the header toggle to ES, then navigate to `/settings/profile` — sidebar toggle should show ES selected (locale persisted via `UPDATE_MY_PROFILE`)
- [ ] On `/settings/privacy`, confirm consent pill colors: granted=sage filled, withdrawn=yellow, denied=red, pending/notSet=neutral, required=outlined sage
- [ ] On `/settings/addresses`, confirm Primary=filled sage / Verified=outlined sage on the same address card
- [ ] Sign out, click the EN/ES toggle as an unauthenticated user — UI locale should flip with no GraphQL call
- [ ] Spanish locale full walk: register fresh user → toggle ES on the Welcome step → walk all 9 steps; copy fits
- [ ] `pnpm lint` → 0 errors
- [ ] `pnpm test` → 1315/1315 pass (includes 17 new tests across `StatusPill`, `LanguageToggle`, onboarding a11y)
- [ ] `pnpm test:a11y` → 37/37
- [ ] `pnpm build` → clean

## Screenshots

(Attach before/after pairs from local — recommended set):
- `/onboarding` welcome step — old dark-sage gradient vs new neutral canvas + sage hero "O"
- `/settings/profile` — Profile Completion card (single sage track + sage success message + sage core-field badges)
- `/settings/privacy` — consent group with granted/withdrawn/denied + required pill mix
- `/settings/addresses` — Primary (filled sage) + Verified (outlined sage) pills side-by-side
- `/settings/security` — Active Sessions current panel with sage chrome
- Header on any page — EN | ES toggle visible top-right (desktop)
- Same in dark mode

## Linked issues

None — surfaced from a design review thread on the onboarding canvas. Happy to file a retroactive tracking issue if helpful for the changelog.

## Follow-ups (not in this PR)

- 10+ pre-existing `tsc --noEmit` errors in `__tests__/*` fixture mocks across unrelated test files (`useMagicLink`, `proposition-detail`, `representative-detail`, `knowledge`, `LifeContextStep.helpers`, `settings.a11y`, etc.). None introduced here, but they trip strict TS — worth a chore PR so the next silent build failure surfaces locally instead of inside Docker.
- Dark-mode coverage on the remaining settings pages: `/settings/notifications`, `/settings/activity`, `/settings/email-history`. Same `bg-white dark:bg-gray-800` / `text-gray-900 dark:text-gray-100` pattern as what landed here.
- LanguageToggle: when product wants `pending` to be visually distinct from `notSet` for unsigned consents, swap that tone via the same lookup table — no caller changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)