### PR TITLE
feat(frontend): "Your Civic Briefing" personalized bill feed home (#744)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,8 @@ PRs must pass lint and build. Do not merge with failing checks.
 - `docs/architecture/system-overview.md` — full architecture with diagrams
 - `docs/architecture/provider-pattern.md` — pluggable provider design
 - `docs/architecture/ai-ml-pipeline.md` — RAG and embeddings
+- `docs/architecture/personalized-relevance.md` — signal taxonomy, T1/T2/T3 tiers, ranking axes, briefing design (epic #740)
+- `docs/architecture/frontend-architecture.md` — Next.js App Router layout, i18n namespaces, /me/* surfaces
 - `docs/guides/getting-started.md` — first-time setup
 - `docs/guides/auth-security.md` — auth flows and HMAC details
 - `docs/guides/region-provider.md` — adding a civic region

--- a/apps/frontend/__tests__/components/briefing/BillsTopicFilter.test.tsx
+++ b/apps/frontend/__tests__/components/briefing/BillsTopicFilter.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { BillsTopicFilter } from "@/components/briefing/bills/BillsTopicFilter";
+
+describe("BillsTopicFilter", () => {
+  it("renders one chip per stored interest tag, looking up the i18n label", () => {
+    render(<BillsTopicFilter topics={["healthcare", "taxes", "justice"]} />);
+    // The labels come from the profile namespace's interestTags options
+    // (matching the model-of-me vocab). Spot-check a couple.
+    expect(screen.getByText(/healthcare/i)).toBeInTheDocument();
+    expect(screen.getByText(/taxes & budget/i)).toBeInTheDocument();
+    expect(screen.getByText(/justice reform/i)).toBeInTheDocument();
+  });
+
+  it("renders the 'Edit your interests' linkout to /me/profile", () => {
+    render(<BillsTopicFilter topics={["healthcare"]} />);
+    const link = screen.getByRole("link", { name: /edit your interests/i });
+    expect(link).toHaveAttribute("href", "/me/profile");
+  });
+
+  it("renders nothing when there are no topics — avoids an empty bar", () => {
+    const { container } = render(<BillsTopicFilter topics={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("falls back to the slug when the i18n label is missing", () => {
+    render(<BillsTopicFilter topics={["unknown_topic"]} />);
+    expect(screen.getByText("unknown_topic")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/components/briefing/BriefingSection.test.tsx
+++ b/apps/frontend/__tests__/components/briefing/BriefingSection.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { BriefingSection } from "@/components/briefing/BriefingSection";
+
+describe("BriefingSection", () => {
+  it("renders the title + subtitle + children", () => {
+    render(
+      <BriefingSection
+        slug="bills"
+        title="Bills moving this week"
+        subtitle="Ranked by relevance to your life."
+        seeAllHref="/region/bills"
+      >
+        <p>body content</p>
+      </BriefingSection>,
+    );
+    expect(
+      screen.getByRole("heading", {
+        level: 2,
+        name: /bills moving this week/i,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/ranked by relevance/i)).toBeInTheDocument();
+    expect(screen.getByText("body content")).toBeInTheDocument();
+  });
+
+  it("renders the See all link pointing at the supplied href", () => {
+    render(
+      <BriefingSection slug="bills" title="Bills" seeAllHref="/region/bills">
+        <p>body</p>
+      </BriefingSection>,
+    );
+    const link = screen.getByRole("link", { name: /see all/i });
+    expect(link).toHaveAttribute("href", "/region/bills");
+  });
+
+  it("exposes a data-section attribute matching the slug for e2e selectors", () => {
+    const { container } = render(
+      <BriefingSection
+        slug="reps"
+        title="Reps"
+        seeAllHref="/region/representatives"
+      >
+        <p>body</p>
+      </BriefingSection>,
+    );
+    expect(
+      container.querySelector('[data-section="reps"]'),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an optional icon when provided", () => {
+    render(
+      <BriefingSection
+        slug="bills"
+        title="Bills"
+        seeAllHref="/region/bills"
+        icon={<svg data-testid="bills-icon" />}
+      >
+        <p>body</p>
+      </BriefingSection>,
+    );
+    expect(screen.getByTestId("bills-icon")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/components/briefing/WhyThisPanel.test.tsx
+++ b/apps/frontend/__tests__/components/briefing/WhyThisPanel.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { WhyThisPanel } from "@/components/briefing/bills/WhyThisPanel";
+import type { AxisScores } from "@/lib/graphql/personalized-feed";
+
+const baseAxes: AxisScores = {
+  directMaterial: 0,
+  valuesAlignment: 0,
+  actionability: 0,
+  indirectMaterial: 0,
+  coalitionSignal: 0,
+  counterfactual: 0,
+  noveltyRepetition: 0,
+};
+
+describe("WhyThisPanel", () => {
+  it("starts collapsed; clicking expands the panel", async () => {
+    const user = userEvent.setup();
+    render(
+      <WhyThisPanel
+        axisScores={{ ...baseAxes, directMaterial: 0.8 }}
+        scopeId="bill-1"
+      />,
+    );
+    const toggle = screen.getByRole("button", {
+      name: /why is this on my briefing/i,
+    });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("picks the top-scoring axis (directMaterial wins over valuesAlignment)", async () => {
+    const user = userEvent.setup();
+    render(
+      <WhyThisPanel
+        axisScores={{ ...baseAxes, directMaterial: 0.9, valuesAlignment: 0.3 }}
+        scopeId="bill-1"
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    expect(
+      screen.getByText(/money, rights, health, or services/i),
+    ).toBeInTheDocument();
+  });
+
+  it("picks valuesAlignment when it dominates", async () => {
+    const user = userEvent.setup();
+    render(
+      <WhyThisPanel
+        axisScores={{ ...baseAxes, directMaterial: 0.1, valuesAlignment: 0.9 }}
+        scopeId="bill-2"
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    expect(
+      screen.getByText(/topics you said you care about/i),
+    ).toBeInTheDocument();
+  });
+
+  it("omits the axis sentence when every axis is zero (theoretical 4-7-only surfacing)", async () => {
+    const user = userEvent.setup();
+    render(<WhyThisPanel axisScores={baseAxes} scopeId="bill-zero" />);
+    await user.click(screen.getByRole("button"));
+    // None of the three axis sentences should render — only the #745 placeholder.
+    expect(
+      screen.queryByText(/money, rights, health, or services/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/topics you said you care about/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/llm explanation pipeline ships/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the #745 placeholder note inside the expanded panel", async () => {
+    const user = userEvent.setup();
+    render(
+      <WhyThisPanel
+        axisScores={{ ...baseAxes, actionability: 0.7 }}
+        scopeId="bill-3"
+      />,
+    );
+    await user.click(screen.getByRole("button"));
+    expect(
+      screen.getByText(/llm explanation pipeline ships/i),
+    ).toBeInTheDocument();
+  });
+
+  it("scopes aria-controls with the supplied scopeId so multiple cards stay isolated", () => {
+    render(<WhyThisPanel axisScores={baseAxes} scopeId="bill-42" />);
+    const toggle = screen.getByRole("button");
+    expect(toggle).toHaveAttribute("aria-controls", "why-bill-42");
+  });
+});

--- a/apps/frontend/__tests__/components/onboarding/OnboardingSteps.test.tsx
+++ b/apps/frontend/__tests__/components/onboarding/OnboardingSteps.test.tsx
@@ -165,7 +165,7 @@ describe("OnboardingSteps", () => {
       await userEvent.click(screen.getByRole("button", { name: /skip/i }));
 
       expect(mockSkipOnboarding).toHaveBeenCalled();
-      expect(mockPush).toHaveBeenCalledWith("/region");
+      expect(mockPush).toHaveBeenCalledWith("/me/briefing");
     });
   });
 

--- a/apps/frontend/__tests__/lib/graphql/personalized-feed.test.ts
+++ b/apps/frontend/__tests__/lib/graphql/personalized-feed.test.ts
@@ -1,0 +1,68 @@
+import {
+  stripTypename,
+  topAxisFor,
+  type AxisScores,
+} from "@/lib/graphql/personalized-feed";
+
+// stripTypename is shape-agnostic, so the fixture deliberately uses a
+// minimal flag-like object rather than enumerating all 20 RankingFlags
+// booleans. The full type's shape is enforced by the resolver layer.
+const baseFlags = { isRenter: true, isParent: true, isWorker: false } as const;
+
+describe("stripTypename — regression for the __typename bug surfaced in UAT", () => {
+  it("removes the __typename field Apollo auto-adds to query responses", () => {
+    const withTypename = { ...baseFlags, __typename: "RankingFlags" };
+    const cleaned = stripTypename(withTypename);
+    expect("__typename" in cleaned).toBe(false);
+  });
+
+  it("preserves every other field verbatim", () => {
+    const withTypename = { ...baseFlags, __typename: "RankingFlags" };
+    expect(stripTypename(withTypename)).toEqual(baseFlags);
+  });
+
+  it("is a no-op when the input has no __typename", () => {
+    expect(stripTypename(baseFlags)).toEqual(baseFlags);
+  });
+});
+
+describe("topAxisFor", () => {
+  const zeros: AxisScores = {
+    directMaterial: 0,
+    valuesAlignment: 0,
+    actionability: 0,
+    indirectMaterial: 0,
+    coalitionSignal: 0,
+    counterfactual: 0,
+    noveltyRepetition: 0,
+  };
+
+  it("picks the highest of axes 1–3", () => {
+    expect(
+      topAxisFor({ ...zeros, directMaterial: 0.8, valuesAlignment: 0.3 }),
+    ).toBe("directMaterial");
+    expect(
+      topAxisFor({ ...zeros, valuesAlignment: 0.9, actionability: 0.2 }),
+    ).toBe("valuesAlignment");
+    expect(
+      topAxisFor({ ...zeros, actionability: 0.7, valuesAlignment: 0.6 }),
+    ).toBe("actionability");
+  });
+
+  it("ignores v1.1 placeholder axes (4–7) even if they happen to be non-zero", () => {
+    // v1.0 contract: axes 4-7 return 0.0; if a test fixture ever leaks
+    // a non-zero, the heuristic must still pick from axes 1-3.
+    expect(
+      topAxisFor({
+        ...zeros,
+        directMaterial: 0.1,
+        indirectMaterial: 0.9,
+        coalitionSignal: 0.9,
+      }),
+    ).toBe("directMaterial");
+  });
+
+  it("falls back to directMaterial when every axis is zero", () => {
+    expect(topAxisFor(zeros)).toBe("directMaterial");
+  });
+});

--- a/apps/frontend/__tests__/pages/auth-callback.test.tsx
+++ b/apps/frontend/__tests__/pages/auth-callback.test.tsx
@@ -227,7 +227,7 @@ describe("AuthCallbackPage", () => {
       });
       await userEvent.click(continueButton);
 
-      expect(mockPush).toHaveBeenCalledWith("/region");
+      expect(mockPush).toHaveBeenCalledWith("/me/briefing");
     });
   });
 

--- a/apps/frontend/__tests__/pages/onboarding.test.tsx
+++ b/apps/frontend/__tests__/pages/onboarding.test.tsx
@@ -95,7 +95,7 @@ describe("OnboardingPage", () => {
     render(<OnboardingPage />);
 
     await waitFor(() => {
-      expect(mockReplace).toHaveBeenCalledWith("/region");
+      expect(mockReplace).toHaveBeenCalledWith("/me/briefing");
     });
   });
 

--- a/apps/frontend/app/(auth)/auth/callback/page.tsx
+++ b/apps/frontend/app/(auth)/auth/callback/page.tsx
@@ -74,7 +74,7 @@ function AuthCallbackContent() {
   } = useAuth();
   const rawRedirect = searchParams.get("redirect");
   const skipTarget = resolveRedirect(rawRedirect, "/onboarding");
-  const continueTarget = resolveRedirect(rawRedirect, "/region");
+  const continueTarget = resolveRedirect(rawRedirect, "/me/briefing");
 
   const [status, setStatus] = useState<"verifying" | "success" | "error">(
     "verifying",

--- a/apps/frontend/app/me/briefing/layout.tsx
+++ b/apps/frontend/app/me/briefing/layout.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
+
+/**
+ * The civic-briefing home shares the same chrome as /region/* —
+ * Header at top, Footer at bottom, ProtectedRoute auth-guard. The
+ * /me/profile page uses the SettingsShellLayout because the sidebar
+ * makes sense for "all the user-data tabs"; the briefing home is the
+ * landing destination, not a settings tab, so it wears the same
+ * lightweight chrome as the rest of the public-facing app.
+ */
+export default function MeBriefingLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <ProtectedRoute>
+      <Header />
+      {children}
+      <Footer />
+    </ProtectedRoute>
+  );
+}

--- a/apps/frontend/app/me/briefing/page.tsx
+++ b/apps/frontend/app/me/briefing/page.tsx
@@ -1,0 +1,7 @@
+import { BriefingPage } from "@/components/briefing/BriefingPage";
+
+// Auth guard lives in the layout via ProtectedRoute, so this page
+// just renders.
+export default function MeBriefingPage() {
+  return <BriefingPage />;
+}

--- a/apps/frontend/app/onboarding/page.tsx
+++ b/apps/frontend/app/onboarding/page.tsx
@@ -16,7 +16,7 @@ export default function OnboardingPage() {
       router.replace("/login");
     }
     if (!authLoading && hasCompletedOnboarding) {
-      router.replace("/region");
+      router.replace("/me/briefing");
     }
   }, [authLoading, isAuthenticated, hasCompletedOnboarding, router]);
 

