### PR TITLE
fix(frontend): render Bill.aiSummary on detail page (#779)

### DIFF
--- a/apps/frontend/__tests__/pages/region/bill-detail.test.tsx
+++ b/apps/frontend/__tests__/pages/region/bill-detail.test.tsx
@@ -52,6 +52,16 @@ const AB_MEASURE_TYPE: CivicsMeasureType = {
   ],
 };
 
+const mockAiSummary = {
+  plainEnglishSummary:
+    "This bill changes how the state housing department designates jurisdictions as prohousing, replacing emergency rules with permanent regulations.",
+  topics: ["housing", "government-operations"],
+  whoItAffects: ["homeowners", "renters"],
+  stakeholderImpact:
+    "Small rural jurisdictions gain reduced administrative burdens.",
+  fiscalImpact: { level: "low", summary: "Not specified in the bill text." },
+};
+
 const mockBill = {
   id: "bill-1",
   externalId: "20252026AB100",
@@ -75,6 +85,7 @@ const mockBill = {
   updatedAt: "2025-10-02T00:00:00Z",
   votes: [],
   coAuthors: [],
+  aiSummary: null as typeof mockAiSummary | null,
 };
 
 let mockQueryResult: {
@@ -177,6 +188,108 @@ describe("BillDetailPage", () => {
       render(<BillDetailPage />);
       expect(screen.getByText("Chaptered")).toBeInTheDocument();
       expect(screen.getByText("Failed")).toBeInTheDocument();
+    });
+  });
+
+  describe("AI summary block (#779)", () => {
+    it("renders the plain-English summary at the top of the snapshot layer", () => {
+      mockQueryResult = {
+        data: { bill: { ...mockBill, aiSummary: mockAiSummary } },
+        loading: false,
+        error: null,
+      };
+      render(<BillDetailPage />);
+      expect(
+        screen.getByText(/state housing department designates jurisdictions/i),
+      ).toBeInTheDocument();
+    });
+
+    it("renders topic and audience chips with humanized labels", () => {
+      mockQueryResult = {
+        data: { bill: { ...mockBill, aiSummary: mockAiSummary } },
+        loading: false,
+        error: null,
+      };
+      render(<BillDetailPage />);
+      // "government-operations" → "Government Operations"
+      expect(screen.getByText("Government Operations")).toBeInTheDocument();
+      expect(screen.getByText("Housing")).toBeInTheDocument();
+      expect(screen.getByText("Renters")).toBeInTheDocument();
+      expect(screen.getByText("Homeowners")).toBeInTheDocument();
+    });
+
+    it("renders the fiscal-impact level badge", () => {
+      mockQueryResult = {
+        data: { bill: { ...mockBill, aiSummary: mockAiSummary } },
+        loading: false,
+        error: null,
+      };
+      render(<BillDetailPage />);
+      expect(screen.getAllByText(/low fiscal impact/i).length).toBeGreaterThan(
+        0,
+      );
+    });
+
+    it("renders stakeholderImpact under a 'Who this affects' label", () => {
+      mockQueryResult = {
+        data: { bill: { ...mockBill, aiSummary: mockAiSummary } },
+        loading: false,
+        error: null,
+      };
+      render(<BillDetailPage />);
+      expect(screen.getByText(/who this affects:/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/small rural jurisdictions gain reduced/i),
+      ).toBeInTheDocument();
+    });
+
+    it("shows the pending placeholder when aiSummary is null", () => {
+      // mockBill already has aiSummary: null
+      render(<BillDetailPage />);
+      expect(
+        screen.getByText(/plain-english summary pending/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Sources layer fiscal impact (#779)", () => {
+    it("renders the structured aiSummary.fiscalImpact.summary on the Sources tab", () => {
+      mockQueryResult = {
+        data: { bill: { ...mockBill, aiSummary: mockAiSummary } },
+        loading: false,
+        error: null,
+      };
+      render(<BillDetailPage />);
+      // Navigate Snapshot → History → Votes → Sources
+      fireEvent.click(screen.getByRole("button", { name: /^Sources$/ }));
+      expect(
+        screen.getByText(/not specified in the bill text/i),
+      ).toBeInTheDocument();
+    });
+
+    it("falls back to legacy bill.fiscalImpact when aiSummary is null", () => {
+      const legacyBill = {
+        ...mockBill,
+        aiSummary: null,
+        fiscalImpact: "Legacy fiscal note from the data source.",
+      };
+      mockQueryResult = {
+        data: { bill: legacyBill },
+        loading: false,
+        error: null,
+      };
+      render(<BillDetailPage />);
+      fireEvent.click(screen.getByRole("button", { name: /^Sources$/ }));
+      expect(
+        screen.getByText(/legacy fiscal note from the data source/i),
+      ).toBeInTheDocument();
+    });
+
+    it("hides the fiscal-impact section when neither source has a value", () => {
+      // mockBill.aiSummary is null and mockBill.fiscalImpact is null
+      render(<BillDetailPage />);
+      fireEvent.click(screen.getByRole("button", { name: /^Sources$/ }));
+      expect(screen.queryByText(/^Fiscal impact$/)).not.toBeInTheDocument();
     });
   });
 

--- a/apps/frontend/app/region/bills/[id]/page.tsx
+++ b/apps/frontend/app/region/bills/[id]/page.tsx
@@ -6,6 +6,8 @@ import { useQuery } from "@apollo/client/react";
 import type { CivicsLifecycleStage } from "@/lib/graphql/region";
 import {
   GET_BILL,
+  type BillAiFiscalImpact,
+  type BillAiSummary,
   type BillData,
   type BillIdVars,
   type BillVote,
@@ -38,6 +40,21 @@ const POSITION_STYLES: Record<string, { cls: string; label: string }> = {
   excused: { cls: "bg-blue-100 text-blue-700", label: "Excused" },
   no_vote: { cls: "bg-gray-100 text-gray-400", label: "—" },
 };
+
+const FISCAL_LEVEL_STYLES: Record<string, { cls: string; label: string }> = {
+  none: { cls: "bg-gray-100 text-gray-600", label: "No fiscal impact" },
+  low: { cls: "bg-green-100 text-green-800", label: "Low fiscal impact" },
+  medium: { cls: "bg-amber-100 text-amber-800", label: "Medium fiscal impact" },
+  high: { cls: "bg-red-100 text-red-800", label: "High fiscal impact" },
+};
+
+function humanizeTag(slug: string): string {
+  return slug
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
 
 function MeasureTypeBadge({ code }: { readonly code: string }) {
   const cls = MEASURE_TYPE_STYLES[code] ?? "bg-gray-100 text-gray-800";
@@ -90,6 +107,88 @@ function VoteSummaryBar({ votes }: { readonly votes: BillVote[] }) {
   );
 }
 
+// ── AI summary block (Snapshot layer header) ──────────────────────────────────
+
+function TagChip({ label }: { readonly label: string }) {
+  return (
+    <span className="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-[#334155]">
+      {label}
+    </span>
+  );
+}
+
+function ChipRow({
+  label,
+  tags,
+}: {
+  readonly label: string;
+  readonly tags: readonly string[];
+}) {
+  if (tags.length === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+      <span className="text-xs font-semibold uppercase tracking-wider text-[#595959]">
+        {label}
+      </span>
+      {tags.map((t) => (
+        <TagChip key={t} label={humanizeTag(t)} />
+      ))}
+    </div>
+  );
+}
+
+function FiscalImpactBadge({
+  fiscalImpact,
+}: {
+  readonly fiscalImpact: BillAiFiscalImpact;
+}) {
+  const style =
+    FISCAL_LEVEL_STYLES[fiscalImpact.level] ?? FISCAL_LEVEL_STYLES.none;
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${style.cls}`}
+    >
+      {style.label}
+    </span>
+  );
+}
+
+function AiSummaryBlock({ summary }: { readonly summary: BillAiSummary }) {
+  return (
+    <section
+      aria-label="Plain-English summary"
+      className="mb-6 rounded-lg border-l-4 border-[var(--color-sage)] bg-slate-50 p-5"
+    >
+      <p className="text-base leading-relaxed text-[#222222]">
+        {summary.plainEnglishSummary}
+      </p>
+      {summary.stakeholderImpact && (
+        <p className="mt-3 text-sm leading-relaxed text-[#334155]">
+          <span className="font-semibold">Who this affects: </span>
+          {summary.stakeholderImpact}
+        </p>
+      )}
+      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+        <FiscalImpactBadge fiscalImpact={summary.fiscalImpact} />
+        <ChipRow label="Topics" tags={summary.topics} />
+        <ChipRow label="Audience" tags={summary.whoItAffects} />
+      </div>
+    </section>
+  );
+}
+
+function AiSummaryPending() {
+  return (
+    <section
+      aria-label="Plain-English summary"
+      className="mb-6 rounded-lg border border-dashed border-slate-300 bg-slate-50 p-5 text-sm text-slate-500"
+    >
+      Plain-English summary pending. This bill hasn’t been processed by the
+      summarizer yet — check back shortly.
+    </section>
+  );
+}
+
 // ── Layer components ──────────────────────────────────────────────────────────
 
 function Snapshot({
@@ -103,6 +202,13 @@ function Snapshot({
 }) {
   return (
     <div className="animate-layer-enter">
+      {/* Plain-English AI summary (or pending placeholder) */}
+      {bill.aiSummary ? (
+        <AiSummaryBlock summary={bill.aiSummary} />
+      ) : (
+        <AiSummaryPending />
+      )}
+
       {/* Status + last action */}
       {bill.status && (
         <div className="mb-4 rounded-lg bg-slate-50 px-4 py-3 text-sm text-[#334155]">
@@ -312,13 +418,18 @@ function Sources({
   readonly bill: NonNullable<BillData["bill"]>;
   readonly onBack: () => void;
 }) {
+  // `||` (not `??`) so an empty-string summary still falls back to the
+  // legacy column; the LLM contract says summary is non-empty but we don't
+  // want a stray "" to render an empty paragraph.
+  const fiscalImpactBody =
+    bill.aiSummary?.fiscalImpact?.summary || bill.fiscalImpact;
   return (
     <div className="animate-layer-enter">
-      {bill.fiscalImpact && (
+      {fiscalImpactBody && (
         <div className="mb-6">
           <SectionTitle>Fiscal impact</SectionTitle>
           <p className="text-sm text-[#334155] leading-relaxed">
-            {bill.fiscalImpact}
+            {fiscalImpactBody}
           </p>
         </div>
       )}

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -1509,6 +1509,25 @@ export interface BillCoAuthor {
   coAuthorType?: string;
 }
 
+export interface BillAiFiscalImpact {
+  /** none | low | medium | high */
+  level: string;
+  summary: string;
+}
+
+/**
+ * Structured AI summary for a bill. Null when the bill has not yet been
+ * enriched, or when the LLM emitted `{ skip: true }` for garbled input.
+ * See `BillAiSummaryModel` on the backend.
+ */
+export interface BillAiSummary {
+  plainEnglishSummary: string;
+  topics: string[];
+  whoItAffects: string[];
+  fiscalImpact: BillAiFiscalImpact;
+  stakeholderImpact: string;
+}
+
 export interface Bill {
   id: string;
   externalId: string;
@@ -1531,6 +1550,7 @@ export interface Bill {
   updatedAt: string;
   votes: BillVote[];
   coAuthors: BillCoAuthor[];
+  aiSummary?: BillAiSummary | null;
 }
 
 export interface PaginatedBills {
@@ -1653,6 +1673,16 @@ export const GET_BILL = gql`
       }
       coAuthors {
         ...BillCoAuthorFields
+      }
+      aiSummary {
+        plainEnglishSummary
+        topics
+        whoItAffects
+        stakeholderImpact
+        fiscalImpact {
+          level
+          summary
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- The bill detail page's `GET_BILL` query never requested `aiSummary` and the page never rendered it, so users clicking **Read the bill →** from their civic briefing landed on a page of pure metadata (status, last action, author) with no description.
- Adds `aiSummary { plainEnglishSummary, topics, whoItAffects, stakeholderImpact, fiscalImpact { level, summary } }` to the query and renders a summary block at the top of the Snapshot layer (paragraph + "Who this affects" line + fiscal-level pill + Topics/Audience chips). Sources layer now prefers the structured fiscal-impact summary and falls back to the legacy column.
- Bills not yet enriched render a dashed "Plain-English summary pending" placeholder so the empty state reads as intentional rather than broken.

Closes #779.

## Test plan

- [ ] On the local UAT stack, hit `/region/bills/<AB 36 id>` (a bill known to have `ai_summary` populated). Verify:
  - [ ] Summary paragraph appears at the top of the Snapshot layer
  - [ ] "Who this affects: …" line renders below the paragraph
  - [ ] "Low fiscal impact" pill + "Topics: Housing · Government Operations" + "Audience: Homeowners · Renters" chip rows render
  - [ ] Sources tab shows the structured fiscal-impact prose once, with no duplicate badge
- [ ] Open a bill with `ai_summary IS NULL` (e.g. AB 46). Verify the dashed "Plain-English summary pending" placeholder renders in the same slot.
- [ ] Open a bill with a non-null legacy `fiscal_impact` text column but `ai_summary IS NULL`. Verify Sources falls back to the legacy text.
- [ ] `pnpm test __tests__/pages/region/bill-detail.test.tsx` passes (17/17, includes 4 new tests covering populated summary, humanized chips, fiscal badge, pending placeholder, stakeholderImpact, Sources structured + legacy fallback, and Sources hide-when-empty).