--- a/apps/frontend/components/Header.tsx
+++ b/apps/frontend/components/Header.tsx
@@ -33,6 +33,9 @@ export function Header() {
     if (isAuthenticated && user) {
       return (
         <>
+          <Link href="/me/briefing" className={navLinkClass}>
+            Briefing
+          </Link>
           <Link href="/region" className={navLinkClass}>
             Region
           </Link>
@@ -85,6 +88,13 @@ export function Header() {
     if (isAuthenticated && user) {
       return (
         <>
+          <Link
+            href="/me/briefing"
+            className={navLinkClass}
+            onClick={closeMenu}
+          >
+            Briefing
+          </Link>
           <Link href="/region" className={navLinkClass} onClick={closeMenu}>
             Region
           </Link>
@@ -134,7 +144,10 @@ export function Header() {
   return (
     <header className="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
       <div className="max-w-6xl mx-auto px-8 py-4 flex items-center justify-between">
-        <Link href="/" className="hover:opacity-80 transition-opacity">
+        <Link
+          href={isAuthenticated ? "/me/briefing" : "/"}
+          className="hover:opacity-80 transition-opacity"
+        >
           <img
             src="/logos/svg/op-horizontal-light.svg"
             alt="Opus Populi"

--- a/apps/frontend/components/briefing/BriefingPage.tsx
+++ b/apps/frontend/components/briefing/BriefingPage.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { BillsBriefingSection } from "./bills/BillsBriefingSection";
+import { BriefingPageHeader } from "./BriefingPageHeader";
+import { CommitteesBriefingPlaceholder } from "./placeholders/CommitteesBriefingPlaceholder";
+import { PropositionsBriefingPlaceholder } from "./placeholders/PropositionsBriefingPlaceholder";
+import { RepsBriefingPlaceholder } from "./placeholders/RepsBriefingPlaceholder";
+
+/**
+ * The authenticated home page. Composes the page header (with the
+ * "Browse all civic data →" link to /region) and four BriefingSection
+ * cards — Bills (the AC of #744) plus the three placeholder sections
+ * for Reps, Committees, Propositions whose personalized variants land
+ * via #769 / #770 / #771.
+ *
+ * Each section owns its own loading / empty / error / no-profile
+ * branches so the page composes without a top-level Suspense boundary.
+ */
+export function BriefingPage() {
+  return (
+    <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-10 space-y-8">
+      <BriefingPageHeader />
+      <div className="space-y-5">
+        <BillsBriefingSection />
+        <RepsBriefingPlaceholder />
+        <CommitteesBriefingPlaceholder />
+        <PropositionsBriefingPlaceholder />
+      </div>
+    </main>
+  );
+}

--- a/apps/frontend/components/briefing/BriefingPageHeader.tsx
+++ b/apps/frontend/components/briefing/BriefingPageHeader.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Top of the civic briefing home page. Renders the page title +
+ * subtitle plus a right-aligned "Browse all civic data →" link to
+ * /region so users have a one-click escape into the data-browse
+ * hub from any personalized briefing context.
+ */
+export function BriefingPageHeader() {
+  const { t } = useTranslation("briefing");
+  return (
+    <header className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-3 pb-2">
+      <div>
+        <h1 className="text-3xl font-bold text-[#222222] dark:text-white">
+          {t("page.title")}
+        </h1>
+        <p className="text-base text-[#4d4d4d] dark:text-gray-300 mt-1">
+          {t("page.subtitle")}
+        </p>
+      </div>
+      <Link
+        href="/region"
+        aria-label={t("page.browseAllAria")}
+        className="text-sm font-medium text-[#5A7A6A] hover:text-[#2D4A3C] dark:text-sage-200 dark:hover:text-white whitespace-nowrap"
+      >
+        {t("page.browseAllLink")}
+      </Link>
+    </header>
+  );
+}

--- a/apps/frontend/components/briefing/BriefingSection.tsx
+++ b/apps/frontend/components/briefing/BriefingSection.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+interface BriefingSectionProps {
+  /** Section heading — e.g. "Bills", "Your representatives". */
+  readonly title: string;
+  /** One-line context for what this section ranks. */
+  readonly subtitle?: string;
+  /** Optional decorative icon next to the title. */
+  readonly icon?: ReactNode;
+  /** Render the section body — featured item + list, or placeholder. */
+  readonly children: ReactNode;
+  /** Route that the "See all" affordance lands on. */
+  readonly seeAllHref: string;
+  /** Override the default "See all →" label (i18n: briefing.section.seeAll). */
+  readonly seeAllLabel?: string;
+  /**
+   * `data-section` exposes the consumer's identity for e2e selectors
+   * and any future telemetry. Use the slug ("bills", "reps", etc.).
+   */
+  readonly slug: string;
+}
+
+/**
+ * Domain-agnostic shell for one card on the civic briefing home page.
+ * Each personalized section (Bills now, Reps/Committees/Propositions in
+ * #769/#770/#771) wraps its content in this so the four cards on the
+ * home page share the same chrome — title row, body, see-all linkout.
+ *
+ * Per the issue, "See all" always points at the existing /region/*
+ * surface so users can browse the unfiltered domain when the
+ * personalized list isn't what they need.
+ */
+export function BriefingSection({
+  title,
+  subtitle,
+  icon,
+  children,
+  seeAllHref,
+  seeAllLabel,
+  slug,
+}: BriefingSectionProps) {
+  const { t } = useTranslation("briefing");
+  return (
+    <section
+      data-section={slug}
+      aria-labelledby={`briefing-section-${slug}-title`}
+      className="bg-white dark:bg-gray-800 rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 overflow-hidden"
+    >
+      <header className="flex items-start justify-between gap-4 px-6 pt-6">
+        <div className="flex items-start gap-3 min-w-0">
+          {icon && (
+            <span
+              aria-hidden="true"
+              className="text-gray-500 dark:text-gray-400 shrink-0 mt-0.5"
+            >
+              {icon}
+            </span>
+          )}
+          <div className="min-w-0">
+            <h2
+              id={`briefing-section-${slug}-title`}
+              className="text-xl font-semibold text-[#222222] dark:text-white"
+            >
+              {title}
+            </h2>
+            {subtitle && (
+              <p className="text-sm text-[#4d4d4d] dark:text-gray-300 mt-0.5">
+                {subtitle}
+              </p>
+            )}
+          </div>
+        </div>
+        <Link
+          href={seeAllHref}
+          className="text-sm font-medium text-[#5A7A6A] hover:text-[#2D4A3C] dark:text-sage-200 dark:hover:text-white shrink-0 mt-1 whitespace-nowrap"
+        >
+          {seeAllLabel ?? t("section.seeAll")}
+        </Link>
+      </header>
+      <div className="px-6 py-5">{children}</div>
+    </section>
+  );
+}

--- a/apps/frontend/components/briefing/README.md
+++ b/apps/frontend/components/briefing/README.md
@@ -1,0 +1,135 @@
+# `components/briefing/` — Your Civic Briefing home page
+
+Implements `/me/briefing` from issue #744: the post-auth landing page
+that personalizes the four civic-data surfaces (bills, reps,
+committees, propositions) using the user's `SignalProfile` +
+`RankingFlags` from the `users` service and the relevance scoring in
+the `knowledge` service.
+
+In v1.0 only the **bills** section is fully personalized — the other
+three sections render placeholder cards that link back to the
+non-personalized `/region/*` surfaces. Their personalization layers
+are tracked in follow-up issues #769 (reps), #770 (committees), and
+#771 (propositions).
+
+## Composition pattern
+
+The page is a domain-agnostic **shell + N sections** composer:
+
+```
+BriefingPage
+├── BriefingPageHeader            ("Your Civic Briefing" + Browse all civic data →)
+├── BriefingSection slug="bills"  ← BillsBriefingSection (real)
+├── BriefingSection slug="reps"   ← RepsBriefingPlaceholder
+├── BriefingSection slug="committees"
+│                                 ← CommitteesBriefingPlaceholder
+└── BriefingSection slug="propositions"
+                                  ← PropositionsBriefingPlaceholder
+```
+
+`BriefingSection` is the unit of composition. It owns the section
+chrome (title, subtitle, optional icon, "See all →" link) and
+exposes `data-section={slug}` for e2e selectors. When #769/#770/#771
+ship, each replaces its placeholder body with a real
+`<XBriefingSection />` component matching the bills pattern — no
+changes to the shell.
+
+## Where the data comes from
+
+The bills section orchestrates a **three-step GraphQL fetch chain**
+(see `bills/useBillBriefing.ts`):
+
+1. `myRankingFlags` + `mySignalProfile { interestTags }` — the 20
+   boolean derivations and declared topics, from the `users` service.
+2. `myPersonalizedBillFeed(input, limit)` — the ranked `[billId,
+relevanceScore, axisScores]` list, from the `knowledge` service.
+   The frontend passes step-1's output as input here per the v1.0
+   federation boundary (planning doc §6.3).
+3. `bill(id)` × N — the bill detail records, from the `region`
+   service, fanned out in an effect once the feed resolves.
+
+The two-service boundary (knowledge needs flags + tags) is a v1.0
+shape that #761 will collapse into a subgraph-to-subgraph call. The
+frontend will then only see the ranked feed.
+
+### Apollo `__typename` gotcha
+
+Apollo Client auto-decorates fetched objects with `__typename`. When
+the step-1 `RankingFlags` object is passed back as the
+`RankingFlagsInputDto` argument in step 2, the InputType validator
+rejects the extra field. The hook strips it via `stripTypename()`
+(`lib/graphql/personalized-feed.ts`) before constructing the input.
+There is a regression test in
+`__tests__/lib/graphql/personalized-feed.test.ts`.
+
+## Two paradigms across `/me/*` — when to use which
+
+### Settings shell (`/settings/*`, `/me/profile`)
+
+Sidebar + content area, single-form-per-tab. Used for
+**configuration** — places where the user is changing their own
+state. The sidebar lives at module scope and persists across tabs.
+
+### Briefing shell (`/me/briefing`)
+
+Header + Footer + page body, no sidebar. Used for
+**consumption** — places where the user is reading information the
+platform produced. Matches the `/region/*` chrome so the cross-link
+between Briefing and Region feels like one surface.
+
+Both reuse `ProtectedRoute` for auth-gating. The auth check lives in
+the route's `layout.tsx`, not the page, so the page can be a pure
+composition function.
+
+## Key files
+
+| File                                               | Purpose                                                                                               |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `BriefingPage.tsx`                                 | Top-level composer; renders header + 4 sections                                                       |
+| `BriefingPageHeader.tsx`                           | Page H1 + "Browse all civic data →" linkout to `/region`                                              |
+| `BriefingSection.tsx`                              | Domain-agnostic section shell (slug, title, subtitle, icon, seeAllHref)                               |
+| `bills/BillsBriefingSection.tsx`                   | Bills section orchestrator — owns hero + compact list + empty / noProfile / error states              |
+| `bills/useBillBriefing.ts`                         | The three-step fetch hook; returns `BillBriefingState`                                                |
+| `bills/BillBriefingHero.tsx`                       | Featured top card; renders the highest-ranked bill                                                    |
+| `bills/BillBriefingCard.tsx`                       | Compact card for ranks 2–N                                                                            |
+| `bills/RelevanceChip.tsx`                          | 3-tier relevance badge (≥70 / ≥40 / <40)                                                              |
+| `bills/WhyThisPanel.tsx`                           | Collapsible per-card disclosure; picks the top axis via `topAxisFor()` to render the i18n explanation |
+| `bills/BillsTopicFilter.tsx`                       | Read-only chips of `interestTags` + "Edit your interests →" linkout to `/me/profile`                  |
+| `placeholders/PlaceholderBody.tsx`                 | Shared placeholder card layout                                                                        |
+| `placeholders/RepsBriefingPlaceholder.tsx`         | Reps placeholder; references #769                                                                     |
+| `placeholders/CommitteesBriefingPlaceholder.tsx`   | Committees placeholder; references #770                                                               |
+| `placeholders/PropositionsBriefingPlaceholder.tsx` | Propositions placeholder; references #771                                                             |
+
+## i18n
+
+All copy lives in `locales/{en,es}/briefing.json` under the
+`briefing` namespace. Sections, placeholder bodies, the "why this"
+axis explanations, and the empty/loading/no-profile states are all
+keyed there. Add the namespace once in `lib/i18n/index.ts`.
+
+## Where each follow-up plugs in
+
+| Issue | What it replaces                                                                                                |
+| ----- | --------------------------------------------------------------------------------------------------------------- |
+| #745  | `WhyThisPanel`'s heuristic axis-based explanation → LLM-written sentence (heuristic stays as fallback)          |
+| #761  | `useBillBriefing`'s three-step chain → single `myPersonalizedBillFeed` query that already includes bill details |
+| #769  | `RepsBriefingPlaceholder` → real `RepsBriefingSection`                                                          |
+| #770  | `CommitteesBriefingPlaceholder` → real `CommitteesBriefingSection`                                              |
+| #771  | `PropositionsBriefingPlaceholder` → real `PropositionsBriefingSection`                                          |
+
+Each follow-up should match the bills pattern: a `<XBriefingSection>`
+hosted inside `<BriefingSection slug="x">` with its own
+`use<X>Briefing` hook. The shell stays untouched.
+
+## Testing
+
+- Unit tests for shell + helpers live in
+  `__tests__/components/briefing/` and
+  `__tests__/lib/graphql/personalized-feed.test.ts` (including the
+  `__typename` strip regression).
+- E2E coverage in `e2e/briefing.spec.ts`: render, header / footer
+  chrome, all four "See all" linkouts, the "Browse all civic data →"
+  link, the unauthenticated → `/login` redirect, mobile render, and a
+  WCAG 2.2 AA axe scan. The Header desktop nav assertions skip on
+  `mobile-chrome` / `mobile-safari` because Header uses
+  `hidden md:flex` — the mobile menu is covered by `Header.test.tsx`.

--- a/apps/frontend/components/briefing/bills/BillBriefingCard.tsx
+++ b/apps/frontend/components/briefing/bills/BillBriefingCard.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import type { RankedBill } from "./useBillBriefing";
+import { RelevanceChip } from "./RelevanceChip";
+import { WhyThisPanel } from "./WhyThisPanel";
+
+interface BillBriefingCardProps {
+  readonly item: RankedBill;
+}
+
+/**
+ * Compact non-featured card. Reuses the same Why-this disclosure
+ * and the same #751/#753 stub slots as the hero but in a tighter
+ * row meant for stacks of 4–9 underneath the hero.
+ */
+export function BillBriefingCard({ item }: BillBriefingCardProps) {
+  const { bill, result } = item;
+  if (!bill) return null;
+
+  const summary = bill.subject ?? bill.lastAction ?? null;
+
+  return (
+    <article className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <Link
+            href={`/region/bills/${bill.id}`}
+            className="block text-base font-semibold text-[#222222] dark:text-white hover:text-[#5A7A6A] dark:hover:text-sage-300 transition-colors line-clamp-2"
+          >
+            {bill.title}
+          </Link>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            {bill.billNumber} · {bill.sessionYear}
+            {bill.status ? ` · ${bill.status}` : ""}
+          </p>
+        </div>
+        <RelevanceChip score={result.relevanceScore} />
+      </div>
+      {summary && (
+        <p className="mt-2 text-sm text-[#4d4d4d] dark:text-gray-300 line-clamp-2">
+          {summary}
+        </p>
+      )}
+      <div className="mt-2">
+        <WhyThisPanel axisScores={result.axisScores} scopeId={bill.id} />
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/components/briefing/bills/BillBriefingHero.tsx
+++ b/apps/frontend/components/briefing/bills/BillBriefingHero.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+import type { RankedBill } from "./useBillBriefing";
+import { RelevanceChip } from "./RelevanceChip";
+import { WhyThisPanel } from "./WhyThisPanel";
+
+interface BillBriefingHeroProps {
+  readonly item: RankedBill;
+}
+
+/**
+ * Featured top card of the bills briefing — bigger title, full
+ * plain-English summary, large relevance chip + Why-this disclosure.
+ *
+ * Counter-frame (#751) + action-affordance (#753) stubs render as
+ * disclosure-only `<p>` until those pipelines ship; the placement
+ * lets the future components slot in without restructuring this card.
+ */
+export function BillBriefingHero({ item }: BillBriefingHeroProps) {
+  const { t } = useTranslation("briefing");
+  const { bill, result } = item;
+  if (!bill) return null;
+
+  const summary = bill.subject ?? bill.lastAction ?? null;
+
+  return (
+    <article className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 sm:p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <Link
+            href={`/region/bills/${bill.id}`}
+            className="block text-xl sm:text-2xl font-bold text-[#222222] dark:text-white hover:text-[#5A7A6A] dark:hover:text-sage-300 transition-colors"
+          >
+            {bill.title}
+          </Link>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 uppercase tracking-wider">
+            {bill.billNumber} · {bill.sessionYear}
+          </p>
+        </div>
+        <RelevanceChip score={result.relevanceScore} size="md" />
+      </div>
+      {summary && (
+        <p className="mt-3 text-sm text-[#4d4d4d] dark:text-gray-300">
+          {summary}
+        </p>
+      )}
+      {bill.status && (
+        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+          <span className="font-semibold">{t("bills.statusLabel")}</span>{" "}
+          {bill.status}
+        </p>
+      )}
+      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+        <WhyThisPanel axisScores={result.axisScores} scopeId={bill.id} />
+        <Link
+          href={`/region/bills/${bill.id}`}
+          className="text-xs font-medium text-[#5A7A6A] hover:text-[#2D4A3C] dark:text-sage-300 dark:hover:text-white"
+        >
+          {t("bills.readBillLink")}
+        </Link>
+      </div>
+      <div className="mt-4 rounded-lg border border-dashed border-gray-300 dark:border-gray-600 p-3 space-y-1">
+        <p className="text-xs text-gray-500 dark:text-gray-400 italic">
+          {t("stubs.counterFrame")}
+        </p>
+        <p className="text-xs text-gray-500 dark:text-gray-400 italic">
+          {t("stubs.actionAffordances")}
+        </p>
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/components/briefing/bills/BillsBriefingSection.tsx
+++ b/apps/frontend/components/briefing/bills/BillsBriefingSection.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+import { BriefingSection } from "../BriefingSection";
+import { BillBriefingCard } from "./BillBriefingCard";
+import { BillBriefingHero } from "./BillBriefingHero";
+import { BillsTopicFilter } from "./BillsTopicFilter";
+import { useBillBriefing } from "./useBillBriefing";
+
+// Planning-doc §1 / #743 default: top 5 keeps the list at the
+// civic-attention sweet spot. Raise if the home page can absorb
+// more without diluting focus.
+const FEED_LIMIT = 5;
+
+export function BillsBriefingSection() {
+  const { t } = useTranslation("briefing");
+  const { loading, error, noProfile, empty, topicTags, rankedBills } =
+    useBillBriefing(FEED_LIMIT);
+
+  const billIcon = (
+    <svg
+      className="w-6 h-6"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+      />
+    </svg>
+  );
+
+  return (
+    <BriefingSection
+      slug="bills"
+      title={t("bills.title")}
+      subtitle={t("bills.subtitle")}
+      seeAllHref="/region/bills"
+      icon={billIcon}
+    >
+      <BillsTopicFilter topics={topicTags} />
+
+      {noProfile && (
+        <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-600 p-4">
+          <p className="text-sm font-medium text-[#222222] dark:text-white">
+            {t("page.noProfileTitle")}
+          </p>
+          <p className="text-sm text-[#4d4d4d] dark:text-gray-300 mt-1">
+            {t("page.noProfileBody")}
+          </p>
+          <Link
+            href="/onboarding"
+            className="inline-block mt-2 text-sm font-medium text-[#5A7A6A] hover:text-[#2D4A3C] dark:text-sage-300 dark:hover:text-white"
+          >
+            {t("page.noProfileCta")}
+          </Link>
+        </div>
+      )}
+
+      {error && !noProfile && (
+        <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+          {error}
+        </p>
+      )}
+
+      {loading && !rankedBills.length && (
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="animate-pulse h-24 rounded-xl bg-gray-100 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700"
+            />
+          ))}
+        </div>
+      )}
+
+      {empty && (
+        <p className="text-sm text-[#4d4d4d] dark:text-gray-300">
+          {t("bills.empty")}
+        </p>
+      )}
+
+      {rankedBills.length > 0 && (
+        <div className="space-y-4">
+          {rankedBills[0] && <BillBriefingHero item={rankedBills[0]} />}
+          {rankedBills.length > 1 && (
+            <div className="space-y-3">
+              {rankedBills.slice(1).map((item) => (
+                <BillBriefingCard key={item.result.billId} item={item} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </BriefingSection>
+  );
+}

--- a/apps/frontend/components/briefing/bills/BillsTopicFilter.tsx
+++ b/apps/frontend/components/briefing/bills/BillsTopicFilter.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+
+interface BillsTopicFilterProps {
+  /** The user's stored interest tags (canonical slugs). */
+  readonly topics: readonly string[];
+}
+
+/**
+ * Read-only chip badges showing the user's interest tags. The
+ * personalized feed is already ranked against these on the backend
+ * so the chips don't filter the list client-side — they exist as a
+ * trust signal ("these are the topics driving your briefing") plus
+ * an "Edit your interests →" link out to /me/profile.
+ *
+ * When richer interactive filtering lands (e.g. multi-topic
+ * subset selection), this component is the right place to add it.
+ */
+export function BillsTopicFilter({ topics }: BillsTopicFilterProps) {
+  const { t } = useTranslation("briefing");
+  if (topics.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-2 mb-4">
+      {topics.map((topic) => (
+        <span
+          key={topic}
+          className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[#5A7A6A]/10 text-[#2D4A3C] border border-[#5A7A6A]/30 dark:bg-sage-900/30 dark:text-sage-200 dark:border-sage-700"
+        >
+          {t(`fields.interestTags.options.${topic}`, {
+            ns: "profile",
+            defaultValue: topic,
+          })}
+        </span>
+      ))}
+      <Link
+        href="/me/profile"
+        className="text-xs font-medium text-[#5A7A6A] hover:text-[#2D4A3C] dark:text-sage-300 dark:hover:text-white ml-auto"
+      >
+        {t("bills.broadenLink")}
+      </Link>
+    </div>
+  );
+}

--- a/apps/frontend/components/briefing/bills/RelevanceChip.tsx
+++ b/apps/frontend/components/briefing/bills/RelevanceChip.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+interface RelevanceChipProps {
+  /** Composite score 0.0–1.0 from the personalized-feed ranker. */
+  readonly score: number;
+  readonly size?: "sm" | "md";
+}
+
+/**
+ * Renders the 0.0–1.0 composite relevance as a percentage chip.
+ * Higher scores fill darker; this gives a quick scan signal at a
+ * glance without burying the citizen in numbers.
+ */
+function tierFor(pct: number): string {
+  if (pct >= 70) return "bg-[#5A7A6A] text-white border-[#5A7A6A]";
+  if (pct >= 40) {
+    return "bg-[#5A7A6A]/15 text-[#2D4A3C] border-[#5A7A6A]/40 dark:bg-sage-900/30 dark:text-sage-200 dark:border-sage-700";
+  }
+  return "bg-gray-100 text-gray-700 border-gray-200 dark:bg-gray-700 dark:text-gray-200 dark:border-gray-600";
+}
+
+export function RelevanceChip({ score, size = "sm" }: RelevanceChipProps) {
+  const { t } = useTranslation("briefing");
+  const pct = Math.round(score * 100);
+  const tier = tierFor(pct);
+  const sizeCls =
+    size === "md"
+      ? "px-3 py-1 text-sm font-semibold"
+      : "px-2.5 py-0.5 text-xs font-semibold";
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border ${sizeCls} ${tier}`}
+      aria-label={`${t("whyThis.scoreLabel")} ${pct}%`}
+    >
+      <span aria-hidden="true">{t("whyThis.scoreLabel")}</span>
+      <span aria-hidden="true">{pct}%</span>
+    </span>
+  );
+}

--- a/apps/frontend/components/briefing/bills/WhyThisPanel.tsx
+++ b/apps/frontend/components/briefing/bills/WhyThisPanel.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { topAxisFor, type AxisScores } from "@/lib/graphql/personalized-feed";
+
+interface WhyThisPanelProps {
+  readonly axisScores: AxisScores;
+  /**
+   * Stable id used to scope `aria-controls` between the disclosure
+   * button and its panel. Pass the bill id so multiple cards on the
+   * page have distinct ids.
+   */
+  readonly scopeId: string;
+}
+
+const AXIS_I18N: Record<keyof AxisScores, string | null> = {
+  directMaterial: "whyThis.axisDirectMaterial",
+  valuesAlignment: "whyThis.axisValuesAlignment",
+  actionability: "whyThis.axisActionability",
+  // Axes 4–7 — v1.1 placeholders, never the top reason today
+  indirectMaterial: null,
+  coalitionSignal: null,
+  counterfactual: null,
+  noveltyRepetition: null,
+};
+
+/**
+ * Collapsible disclosure that explains why a bill is on the user's
+ * briefing. v1.0 renders a heuristic sentence keyed on the top
+ * scoring axis (directMaterial / valuesAlignment / actionability).
+ * When #745 ships an LLM-written sentence the heuristic stays as
+ * the offline / opt-out fallback.
+ */
+export function WhyThisPanel({ axisScores, scopeId }: WhyThisPanelProps) {
+  const { t } = useTranslation("briefing");
+  const [open, setOpen] = useState(false);
+  const top = topAxisFor(axisScores);
+  // If the top axis itself scored zero (theoretically possible if a bill
+  // is surfaced only by axes 4-7, which today emit 0.0), the heuristic
+  // sentence is misleading — fall through to the #745 placeholder note.
+  const i18nKey = axisScores[top] > 0 ? AXIS_I18N[top] : null;
+  const panelId = `why-${scopeId}`;
+  const buttonId = `why-toggle-${scopeId}`;
+
+  return (
+    <div>
+      <button
+        id={buttonId}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className="text-xs font-medium text-[#5A7A6A] hover:text-[#2D4A3C] dark:text-sage-300 dark:hover:text-white"
+      >
+        {open ? t("whyThis.toggleClose") : t("whyThis.toggleOpen")}
+      </button>
+      {open && (
+        <div
+          id={panelId}
+          role="region"
+          aria-labelledby={buttonId}
+          className="mt-2 rounded-lg bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700 p-3 space-y-2"
+        >
+          {i18nKey ? (
+            <p className="text-sm text-[#222222] dark:text-gray-100">
+              {t(i18nKey)}
+            </p>
+          ) : null}
+          <p className="text-xs text-gray-500 dark:text-gray-400 italic">
+            {t("whyThis.placeholderFor745")}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/briefing/bills/useBillBriefing.ts
+++ b/apps/frontend/components/briefing/bills/useBillBriefing.ts
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useApolloClient, useQuery } from "@apollo/client/react";
+import { GET_BILL, type Bill, type BillData } from "@/lib/graphql/region";
+import {
+  GET_BRIEFING_PREFETCH,
+  GET_MY_PERSONALIZED_BILL_FEED,
+  stripTypename,
+  type BriefingPrefetchData,
+  type PersonalizationInput,
+  type PersonalizedBillFeedData,
+  type PersonalizedBillResult,
+} from "@/lib/graphql/personalized-feed";
+
+export interface RankedBill {
+  readonly result: PersonalizedBillResult;
+  readonly bill: Bill | null;
+}
+
+export interface BillBriefingState {
+  readonly loading: boolean;
+  readonly error: string | null;
+  /** True before the prefetch resolves (rare beyond first paint). */
+  readonly noProfile: boolean;
+  /** True after prefetch + feed resolve but the feed is empty. */
+  readonly empty: boolean;
+  readonly topicTags: readonly string[];
+  readonly rankedBills: readonly RankedBill[];
+}
+
+/**
+ * Orchestrates the three-step bill-briefing fetch:
+ *   1. `myRankingFlags` + `mySignalProfile { interestTags }`
+ *   2. `myPersonalizedBillFeed(input, limit)` — chained, requires #1
+ *   3. `bill(id)` for each returned billId — parallel; details come
+ *      from the region service since the personalized-feed resolver
+ *      returns only the ranking output (planning doc §6.3).
+ *
+ * v1.0 caveat: `bill(id)` runs N parallel requests. Apollo's
+ * normalized cache dedupes per session, but the first-paint N
+ * round-trips is what #761's batched/composite resolver eliminates.
+ */
+export function useBillBriefing(limit: number): BillBriefingState {
+  const client = useApolloClient();
+
+  const prefetch = useQuery<BriefingPrefetchData>(GET_BRIEFING_PREFETCH, {
+    fetchPolicy: "cache-and-network",
+  });
+
+  const flags = prefetch.data?.myRankingFlags;
+  const interestTags = prefetch.data?.mySignalProfile?.interestTags;
+  const input: PersonalizationInput | null = useMemo(() => {
+    if (!flags || !interestTags) return null;
+    // Strip Apollo's auto-added `__typename` before passing the flags
+    // back as a GraphQL InputType (RankingFlagsInputDto rejects the
+    // extra field). The helper is unit-tested.
+    return {
+      flags: stripTypename(flags),
+      interestTags: [...interestTags],
+    };
+  }, [flags, interestTags]);
+
+  const feed = useQuery<PersonalizedBillFeedData>(
+    GET_MY_PERSONALIZED_BILL_FEED,
+    {
+      variables: input ? { input, limit } : undefined,
+      skip: !input,
+      fetchPolicy: "cache-and-network",
+    },
+  );
+
+  const feedResults = feed.data?.myPersonalizedBillFeed;
+
+  const [bills, setBills] = useState<Map<string, Bill | null>>(new Map());
+  const [billsLoading, setBillsLoading] = useState(false);
+  const [billsError, setBillsError] = useState<string | null>(null);
+
+  /* eslint-disable react-hooks/set-state-in-effect -- Bill details
+     fan-out can't happen until the feed ids land, and Apollo
+     doesn't expose a hook-friendly way to fetch N independent
+     queries whose count is data-dependent. The effect launches an
+     out-of-band fan-out and stores the result; standard pattern
+     for "fetch N things on resolve, render when all settle". */
+  useEffect(() => {
+    if (!feedResults || feedResults.length === 0) return;
+    let cancelled = false;
+    setBillsLoading(true);
+    setBillsError(null);
+
+    Promise.all(
+      feedResults.map((r) =>
+        client
+          .query<BillData>({
+            query: GET_BILL,
+            variables: { id: r.billId },
+            fetchPolicy: "cache-first",
+          })
+          .then((res) => [r.billId, res.data?.bill ?? null] as const),
+      ),
+    )
+      .then((entries) => {
+        if (cancelled) return;
+        setBills(new Map(entries));
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setBillsError(
+          err instanceof Error ? err.message : "Failed to load bill details",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setBillsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [feedResults, client]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const rankedBills: RankedBill[] = useMemo(
+    () =>
+      (feedResults ?? []).map((r) => ({
+        result: r,
+        bill: bills.get(r.billId) ?? null,
+      })),
+    [feedResults, bills],
+  );
+
+  const noProfile =
+    !prefetch.loading && (!flags || !interestTags || interestTags.length === 0);
+
+  const queryError = prefetch.error ?? feed.error;
+  const loading =
+    prefetch.loading || feed.loading || (!!feedResults && billsLoading);
+  const empty = !loading && (feedResults?.length ?? 0) === 0 && !noProfile;
+  const error = queryError?.message ?? billsError ?? null;
+
+  return {
+    loading,
+    error,
+    noProfile,
+    empty,
+    topicTags: interestTags ?? [],
+    rankedBills,
+  };
+}

--- a/apps/frontend/components/briefing/placeholders/CommitteesBriefingPlaceholder.tsx
+++ b/apps/frontend/components/briefing/placeholders/CommitteesBriefingPlaceholder.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { BriefingSection } from "../BriefingSection";
+import { PlaceholderBody } from "./PlaceholderBody";
+
+const COMMITTEES_ISSUE = 770;
+
+export function CommitteesBriefingPlaceholder() {
+  const { t } = useTranslation("briefing");
+  return (
+    <BriefingSection
+      slug="committees"
+      title={t("committees.title")}
+      subtitle={t("committees.subtitle")}
+      seeAllHref="/region/legislative-committees"
+      icon={
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M4 20h16M5 20v-7m14 7v-7M5 13h14M6 13V9a6 6 0 0112 0v4M12 3v3"
+          />
+        </svg>
+      }
+    >
+      <PlaceholderBody i18nKey="committees" issueNumber={COMMITTEES_ISSUE} />
+    </BriefingSection>
+  );
+}

--- a/apps/frontend/components/briefing/placeholders/PlaceholderBody.tsx
+++ b/apps/frontend/components/briefing/placeholders/PlaceholderBody.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+interface PlaceholderBodyProps {
+  /** i18n key root under `briefing.{slug}.placeholder` — body + comingSoonNote. */
+  readonly i18nKey: "reps" | "committees" | "propositions";
+  /** Issue number that will replace the placeholder when shipped. */
+  readonly issueNumber: number;
+}
+
+/**
+ * Shared body for the three personalization-pending BriefingSection
+ * cards. Renders the "what's coming" copy + a small disclosure note
+ * that points at the tracking issue. Honest about the gap; the
+ * `<BriefingSection>`'s own "See all →" already wires the user out
+ * to the existing /region/* browse surface.
+ */
+export function PlaceholderBody({
+  i18nKey,
+  issueNumber,
+}: PlaceholderBodyProps) {
+  const { t } = useTranslation("briefing");
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-[#4d4d4d] dark:text-gray-300">
+        {t(`${i18nKey}.placeholder.body`)}
+      </p>
+      <p className="text-xs text-gray-500 dark:text-gray-400 italic">
+        {t(`${i18nKey}.placeholder.comingSoonNote`)}
+        <span className="ml-1">(#{issueNumber})</span>
+      </p>
+    </div>
+  );
+}

--- a/apps/frontend/components/briefing/placeholders/PropositionsBriefingPlaceholder.tsx
+++ b/apps/frontend/components/briefing/placeholders/PropositionsBriefingPlaceholder.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { BriefingSection } from "../BriefingSection";
+import { PlaceholderBody } from "./PlaceholderBody";
+
+const PROPOSITIONS_ISSUE = 771;
+
+export function PropositionsBriefingPlaceholder() {
+  const { t } = useTranslation("briefing");
+  return (
+    <BriefingSection
+      slug="propositions"
+      title={t("propositions.title")}
+      subtitle={t("propositions.subtitle")}
+      seeAllHref="/region/propositions"
+      icon={
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+      }
+    >
+      <PlaceholderBody
+        i18nKey="propositions"
+        issueNumber={PROPOSITIONS_ISSUE}
+      />
+    </BriefingSection>
+  );
+}

--- a/apps/frontend/components/briefing/placeholders/RepsBriefingPlaceholder.tsx
+++ b/apps/frontend/components/briefing/placeholders/RepsBriefingPlaceholder.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+import { BriefingSection } from "../BriefingSection";
+import { PlaceholderBody } from "./PlaceholderBody";
+
+const REPS_ISSUE = 769;
+
+export function RepsBriefingPlaceholder() {
+  const { t } = useTranslation("briefing");
+  return (
+    <BriefingSection
+      slug="reps"
+      title={t("reps.title")}
+      subtitle={t("reps.subtitle")}
+      seeAllHref="/region/representatives"
+      icon={
+        <svg
+          className="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+          />
+        </svg>
+      }
+    >
+      <PlaceholderBody i18nKey="reps" issueNumber={REPS_ISSUE} />
+    </BriefingSection>
+  );
+}

--- a/apps/frontend/components/landing/LandingCTA.tsx
+++ b/apps/frontend/components/landing/LandingCTA.tsx
@@ -17,7 +17,7 @@ export function LandingCTA() {
   if (isAuthenticated) {
     return (
       <Link
-        href="/region"
+        href="/me/briefing"
         className="inline-block px-8 py-3 bg-[#5A7A6A] text-white text-lg font-semibold rounded-lg hover:bg-[#4A6A5A] transition-colors"
       >
         {t("hero.ctaSignedIn")}

--- a/apps/frontend/components/onboarding/OnboardingSteps.tsx
+++ b/apps/frontend/components/onboarding/OnboardingSteps.tsx
@@ -31,12 +31,12 @@ export function OnboardingSteps() {
 
   const handleComplete = () => {
     completeOnboarding();
-    router.push("/region");
+    router.push("/me/briefing");
   };
 
   const handleSkip = () => {
     skipOnboarding();
-    router.push("/region");
+    router.push("/me/briefing");
   };
 
   const isLastStep = currentStep === totalSteps - 1;

--- a/apps/frontend/e2e/briefing.spec.ts
+++ b/apps/frontend/e2e/briefing.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Civic briefing home page E2E (#744).
+ *
+ * Covers the AC-required behaviors: page renders for authed users,
+ * navigation in + out (Header, "Browse all civic data →", placeholder
+ * see-all linkouts), unauthenticated → /login redirect, plus WCAG 2.2
+ * AA axe scans. Per-bill content rendering + Why-this expansion are
+ * covered by unit tests against the components.
+ */
+import { test, expect, type Page } from "@playwright/test";
+import {
+  setupAuthSession,
+  checkAccessibility,
+  viewports,
+} from "./utils/test-helpers";
+
+async function setupAuthed(page: Page) {
+  await setupAuthSession(page);
+}
+
+// The settings shell's mobile sidebar overlap (#766) doesn't apply to
+// the briefing page (it uses the Header/Footer pattern, not the
+// settings shell), but we keep the mobile-skip pattern available in
+// case other mobile-only chrome issues surface.
+const MOBILE_PROJECTS = ["mobile-chrome", "mobile-safari"];
+
+test.describe("Civic briefing page", () => {
+  test("authenticated user lands on the page with header + four sections", async ({
+    page,
+  }) => {
+    await setupAuthed(page);
+    await page.goto("/me/briefing");
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /your civic briefing/i }),
+    ).toBeVisible();
+
+    // 4 section headings (Bills + Reps + Committees + Propositions)
+    const sectionHeadings = page.getByRole("heading", { level: 2 });
+    await expect(sectionHeadings).toHaveCount(4);
+  });
+
+  test("Browse all civic data → navigates to /region", async ({ page }) => {
+    await setupAuthed(page);
+    await page.goto("/me/briefing");
+
+    const link = page.getByRole("link", {
+      name: /browse all civic data/i,
+    });
+    await expect(link).toHaveAttribute("href", "/region");
+  });
+
+  test("Reps placeholder See all → /region/representatives", async ({
+    page,
+  }) => {
+    await setupAuthed(page);
+    await page.goto("/me/briefing");
+
+    const repsSection = page.locator('[data-section="reps"]');
+    await expect(repsSection).toBeVisible();
+    await expect(
+      repsSection.getByRole("link", { name: /see all/i }),
+    ).toHaveAttribute("href", "/region/representatives");
+  });
+
+  test("Committees placeholder See all → /region/legislative-committees", async ({
+    page,
+  }) => {
+    await setupAuthed(page);
+    await page.goto("/me/briefing");
+
+    const section = page.locator('[data-section="committees"]');
+    await expect(section).toBeVisible();
+    await expect(
+      section.getByRole("link", { name: /see all/i }),
+    ).toHaveAttribute("href", "/region/legislative-committees");
+  });
+
+  test("Propositions placeholder See all → /region/propositions", async ({
+    page,
+  }) => {
+    await setupAuthed(page);
+    await page.goto("/me/briefing");
+
+    const section = page.locator('[data-section="propositions"]');
+    await expect(section).toBeVisible();
+    await expect(
+      section.getByRole("link", { name: /see all/i }),
+    ).toHaveAttribute("href", "/region/propositions");
+  });
+
+  test("Bills section See all → /region/bills", async ({ page }) => {
+    await setupAuthed(page);
+    await page.goto("/me/briefing");
+
+    const section = page.locator('[data-section="bills"]');
+    await expect(section).toBeVisible();
+    await expect(
+      section.getByRole("link", { name: /see all/i }),
+    ).toHaveAttribute("href", "/region/bills");
+  });
+
+  test("Header includes a Briefing nav link back to /me/briefing", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      MOBILE_PROJECTS.includes(testInfo.project.name),
+      "Header desktop nav is hidden < md viewport; mobile menu flow is unit-tested in Header.test.tsx",
+    );
+    await setupAuthed(page);
+    await page.goto("/region");
+
+    // Header should expose the Briefing link for authed users.
+    await expect(
+      page.getByRole("link", { name: /^briefing$/i }),
+    ).toHaveAttribute("href", "/me/briefing");
+  });
+
+  test("Logo in the Header points at the briefing when authenticated", async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      MOBILE_PROJECTS.includes(testInfo.project.name),
+      "Mobile logo behavior is identical but the desktop nav assertion shape varies — covered by Header unit tests",
+    );
+    await setupAuthed(page);
+    await page.goto("/region");
+
+    const logoLink = page.getByRole("link", { name: /opus populi/i }).first();
+    await expect(logoLink).toHaveAttribute("href", "/me/briefing");
+  });
+
+  test("unauthenticated user is redirected to /login", async ({ page }) => {
+    await page.goto("/me/briefing");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("displays correctly on mobile", async ({ page }, testInfo) => {
+    test.skip(
+      MOBILE_PROJECTS.includes(testInfo.project.name),
+      "Header mobile menu interaction covered by Header unit tests; this only asserts render",
+    );
+    await setupAuthed(page);
+    await page.setViewportSize(viewports.mobile);
+    await page.goto("/me/briefing");
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: /your civic briefing/i }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("Civic briefing — Accessibility (WCAG 2.2 AA)", () => {
+  test("default state has no violations", async ({ page }) => {
+    await setupAuthed(page);
+    await page.goto("/me/briefing");
+    await expect(
+      page.getByRole("heading", { level: 1, name: /your civic briefing/i }),
+    ).toBeVisible();
+    expect(await checkAccessibility(page)).toEqual([]);
+  });
+});

--- a/apps/frontend/e2e/onboarding.spec.ts
+++ b/apps/frontend/e2e/onboarding.spec.ts
@@ -106,7 +106,7 @@ test.describe("Onboarding Flow", () => {
 
     // Last data step's primary action is "Get Started".
     await page.getByRole("button", { name: /get started/i }).click();
-    await expect(page).toHaveURL(/\/region/);
+    await expect(page).toHaveURL(/\/me\/briefing/);
   });
 
   test("global Skip aborts entire flow from any step", async ({ page }) => {
@@ -116,7 +116,7 @@ test.describe("Onboarding Flow", () => {
     // The header "Skip" button is the global abort; data steps render
     // "Skip this" for the per-field skip.
     await page.getByRole("button", { name: "Skip", exact: true }).click();
-    await expect(page).toHaveURL(/\/region/);
+    await expect(page).toHaveURL(/\/me\/briefing/);
   });
 
   test("should navigate back to previous step", async ({ page }) => {
@@ -150,7 +150,7 @@ test.describe("Onboarding Flow", () => {
     expect(before).toBeNull();
 
     await page.getByRole("button", { name: "Skip", exact: true }).click();
-    await expect(page).toHaveURL(/\/region/);
+    await expect(page).toHaveURL(/\/me\/briefing/);
 
     const completed = await page.evaluate(() =>
       localStorage.getItem("opuspopuli_onboarding_completed"),
@@ -297,7 +297,7 @@ test.describe("Onboarding - Returning User", () => {
   test("should redirect completed user to /region", async ({ page }) => {
     await setupReturningUserSession(page);
     await page.goto("/onboarding");
-    await expect(page).toHaveURL(/\/region/);
+    await expect(page).toHaveURL(/\/me\/briefing/);
   });
 });
 

--- a/apps/frontend/lib/graphql/personalized-feed.ts
+++ b/apps/frontend/lib/graphql/personalized-feed.ts
@@ -1,0 +1,163 @@
+import { gql } from "@apollo/client";
+
+// ============================================
+// Personalized bill feed (#743 / #744).
+//
+// Two queries chain here:
+//   1. `myRankingFlags` + `mySignalProfile { interestTags }` from the
+//      users service — these are the 20 boolean derivations + the
+//      user's declared topics. v1.0 of the federation boundary
+//      (planning doc §6.3) requires the frontend to pass these into
+//      the feed resolver as arguments; #761 will collapse this into
+//      a subgraph-to-subgraph call so the frontend only sees the feed.
+//   2. `myPersonalizedBillFeed(input, limit)` from the knowledge
+//      service — returns ranked `PersonalizedBillResult[]` with
+//      `billId`, `relevanceScore`, and the per-axis breakdown. Bill
+//      details (title, summary, status, …) are *not* embedded — the
+//      frontend resolves them via region's existing `bill(id)` query
+//      one step later (see GET_BILL_BY_ID in `region.ts`).
+//
+// v1.0 known shape: axes 1–3 (directMaterial / valuesAlignment /
+// actionability) are populated; axes 4–7 are placeholder 0.0 until
+// the planning-doc §5.1 follow-ups land.
+// ============================================
+
+export interface RankingFlags {
+  // T1/T2-derived
+  isRenter: boolean;
+  isHomeowner: boolean;
+  isParent: boolean;
+  isCaregiver: boolean;
+  isStudent: boolean;
+  isEducator: boolean;
+  isWorker: boolean;
+  isBusinessOwner: boolean;
+  isUnionMember: boolean;
+  isGigWorker: boolean;
+  isTransitRider: boolean;
+  isDriver: boolean;
+  hasSpecialLicense: boolean;
+  // T3-derived (masked when noFieldsMode is on)
+  hasImmigrationConcern: boolean;
+  hasHealthCondition: boolean;
+  hasPublicHealthInsurance: boolean;
+  isVeteran: boolean;
+  hasJusticeInvolvement: boolean;
+  isLowIncome: boolean;
+  receivesPublicBenefits: boolean;
+}
+
+export interface BriefingPrefetchData {
+  myRankingFlags: RankingFlags;
+  mySignalProfile: { interestTags: string[] } | null;
+}
+
+export const GET_BRIEFING_PREFETCH = gql`
+  query BriefingPrefetch {
+    myRankingFlags {
+      isRenter
+      isHomeowner
+      isParent
+      isCaregiver
+      isStudent
+      isEducator
+      isWorker
+      isBusinessOwner
+      isUnionMember
+      isGigWorker
+      isTransitRider
+      isDriver
+      hasSpecialLicense
+      hasImmigrationConcern
+      hasHealthCondition
+      hasPublicHealthInsurance
+      isVeteran
+      hasJusticeInvolvement
+      isLowIncome
+      receivesPublicBenefits
+    }
+    mySignalProfile {
+      interestTags
+    }
+  }
+`;
+
+export interface AxisScores {
+  /** Axis 1: does this change the user's money, rights, health, services? */
+  directMaterial: number;
+  /** Axis 2: does it advance or threaten priorities the user declared? */
+  valuesAlignment: number;
+  /** Axis 3: is there a vote / comment window the user can affect now? */
+  actionability: number;
+  // Axes 4-7 — placeholder 0.0 in v1.0 (planning doc §5.1 follow-ups)
+  indirectMaterial: number;
+  coalitionSignal: number;
+  counterfactual: number;
+  noveltyRepetition: number;
+}
+
+export interface PersonalizedBillResult {
+  billId: string;
+  relevanceScore: number;
+  axisScores: AxisScores;
+}
+
+export interface PersonalizedBillFeedData {
+  myPersonalizedBillFeed: PersonalizedBillResult[];
+}
+
+export interface PersonalizationInput {
+  flags: RankingFlags;
+  interestTags: string[];
+}
+
+export const GET_MY_PERSONALIZED_BILL_FEED = gql`
+  query MyPersonalizedBillFeed($input: PersonalizationInputDto!, $limit: Int!) {
+    myPersonalizedBillFeed(input: $input, limit: $limit) {
+      billId
+      relevanceScore
+      axisScores {
+        directMaterial
+        valuesAlignment
+        actionability
+        indirectMaterial
+        coalitionSignal
+        counterfactual
+        noveltyRepetition
+      }
+    }
+  }
+`;
+
+/**
+ * Apollo Client auto-decorates every fetched object with `__typename`
+ * (and for our RankingFlags it tags it as "RankingFlags"). When that
+ * shape is fed back as the `RankingFlagsInputDto` argument of the
+ * `myPersonalizedBillFeed` mutation, the InputType validator on the
+ * server rejects the extra `__typename` field. Strip it before
+ * passing the object back over the wire.
+ */
+export function stripTypename<T extends object>(obj: T): Omit<T, "__typename"> {
+  const { __typename: _typename, ...rest } = obj as T & {
+    __typename?: string;
+  };
+  return rest;
+}
+
+/**
+ * Convenience: the AC asks for a "Why this matters to you" affordance
+ * keyed on the axis scores. This pulls the top-scoring axis to drive
+ * the i18n explanation we render today. When #745 ships an LLM-written
+ * sentence the frontend stops reading this — but the heuristic stays
+ * as a fallback when the LLM is offline or the user opted out.
+ */
+export function topAxisFor(scores: AxisScores): keyof AxisScores {
+  const axes: (keyof AxisScores)[] = [
+    "directMaterial",
+    "valuesAlignment",
+    "actionability",
+  ];
+  return axes.reduce((best, axis) =>
+    (scores[axis] ?? 0) > (scores[best] ?? 0) ? axis : best,
+  );
+}

--- a/apps/frontend/lib/graphql/personalized-feed.ts
+++ b/apps/frontend/lib/graphql/personalized-feed.ts
@@ -138,9 +138,8 @@ export const GET_MY_PERSONALIZED_BILL_FEED = gql`
  * passing the object back over the wire.
  */
 export function stripTypename<T extends object>(obj: T): Omit<T, "__typename"> {
-  const { __typename: _typename, ...rest } = obj as T & {
-    __typename?: string;
-  };
+  const rest = { ...obj } as Omit<T, "__typename"> & { __typename?: string };
+  delete rest.__typename;
   return rest;
 }
 
@@ -157,7 +156,8 @@ export function topAxisFor(scores: AxisScores): keyof AxisScores {
     "valuesAlignment",
     "actionability",
   ];
-  return axes.reduce((best, axis) =>
-    (scores[axis] ?? 0) > (scores[best] ?? 0) ? axis : best,
+  return axes.reduce<keyof AxisScores>(
+    (best, axis) => ((scores[axis] ?? 0) > (scores[best] ?? 0) ? axis : best),
+    axes[0],
   );
 }

--- a/apps/frontend/lib/i18n/index.ts
+++ b/apps/frontend/lib/i18n/index.ts
@@ -8,6 +8,7 @@ import enPetition from "@/locales/en/petition.json";
 import enLanding from "@/locales/en/landing.json";
 import enCivics from "@/locales/en/civics.json";
 import enProfile from "@/locales/en/profile.json";
+import enBriefing from "@/locales/en/briefing.json";
 import esCommon from "@/locales/es/common.json";
 import esSettings from "@/locales/es/settings.json";
 import esOnboarding from "@/locales/es/onboarding.json";
@@ -15,6 +16,7 @@ import esPetition from "@/locales/es/petition.json";
 import esLanding from "@/locales/es/landing.json";
 import esCivics from "@/locales/es/civics.json";
 import esProfile from "@/locales/es/profile.json";
+import esBriefing from "@/locales/es/briefing.json";
 
 export const defaultNS = "common";
 export const supportedLanguages = ["en", "es"] as const;
@@ -29,6 +31,7 @@ export const resources = {
     landing: enLanding,
     civics: enCivics,
     profile: enProfile,
+    briefing: enBriefing,
   },
   es: {
     common: esCommon,
@@ -38,6 +41,7 @@ export const resources = {
     landing: esLanding,
     civics: esCivics,
     profile: esProfile,
+    briefing: esBriefing,
   },
 } as const;
 

--- a/apps/frontend/locales/en/briefing.json
+++ b/apps/frontend/locales/en/briefing.json
@@ -1,0 +1,60 @@
+{
+  "page": {
+    "title": "Your Civic Briefing",
+    "subtitle": "Bills, representatives, and propositions ranked by what matters to your life — based on the signals you've shared.",
+    "browseAllLink": "Browse all civic data →",
+    "browseAllAria": "Browse all civic data — go to the data hub",
+    "errorTitle": "We couldn't load your briefing.",
+    "noProfileTitle": "Tell us what matters to you",
+    "noProfileBody": "Onboarding takes about a minute and unlocks the personalized feed.",
+    "noProfileCta": "Complete onboarding →"
+  },
+  "section": {
+    "seeAll": "See all →"
+  },
+  "bills": {
+    "title": "Bills moving this week",
+    "subtitle": "Legislation ranked by relevance to your interests + life context.",
+    "empty": "No bills above your relevance threshold this week. Broaden your interests to see more.",
+    "broadenLink": "Edit your interests →",
+    "statusLabel": "Status:",
+    "readBillLink": "Read the bill →"
+  },
+  "reps": {
+    "title": "Your representatives",
+    "subtitle": "What the people who represent you are doing this week.",
+    "placeholder": {
+      "body": "Personalized rep activity (upcoming votes, recent stances, public events) is coming soon. Until then, browse representatives in your jurisdictions.",
+      "comingSoonNote": "We'll show ranked moments from your reps here once that signal pipeline ships."
+    }
+  },
+  "committees": {
+    "title": "Committees on your topics",
+    "subtitle": "Hearings + comment windows in your jurisdictions, ranked by topic match.",
+    "placeholder": {
+      "body": "Personalized committee briefings are coming soon. Until then, browse all legislative committees.",
+      "comingSoonNote": "We'll show hearings + open comment windows ranked for you once that signal pipeline ships."
+    }
+  },
+  "propositions": {
+    "title": "Active propositions",
+    "subtitle": "Ballot measures in your jurisdictions, ranked by relevance + your trusted organizations.",
+    "placeholder": {
+      "body": "Personalized proposition briefings are coming soon. Until then, browse all active ballot measures.",
+      "comingSoonNote": "We'll show ranked props with trusted-org endorsements here once that signal pipeline ships."
+    }
+  },
+  "whyThis": {
+    "toggleOpen": "Why is this on my briefing?",
+    "toggleClose": "Hide reason",
+    "axisDirectMaterial": "Touches your money, rights, health, or services.",
+    "axisValuesAlignment": "Aligns with topics you said you care about.",
+    "axisActionability": "Has a vote or comment window you can influence soon.",
+    "placeholderFor745": "We'll write you a plain-language sentence here once the LLM explanation pipeline ships.",
+    "scoreLabel": "Relevance"
+  },
+  "stubs": {
+    "counterFrame": "The opposing position will show here once the counter-frame pipeline ships.",
+    "actionAffordances": "Vote dates, comment windows, and contact buttons will surface here once that data lands."
+  }
+}

--- a/apps/frontend/locales/es/briefing.json
+++ b/apps/frontend/locales/es/briefing.json
@@ -1,0 +1,60 @@
+{
+  "page": {
+    "title": "Tu Resumen Cívico",
+    "subtitle": "Proyectos de ley, representantes y proposiciones priorizados según lo que importa a tu vida — basado en las señales que has compartido.",
+    "browseAllLink": "Explora todos los datos cívicos →",
+    "browseAllAria": "Explora todos los datos cívicos — ir al centro de datos",
+    "errorTitle": "No pudimos cargar tu resumen.",
+    "noProfileTitle": "Cuéntanos qué te importa",
+    "noProfileBody": "La incorporación toma aproximadamente un minuto y desbloquea el feed personalizado.",
+    "noProfileCta": "Completar incorporación →"
+  },
+  "section": {
+    "seeAll": "Ver todo →"
+  },
+  "bills": {
+    "title": "Proyectos de ley esta semana",
+    "subtitle": "Legislación priorizada por relevancia para tus intereses y contexto de vida.",
+    "empty": "Ningún proyecto sobre tu umbral de relevancia esta semana. Amplía tus intereses para ver más.",
+    "broadenLink": "Editar tus intereses →",
+    "statusLabel": "Estado:",
+    "readBillLink": "Leer el proyecto →"
+  },
+  "reps": {
+    "title": "Tus representantes",
+    "subtitle": "Lo que están haciendo esta semana las personas que te representan.",
+    "placeholder": {
+      "body": "La actividad personalizada de tus representantes (votos próximos, posiciones recientes, eventos públicos) llegará pronto. Por ahora, explora los representantes de tus jurisdicciones.",
+      "comingSoonNote": "Mostraremos aquí momentos priorizados de tus representantes cuando esa señal esté lista."
+    }
+  },
+  "committees": {
+    "title": "Comités sobre tus temas",
+    "subtitle": "Audiencias y ventanas de comentarios en tus jurisdicciones, priorizadas por coincidencia temática.",
+    "placeholder": {
+      "body": "Los resúmenes personalizados de comités llegarán pronto. Por ahora, explora todos los comités legislativos.",
+      "comingSoonNote": "Mostraremos aquí audiencias y ventanas abiertas priorizadas para ti cuando esa señal esté lista."
+    }
+  },
+  "propositions": {
+    "title": "Proposiciones activas",
+    "subtitle": "Medidas electorales en tus jurisdicciones, priorizadas por relevancia y por tus organizaciones de confianza.",
+    "placeholder": {
+      "body": "Los resúmenes personalizados de proposiciones llegarán pronto. Por ahora, explora todas las medidas electorales activas.",
+      "comingSoonNote": "Mostraremos aquí proposiciones priorizadas con respaldos de organizaciones de confianza cuando esa señal esté lista."
+    }
+  },
+  "whyThis": {
+    "toggleOpen": "¿Por qué esto está en mi resumen?",
+    "toggleClose": "Ocultar razón",
+    "axisDirectMaterial": "Afecta tu dinero, derechos, salud o servicios.",
+    "axisValuesAlignment": "Coincide con temas que dijiste que te importan.",
+    "axisActionability": "Tiene una votación o ventana de comentarios que puedes influir pronto.",
+    "placeholderFor745": "Escribiremos aquí una frase en lenguaje claro cuando el pipeline de explicación con IA esté listo.",
+    "scoreLabel": "Relevancia"
+  },
+  "stubs": {
+    "counterFrame": "La posición opuesta aparecerá aquí cuando se active el pipeline de contracuadro.",
+    "actionAffordances": "Fechas de votación, ventanas de comentarios y botones de contacto aparecerán aquí cuando esos datos estén disponibles."
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ As-built documentation describing how the system is designed and implemented.
 - [**Provider Pattern**](architecture/provider-pattern.md) - Pluggable provider architecture
 - [**Data Layer**](architecture/data-layer.md) - Database, vector storage, and user profile data architecture
 - [**AI/ML Pipeline**](architecture/ai-ml-pipeline.md) - Embeddings, RAG, and LLM architecture
+- [**Personalized Civic Relevance**](architecture/personalized-relevance.md) - Signal taxonomy, T1/T2/T3 tiers, ranking axes, model-of-me + briefing design (epic #740)
 - [**Frontend Architecture**](architecture/frontend-architecture.md) - React/Next.js frontend design
 - [**Deployment Architecture**](architecture/deployment.md) - Deployment topology, networking, and multi-environment strategy
 - [**Async Workers**](architecture/async-workers.md) - BullMQ worker pattern, `pipeline_jobs` table, adding new workers
@@ -69,6 +70,7 @@ Practical guides for common tasks and workflows.
 
 ### For AI/ML Engineers
 - [AI/ML Pipeline](architecture/ai-ml-pipeline.md)
+- [Personalized Civic Relevance](architecture/personalized-relevance.md) - Signal taxonomy + relevance scoring
 - [LLM Configuration](guides/llm-configuration.md)
 - [RAG Implementation](guides/rag-implementation.md)
 

--- a/docs/architecture/frontend-architecture.md
+++ b/docs/architecture/frontend-architecture.md
@@ -34,14 +34,19 @@ apps/frontend/
 │   │   ├── forgot-password/  # Password reset request
 │   │   └── reset-password/   # Password reset form
 │   ├── onboarding/           # First-time user onboarding (4 steps)
+│   ├── me/                   # Post-auth personal surfaces
+│   │   ├── briefing/         # "Your Civic Briefing" — post-auth landing page (#744)
+│   │   └── profile/          # Per-field model-of-me editor (#752)
 │   ├── petition/             # Petition feature
 │   │   ├── capture/          # Camera-based petition scanning
 │   │   └── results/          # Petition analysis results & ballot linking
 │   ├── rag-demo/             # RAG Demo (document indexing & querying)
-│   ├── region/               # Civic data browsing
+│   ├── region/               # Civic data browsing (non-personalized)
 │   │   ├── meetings/         # Public meeting agendas & minutes
 │   │   ├── propositions/     # Ballot propositions & measures
-│   │   └── representatives/  # Elected officials directory
+│   │   ├── representatives/  # Elected officials directory
+│   │   ├── bills/            # Legislative bills
+│   │   └── legislative-committees/ # Committees
 │   ├── settings/             # User settings pages
 │   │   ├── page.tsx          # Profile settings
 │   │   ├── activity/         # Activity log & session management
@@ -77,17 +82,34 @@ apps/frontend/
 │   │   └── TrackOnBallotButton.tsx      # Search & link petitions to ballot measures
 │   ├── onboarding/
 │   │   ├── OnboardingSteps.tsx        # Step container/navigation
-│   │   └── steps/
-│   │       ├── WelcomeStep.tsx        # Step 1: Welcome
-│   │       ├── ScanStep.tsx           # Step 2: Scan petitions
-│   │       ├── TrackStep.tsx          # Step 3: Track civic data
-│   │       └── AnalyzeStep.tsx        # Step 4: AI analysis
-│   └── profile/              # Profile management
-│       ├── AvatarUpload.tsx
-│       ├── CivicFieldsSection.tsx
-│       ├── DemographicFieldsSection.tsx
-│       ├── ProfileCompletionIndicator.tsx
-│       └── ProfileVisibilityToggle.tsx
+│   │   ├── ChipPicker.tsx             # Top-3 chip selector used in tier-1 steps
+│   │   ├── StepFooter.tsx             # Shared Back/Next/Skip footer
+│   │   └── steps/                     # 4 onboarding step pages
+│   ├── briefing/             # Your Civic Briefing landing page (#744) — see README.md
+│   │   ├── BriefingPage.tsx           # Shell composer (header + 4 sections)
+│   │   ├── BriefingPageHeader.tsx     # H1 + Browse all civic data link
+│   │   ├── BriefingPageSkeleton.tsx
+│   │   ├── BriefingPageError.tsx
+│   │   ├── BriefingSection.tsx        # Domain-agnostic section shell
+│   │   ├── bills/                     # Bills personalization (3-step fetch)
+│   │   │   ├── BillsBriefingSection.tsx
+│   │   │   ├── useBillBriefing.ts     # Orchestrates prefetch → feed → bill fan-out
+│   │   │   ├── BillBriefingHero.tsx
+│   │   │   ├── BillBriefingCard.tsx
+│   │   │   ├── BillsTopicFilter.tsx
+│   │   │   ├── RelevanceChip.tsx
+│   │   │   └── WhyThisPanel.tsx
+│   │   └── placeholders/              # #769/#770/#771 plug in here
+│   ├── profile/              # Per-field model-of-me editor (#752) — see README.md
+│   │   ├── ModelOfMePage.tsx          # Inline-edit composer for ~50 signal fields
+│   │   ├── EditableField.tsx          # Per-field dispatcher (7 input variants)
+│   │   ├── inputs.tsx
+│   │   ├── CategorySection.tsx
+│   │   ├── NoFieldsModePanel.tsx
+│   │   ├── ClearFieldDialog.tsx
+│   │   ├── AvatarUpload.tsx           # Reused from /settings
+│   │   ├── ProfileCompletionIndicator.tsx
+│   │   └── ProfileVisibilityToggle.tsx
 ├── lib/                       # Shared utilities
 │   ├── apollo-client.ts      # Apollo Client configuration
 │   ├── apollo-provider.tsx   # Apollo Provider wrapper
@@ -112,7 +134,8 @@ apps/frontend/
 │       ├── knowledge.ts      # RAG: index, query, search
 │       ├── activity.ts       # Activity log & session management
 │       ├── email.ts          # Email correspondence & representative contact
-│       ├── region.ts         # Civic data: propositions, meetings, representatives
+│       ├── region.ts         # Civic data: propositions, meetings, representatives, bills
+│       ├── personalized-feed.ts # SignalProfile prefetch + myPersonalizedBillFeed (#744)
 │       └── documents.ts      # Document location management
 ├── locales/                   # Translation files
 │   ├── en/                   # English
@@ -138,12 +161,21 @@ app/
 ├── page.tsx               # Home page (/)
 ├── (auth)/                # Auth route group (login, register, callback)
 ├── onboarding/            # First-time user flow (/onboarding)
+├── me/                    # Post-auth personal surfaces
+│   ├── briefing/          # Your Civic Briefing — post-auth landing (/me/briefing)
+│   └── profile/           # Per-field model-of-me editor (/me/profile)
 ├── petition/capture/      # Petition scanning (/petition/capture)
 ├── petition/results/      # Petition analysis & ballot linking (/petition/results)
 ├── rag-demo/              # RAG Demo (/rag-demo)
 ├── region/                # Civic data (/region, /region/meetings, etc.)
 └── settings/              # User settings (/settings, /settings/security, etc.)
 ```
+
+**Post-auth landing page**: completed onboarding flows and magic-link
+callbacks now resolve to `/me/briefing` (the personalized civic
+briefing), not `/region`. The Header's logo links to `/me/briefing`
+when the user is authenticated and `/` otherwise. See
+`components/briefing/README.md` for the composition pattern.
 
 **Key Features**:
 - Server Components by default for improved performance
@@ -179,7 +211,8 @@ All GraphQL queries and mutations are centralized in `lib/graphql/`:
 | **knowledge.ts** | IndexDocument, AnswerQuery, SearchText |
 | **activity.ts** | GetMyActivityLog, GetMyActivitySummary, GetMySessions, RevokeSession, RevokeAllOtherSessions |
 | **email.ts** | GetEmailHistory, GetEmail, ContactRepresentative, GetMailtoLink |
-| **region.ts** | GetRegionInfo, GetPropositions, GetMeetings, GetRepresentatives, SyncAll, SyncDataType |
+| **region.ts** | GetRegionInfo, GetPropositions, GetMeetings, GetRepresentatives, GetBill, SyncAll, SyncDataType |
+| **personalized-feed.ts** | BriefingPrefetch (`myRankingFlags` + `mySignalProfile.interestTags`), MyPersonalizedBillFeed, `stripTypename` helper, `topAxisFor` helper |
 | **documents.ts** | SetDocumentLocation, AnalyzeDocument, GetLinkedPropositions, SearchPropositions, LinkDocumentToProposition, UnlinkDocumentFromProposition, GetPetitionDocumentsForProposition, PetitionActivityFeed |
 
 ```typescript
@@ -584,13 +617,13 @@ The i18n system is initialized globally via `lib/i18n/index.ts` (imported in `je
 ```
 apps/frontend/locales/
 ├── en/
-│   ├── common.json     # Shared (buttons, errors, status, accessibility)
-│   ├── settings.json   # Settings pages
-│   └── petition.json   # Petition feature (results, ballot tracking)
-└── es/
-    ├── common.json
-    ├── settings.json
-    └── petition.json
+│   ├── common.json      # Shared (buttons, errors, status, accessibility)
+│   ├── settings.json    # Settings pages
+│   ├── petition.json    # Petition feature (results, ballot tracking)
+│   ├── onboarding.json  # First-time onboarding flow
+│   ├── profile.json     # Model-of-me page (/me/profile)
+│   └── briefing.json    # Your Civic Briefing (/me/briefing)
+└── es/                  # Spanish parity for every namespace above
 ```
 
 ### Key Files
@@ -648,6 +681,9 @@ function LanguageSelector() {
 | `common` | Shared UI elements (buttons, errors, status badges) |
 | `settings` | Settings pages (profile, addresses, notifications, privacy, security) |
 | `petition` | Petition feature (results, ballot tracking, activity feed) |
+| `onboarding` | First-time user onboarding (4 steps + top-3 chip pickers) |
+| `profile` | `/me/profile` per-field editor (category labels, field metadata, no-fields mode) |
+| `briefing` | `/me/briefing` page chrome, section titles, "why this" axis explanations, placeholders |
 
 ### Profile-Specific Translation Keys
 

--- a/docs/architecture/personalized-relevance.md
+++ b/docs/architecture/personalized-relevance.md
@@ -1,0 +1,961 @@
+# Personalized Civic Relevance
+
+**Status:** Active — Phases 0 + 1 shipped to `develop`; Phase 2 in flight
+**Owner:** Opus Populi platform team
+**Last updated:** 2026-05-29
+**Related work:** Epic #740 (personalized bill feed), shipped issues #742 / #758 / #752 / #743 / #744
+**Audiences:** internal engineering · citizens & users · grant reviewers & funders
+
+> *"Everyone attempting to pay attention to everything is useless. Focused groups of people paying attention to things that matter to them deeply can change the world for the better."*
+
+This document defines how Opus Populi turns minimal, user-controlled information into a personalized civic relevance signal — so a busy citizen can spend ten minutes a week and know, with confidence, which bills, propositions, and meetings actually matter to them and what they can do about them.
+
+It is intended to be read by three audiences and is structured so each can find what they need:
+
+- **Engineers** can skip to §6 (data architecture), §11 (roadmap), and Appendix A (schema).
+- **Citizens & advocates** can read §1–3, §9, §10, and Appendix D (FAQ).
+- **Grant reviewers** can read the Executive Summary, §1–4, §10, §13, and Appendix C (grant alignment matrix).
+
+---
+
+## Executive summary
+
+Civic information is broken in two opposite directions at once. National outlets flood citizens with high-stakes drama about issues they can rarely influence. Local government — where most decisions that actually shape daily life happen — is invisible, fragmented across dozens of agencies, and written in language designed for lawyers and lobbyists. The predictable result is a citizenry that is simultaneously over-stimulated and under-informed, which is exactly the equilibrium that incumbents and well-funded interest groups thrive in.
+
+Opus Populi addresses this by building a **personalized civic relevance engine**: an AI system that reads every bill, proposition, and public meeting in a user's jurisdictions, then explains — in plain language — which ones touch the user's life, household, work, or stated values, and what the user can do about them while it still matters.
+
+The engine is built on four commitments that distinguish it from commercial recommendation systems:
+
+1. **The user owns the model of themselves.** Every inferred attribute is visible, editable, exportable, and deletable.
+2. **We ask for as little as possible up front.** Geography plus three opt-in tags unlocks roughly 40% of relevance; the rest is learned through behavior and progressive disclosure.
+3. **Relevance is explained, not just ranked.** Every recommendation comes with a human-readable reason: *"This matters because [you rent] AND [your council votes Thursday] AND [a tenant union you follow opposes it]."*
+4. **The same signals are never used for advertising, lead generation, political targeting, or sale.** This is enforced contractually, architecturally, and in the license.
+
+The MVP ships by July 4, 2026.
+
+---
+
+## 1. The problem
+
+### 1.1 The attention economy is a civic crisis
+
+The dominant information systems available to citizens — social media feeds, cable news, search aggregators — are optimized for engagement, which means they reward outrage, novelty, and proximity to national identity conflicts. They are not optimized for civic agency. The result is a structural mismatch:
+
+- The decisions a citizen has the **most power to influence** (city council, school board, water district, state assembly) get **the least coverage**.
+- The decisions a citizen has the **least power to influence** (federal partisan combat, foreign policy, presidential drama) get **saturation coverage**.
+- The information about local decisions that *does* exist is buried in PDFs, agenda packets, and procedural language that is functionally inaccessible to a working adult with no specialized training.
+
+This is not an accident. It is the equilibrium that benefits well-resourced interests: when the public is exhausted by national symbolism and ignorant of local mechanics, the actual levers of governance are pulled quietly by people who are paid to be in the room.
+
+### 1.2 The "pay attention to everything" failure mode
+
+The conventional civic-tech response — "stay informed, follow your representatives, read the news" — is a category error. There are too many bills (tens of thousands per year across all overlapping U.S. jurisdictions), too many agencies, too many meetings. A citizen who tries to follow all of it burns out within months and disengages entirely. A citizen who follows a curated subset chosen by a commercial outlet ends up inside that outlet's editorial frame.
+
+The empirically successful pattern, when civic engagement *does* change outcomes, looks completely different: small groups of motivated people pay sustained attention to a narrow set of issues that matter to them deeply, build relationships with the relevant decision-makers, and show up consistently. NIMBYs and YIMBYs both win zoning fights this way. Disability rights advocates won the ADA this way. Mothers Against Drunk Driving changed federal law this way. The pattern is *focused depth*, not *broad shallowness*.
+
+### 1.3 What's missing
+
+The missing piece is a system that does the *first* part of focused engagement — figuring out which of the thousands of available civic decisions actually matter to a specific person — without doing the *bad* part of personalization, which is harvesting and selling identity data to manipulate behavior.
+
+That is what this system is.
+
+---
+
+## 2. Thesis & theory of change
+
+### 2.1 Thesis
+
+> A small number of well-matched civic decisions, surfaced with enough context for a citizen to act on them while there is still time to influence the outcome, is more valuable than any volume of well-written general civic news.
+
+### 2.2 Theory of change
+
+```
+Better-matched information
+  → higher comprehension per minute spent
+    → higher likelihood of taking a meaningful action (comment, vote, attend, contact rep)
+      → more diverse citizen voices in the record
+        → decision-makers see broader input than just paid lobbyists
+          → outcomes shift toward population preferences
+```
+
+Each arrow in that chain is a measurable hypothesis. The relevance engine is the first arrow; the rest of the platform — civic data infrastructure, action workflows, representative tracking — supports the downstream ones.
+
+### 2.3 What we are not trying to do
+
+- **We are not building a partisan tool.** The engine works identically for users across the political spectrum because it personalizes on the user's stated and revealed priorities, not on an editorial worldview.
+- **We are not replacing journalism.** Reporters investigate; we route. Both are needed.
+- **We are not optimizing for engagement.** Time-on-site is an anti-goal. Successful sessions are short, decisive, and infrequent.
+- **We are not building social media.** No follower counts, no virality mechanics, no algorithmic amplification of users by other users.
+
+---
+
+## 3. Design principles
+
+Every architectural and product decision in this system is evaluated against these principles. They are listed in priority order; when they conflict, earlier principles win.
+
+1. **User sovereignty.** The user owns the model the system builds of them. They can see it, edit it, export it, and delete it in full. No "shadow profile" exists outside what the user can inspect.
+2. **Minimum viable disclosure.** We ask for the least amount of information that yields a useful answer, and we explain *why* every time we ask for more.
+3. **Explainability is a feature, not a debug tool.** Every recommendation is accompanied by a plain-language reason. If the system cannot explain itself, it does not ship.
+4. **Behavioral inference over interrogation.** Most personalization should come from observing what the user does, not from filling out forms. This is also kinder to users with low literacy, time pressure, or trauma around bureaucratic forms.
+5. **Defensive defaults.** Sensitive identity fields (race, religion, sexuality, immigration status, health conditions, justice involvement) are never required, are off by default, and are stored encrypted with separate access policies.
+6. **No secondary use.** Signals collected for civic relevance are used only for civic relevance. They are not sold, shared with advertisers, used for political-campaign targeting, or used to train external models.
+7. **Public-good license.** The system is released under AGPL-3.0 so that any derivative deployment must remain open. Commercial extensions sit outside the relevance engine, not inside it.
+8. **Bounded LLM authority.** The LLM ranks and explains. It does not author policy positions, does not predict user opinions, and does not generate content presented as fact without source citation.
+
+---
+
+## 4. The signal taxonomy
+
+The system organizes everything it knows about a user into 16 categories. Each category answers part of the central question: *"Why might this bill matter to this person?"*
+
+For each category we document: (a) what signals belong in it, (b) why an LLM needs them, (c) how they are typically collected, and (d) sensitivity tier.
+
+**Sensitivity tiers** govern storage, access, and disclosure:
+- **T1 (open)** — non-identifying, low-risk (e.g., issue interest tags)
+- **T2 (personal)** — identifying but ordinary (e.g., address, household composition)
+- **T3 (sensitive)** — protected categories or high-risk inference (e.g., immigration status, health conditions, justice involvement). Encrypted at rest with separate access policy; never appears in logs or analytics.
+
+### 4.1 Geography (T2)
+
+A single address derives a stack of overlapping jurisdictions, each with independent decision-making bodies:
+
+- Street → census block → neighborhood → city council district → county supervisor district → state assembly/senate district → US congressional district
+- Special districts: school, community college, water, fire protection, transit, air quality, port, harbor, special tax, redevelopment
+- Environmental overlays: flood zone, wildfire urban-interface zone, sea-level-rise projection zone, seismic fault proximity, refinery/freeway proximity, agricultural zone
+- Historic/cultural overlays: tribal lands, historic preservation zones, opportunity zones
+
+**Why the LLM needs this:** Most bills are jurisdictional. A water rate increase 200 feet outside your district is irrelevant; one inside it changes your bill. Most civic tools stop at city; this is why they miss most relevant decisions.
+
+**Collection:** address at signup → all derivations are automatic via public GIS data.
+
+### 4.2 Housing & property (T2)
+
+- Tenure: owner / renter / public housing resident / shared housing / unhoused / institutional
+- Building type: single-family / condo / townhome / ADU / multifamily / mobile home / rural / RV
+- Tax exposure: property tax, parcel tax, Mello-Roos assessment, HOA, transfer tax
+- Status flags: rent-regulated unit, Section 8, first-time buyer, underwater mortgage, recently moved
+
+**Why the LLM needs this:** Housing legislation is one of the most heavily contested categories at every level. Renters and owners are affected by inverse provisions of the same bill.
+
+**Collection:** one-question progressive disclosure ("are you renting or do you own?"); inferred over time from saved bills.
+
+### 4.3 Household composition (T2, with T3 sub-fields for dependents)
+
+- Children, with coarse age bands (0–5, K–5, 6–12, high school, college)
+- Dependents requiring eldercare or disability care
+- Multigenerational household indicator
+- Pets (relevant for animal welfare, leash laws, breed restrictions, noise ordinances)
+- Partner status (tax and benefit implications)
+
+**Why the LLM needs this:** Household composition is the strongest predictor of which "indirect" bills (schools, eldercare, child welfare) the user cares about — often more than direct effects on themselves.
+
+**Collection:** opt-in life-stage prompts; never required.
+
+### 4.4 Work & income (T2, income band is T3)
+
+- Employment status: W-2 / 1099 / self-employed / business owner / unemployed / retired / student / unpaid caregiver
+- Industry, occupation (coarse, NAICS-like categorization)
+- Employer size band (<5, 5–50, 50–500, 500+, public sector, non-profit)
+- Union membership; gig-worker status; tipped-worker status
+- Income band (self-reported, optional, used for benefits-cliff bills)
+- Public benefits received: SNAP, Medicaid, WIC, SSDI, unemployment, EITC (T3)
+
+**Why the LLM needs this:** Labor laws, business regulation, tax policy, and benefits cliffs all hinge on these. A $15 minimum wage debate is meaningless without knowing whether the user is an employer, employee, both, or neither.
+
+**Collection:** behavioral inference plus opt-in disclosure for benefits.
+
+### 4.5 Health & care (T3)
+
+- Insurance type: employer / Medicare / Medicaid / ACA marketplace / VA / TRICARE / uninsured
+- Chronic condition categories at very coarse granularity (cardiovascular, metabolic, mental health, etc.), user-toggled only
+- Caregiver status (for child, parent, disabled family member)
+- Reproductive-health relevance (age band + opt-in)
+- Disability accommodations needed for the platform itself
+
+**Why the LLM needs this:** Healthcare policy is dense, technical, and affects different cohorts in opposite directions in the same bill. Caregiver status is one of the most underused signals in civic tech.
+
+**Collection:** strict opt-in only, with prominent disclosure of how the data is stored and used. Never required.
+
+### 4.6 Transportation (T2)
+
+- Primary mode: car / public transit / bike / walk / rideshare / remote work
+- Vehicle type: EV / hybrid / ICE / truck / motorcycle / none
+- Commute distance band
+- Special licenses: CDL, pilot, mariner, hazmat — these unlock niche regulatory bills
+- Transit pass holder; bike-share member
+
+**Why the LLM needs this:** Transit funding, road repair, parking policy, EV incentives, and vehicle regulation all have inverted effects across modes.
+
+**Collection:** opt-in tags or behavioral.
+
+### 4.7 Education (T2)
+
+- Currently a student (level: K–12, vocational, undergrad, grad)
+- Parent of student (public / private / charter / homeschool, level)
+- Educator or school staff (teacher, admin, support staff)
+- Student loan balance band
+- Vocational, apprenticeship, or trade-school affiliation
+
+**Why the LLM needs this:** Education policy is intensely local (school board) and intensely federal (loan policy) with little in between. Parents of public-school students care about completely different bills than parents of homeschoolers.
+
+**Collection:** opt-in tags.
+
+### 4.8 Citizenship & civic status (mixed T2/T3)
+
+- Citizenship status: citizen / permanent resident / DACA / visa holder / undocumented / asylum-seeking *(T3 — extreme care)*
+- Voter registration status and party (if disclosed)
+- Veteran or active duty; military family
+- Justice involvement: currently incarcerated, formerly incarcerated, on parole/probation, family member affected *(T3)*
+
+**Why the LLM needs this:** Many bills explicitly target one of these statuses (immigration enforcement, voting rights, veterans' benefits, criminal-justice reform).
+
+**Collection:** Citizenship and justice fields are *strictly opt-in*, stored separately, and accompanied by an explicit explanation: *"This field exists so we can warn you when bills target your community. You can leave it blank, and we will simply not be able to flag those bills for you."* In high-risk jurisdictions, the system supports a "no-fields mode" that skips these categories entirely.
+
+### 4.9 Cultural & community identity (T3, fully opt-in)
+
+- Race / ethnicity
+- Primary language(s)
+- Religious community
+- LGBTQ+ identity
+- Immigration generation (1st / 2nd / 3rd+)
+- Tribal enrollment / sovereign nation affiliation
+
+**Why the LLM needs this:** Many bills explicitly or implicitly target identity-coded communities. The same bill can read as protection from one perspective and threat from another. Without this signal, the system inherits a default majoritarian framing that erases minority experience.
+
+**Collection:** opt-in only, with the framing *"This helps us tell you when bills are written about your community."* Never sold, never shared, never used for outreach segmentation.
+
+### 4.10 Declared values & priorities (T1)
+
+The "what do you care about" tag cloud:
+
+- Issue tags the user explicitly follows: climate, housing affordability, public safety, immigration, education, healthcare, labor, criminal justice, technology & privacy, animal welfare, election integrity, gun policy, reproductive rights, religious liberty, fiscal responsibility, transit, agriculture, veterans, disability rights, indigenous sovereignty, etc.
+- Conviction strength per tag: passing interest / important / core priority
+- Optional political self-identification (no required scale; users can decline)
+
+**Why the LLM needs this:** Declared priorities are the single most useful signal because they are unambiguous. Three tags at signup yield substantial relevance gains immediately.
+
+**Collection:** explicit at signup ("pick up to five things you care about") and editable always.
+
+### 4.11 Organizational affiliations (T2)
+
+- Union, professional association, alumni network
+- Faith community
+- Advocacy organizations the user trusts (e.g., ACLU, NRA, Sierra Club, NAACP, Heritage, Audubon — the user discloses which)
+- Neighborhood association, HOA, civic club
+- Mutual aid networks
+
+**Why the LLM needs this:** "Sierra Club opposes this" is a stronger signal for an environmentalist than 2,000 words of bill analysis. Trust transitively flows through organizations the user already vetted.
+
+**Collection:** opt-in follow lists; users can also follow organizations like a feed.
+
+### 4.12 Behavioral signals (T2 — derived, not declared)
+
+The richest source, and the only category that requires no asking:
+
+- Open, save, share, dismiss events on bills and articles
+- Dwell time per topic and per bill
+- Voices, representatives, and organizations the user follows
+- Past actions: petition signed, meeting attended, representative contacted, primary voted in (where lawfully observable)
+- Engagement cadence: daily reader vs. election-cycle reader
+- Topic graph: clustering of attention over rolling 60/90-day windows
+- Format preferences inferred from what they actually finish reading
+
+**Why the LLM needs this:** Behavioral data is the highest-fidelity signal of revealed (rather than stated) priorities. It also lets the system catch interests the user has not yet thought to declare.
+
+**Collection:** automatic, with full visibility into what is being recorded and a one-click "delete my behavioral history" option.
+
+### 4.13 Attention budget & format preference (T1)
+
+- Time available per week (self-set)
+- Preferred depth: headline / short summary / deep brief / source documents
+- Notification tolerance and channel preferences
+- Accessibility needs: screen reader compatibility, plain language, translation, dyslexia-friendly typography
+- Reading-level preference for briefings
+- Language preference for the briefing itself (English, Spanish, others as added)
+
+**Why the LLM needs this:** Same bill, different audience, different output. A 200-word plain-language summary for one user; a full legal analysis with citations for another.
+
+**Collection:** explicit settings, with smart defaults.
+
+### 4.14 Relational graph — "who in my life" (T2)
+
+The most underused signal in civic tech. Many users care about bills *because of someone they love*, not because of themselves.
+
+- Household members
+- Employer
+- Children's school (separate jurisdiction from home if applicable)
+- Aging parents' location (often a different state)
+- Neighborhood / immediate community
+
+**Why the LLM needs this:** A bill restricting Medicare home-care reimbursement matters intensely to the adult child managing an out-of-state parent's care — even when it does not touch the user's own life.
+
+**Collection:** opt-in "who's in my life" prompts with light touch; geography of dependents derives further overlays.
+
+### 4.15 Temporal & action context (T1, T2)
+
+- Election cycle proximity for the user's districts
+- Active votes and hearings this week in the user's districts
+- Public comment windows that are still open
+- The user's representatives' upcoming votes
+- Recent life events (just moved, new baby, new job, retired, new diagnosis) — surfaced via gentle prompts
+
+**Why the LLM needs this:** A bill that *will be voted on next Tuesday* is operationally different from a bill that *was introduced last week and may never advance*. Time-to-action determines whether attention is useful.
+
+**Collection:** derived from civic data + opt-in life-event prompts.
+
+### 4.16 Trust calibration — the meta-signal (T2)
+
+- Whom does the user trust as a heuristic? (specific representatives, journalists, organizations, neighbors)
+- How skeptical is the user of government, corporations, mainstream media, specific outlets?
+
+**Why the LLM needs this:** Trust signals determine *framing*, not just selection. The same bill is "regulatory overreach" or "consumer protection" depending on the user's prior. The system never lies about the bill — but it leads with the framing the user is most likely to engage with, then offers the counter-frame as an explicit "here's the other side" panel.
+
+**Collection:** inferred from follow lists and engagement, never directly asked.
+
+---
+
+## 5. The relevance scoring model
+
+For every bill, proposition, or scheduled meeting in the user's jurisdictions, the relevance engine produces three artifacts:
+
+1. A **relevance score** (0.0–1.0)
+2. A **reason narrative** in plain language
+3. A **set of action affordances** (vote upcoming, public comment open, representative undecided, etc.)
+
+### 5.1 Scoring axes
+
+The score is composed from seven axes, each weighted per user:
+
+| Axis | Question | Weight signals from |
+|---|---|---|
+| Direct material | Does this change the user's money, rights, health, services, or legal exposure? | §4.1–4.8 |
+| Indirect material | Does it hit their household, employer, school, neighborhood, or community? | §4.3, 4.4, 4.7, 4.14 |
+| Values alignment | Does it advance or threaten priorities the user declared or revealed? | §4.10, 4.12 |
+| Coalition signal | Are organizations or people the user trusts loudly for or against? | §4.11, 4.16 |
+| Actionability | Is there a vote, hearing, or public-comment window the user can affect *now*? | §4.15 |
+| Counterfactual | Without the user's attention, is this likely to pass quietly? (rewards focus on under-covered local bills) | civic data layer |
+| Novelty / repetition | Has the user already seen many bills like this? (diminishing returns) | §4.12 |
+
+### 5.2 The reason narrative
+
+The output is not a score — it is a sentence. The LLM produces, for example:
+
+> *"This matters because you rent in a rent-stabilized building, your council district votes Thursday at 6 PM, and the tenant union you follow is opposing it. The most contested provision is §3(b), which would allow ‘substantial rehabilitation’ exemptions. Public comment is open until Wednesday at 5 PM."*
+
+The narrative is constrained by a structured prompt that forces the model to:
+
+- Name **two to four specific reasons**, drawn from the user's signals.
+- Cite **the bill's section** that contains the most consequential provision.
+- Identify **the active action window**, if any.
+- **Decline to recommend a position.** The system explains relevance, not opinion.
+
+If the model cannot produce a defensible narrative, the bill is not surfaced.
+
+### 5.3 What the LLM is *not* allowed to do
+
+- It does not write content presented as fact without a citation to the source document.
+- It does not predict the user's opinion on the bill.
+- It does not generate persuasive content urging a particular vote.
+- It does not infer protected-class membership from indirect signals; T3 fields are populated only by the user.
+- It does not produce content about specific named private individuals beyond officials acting in their official capacity.
+
+### 5.4 Counter-frame surfacing
+
+To prevent filter-bubble drift, every high-relevance bill includes an explicit **"the other side"** panel. The system identifies organizations or representatives that hold the opposing position and shows the user their stated reasoning. The user can collapse this panel but cannot hide it permanently. This is a deliberate friction designed to keep the system from becoming a confirmation engine.
+
+---
+
+## 6. Data architecture
+
+### 6.1 Where things live
+
+The system spans three existing services and adds one new component:
+
+| Layer | Service | Responsibility |
+|---|---|---|
+| Identity & profile | `users` (port 3001) | Auth, basic profile, the declared portions of the signal taxonomy |
+| Behavioral events | `users` (new module) | Append-only event log of opens, saves, dismisses, follows |
+| Civic data | `region` (port 3004) | Bills, propositions, representatives, meetings, jurisdictions |
+| Relevance ranking | `knowledge` (port 3003) | The LLM-based relevance engine, scoring, and narrative generation |
+
+The relevance engine is a **read-only consumer** of user signals. It never writes to the user profile.
+
+### 6.2 Logical data model
+
+Two new top-level entities, plus extensions to existing ones:
+
+- **`SignalProfile`** — declared signals (§4.1–4.11, 4.13, 4.14, 4.16). One per user. Versioned. Every field can be set, unset, and edited.
+- **`UserEvent`** — append-only behavioral log (§4.12). Each event records a verb (open, save, dismiss, share, follow, contact, attend), an object (bill, proposition, meeting, representative, organization), and a timestamp.
+- **`RelevanceScore`** — per-user, per-bill output of the engine. Cached, regenerated when either the bill or the relevant signals change. Includes the score, the reason narrative, the contributing signals, and the model version.
+
+See **Appendix A** for the full schema sketch.
+
+### 6.3 Encryption and access boundaries
+
+- **T1 fields** stored as ordinary columns.
+- **T2 fields** stored as ordinary columns with row-level security; only the user (or a fully-authenticated user-initiated request) can read.
+- **T3 fields** stored in a separately-encrypted table with per-row keys derived from a user-held secret. Service code reads decrypted T3 fields only when explicitly required for ranking, and never logs them. The relevance engine receives T3-derived *flags* (e.g., `has_immigration_concern: true`), not raw values.
+- **Behavioral events** are stored in a dedicated table with a 24-month rolling retention by default, configurable per user (down to "no retention beyond session").
+
+### 6.4 What is *never* stored
+
+- Browser fingerprints beyond what is required for session security
+- Cross-site tracking IDs of any kind
+- IP geolocation beyond a coarse city-level rate-limit bucket
+- Inferred protected-class membership (race, religion, sexuality, immigration, health) that the user did not self-declare
+- Predicted political opinions or vote intentions
+
+### 6.5 Federation & cross-service flow
+
+Because Opus Populi runs on GraphQL Federation with bounded-context microservices, the relevance engine never queries the user database directly. The flow is:
+
+1. The frontend requests a personalized feed.
+2. The API Gateway authenticates the user, signs the request, and forwards it to `knowledge`.
+3. `knowledge` requests the user's *relevance-relevant* signals from `users` via Federation. T3 fields are resolved as boolean flags, not raw values, except when the user has explicitly enabled "show me why" mode.
+4. `knowledge` queries `region` for active bills in the user's jurisdictions.
+5. `knowledge` ranks, scores, and generates narratives; results are cached in a per-user table with TTL bound to the underlying data.
+
+---
+
+## 7. Collection strategy
+
+The system collects signals along five overlapping channels, listed from highest yield to lowest friction.
+
+### 7.1 Onboarding: the 30-second baseline
+
+- **Address** (required for the system to function — derives §4.1, 4.15)
+- **Three opt-in interest tags** (drawn from §4.10)
+- **Language preference** (drawn from §4.13)
+
+This alone produces a meaningfully personalized feed. Approximately 40% of relevance signal lift comes from these three inputs.
+
+### 7.2 Progressive disclosure
+
+When the system encounters a bill where one missing signal would meaningfully change the relevance score, it asks **one targeted question** inline:
+
+> *"This bill changes rent-control rules. To know if it affects you, we'd need to know — are you currently renting?"*
+> *[Yes] [No] [Skip — don't ask again]*
+
+The user can always skip, and the system remembers skips. Each question is justified by the specific bill that prompted it, never by abstract "tell us about yourself" framing.
+
+### 7.3 Behavioral learning
+
+Every meaningful interaction (open, dwell, save, share, dismiss, follow) updates an internal model. After roughly 20–30 interactions the behavioral signal becomes the dominant driver of personalization. This is invisible to the user but fully visible on demand via the **"What we've learned about you"** panel (§9.1).
+
+### 7.4 Life-event prompts
+
+Periodically (not more than once a month), the system asks an open-ended gentle prompt:
+
+> *"Anything change recently? New job, new home, new kid, retirement, new diagnosis — these change which bills matter to you."*
+
+The user can ignore this indefinitely; it is never required.
+
+### 7.5 Trust import
+
+When a user follows a representative, journalist, or organization, the system records this as both an interest signal *and* a trust signal for narrative framing (§5.2). This requires no separate questioning.
+
+### 7.6 What we deliberately do not ask
+
+- We do not ask race, religion, sexuality, immigration status, or health conditions at signup. These are surfaced only inside the targeted-disclosure flow tied to a specific bill, with an explicit explanation of how the signal will be used.
+- We do not require email verification beyond what is needed to recover an account.
+- We do not require a phone number.
+- We do not require a real name. A handle is sufficient.
+
+---
+
+## 8. Transparency & user agency
+
+### 8.1 The model-of-me page
+
+Every user has a single page that shows them, in full, what the system has stored and inferred:
+
+- All declared signals from the taxonomy
+- All behavioral inferences and the confidence the system has in each
+- The current relevance weights derived from their behavior
+- The full event log with timestamps
+
+From this page the user can:
+
+- **Edit** any field
+- **Delete** any field (with a confirmation step)
+- **Reset** behavioral history (one click, wipes the event log and re-derives from scratch)
+- **Export** the entire profile as a portable JSON file
+- **Delete the account**, which removes all data within 30 days, including from backups
+
+### 8.2 Why-this-bill panel
+
+For every recommended bill, a "Why this?" affordance opens a panel showing:
+
+- Which of the user's signals contributed to this recommendation
+- The score on each of the seven relevance axes
+- The opposing-view summary (§5.4)
+- A link to the raw source document
+
+### 8.3 Model card
+
+The system publishes an updated **model card** for the relevance engine each quarter, documenting:
+
+- Which LLM models are in use, at what versions
+- The system prompt and its change history
+- Known biases identified in evaluation
+- Aggregate measures of recommendation diversity across user political self-identification (when users have opted to share it)
+
+The model card is public.
+
+---
+
+## 9. Privacy, security, threat model
+
+### 9.1 Adversaries we design against
+
+| Adversary | Capability | Mitigation |
+|---|---|---|
+| Commercial data broker | Bulk purchase or scrape | No sale; rate limits; bot detection; AGPL forces derivatives open |
+| Political operative | Targeted opposition research on users | T3 fields encrypted, never returned in bulk; aggregate queries rate-limited |
+| Hostile government (foreign or domestic) | Subpoena or seizure | Minimum-viable retention; per-user encryption for T3; supports "no-fields mode" for high-risk users |
+| Abusive intimate partner | Account takeover | Passkeys (WebAuthn); session anomaly detection; profile-export rate limits; no public profile by default |
+| Compromised employee or insider | Privileged access | Separation of duties for T3 access; access logged and reviewable by user |
+| LLM provider | Training on user data | We run inference locally (Ollama) by default; cloud LLMs are opt-in and never receive raw T3 |
+| The system's own future self | Mission drift, founder turnover | License (AGPL), governance commitments, open model card |
+
+### 9.2 No-fields mode
+
+Users in high-risk situations (immigration enforcement, domestic violence, journalists, activists in hostile jurisdictions) can enable a mode that:
+
+- Stores **only** address (and only the coarse jurisdiction derivations, not the precise address)
+- Disables **all** T3 fields
+- Disables behavioral logging
+- Disables cloud LLM use
+
+The system still works — just less precisely. We treat this as a feature, not a degraded experience.
+
+### 9.3 Minimum retention
+
+- Behavioral events: 24 months default, user-configurable down to "session only"
+- Relevance scores: regenerated on demand, no permanent retention required
+- Backups: retain only what is required for disaster recovery, with the same retention windows
+- Server logs: 30 days, with PII masking already in place per the existing audit logging system
+
+### 9.4 Auditability
+
+The platform already runs structured audit logging across all GraphQL operations. The relevance engine inherits this, with the additional rule that T3 field reads are logged at the boolean-flag level only (never the raw value).
+
+---
+
+## 10. Ethical framework & public commitments
+
+These are the commitments we make to citizens, written so they can be quoted in a grant application and in user-facing material.
+
+1. **You own you.** The model of you that this system builds is yours to see, edit, export, or delete in full. Nothing about you lives somewhere we cannot show you.
+2. **We ask for less, not more.** We will never require information we do not strictly need to surface a bill you should know about. When we ask, we explain why.
+3. **We will never sell your data.** Not to advertisers. Not to campaigns. Not to data brokers. Not to researchers without your explicit opt-in. This is in our license, our terms, and our architecture.
+4. **We will never use your information to target you politically.** The relevance engine personalizes which bills you see; it does not modify content to change your mind. We do not produce persuasive content urging votes.
+5. **We will tell you why.** Every recommendation is accompanied by the specific signals that produced it. You can disagree.
+6. **We will show you the other side.** Every high-relevance bill includes a panel showing the opposing position and who holds it. You cannot opt out of this.
+7. **We will not silently change the rules.** Material changes to how the relevance engine works are published in the quarterly model card, before they take effect.
+8. **We will not require you to be legible.** You do not have to disclose race, religion, sexuality, immigration status, health, or justice involvement to use this platform. If you choose to share, it is to help us help you — never to categorize you for someone else.
+9. **We are accountable to a public mission, not a private return.** The platform is open source under AGPL-3.0; the data infrastructure is non-profit-governed; the founders do not personally profit from user data.
+10. **If we fail at any of the above, you have the right to know.** Security incidents are disclosed within 72 hours, with full detail, no marketing language.
+
+---
+
+## 11. Implementation roadmap
+
+The MVP target is **July 4, 2026.** The roadmap below sequences work to ensure the relevance engine ships with the platform.
+
+### Phase 0 — Foundation (May–June 2026) — **shipped**
+- ✅ Signal taxonomy + T1/T2/T3 classifications locked (this document)
+- ✅ `SignalProfile`, `SensitiveProfile`, `UserEvent` schema in the `users` service (#742, PR #757)
+- ✅ RLS policies for T2 and per-row encryption for T3 (#742)
+- ✅ Behavioral event ingestion endpoint (`recordEvent` mutation)
+- ✅ "Model-of-me" page with per-field inline edit (#752, PR #767) — see
+  `apps/frontend/components/profile/README.md`
+- ✅ Supabase Vault seeding for the T3 encryption key over HTTP at db-migrate (#742)
+
+### Phase 1 — Baseline relevance (June 2026) — **shipped**
+- ✅ Onboarding: address + top-3 tags + language with reasons (#758, PR #764)
+- ✅ Bill data pipeline live on `feat/bill-data-686` (#686)
+- ✅ `RankingFlags` projection — 20 booleans derived from T1/T2/T3 with T3 masking
+  when `noFieldsMode` is on (#742-A)
+- ✅ Relevance engine v1: rule-based ranker (#743)
+  - Scoring on axes 1 (direct material), 2 (values alignment), 3 (actionability)
+  - Axes 4–7 emit placeholder 0.0 until Phase 2
+- ✅ `myPersonalizedBillFeed(input, limit)` resolver in the `knowledge` service (#743)
+- ✅ "Your Civic Briefing" home page at `/me/briefing` — bills section live, reps /
+  committees / propositions render placeholders linking to `/region/*` (#744)
+  - Post-auth landing redirects (onboarding completion + magic-link callback) point here
+  - Heuristic "Why this?" panel using `topAxisFor()` — see
+    `apps/frontend/components/briefing/README.md`
+
+### Phase 2 — LLM-driven relevance (mid-June 2026) — **in flight**
+- Switch narrative generation to LLM (prompt-service for templates) (#745)
+- Add axes 4–7 (indirect material, coalition signal, counterfactual, novelty) (#747)
+- Counter-frame surfacing for high-relevance bills
+- Replace the three-step prefetch + feed + bill fan-out with a single batched
+  `myPersonalizedBillFeed` that includes bill details (#761)
+- Per-section briefing personalization: Reps (#769), Committees (#770),
+  Propositions (#771)
+
+### Phase 3 — Behavioral learning (late June 2026)
+- Behavioral signal ingestion live
+- 20–30-interaction calibration window
+- Dynamic re-weighting of axes per user
+- "What we've learned about you" surface in the model-of-me page
+
+### Phase 4 — Disclosure & trust (late June 2026)
+- Progressive-disclosure prompts inline with bills
+- Life-event prompts (monthly cadence cap)
+- First model card published
+- No-fields mode enabled
+
+### Phase 5 — MVP launch (July 4, 2026)
+- All taxonomy categories supported (even if some are sparsely populated)
+- Public ethical commitments published as part of user terms
+- Model card live
+- Export / delete fully working
+
+### Post-MVP candidates
+- Relational graph (§4.14) full implementation
+- Trust calibration (§4.16) signal modeling
+- Multi-language briefings beyond English/Spanish
+- Mobile push for time-sensitive action windows
+- Optional research-grade opt-in for aggregate civic-engagement research
+
+---
+
+## 12. Success metrics
+
+We measure success against the theory of change in §2.2 — not against engagement metrics.
+
+### 12.1 Comprehension per minute
+
+The headline metric. Measured via voluntary user surveys after a session: *"Did you learn something specific that you can act on?"* Goal: >70% yes, with median session under 12 minutes.
+
+### 12.2 Action conversion rate
+
+Of bills surfaced as "high relevance with active action window," what fraction lead to a user taking *any* action (public comment, contacting a rep, attending a meeting, saving the bill for follow-up)?
+Baseline civic-tech rate is roughly 1–3%. Goal: 8%+ for high-relevance bills.
+
+### 12.3 Recommendation diversity
+
+For each user, the fraction of recommended bills that align vs. challenge their stated views. A healthy system should not be 95% confirmatory. Goal: at least 20% of recommendations expose the user to perspectives that challenge their declared priors.
+
+### 12.4 Retention without addiction
+
+We track 4-week and 12-week retention but penalize sessions over 20 minutes and high session-frequency users. This is not Facebook. A user who checks in once a week for 8 minutes and takes one action is the success case.
+
+### 12.5 Equity of impact
+
+Recommendation quality should not be substantially better for users with denser declared profiles than for users in "no-fields mode." We measure the action conversion gap between the two groups; goal is < 25% degradation for no-fields users.
+
+### 12.6 Trust signals
+
+Quarterly survey: *"Do you trust this platform with information about you?"* Target: > 80% yes among active users, with explanations published in the model card.
+
+---
+
+## 13. Risks & open questions
+
+### 13.1 Risks
+
+- **R1: Cold-start failure.** Without behavioral data, new users may get a generic feed. *Mitigation:* address + three tags must yield a meaningfully better feed than any commercial alternative. We will test this with focus groups before MVP launch.
+- **R2: LLM hallucination on bill content.** A briefing that misrepresents a bill is worse than no briefing. *Mitigation:* every narrative must cite specific bill sections; outputs are validated against the source text before display; users can flag inaccuracies and we publish the fix rate.
+- **R3: Filter bubble.** Personalization tends toward confirmation. *Mitigation:* counter-frame panel is mandatory and cannot be permanently hidden.
+- **R4: Sensitive-data subpoena.** Even encrypted T3 data can be compelled. *Mitigation:* no-fields mode; user-held key portion for T3; minimum retention.
+- **R5: Mission drift.** Future leadership might monetize signals. *Mitigation:* AGPL license, governance design (TBD), founder commitments encoded in terms.
+- **R6: Inequitable participation.** The platform might amplify already-engaged demographics. *Mitigation:* tracked as a success metric (§12.5); outreach prioritizes under-represented communities; multilingual support from MVP.
+
+### 13.2 Open questions
+
+- **Q1: Governance structure.** Should the platform be governed by a non-profit, a public-benefit corporation, a co-op, or a hybrid? This affects how strongly the public commitments (§10) bind future operators.
+- **Q2: Behavioral inference granularity.** How fine-grained should behavioral inference go before it becomes creepy? We need user research, not just engineering opinions.
+- **Q3: Counter-frame sourcing.** Where does the "other side" content come from? An LLM-generated counter-frame risks straw-manning; a human-curated one introduces editorial bias. Likely answer: cited statements from named opposing organizations only.
+- **Q4: Action attribution.** Most actions (contacting a rep, attending a meeting) happen off-platform. How do we measure them honestly without invasive tracking?
+- **Q5: Cross-jurisdiction users.** Snowbirds, students, military families, divorced co-parents — many people have civic stakes in multiple jurisdictions simultaneously. How does the model represent this?
+
+---
+
+## 14. Glossary
+
+| Term | Plain-language meaning |
+|---|---|
+| Signal | Anything the platform knows about you — whether you told us directly or we noticed through how you use the platform. |
+| Taxonomy | The organized list of every kind of signal we use. |
+| Relevance score | A number from 0 to 1 estimating how much a particular bill matters to you specifically. |
+| Reason narrative | The plain-language explanation of *why* the platform thinks a bill matters to you. |
+| Counter-frame | The opposing view on a bill, deliberately shown so you see the full debate. |
+| T1 / T2 / T3 | Sensitivity tiers — T1 is non-identifying, T2 is ordinary personal data, T3 is highly sensitive (race, health, immigration, etc.). |
+| No-fields mode | A privacy mode that turns off all T3 fields and behavioral logging for users in higher-risk situations. |
+| Model card | A public document that explains how the AI part of the platform works, updated quarterly. |
+| Federation | The way our backend services talk to each other so each owns its own data. |
+| Jurisdiction | A geographic area with its own government — your city, your county, your state, your water district, etc. |
+
+---
+
+## Appendix A — Schema sketch
+
+The schema below is a TypeScript-flavored sketch of the data model. Final implementation in Prisma will follow existing conventions in the `users` service.
+
+```ts
+// One per user. T1 and T2 fields. T3 fields live in SensitiveProfile (see below).
+type SignalProfile = {
+  userId: string;
+
+  // §4.1 Geography (derived from address; address itself encrypted)
+  address: EncryptedString;
+  jurisdictions: Jurisdiction[];          // city, county, state, federal, special districts
+  environmentalOverlays: Overlay[];
+
+  // §4.2 Housing
+  housingTenure?: 'owner' | 'renter' | 'public' | 'shared' | 'unhoused' | 'institutional';
+  buildingType?: BuildingType;
+  taxExposure?: TaxExposure[];
+  housingFlags?: HousingFlag[];
+
+  // §4.3 Household
+  childrenAgeBands?: AgeBand[];
+  hasEldercareDependents?: boolean;
+  multigenerational?: boolean;
+  hasPets?: boolean;
+  partnerStatus?: PartnerStatus;
+
+  // §4.4 Work & income (income band is T3)
+  employmentStatus?: EmploymentStatus;
+  industry?: IndustryCode;
+  occupation?: OccupationCode;
+  employerSizeBand?: SizeBand;
+  unionMember?: boolean;
+  gigWorker?: boolean;
+
+  // §4.6 Transportation
+  primaryTransitMode?: TransitMode;
+  vehicleType?: VehicleType[];
+  commuteBand?: CommuteBand;
+  specialLicenses?: LicenseType[];
+
+  // §4.7 Education
+  studentLevel?: StudentLevel;
+  parentOfStudent?: SchoolType[];
+  educator?: boolean;
+  studentLoanBalanceBand?: Band;
+
+  // §4.10 Declared values
+  interestTags: InterestTag[];
+  convictionStrength: Record<InterestTag, 'passing' | 'important' | 'core'>;
+  politicalSelfId?: string;               // free-text, optional, no enforced scale
+
+  // §4.11 Affiliations
+  unionAffiliation?: string;
+  professionalAssociations?: string[];
+  faithCommunity?: string;
+  trustedOrganizations?: OrgRef[];
+
+  // §4.13 Attention & format
+  weeklyAttentionMinutes?: number;
+  preferredDepth?: 'headline' | 'short' | 'deep' | 'source';
+  notificationPreferences?: NotificationPrefs;
+  accessibilityNeeds?: AccessibilityFlag[];
+  readingLevel?: ReadingLevel;
+  languagePreference: Language;
+
+  // §4.14 Relational
+  householdMembers?: HouseholdMember[];
+  employerLocation?: JurisdictionRef;
+  childrenSchoolLocation?: JurisdictionRef;
+  agingParentsLocation?: JurisdictionRef;
+
+  // §4.15 Temporal
+  recentLifeEvents?: LifeEvent[];
+
+  // §4.16 Trust calibration (largely derived from follow lists)
+  trustedRepresentatives?: RepRef[];
+  trustedJournalists?: PersonRef[];
+
+  // Metadata
+  createdAt: DateTime;
+  updatedAt: DateTime;
+  schemaVersion: string;
+};
+
+// T3 — separate encrypted table; never logged; never returned in bulk.
+// Reads require a freshly authenticated user-initiated request and are audit-logged.
+type SensitiveProfile = {
+  userId: string;
+  encryptedKey: EncryptedString;          // per-row key, derived in part from user-held secret
+
+  // §4.5 Health
+  insuranceType?: InsuranceType;
+  chronicConditionCategories?: HealthCategory[];
+  caregiverFor?: CaregiverType[];
+  reproductiveHealthRelevance?: boolean;
+
+  // §4.8 Citizenship & justice
+  citizenshipStatus?: CitizenshipStatus;
+  veteranStatus?: VeteranStatus;
+  justiceInvolvement?: JusticeInvolvement[];
+
+  // §4.9 Cultural & community identity (all opt-in)
+  raceEthnicity?: string[];
+  primaryLanguages?: string[];
+  religiousCommunity?: string;
+  lgbtqIdentity?: string;
+  immigrationGeneration?: 1 | 2 | 3;
+  tribalAffiliation?: string;
+
+  // §4.4 Income (T3)
+  incomeBand?: IncomeBand;
+  publicBenefits?: BenefitType[];
+
+  // Configurable
+  noFieldsMode: boolean;                   // master switch; disables all reads
+};
+
+// Append-only behavioral event log. Default 24-month retention.
+type UserEvent = {
+  id: string;
+  userId: string;
+  verb: 'open' | 'dwell' | 'save' | 'share' | 'dismiss' | 'follow' | 'unfollow'
+      | 'contact_rep' | 'attend_meeting' | 'sign_petition' | 'vote_recorded';
+  object: {
+    type: 'bill' | 'proposition' | 'meeting' | 'representative' | 'organization' | 'article';
+    id: string;
+  };
+  context?: {
+    dwellMs?: number;
+    referrer?: string;
+    sessionId: string;
+  };
+  occurredAt: DateTime;
+};
+
+// Per-user, per-bill relevance output. Cached, regenerated on relevant change.
+type RelevanceScore = {
+  userId: string;
+  billId: string;
+
+  score: number;                           // 0.0–1.0 composite
+  axisScores: {
+    directMaterial: number;
+    indirectMaterial: number;
+    valuesAlignment: number;
+    coalitionSignal: number;
+    actionability: number;
+    counterfactual: number;
+    noveltyRepetition: number;
+  };
+
+  reasonNarrative: string;                 // generated by LLM, validated against source
+  contributingSignals: SignalReference[];  // which user signals drove this
+  actionAffordances: ActionAffordance[];   // vote dates, comment windows, etc.
+  counterFrame: CounterFrame;              // opposing view summary
+
+  modelVersion: string;
+  generatedAt: DateTime;
+  expiresAt: DateTime;
+};
+```
+
+---
+
+## Appendix B — Worked example
+
+A walkthrough of how the engine processes a single bill for a single hypothetical user.
+
+### The user (illustrative)
+
+- **Address:** Oakland, CA — Council District 3
+- **Onboarding tags:** housing affordability, climate, education
+- **Disclosed during progressive disclosure:** renter, parent of two K–12 students
+- **Follows:** Council member Carroll Fife, East Bay Tenants Union, Sierra Club
+- **Behavioral history:** opens 80% of housing-related bills, dismisses most state-level transportation bills
+
+### The bill
+
+- **AB-2304 (state):** Allows cities to grant "substantial rehabilitation" exemptions to rent-stabilized buildings; pre-empts stronger local rent stabilization in some cases.
+- **Status:** Senate Housing Committee vote scheduled in 5 days.
+- **Active public comment window.**
+
+### The engine's processing
+
+| Axis | Signal | Score |
+|---|---|---|
+| Direct material | User is a renter in a rent-stabilized building (inferred from D3 address overlay + disclosure). High direct exposure. | 0.92 |
+| Indirect material | Children's school is in same district; no direct school impact. | 0.10 |
+| Values alignment | "Housing affordability" is a declared core priority. | 0.95 |
+| Coalition signal | East Bay Tenants Union (followed) is opposing. Carroll Fife (followed) has spoken against the bill. | 0.90 |
+| Actionability | Vote in 5 days; public comment window open. | 0.95 |
+| Counterfactual | Bill has received minimal mainstream coverage; under-watched in Oakland press. | 0.80 |
+| Novelty | User has seen 3 similar bills this cycle; some repetition discount. | -0.15 |
+
+**Composite score:** 0.87 (high).
+
+**Reason narrative (generated):**
+
+> *"AB-2304 matters to you because you rent in District 3, where rent stabilization is one of the strongest tenant protections in California — and this bill would let cities exempt buildings from it. The Senate Housing Committee votes Tuesday. East Bay Tenants Union is opposing it, as is Council Member Carroll Fife, both of whom you follow. The contested provision is §3(b), defining what counts as ‘substantial rehabilitation.' Public comment is open until Monday at 5 PM."*
+
+**Counter-frame panel:**
+
+> *"Supporters argue this bill removes barriers to seismic retrofits of older housing. The California Apartment Association is the primary supporter. Their position summary: [link]."*
+
+**Action affordances surfaced:**
+
+- Read the bill (link to §3(b))
+- Submit public comment (form, pre-filled with user's district)
+- Call Senator's office (number, suggested talking points based on the bill itself, not opinion content)
+
+---
+
+## Appendix C — Grant alignment matrix
+
+For grant applications, the relevance engine aligns with the following common funder priorities. This table lets a grant writer map the project quickly.
+
+| Funder priority | Where in this document | Specific evidence |
+|---|---|---|
+| Digital equity | §4.13, §12.5 | Accessibility-first design; multi-language MVP; no-fields mode prevents requiring identity disclosure |
+| Civic engagement | §2.2, §12.2 | Theory of change explicitly targets action conversion; metrics measure off-platform actions |
+| Algorithmic accountability | §5.3, §8.3 | Bounded LLM authority; quarterly public model cards; explainable recommendations |
+| Privacy & data ethics | §3, §6.3, §9, §10 | Sensitivity tiering; user-owned model; AGPL license; no secondary use commitment |
+| Misinformation resistance | §5.4, §13 R2 | Mandatory citation; counter-frame panel; hallucination flagging |
+| Underrepresented community participation | §4.9, §7.6, §12.5 | Identity disclosure strictly opt-in; equity gap is a tracked success metric |
+| Open-source civic infrastructure | §3.7, throughout | AGPL-3.0 with dual commercial structure; provider-pluggable architecture |
+| Local government engagement | §4.1, §2.1 | Jurisdictional depth beyond city level; special districts and overlays modeled |
+| Youth & first-time voter engagement | §4.13 | Reading-level configurable; plain-language defaults |
+| Multilingual access | §4.13 | English/Spanish at MVP; architecture supports additional languages |
+
+---
+
+## Appendix D — Citizen FAQ
+
+**Q: What does this platform actually do?**
+A: It reads every bill, ballot measure, and public meeting in your area and tells you — in plain English — which ones might actually matter to your life, and what you can do about them.
+
+**Q: How does it know what matters to me?**
+A: From three things: where you live, the topics you tell us you care about, and what you click on over time. You can see and change all of this any time.
+
+**Q: Do you sell my information?**
+A: No. Not to anyone. Not for any reason.
+
+**Q: Do you use my information to influence how I vote?**
+A: No. We pick which bills to show you. We don't tell you how to feel about them, and we always show you the opposing view.
+
+**Q: Do I have to tell you my race, religion, sexuality, or immigration status?**
+A: No. These are off by default. You can share them only if you want us to flag bills that target your community — and you can turn them off again any time.
+
+**Q: What if I'm worried about my safety — like if I'm undocumented or fleeing an abuser?**
+A: There is a "no-fields mode" that turns off all sensitive fields and stops recording your activity. The platform still works, just a little less precisely.
+
+**Q: Can I see everything you've stored about me?**
+A: Yes. There is one page that shows everything we've ever collected or inferred. You can edit any of it, delete any of it, or download all of it. If you delete your account, everything is gone in 30 days, including from backups.
+
+**Q: Why should I trust you?**
+A: You shouldn't, automatically. You should look at our code (it's open source), our license (AGPL-3.0, which means any company that copies us has to share their changes), our model card (published every quarter), and our public commitments (Section 10 of this document, and the user terms). If we ever break those commitments, you have every right to leave — and to take your data with you.
+
+**Q: How is this different from social media?**
+A: Social media is paid to keep you scrolling. We are not. A good visit here is short, useful, and infrequent. If you feel like you're spending too much time on this platform, we have failed.
+
+**Q: How do I help?**
+A: Use it. Tell us what works and what doesn't. If you have time, follow your local representatives and watch what they do. If you have less time, just check in once a week and see if anything is up for a vote that matters to you. That alone is more than 90% of citizens do — and it's enough to change outcomes when enough of us do it.
+
+---
+
+*End of document.*


### PR DESCRIPTION
## Summary

Ships **"Your Civic Briefing"** at `/me/briefing` as the post-auth landing page — the citizen-facing surface of the personalized civic relevance engine (epic #740). Bills are fully ranked; reps / committees / propositions render placeholder cards that link out to the existing `/region/*` surfaces, where their personalized variants will land via #769 / #770 / #771.

Closes #744.

## What's in this PR

### 1. Composition pattern — `BriefingPage` + `BriefingSection` × 4

Domain-agnostic shell so each follow-up section drops into the same chrome without touching the page composer.

```
BriefingPage
├── BriefingPageHeader               ("Your Civic Briefing" + Browse all civic data →)
├── BriefingSection slug="bills"     ← BillsBriefingSection (real)
├── BriefingSection slug="reps"      ← RepsBriefingPlaceholder
├── BriefingSection slug="committees" ← CommitteesBriefingPlaceholder
└── BriefingSection slug="propositions" ← PropositionsBriefingPlaceholder
```

### 2. Bills section — three-step GraphQL fetch

`bills/useBillBriefing.ts` orchestrates the v1.0 federation boundary (planning doc §6.3):
1. `myRankingFlags` + `mySignalProfile.interestTags` (users service)
2. `myPersonalizedBillFeed(input, limit)` (knowledge service)
3. `bill(id)` × N fanned out (region service)

The two-service input chain is what #761 will collapse into a single subgraph-to-subgraph call. Hero + N compact cards render with a `RelevanceChip` (3-tier color) and a `WhyThisPanel` collapsible that picks the top scoring axis via `topAxisFor()`.

### 3. Post-auth landing redirects

| Surface | Before | After |
|---|---|---|
| Onboarding "Get Started" | `/region` | `/me/briefing` |
| Onboarding "Skip" | `/region` | `/me/briefing` |
| Magic-link callback (default redirect) | `/region` | `/me/briefing` |
| `LandingCTA` (authed users on `/`) | `/region` | `/me/briefing` |
| Header logo (authed) | `/` | `/me/briefing` |

Header desktop + mobile nav also gains a "Briefing" link as the first item.

### 4. i18n parity

`locales/{en,es}/briefing.json` — 36 keys each, full Spanish parity. Includes page chrome, section titles + placeholders, "why this" axis explanations, score label, and the #745 / #751 / #753 placeholder copy.

### 5. Documentation

- New `apps/frontend/components/briefing/README.md` — composition pattern, three-step fetch, `__typename` strip gotcha, where #745 / #761 / #769 / #770 / #771 plug in
- New `docs/architecture/personalized-relevance.md` — the planning doc moves from untracked to canonical; §11 roadmap now annotates Phase 0 + 1 as shipped
- Updated `docs/architecture/frontend-architecture.md` — `/me/*` routes, briefing component tree, `personalized-feed.ts` GraphQL module, new i18n namespaces
- Updated `docs/README.md` + root `CLAUDE.md` index entries

## Test plan

- [ ] Drive through onboarding (or use a returning-user fixture) — confirm completion lands on `/me/briefing`, not `/region`
- [ ] Header shows "Briefing" as the first nav link; logo links to `/me/briefing` when authed
- [ ] "Browse all civic data →" in the page header lands on `/region`
- [ ] Each placeholder section's "See all →" lands on the matching `/region/*` surface
- [ ] Bills section: hero + compact cards render with `RelevanceChip` 0–100% badges
- [ ] "Why is this on my briefing?" expands a heuristic axis explanation
- [ ] Topic chips reflect the user's `interestTags`; "Edit your interests →" links to `/me/profile`
- [ ] Spanish locale: every chrome string renders in `es`
- [ ] Unauthenticated → `/me/briefing` redirects to `/login`
- [ ] Empty / no-profile states render their respective prompts
- [ ] `pnpm exec jest __tests__/components/briefing __tests__/lib/graphql/personalized-feed.test.ts` — 19 tests across 4 suites
- [ ] `pnpm exec playwright test e2e/briefing.spec.ts` — 11 scenarios × 6 projects (Header / logo tests skip on `mobile-chrome` / `mobile-safari` per Header's `hidden md:flex`)
- [ ] WCAG 2.2 AA axe scan green on default state

## Out of scope (filed follow-ups)

| Issue | What it replaces |
|---|---|
| #745 | `WhyThisPanel`'s heuristic axis explanation → LLM-written sentence |
| #761 | Three-step fetch → batched `myPersonalizedBillFeed` with bill details inline |
| #769 / #770 / #771 | Reps / Committees / Propositions placeholders → real personalized sections |
| #773 | Header nav hardcoded English → i18n (pre-existing; surfaced during op-review) |

## Screenshots

_To attach: `/me/briefing` desktop (en), `/me/briefing` mobile (en), bills section expanded with Why-this panel, no-profile prompt, Spanish locale render._

🤖 Generated with [Claude Code](https://claude.com/claude-code)