### PR TITLE
feat(knowledge,frontend): personalized Propositions briefing section (#771)

### DIFF
--- a/apps/backend/src/apps/knowledge/src/app.module.ts
+++ b/apps/backend/src/apps/knowledge/src/app.module.ts
@@ -17,6 +17,7 @@ import { createQueryComplexityPlugin } from 'src/common/graphql/query-complexity
 
 import { KnowledgeModule } from './domains/knowledge.module';
 import { PersonalizedFeedModule } from './domains/personalized-feed/personalized-feed.module';
+import { PersonalizedPropositionsModule } from './domains/personalized-propositions/personalized-propositions.module';
 
 import configuration from 'src/config';
 import relationaldbConfig from 'src/config/relationaldb.config';
@@ -69,6 +70,7 @@ import { MetricsModule } from 'src/common/metrics';
     CaslModule.forRoot(),
     KnowledgeModule,
     PersonalizedFeedModule,
+    PersonalizedPropositionsModule,
     HealthModule.forRoot({
       serviceName: 'knowledge-service',
       hasDatabase: true,

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/dto/proposition-personalization-input.dto.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/dto/proposition-personalization-input.dto.ts
@@ -1,0 +1,32 @@
+import { Field, InputType } from '@nestjs/graphql';
+import { Type } from 'class-transformer';
+import { IsArray, IsString, ValidateNested } from 'class-validator';
+import { RankingFlagsInputDto } from '../../personalized-feed/dto/personalization-input.dto';
+
+/**
+ * Bundled input for `myPersonalizedPropositionFeed` (#771). Same shape
+ * as `PersonalizationInputDto` (bills, #743) — the frontend pre-fetches
+ * `myRankingFlags` + `mySignalProfile { interestTags }` from the users
+ * service in one query, then passes them here so this resolver can do
+ * the ranking without making a cross-service call back to users.
+ *
+ * `trustedOrganizations` is intentionally NOT on this DTO for Phase 1
+ * of #771 — endorsement chips ship in the Phase 2 follow-up that also
+ * needs a backing `PropositionEndorsement` data model. Adding it to
+ * the DTO before the data is real would let the frontend send signals
+ * the ranker can't yet honor.
+ */
+@InputType()
+export class PropositionPersonalizationInputDto {
+  /** User's declared topic interests (housing, healthcare, etc.) */
+  @Field(() => [String])
+  @IsArray()
+  @IsString({ each: true })
+  interestTags!: string[];
+
+  /** Derived boolean flags from the users service (re-uses bills DTO). */
+  @Field(() => RankingFlagsInputDto)
+  @ValidateNested()
+  @Type(() => RankingFlagsInputDto)
+  flags!: RankingFlagsInputDto;
+}

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/models/personalized-proposition-result.model.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/models/personalized-proposition-result.model.ts
@@ -1,0 +1,42 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql';
+import { PropositionAxisScoresModel } from './proposition-axis-scores.model';
+
+/**
+ * One entry in the user's personalized proposition feed (#771).
+ * Returns the proposition's id + the ranking output. The frontend
+ * uses `propositionId` with region's existing `proposition(id)` query
+ * to fetch the full Proposition record (title, summary, election
+ * date, outcomes, etc.).
+ *
+ * Same federation tradeoff as `PersonalizedBillResult`: region's
+ * Proposition type isn't declared as an `@key("id")` entity, so
+ * inline expansion via the gateway isn't free. Tracked alongside the
+ * cross-service DB read refactor at #761.
+ */
+@ObjectType('PersonalizedPropositionResult')
+export class PersonalizedPropositionResultModel {
+  /**
+   * Region-owned Proposition id. Frontend resolves details via
+   * region.proposition(id).
+   */
+  @Field(() => ID)
+  propositionId!: string;
+
+  /** Composite 0.0-1.0 score. Higher = more relevant. */
+  @Field()
+  relevanceScore!: number;
+
+  /** Per-axis breakdown so the why-this panel can render reasons. */
+  @Field(() => PropositionAxisScoresModel)
+  axisScores!: PropositionAxisScoresModel;
+
+  /**
+   * LLM-written one-sentence "why this matters to you" — placeholder
+   * for the prop-rerank Phase 2 follow-up (would reuse the
+   * `llm-rerank-worker` infrastructure shipped in #745 with a new
+   * prompt-service template). Always null in Phase 1; frontend falls
+   * back to the heuristic axis explanation rendered by `WhyThisPanel`.
+   */
+  @Field({ nullable: true })
+  relevanceExplanation?: string;
+}

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/models/proposition-axis-scores.model.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/models/proposition-axis-scores.model.ts
@@ -1,0 +1,53 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Per-axis relevance breakdown for a proposition (#771). Each axis is
+ * 0.0-1.0. v1.0 (Phase 1) populates axes 1-3 with non-zero scores;
+ * axes 4-7 return 0.0 placeholders parallel to the bill ranker's
+ * v1.1 wiring (planning doc §5.1).
+ *
+ * Axis 3 is renamed semantically for propositions: bills track
+ * "actionability" (vote/comment window), props track explicit
+ * "election proximity" (days until the ballot). The wire shape stays
+ * named `actionability` so the frontend WhyThisPanel can reuse the
+ * same i18n keys without per-section forking.
+ */
+@ObjectType('PropositionAxisScores')
+export class PropositionAxisScoresModel {
+  /** Axis 1: does this change the user's money, rights, health, services? */
+  @Field()
+  directMaterial!: number;
+
+  /** Axis 2: does it advance or threaten priorities the user declared? */
+  @Field()
+  valuesAlignment!: number;
+
+  /**
+   * Axis 3 (propositions): election proximity — peaks at ~14 days out,
+   * decays linearly toward 0 at 0 days (already past) and at 365 days
+   * (too far out to matter). Maps to the same wire field name as the
+   * bill ranker's "actionability" for shared frontend rendering.
+   */
+  @Field()
+  actionability!: number;
+
+  /** Axis 4 (v1.1): household, employer, school, neighborhood impact. */
+  @Field()
+  indirectMaterial!: number;
+
+  /**
+   * Axis 5 (v1.1 — propositions specifically): trusted-organization
+   * endorsement signal. Phase 2 of #771 populates this once the
+   * endorsement model + ingest path land.
+   */
+  @Field()
+  coalitionSignal!: number;
+
+  /** Axis 6 (v1.1): under-covered local prop rewards. */
+  @Field()
+  counterfactual!: number;
+
+  /** Axis 7 (v1.1): diminishing returns on similar props. */
+  @Field()
+  noveltyRepetition!: number;
+}

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.module.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.module.ts
@@ -1,0 +1,29 @@
+import { Module } from '@nestjs/common';
+
+import { PropositionScoringService } from './proposition-scoring.service';
+import { PersonalizedPropositionsService } from './personalized-propositions.service';
+import { PersonalizedPropositionsResolver } from './personalized-propositions.resolver';
+
+/**
+ * Personalized propositions feed (#771).
+ *
+ * Phase 1: heuristic 3-axis scoring against the user's RankingFlags +
+ * interestTags + the proposition's election date. Reads propositions
+ * directly from the shared DB via DbService — documented cross-service
+ * shortcut, mirrors the bill ranker (#743). Federation refactor at #761.
+ *
+ * Phase 2 follow-ups (not in this module yet):
+ *   - LLM rerank for prop explanations (reuses llm-rerank-worker
+ *     infra from #745 with a new prompt-service template)
+ *   - PropositionEndorsement model + scoring axis 5 (trusted-org
+ *     coalition signal) — gated on the endorsement-data pipeline
+ */
+@Module({
+  providers: [
+    PropositionScoringService,
+    PersonalizedPropositionsService,
+    PersonalizedPropositionsResolver,
+  ],
+  exports: [PersonalizedPropositionsService, PropositionScoringService],
+})
+export class PersonalizedPropositionsModule {}

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.resolver.spec.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.resolver.spec.ts
@@ -1,0 +1,119 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { PersonalizedPropositionsResolver } from './personalized-propositions.resolver';
+import {
+  PersonalizedPropositionsService,
+  PROPOSITION_FEED_DEFAULT_LIMIT,
+} from './personalized-propositions.service';
+import type { GqlContext } from 'src/common/utils/graphql-context';
+import type { PropositionPersonalizationInputDto } from './dto/proposition-personalization-input.dto';
+
+/**
+ * Resolver-layer tests verify the auth-context routing and the
+ * limit-default branch — the contract surface a future refactor
+ * could quietly break. Service is fully mocked; its own logic is
+ * exhaustively covered in personalized-propositions.service.spec.
+ */
+describe('PersonalizedPropositionsResolver', () => {
+  let resolver: PersonalizedPropositionsResolver;
+  let feed: jest.Mocked<PersonalizedPropositionsService>;
+
+  const ctx = (userId: string): GqlContext =>
+    ({ req: { user: { id: userId } } }) as unknown as GqlContext;
+
+  const FLAGS_OFF: PropositionPersonalizationInputDto['flags'] = {
+    isRenter: false,
+    isHomeowner: false,
+    isParent: false,
+    isCaregiver: false,
+    isStudent: false,
+    isEducator: false,
+    isWorker: false,
+    isBusinessOwner: false,
+    isUnionMember: false,
+    isGigWorker: false,
+    isTransitRider: false,
+    isDriver: false,
+    hasSpecialLicense: false,
+    hasImmigrationConcern: false,
+    hasHealthCondition: false,
+    hasPublicHealthInsurance: false,
+    isVeteran: false,
+    hasJusticeInvolvement: false,
+    isLowIncome: false,
+    receivesPublicBenefits: false,
+  };
+
+  beforeEach(async () => {
+    feed = {
+      getFeedForUser: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<PersonalizedPropositionsService>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PersonalizedPropositionsResolver,
+        { provide: PersonalizedPropositionsService, useValue: feed },
+      ],
+    }).compile();
+    resolver = module.get(PersonalizedPropositionsResolver);
+  });
+
+  it('forwards the authenticated userId, input, and limit to the service', async () => {
+    const input = {
+      interestTags: ['housing'],
+      flags: { ...FLAGS_OFF, isRenter: true },
+    };
+    await resolver.getMyPersonalizedPropositionFeed(input, 7, ctx('u-1'));
+
+    expect(feed.getFeedForUser).toHaveBeenCalledWith('u-1', input, 7);
+  });
+
+  it('applies PROPOSITION_FEED_DEFAULT_LIMIT when caller omits the limit arg', async () => {
+    const input = { interestTags: [], flags: FLAGS_OFF };
+    await resolver.getMyPersonalizedPropositionFeed(
+      input,
+      undefined,
+      ctx('u-1'),
+    );
+
+    expect(feed.getFeedForUser).toHaveBeenCalledWith(
+      'u-1',
+      input,
+      PROPOSITION_FEED_DEFAULT_LIMIT,
+    );
+  });
+
+  it('returns the service result unchanged', async () => {
+    const result = [
+      {
+        propositionId: 'p-1',
+        relevanceScore: 0.6,
+        axisScores: {
+          directMaterial: 0.2,
+          valuesAlignment: 1.0,
+          actionability: 1.0,
+          indirectMaterial: 0,
+          coalitionSignal: 0,
+          counterfactual: 0,
+          noveltyRepetition: 0,
+        },
+      },
+    ];
+    feed.getFeedForUser.mockResolvedValue(result as never);
+
+    const out = await resolver.getMyPersonalizedPropositionFeed(
+      { interestTags: [], flags: FLAGS_OFF },
+      5,
+      ctx('u-1'),
+    );
+    expect(out).toBe(result);
+  });
+
+  it('threads different user ids through correctly (no cross-user leak)', async () => {
+    const input = { interestTags: [], flags: FLAGS_OFF };
+    await resolver.getMyPersonalizedPropositionFeed(input, 5, ctx('u-A'));
+    await resolver.getMyPersonalizedPropositionFeed(input, 5, ctx('u-B'));
+
+    expect(feed.getFeedForUser).toHaveBeenNthCalledWith(1, 'u-A', input, 5);
+    expect(feed.getFeedForUser).toHaveBeenNthCalledWith(2, 'u-B', input, 5);
+  });
+});

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.resolver.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.resolver.ts
@@ -1,0 +1,52 @@
+import { UseGuards } from '@nestjs/common';
+import { Args, Context, Int, Query, Resolver } from '@nestjs/graphql';
+import {
+  type GqlContext,
+  getUserFromContext,
+} from 'src/common/utils/graphql-context';
+import { AuthGuard } from 'src/common/guards/auth.guard';
+
+import { PropositionPersonalizationInputDto } from './dto/proposition-personalization-input.dto';
+import { PersonalizedPropositionResultModel } from './models/personalized-proposition-result.model';
+import {
+  PersonalizedPropositionsService,
+  PROPOSITION_FEED_DEFAULT_LIMIT,
+} from './personalized-propositions.service';
+
+/**
+ * v1.0 personalized propositions feed (#771). Mirrors the bill-feed
+ * resolver shape so the frontend pre-fetches `myRankingFlags` +
+ * `mySignalProfile { interestTags }` once and passes them as input
+ * here — no cross-service hop back to users on every briefing render.
+ *
+ * Phase 1 ships heuristic scoring only (axes 1-3 in
+ * `PropositionScoringService`). No mutation surface in this resolver
+ * yet — the LLM rerank flow that lives on the bill feed (#745) is a
+ * Phase 2 candidate for propositions.
+ *
+ * Limit defaults to 5 (briefing surface sweet spot) and is hard-capped
+ * at 10 inside the service — beyond that the briefing card becomes a
+ * list view, which `/region/propositions` already covers.
+ */
+@Resolver()
+@UseGuards(AuthGuard)
+export class PersonalizedPropositionsResolver {
+  constructor(private readonly feed: PersonalizedPropositionsService) {}
+
+  @Query(() => [PersonalizedPropositionResultModel], {
+    name: 'myPersonalizedPropositionFeed',
+  })
+  async getMyPersonalizedPropositionFeed(
+    @Args('input') input: PropositionPersonalizationInputDto,
+    @Args('limit', { type: () => Int, nullable: true })
+    limit: number | undefined,
+    @Context() context: GqlContext,
+  ): Promise<PersonalizedPropositionResultModel[]> {
+    const user = getUserFromContext(context);
+    return this.feed.getFeedForUser(
+      user.id,
+      input,
+      limit ?? PROPOSITION_FEED_DEFAULT_LIMIT,
+    );
+  }
+}

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.service.spec.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.service.spec.ts
@@ -1,0 +1,280 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import {
+  PersonalizedPropositionsService,
+  PROPOSITION_FEED_DEFAULT_LIMIT,
+  PROPOSITION_FEED_MAX_LIMIT,
+} from './personalized-propositions.service';
+import { PropositionScoringService } from './proposition-scoring.service';
+import type { PropositionPersonalizationInputDto } from './dto/proposition-personalization-input.dto';
+
+const FLAGS_OFF: PropositionPersonalizationInputDto['flags'] = {
+  isRenter: false,
+  isHomeowner: false,
+  isParent: false,
+  isCaregiver: false,
+  isStudent: false,
+  isEducator: false,
+  isWorker: false,
+  isBusinessOwner: false,
+  isUnionMember: false,
+  isGigWorker: false,
+  isTransitRider: false,
+  isDriver: false,
+  hasSpecialLicense: false,
+  hasImmigrationConcern: false,
+  hasHealthCondition: false,
+  hasPublicHealthInsurance: false,
+  isVeteran: false,
+  hasJusticeInvolvement: false,
+  isLowIncome: false,
+  receivesPublicBenefits: false,
+};
+
+/**
+ * Synthetic proposition row matching what Prisma's `findMany` returns
+ * for the columns we select. Letting jest see the actual shape catches
+ * column-name drift between the SQL select and the in-memory mapping.
+ *
+ * NB: the proposition schema has AI-extracted fields as FLAT columns,
+ * not an `aiSummary` JSON column like bills. The `keyProvisions` /
+ * `existingVsProposed` / `analysisSections` columns are JSONB and can
+ * carry strings, arrays, or nested objects — the service flattens
+ * them via `stringLeaves` so test fixtures should pass realistic shapes.
+ */
+type PropRowInput = {
+  id?: string;
+  summary?: string;
+  electionDate?: Date;
+  analysisSummary?: string | null;
+  keyProvisions?: unknown;
+  fiscalImpact?: string | null;
+  yesOutcome?: string | null;
+  noOutcome?: string | null;
+  existingVsProposed?: unknown;
+  analysisSections?: unknown;
+};
+
+const propRow = (overrides: PropRowInput = {}) => ({
+  id: 'p-1',
+  summary: '',
+  electionDate: new Date('2026-11-03T00:00:00Z'),
+  analysisSummary: null,
+  keyProvisions: null,
+  fiscalImpact: null,
+  yesOutcome: null,
+  noOutcome: null,
+  existingVsProposed: null,
+  analysisSections: null,
+  ...overrides,
+});
+
+describe('PersonalizedPropositionsService', () => {
+  let service: PersonalizedPropositionsService;
+  let db: { proposition: { findMany: jest.Mock } };
+
+  beforeEach(async () => {
+    db = { proposition: { findMany: jest.fn() } };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PersonalizedPropositionsService,
+        PropositionScoringService,
+        { provide: DbService, useValue: db },
+      ],
+    }).compile();
+
+    service = module.get(PersonalizedPropositionsService);
+  });
+
+  it('returns an empty array when no propositions are active', async () => {
+    db.proposition.findMany.mockResolvedValue([]);
+    const out = await service.getFeedForUser(
+      'u-1',
+      { interestTags: ['housing'], flags: { ...FLAGS_OFF, isRenter: true } },
+      5,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('drops zero-relevance propositions so the feed never pads with garbage', async () => {
+    db.proposition.findMany.mockResolvedValue([
+      propRow({
+        id: 'unrelated',
+        summary: 'Statewide bond issue for completely unrelated topic',
+      }),
+    ]);
+    const out = await service.getFeedForUser(
+      'u-1',
+      { interestTags: ['housing'], flags: { ...FLAGS_OFF, isRenter: true } },
+      5,
+    );
+    expect(out).toEqual([]);
+  });
+
+  it('returns scored props sorted by composite desc', async () => {
+    db.proposition.findMany.mockResolvedValue([
+      propRow({
+        id: 'p-lowmatch',
+        summary: 'mentions housing only',
+        electionDate: new Date('2027-06-01T00:00:00Z'), // far out
+      }),
+      propRow({
+        id: 'p-highmatch',
+        summary: 'protects renters and housing affordability',
+        analysisSummary: 'Caps rent increases statewide.',
+        electionDate: new Date(Date.now() + 14 * 86_400_000), // 14d out (urgent)
+      }),
+    ]);
+
+    const out = await service.getFeedForUser(
+      'u-1',
+      { interestTags: ['housing'], flags: { ...FLAGS_OFF, isRenter: true } },
+      5,
+    );
+
+    expect(out).toHaveLength(2);
+    expect(out[0].propositionId).toBe('p-highmatch');
+    expect(out[1].propositionId).toBe('p-lowmatch');
+    expect(out[0].relevanceScore).toBeGreaterThan(out[1].relevanceScore);
+  });
+
+  it('honors the requested limit', async () => {
+    const rows = Array.from({ length: 8 }, (_, i) =>
+      propRow({
+        id: `p-${i}`,
+        summary: 'housing',
+        electionDate: new Date(Date.now() + (10 + i) * 86_400_000),
+      }),
+    );
+    db.proposition.findMany.mockResolvedValue(rows);
+
+    const out = await service.getFeedForUser(
+      'u-1',
+      { interestTags: ['housing'], flags: FLAGS_OFF },
+      3,
+    );
+    expect(out).toHaveLength(3);
+  });
+
+  it('falls back to the default limit when requestedLimit is 0 or negative', async () => {
+    const rows = Array.from({ length: 8 }, (_, i) =>
+      propRow({
+        id: `p-${i}`,
+        summary: 'housing',
+        electionDate: new Date(Date.now() + (10 + i) * 86_400_000),
+      }),
+    );
+    db.proposition.findMany.mockResolvedValue(rows);
+
+    const out = await service.getFeedForUser(
+      'u-1',
+      { interestTags: ['housing'], flags: FLAGS_OFF },
+      0,
+    );
+    expect(out).toHaveLength(PROPOSITION_FEED_DEFAULT_LIMIT);
+  });
+
+  it('clamps to PROPOSITION_FEED_MAX_LIMIT regardless of caller', async () => {
+    const rows = Array.from({ length: 30 }, (_, i) =>
+      propRow({
+        id: `p-${i}`,
+        summary: 'housing',
+        electionDate: new Date(Date.now() + (10 + i) * 86_400_000),
+      }),
+    );
+    db.proposition.findMany.mockResolvedValue(rows);
+
+    const out = await service.getFeedForUser(
+      'u-1',
+      { interestTags: ['housing'], flags: FLAGS_OFF },
+      1_000,
+    );
+    expect(out).toHaveLength(PROPOSITION_FEED_MAX_LIMIT);
+  });
+
+  it('filters at the SQL layer — only active/pending props with future electionDate, not soft-deleted', async () => {
+    db.proposition.findMany.mockResolvedValue([]);
+    await service.getFeedForUser(
+      'u-1',
+      { interestTags: [], flags: FLAGS_OFF },
+      5,
+    );
+    const where = db.proposition.findMany.mock.calls[0][0].where;
+    expect(where.deletedAt).toBeNull();
+    expect(where.status.in).toEqual(['active', 'pending']);
+    expect(where.electionDate.gte).toBeInstanceOf(Date);
+  });
+
+  it('flattens text from multiple analysis columns into the searchable corpus', async () => {
+    db.proposition.findMany.mockResolvedValue([
+      propRow({
+        id: 'p-multi',
+        summary: 'Housing affordability act',
+        analysisSummary: 'Caps rent increases.',
+        // keyProvisions JSONB carries an array of bullets here.
+        keyProvisions: ['Includes protections for renters.'],
+        fiscalImpact: '$2B annually.',
+        // nested JSON should still get its string leaves walked:
+        existingVsProposed: {
+          current: 'No statewide cap.',
+          proposed: 'New annual cap of 5%.',
+        },
+        electionDate: new Date(Date.now() + 14 * 86_400_000),
+      }),
+    ]);
+
+    // user's flag matches "renters" in keyProvisions (case-insensitive)
+    // → axis 1 should fire
+    const out = await service.getFeedForUser(
+      'u-1',
+      { interestTags: [], flags: { ...FLAGS_OFF, isRenter: true } },
+      5,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].axisScores.directMaterial).toBeGreaterThan(0);
+  });
+
+  it('handles propositions with all-null analysis columns by reading only the summary', async () => {
+    db.proposition.findMany.mockResolvedValue([
+      propRow({
+        id: 'p-bare',
+        summary: 'Allows renters to vote on rent control.',
+        electionDate: new Date(Date.now() + 14 * 86_400_000),
+      }),
+    ]);
+    const out = await service.getFeedForUser(
+      'u-1',
+      { interestTags: [], flags: { ...FLAGS_OFF, isRenter: true } },
+      5,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].axisScores.directMaterial).toBeGreaterThan(0);
+  });
+
+  it('ignores non-string JSON leaves (numbers, booleans, dates) when walking keyProvisions', async () => {
+    db.proposition.findMany.mockResolvedValue([
+      propRow({
+        id: 'p-mixed',
+        summary: 'Property tax measure for homeowners',
+        // mix of strings + non-strings; only strings get into the corpus
+        keyProvisions: [
+          'Affects homeowners statewide.',
+          {
+            caveat: 'Subject to legislative review.',
+            priority: 1,
+            active: true,
+          },
+        ],
+        electionDate: new Date(Date.now() + 14 * 86_400_000),
+      }),
+    ]);
+    const out = await service.getFeedForUser(
+      'u-1',
+      { interestTags: [], flags: { ...FLAGS_OFF, isHomeowner: true } },
+      5,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].axisScores.directMaterial).toBeGreaterThan(0);
+  });
+});

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.service.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/personalized-propositions.service.ts
@@ -1,0 +1,231 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
+import type { PropositionPersonalizationInputDto } from './dto/proposition-personalization-input.dto';
+import type { PersonalizedPropositionResultModel } from './models/personalized-proposition-result.model';
+import {
+  PropositionScoringService,
+  type RankableProposition,
+} from './proposition-scoring.service';
+
+/**
+ * Column projection for the propositions ranker. Hoisted so the SQL
+ * `select` clause and the row type stay in lockstep automatically —
+ * a column drift in the schema or this constant is caught by Prisma's
+ * generated `GetPayload` type, not silently swallowed by a hand-rolled
+ * row interface.
+ */
+const PROPOSITION_SELECT = {
+  id: true,
+  summary: true,
+  electionDate: true,
+  analysisSummary: true,
+  keyProvisions: true,
+  fiscalImpact: true,
+  yesOutcome: true,
+  noOutcome: true,
+  existingVsProposed: true,
+  analysisSections: true,
+} as const satisfies Prisma.PropositionSelect;
+
+type PropositionRow = Prisma.PropositionGetPayload<{
+  select: typeof PROPOSITION_SELECT;
+}>;
+
+/**
+ * Default and hard cap for `myPersonalizedPropositionFeed(limit)`.
+ * Ballots typically carry ~5-15 propositions; the briefing card
+ * surfaces a much shorter ranked list. Default 5 mirrors the bill
+ * feed's research-backed sweet spot; max 10 caps it at "full ballot
+ * sized" before becoming a list view that the `/region/propositions`
+ * page already covers.
+ */
+export const PROPOSITION_FEED_DEFAULT_LIMIT = 5;
+export const PROPOSITION_FEED_MAX_LIMIT = 10;
+
+/**
+ * Defensive ceiling on the cross-service propositions read. CA carries
+ * O(10) statewide props per cycle; even with local measures included
+ * this cap leaves headroom. The warn log will flag if a future region
+ * pushes past it.
+ */
+const RANKABLE_PROPS_FETCH_LIMIT = 500;
+
+/**
+ * Maximum recursion depth when walking JSONB columns into string
+ * leaves. Real propositions land at depth 1-2 (arrays of strings,
+ * `{current, proposed}` pairs); 5 is comfortable headroom against
+ * a malformed payload while still bounding worst-case stack use.
+ */
+const MAX_JSON_DEPTH = 5;
+
+/**
+ * Flatten the proposition's text columns into a single lowercased
+ * corpus for keyword matching. Some columns are plain strings (e.g.
+ * `summary`, `analysisSummary`); others are JSONB (`keyProvisions`,
+ * `existingVsProposed`, `analysisSections`) carrying arrays or nested
+ * objects. Defensively walk each JSON shape and pull only string
+ * leaves so axis 1 + 2 see the prose without false-firing on field
+ * names or numeric values. Mirrors the `coerceAiSummary` runtime
+ * validation pattern from #745's review (S14).
+ */
+function extractSearchableText(row: PropositionRow): string {
+  const parts: string[] = [row.summary];
+  for (const v of [
+    row.analysisSummary,
+    row.fiscalImpact,
+    row.yesOutcome,
+    row.noOutcome,
+  ]) {
+    if (typeof v === 'string' && v.length > 0) parts.push(v);
+  }
+  parts.push(...stringLeaves(row.keyProvisions));
+  parts.push(...stringLeaves(row.existingVsProposed));
+  parts.push(...stringLeaves(row.analysisSections));
+  return parts.join(' ').toLowerCase();
+}
+
+/**
+ * Recursively collect every string leaf from an arbitrary JSON value.
+ * Tolerant of null / scalar / array / nested-object shapes; non-string
+ * leaves (numbers, booleans, dates) are ignored. Bounded by
+ * `MAX_JSON_DEPTH` so a pathologically nested payload can't blow the
+ * stack — practically a no-op for real proposition data.
+ */
+function stringLeaves(value: unknown, depth = 0): string[] {
+  if (depth >= MAX_JSON_DEPTH) return [];
+  if (value === null || value === undefined) return [];
+  if (typeof value === 'string') return [value];
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => stringLeaves(item, depth + 1));
+  }
+  if (typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).flatMap((v) =>
+      stringLeaves(v, depth + 1),
+    );
+  }
+  return [];
+}
+
+/**
+ * Orchestrates the v1.0 personalized propositions feed (#771):
+ *   1. Read active propositions with future `electionDate` from the
+ *      shared DB (cross-service read, documented shortcut — region
+ *      owns the table; v1.1 federation refactor tracked at #761).
+ *   2. Score each via PropositionScoringService.
+ *   3. Sort by composite + return top-N capped at PROPOSITION_FEED_MAX_LIMIT.
+ *
+ * No LLM rerank in Phase 1 — heuristic axis explanation in the
+ * frontend WhyThisPanel only. Phase 2 candidate: reuse the
+ * llm-rerank-worker infra from #745 with a new prompt-service template.
+ *
+ * Hard exclusions:
+ *   - Past-election props (`electionDate < now`)
+ *   - Soft-deleted props (`deletedAt IS NOT NULL`)
+ *   - Inactive lifecycle stages (Phase 1: keep status='active'/'pending';
+ *     when richer lifecycle data lands the filter sharpens)
+ *
+ * **Known limitation — jurisdiction filter.** The issue AC asks for
+ * "propositions in the user's jurisdictions". Today the `Proposition`
+ * model has no `regionId` / `jurisdictionId` column and the scraper
+ * ingests California statewide measures only, so the implicit
+ * scope (every user sees every CA prop) matches the AC for the
+ * data we have. Once local / county / city ballot measures get
+ * ingested, this service must filter by the user's resolved
+ * jurisdictions — tracked as a Phase 2 follow-up.
+ */
+@Injectable()
+export class PersonalizedPropositionsService {
+  private readonly logger = new Logger(PersonalizedPropositionsService.name);
+
+  constructor(
+    private readonly db: DbService,
+    private readonly scoring: PropositionScoringService,
+  ) {}
+
+  async getFeedForUser(
+    userId: string,
+    input: PropositionPersonalizationInputDto,
+    requestedLimit: number,
+  ): Promise<PersonalizedPropositionResultModel[]> {
+    const safe =
+      requestedLimit > 0 ? requestedLimit : PROPOSITION_FEED_DEFAULT_LIMIT;
+    const limit = Math.min(safe, PROPOSITION_FEED_MAX_LIMIT);
+
+    const startMs = Date.now();
+    const candidates = await this.fetchRankableProps();
+    const fetchMs = Date.now() - startMs;
+
+    const now = new Date();
+    const scored = candidates
+      .map((prop) => {
+        const { axisScores, composite } = this.scoring.scoreProposition(
+          prop,
+          input,
+          now,
+        );
+        return {
+          propositionId: prop.id,
+          relevanceScore: composite,
+          axisScores,
+        };
+      })
+      // Require at least one PERSONAL signal match (axis 1 or 2). The
+      // briefing surface is about personalization — props with only
+      // election-proximity scores but no signal match aren't
+      // "personally relevant", they're "imminent", and the unfiltered
+      // /region/propositions list page already serves that need.
+      .filter(
+        (r) =>
+          r.axisScores.directMaterial > 0 || r.axisScores.valuesAlignment > 0,
+      )
+      .sort((a, b) => b.relevanceScore - a.relevanceScore)
+      .slice(0, limit);
+
+    const totalMs = Date.now() - startMs;
+    this.logger.log(
+      {
+        event: 'personalized_proposition_feed',
+        userId,
+        candidates: candidates.length,
+        returned: scored.length,
+        requestedLimit,
+        appliedLimit: limit,
+        fetchMs,
+        totalMs,
+      },
+      `Personalized propositions for ${userId}: ${scored.length}/${candidates.length} props (limit=${limit}) in ${totalMs}ms`,
+    );
+
+    return scored;
+  }
+
+  /**
+   * Cross-service read of active propositions. Filters at the SQL
+   * level so we don't pull soft-deleted or past-election rows into
+   * memory just to drop them in the scoring loop.
+   */
+  private async fetchRankableProps(): Promise<RankableProposition[]> {
+    const now = new Date();
+    const rows = await this.db.proposition.findMany({
+      where: {
+        deletedAt: null,
+        electionDate: { gte: now },
+        status: { in: ['active', 'pending'] },
+      },
+      select: PROPOSITION_SELECT,
+      take: RANKABLE_PROPS_FETCH_LIMIT,
+    });
+
+    if (rows.length === RANKABLE_PROPS_FETCH_LIMIT) {
+      this.logger.warn(
+        `Hit RANKABLE_PROPS_FETCH_LIMIT (${RANKABLE_PROPS_FETCH_LIMIT}) — raise the cap or refine the filter.`,
+      );
+    }
+
+    return rows.map((row) => ({
+      id: row.id,
+      electionDate: row.electionDate,
+      searchableText: extractSearchableText(row),
+    }));
+  }
+}

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/proposition-scoring.service.spec.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/proposition-scoring.service.spec.ts
@@ -1,0 +1,276 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  PropositionScoringService,
+  type RankableProposition,
+} from './proposition-scoring.service';
+import type { PropositionPersonalizationInputDto } from './dto/proposition-personalization-input.dto';
+
+const FLAGS_OFF: PropositionPersonalizationInputDto['flags'] = {
+  isRenter: false,
+  isHomeowner: false,
+  isParent: false,
+  isCaregiver: false,
+  isStudent: false,
+  isEducator: false,
+  isWorker: false,
+  isBusinessOwner: false,
+  isUnionMember: false,
+  isGigWorker: false,
+  isTransitRider: false,
+  isDriver: false,
+  hasSpecialLicense: false,
+  hasImmigrationConcern: false,
+  hasHealthCondition: false,
+  hasPublicHealthInsurance: false,
+  isVeteran: false,
+  hasJusticeInvolvement: false,
+  isLowIncome: false,
+  receivesPublicBenefits: false,
+};
+
+const baseProp = (
+  overrides: Partial<RankableProposition> = {},
+): RankableProposition => ({
+  id: 'p-1',
+  electionDate: new Date('2026-11-03T00:00:00Z'),
+  searchableText: '',
+  ...overrides,
+});
+
+describe('PropositionScoringService', () => {
+  let service: PropositionScoringService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [PropositionScoringService],
+    }).compile();
+    service = module.get(PropositionScoringService);
+  });
+
+  describe('scoreDirectMaterial (axis 1)', () => {
+    it('returns 0 when the proposition has no searchable text', () => {
+      expect(
+        service.scoreDirectMaterial(baseProp({ searchableText: '' }), {
+          ...FLAGS_OFF,
+          isRenter: true,
+        }),
+      ).toBe(0);
+    });
+
+    it('returns 0 when the user has no flags declared', () => {
+      expect(
+        service.scoreDirectMaterial(
+          baseProp({
+            searchableText: 'affordable housing for renters and tenants',
+          }),
+          FLAGS_OFF,
+        ),
+      ).toBe(0);
+    });
+
+    it('scores 0.2 per matched flag', () => {
+      const prop = baseProp({
+        searchableText: 'protects renters and workers in california',
+      });
+      const flags = { ...FLAGS_OFF, isRenter: true, isWorker: true };
+      expect(service.scoreDirectMaterial(prop, flags)).toBeCloseTo(0.4);
+    });
+
+    it('caps at 1.0 even when many flags match', () => {
+      const prop = baseProp({
+        searchableText:
+          'renter homeowner parent student worker patient veteran low-income immigration medicaid',
+      });
+      const flags = {
+        ...FLAGS_OFF,
+        isRenter: true,
+        isHomeowner: true,
+        isParent: true,
+        isStudent: true,
+        isWorker: true,
+        hasHealthCondition: true,
+        isVeteran: true,
+        isLowIncome: true,
+        hasImmigrationConcern: true,
+        hasPublicHealthInsurance: true,
+      };
+      expect(service.scoreDirectMaterial(prop, flags)).toBe(1.0);
+    });
+
+    it('honors word boundaries — "renter" does not match "rentier" or "rental car"', () => {
+      const prop = baseProp({
+        searchableText: 'rentier capitalism and rental cars not in scope',
+      });
+      const flags = { ...FLAGS_OFF, isRenter: true };
+      // Neither "rentier" (no word break before "renter") nor "rental"
+      // (different word) should fire.
+      expect(service.scoreDirectMaterial(prop, flags)).toBe(0);
+    });
+
+    it('matches plural keywords (renters, workers, students)', () => {
+      const prop = baseProp({
+        searchableText: 'helps students access higher education',
+      });
+      const flags = { ...FLAGS_OFF, isStudent: true };
+      expect(service.scoreDirectMaterial(prop, flags)).toBeCloseTo(0.2);
+    });
+
+    it('matches hyphenated keywords like "medi-cal" and "low-income"', () => {
+      const prop = baseProp({
+        searchableText: 'expands medi-cal coverage for low-income californians',
+      });
+      const flags = {
+        ...FLAGS_OFF,
+        hasPublicHealthInsurance: true,
+        isLowIncome: true,
+      };
+      expect(service.scoreDirectMaterial(prop, flags)).toBeCloseTo(0.4);
+    });
+
+    it('is case-insensitive', () => {
+      const prop = baseProp({ searchableText: 'PROTECTS RENTERS' });
+      const flags = { ...FLAGS_OFF, isRenter: true };
+      expect(service.scoreDirectMaterial(prop, flags)).toBeCloseTo(0.2);
+    });
+  });
+
+  describe('scoreValuesAlignment (axis 2)', () => {
+    it('returns 0 when interest tags are empty', () => {
+      const prop = baseProp({ searchableText: 'housing reform' });
+      expect(service.scoreValuesAlignment(prop, [])).toBe(0);
+    });
+
+    it('returns 1.0 when single interest matches single occurrence', () => {
+      const prop = baseProp({ searchableText: 'housing affordability act' });
+      expect(service.scoreValuesAlignment(prop, ['housing'])).toBe(1.0);
+    });
+
+    it('normalizes by user interest count — 1 match out of 3 interests = 0.33', () => {
+      const prop = baseProp({ searchableText: 'housing affordability' });
+      expect(
+        service.scoreValuesAlignment(prop, [
+          'housing',
+          'healthcare',
+          'justice',
+        ]),
+      ).toBeCloseTo(1 / 3);
+    });
+
+    it('matches multiple interests when both appear', () => {
+      const prop = baseProp({
+        searchableText: 'housing and healthcare access reform',
+      });
+      expect(
+        service.scoreValuesAlignment(prop, ['housing', 'healthcare']),
+      ).toBe(1.0);
+    });
+
+    it('honors word boundaries on interest tags', () => {
+      const prop = baseProp({ searchableText: 'farmhouse renovations' });
+      // "housing" should NOT match inside "farmhouse"
+      expect(service.scoreValuesAlignment(prop, ['housing'])).toBe(0);
+    });
+  });
+
+  describe('scoreElectionProximity (axis 3)', () => {
+    const now = new Date('2026-10-01T00:00:00Z');
+
+    it('returns 0 for past elections', () => {
+      const prop = baseProp({ electionDate: new Date('2026-09-01T00:00:00Z') });
+      expect(service.scoreElectionProximity(prop, now)).toBe(0);
+    });
+
+    it('returns 0 when no election date is set', () => {
+      expect(
+        service.scoreElectionProximity(baseProp({ electionDate: null }), now),
+      ).toBe(0);
+    });
+
+    it('peaks at 1.0 inside the 30-day urgent window', () => {
+      const prop = baseProp({ electionDate: new Date('2026-10-15T00:00:00Z') }); // 14d
+      expect(service.scoreElectionProximity(prop, now)).toBe(1.0);
+    });
+
+    it('returns 1.0 on election day exactly', () => {
+      const prop = baseProp({ electionDate: now });
+      expect(service.scoreElectionProximity(prop, now)).toBe(1.0);
+    });
+
+    it('decays linearly between 30 and 90 days (1.0 → 0.4)', () => {
+      // 60 days out — midpoint of 30-90 band → ~0.7
+      const prop = baseProp({
+        electionDate: new Date('2026-11-30T00:00:00Z'),
+      });
+      const score = service.scoreElectionProximity(prop, now);
+      expect(score).toBeGreaterThan(0.6);
+      expect(score).toBeLessThan(0.8);
+    });
+
+    it('decays further between 90 and 365 days (0.4 → 0.0)', () => {
+      // 200 days out — well inside the long-tail band → < 0.4
+      const prop = baseProp({
+        electionDate: new Date('2027-04-19T00:00:00Z'),
+      });
+      const score = service.scoreElectionProximity(prop, now);
+      expect(score).toBeGreaterThan(0);
+      expect(score).toBeLessThan(0.4);
+    });
+
+    it('returns 0 for elections more than a year out', () => {
+      const prop = baseProp({ electionDate: new Date('2028-01-01T00:00:00Z') });
+      expect(service.scoreElectionProximity(prop, now)).toBe(0);
+    });
+  });
+
+  describe('scoreProposition (composite)', () => {
+    it('combines all three axes with the 50/30/20 weighting', () => {
+      const prop = baseProp({
+        searchableText: 'housing reform protects renters',
+        electionDate: new Date('2026-10-15T00:00:00Z'),
+      });
+      const input: PropositionPersonalizationInputDto = {
+        interestTags: ['housing'],
+        flags: { ...FLAGS_OFF, isRenter: true },
+      };
+      const now = new Date('2026-10-01T00:00:00Z');
+
+      const { axisScores, composite } = service.scoreProposition(
+        prop,
+        input,
+        now,
+      );
+
+      expect(axisScores.directMaterial).toBeCloseTo(0.2);
+      expect(axisScores.valuesAlignment).toBe(1.0);
+      expect(axisScores.actionability).toBe(1.0);
+      // 0.2 * 0.5 + 1.0 * 0.3 + 1.0 * 0.2 = 0.1 + 0.3 + 0.2 = 0.6
+      expect(composite).toBeCloseTo(0.6);
+    });
+
+    it('placeholder axes (4-7) stay at 0 in v1.0', () => {
+      const prop = baseProp({ searchableText: 'anything' });
+      const { axisScores } = service.scoreProposition(
+        prop,
+        { interestTags: [], flags: FLAGS_OFF },
+        new Date(),
+      );
+      expect(axisScores.indirectMaterial).toBe(0);
+      expect(axisScores.coalitionSignal).toBe(0);
+      expect(axisScores.counterfactual).toBe(0);
+      expect(axisScores.noveltyRepetition).toBe(0);
+    });
+
+    it('composite is 0 for a prop with no overlap and no proximity', () => {
+      const prop = baseProp({
+        searchableText: 'unrelated topic',
+        electionDate: new Date('2028-01-01T00:00:00Z'),
+      });
+      const { composite } = service.scoreProposition(
+        prop,
+        { interestTags: ['housing'], flags: FLAGS_OFF },
+        new Date('2026-10-01T00:00:00Z'),
+      );
+      expect(composite).toBe(0);
+    });
+  });
+});

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/proposition-scoring.service.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-propositions/proposition-scoring.service.ts
@@ -1,0 +1,259 @@
+import { Injectable } from '@nestjs/common';
+import type { PropositionPersonalizationInputDto } from './dto/proposition-personalization-input.dto';
+import type { PropositionAxisScoresModel } from './models/proposition-axis-scores.model';
+
+type FlagSet = PropositionPersonalizationInputDto['flags'];
+
+/**
+ * Subset of Proposition fields the v1.0 ranker needs. Sourced from
+ * the cross-service propositions read (see PersonalizedPropositionsService)
+ * — DOES NOT include the full Proposition row. Keeping the shape narrow
+ * makes the scoring function testable as a pure function with no DB.
+ *
+ * `searchableText` is a pre-flattened, lowercased corpus assembled
+ * from `summary`, `aiSummary.analysisSummary`, `aiSummary.keyProvisions`,
+ * `aiSummary.yesOutcome`, and `aiSummary.noOutcome`. The orchestrator
+ * service builds it once per proposition so axis 1 and 2 don't need
+ * to traverse the JSON tree on every flag/tag check.
+ */
+export interface RankableProposition {
+  id: string;
+  electionDate: Date | null;
+  /** Lowercased plain-text corpus for keyword matching. */
+  searchableText: string;
+}
+
+/**
+ * Flag → keyword dictionary for axis 1 (proposition material relevance).
+ *
+ * Propositions don't have a structured `whoItAffects` array like bills'
+ * `aiSummary.whoItAffects`. Phase 1 of #771 substring-matches a small
+ * keyword vocabulary per flag against the proposition's plain text
+ * (analysisSummary + keyProvisions + summary + yesOutcome + noOutcome).
+ * Phase 2 candidate: extend proposition ingest to populate a structured
+ * `whoItAffects` field parallel to bills, then collapse this dictionary
+ * into the same `WHO_TO_FLAG` shape the bill ranker uses.
+ *
+ * Keywords are lowercased and matched with `\b` boundaries so "renter"
+ * doesn't match "rentier" or "rental" (rentals get an explicit entry
+ * where they're meaningful).
+ */
+const FLAG_KEYWORDS: Record<keyof FlagSet, readonly string[]> = {
+  isRenter: ['renter', 'renters', 'tenant', 'tenants', 'rental housing'],
+  isHomeowner: ['homeowner', 'homeowners', 'property tax'],
+  isParent: ['parent', 'parents', 'child', 'children', 'k-12', 'public school'],
+  isCaregiver: ['caregiver', 'caregivers', 'elderly', 'eldercare'],
+  isStudent: [
+    'student',
+    'students',
+    'college',
+    'university',
+    'higher education',
+  ],
+  isEducator: ['teacher', 'teachers', 'educator', 'educators', 'k-12'],
+  isWorker: ['worker', 'workers', 'employee', 'employees', 'wage', 'wages'],
+  isBusinessOwner: ['small business', 'business owner', 'small businesses'],
+  isUnionMember: ['union', 'unions', 'collective bargaining'],
+  isGigWorker: ['gig worker', 'gig workers', 'independent contractor'],
+  isTransitRider: ['transit', 'public transportation', 'bus', 'rail'],
+  isDriver: ['driver', 'drivers', 'motorist', 'motorists', 'vehicle'],
+  hasSpecialLicense: ['commercial driver', 'cdl'],
+  hasImmigrationConcern: [
+    'immigrant',
+    'immigrants',
+    'undocumented',
+    'immigration',
+  ],
+  hasHealthCondition: [
+    'patient',
+    'patients',
+    'disabled',
+    'disability',
+    'chronic',
+  ],
+  hasPublicHealthInsurance: ['medicaid', 'medi-cal', 'medicare'],
+  isVeteran: ['veteran', 'veterans'],
+  hasJusticeInvolvement: [
+    'formerly incarcerated',
+    'criminal record',
+    'expungement',
+  ],
+  isLowIncome: ['low-income', 'low income', 'poverty', 'safety net'],
+  receivesPublicBenefits: [
+    'snap',
+    'food stamps',
+    'public benefits',
+    'calworks',
+    'tanf',
+  ],
+};
+
+/**
+ * Escape regex metacharacters in a keyword so the `\b` anchors are
+ * the only special tokens in the compiled pattern. The hyphen in
+ * "medi-cal" doesn't need escaping (literal in this position) but
+ * the function handles all `RegExp` metacharacters uniformly.
+ */
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Pre-compile a `\b`-anchored case-insensitive regex per keyword once
+ * at module load so per-prop scoring stays O(flags × keywords) without
+ * any regex compilation hot path. Keyed-reducer pattern (not
+ * `Object.fromEntries`) so TypeScript can infer the result type
+ * directly without an `unknown`-cast escape hatch.
+ */
+const FLAG_REGEXES = (Object.keys(FLAG_KEYWORDS) as (keyof FlagSet)[]).reduce(
+  (acc, flag) => {
+    acc[flag] = FLAG_KEYWORDS[flag].map(
+      (kw) => new RegExp(`\\b${escapeRegExp(kw)}\\b`, 'i'),
+    );
+    return acc;
+  },
+  {} as Record<keyof FlagSet, readonly RegExp[]>,
+);
+
+/**
+ * v1.0 axis weights — same shape as the bill ranker so a future shared
+ * abstraction can collapse the two. Sum to 1.0.
+ */
+const AXIS_WEIGHTS = {
+  directMaterial: 0.5,
+  valuesAlignment: 0.3,
+  actionability: 0.2,
+} as const;
+
+/**
+ * Pure scoring functions for the v1.0 propositions ranker (#771).
+ * Three axes parallel to the bill ranker (#743), adapted to the
+ * different data shape propositions carry:
+ *
+ *   - Axis 1: substring keyword matching (no structured `whoItAffects`)
+ *   - Axis 2: substring keyword matching against `interestTags` (no
+ *     structured `topics` array)
+ *   - Axis 3: election proximity (props have `electionDate`; bills had
+ *     the much looser `lastActionDate` recency proxy)
+ *
+ * Why keyword match not embeddings or structured tags? Same MVP-scope
+ * reasoning as bills: cheap, debuggable, well-targeted. Phase 2 candidate:
+ * extend prop ingest to populate `aiSummary.topics` + `aiSummary.whoItAffects`
+ * the same way the bill pipeline does — then this service can collapse
+ * into the bill ranker's exact code path.
+ */
+@Injectable()
+export class PropositionScoringService {
+  /**
+   * Axis 1 — Direct material. For each user flag that's TRUE, check
+   * whether any of its keywords appears in the proposition's text.
+   * Score = matched_flags × 0.2, capped at 1.0 (5 matches saturates).
+   * Mirrors the bill ranker's saturation point so the two cards
+   * surface comparably "strong" relevance scores.
+   */
+  scoreDirectMaterial(
+    proposition: RankableProposition,
+    flags: FlagSet,
+  ): number {
+    if (!proposition.searchableText) return 0;
+    let matches = 0;
+    for (const [flag, isTrue] of Object.entries(flags)) {
+      if (!isTrue) continue;
+      const regexes = FLAG_REGEXES[flag as keyof FlagSet];
+      if (!regexes) continue;
+      if (regexes.some((r) => r.test(proposition.searchableText))) {
+        matches += 1;
+      }
+    }
+    return Math.min(matches * 0.2, 1.0);
+  }
+
+  /**
+   * Axis 2 — Values alignment. Substring match each user `interestTag`
+   * against the prop's text. Same normalization as the bill ranker:
+   * divide by the user's declared interest count so a user with 3
+   * interests + 1 match = 0.33; with 1 interest + 1 match = 1.0.
+   */
+  scoreValuesAlignment(
+    proposition: RankableProposition,
+    interestTags: string[],
+  ): number {
+    if (!proposition.searchableText || interestTags.length === 0) return 0;
+    let matches = 0;
+    for (const tag of interestTags) {
+      const re = new RegExp(`\\b${escapeRegExp(tag)}\\b`, 'i');
+      if (re.test(proposition.searchableText)) matches += 1;
+    }
+    return matches / interestTags.length;
+  }
+
+  /**
+   * Axis 3 — Election proximity. Piecewise function:
+   *
+   *   < 0 days (election past)        → 0.0
+   *   0–30 days  (urgent voting window) → 1.0
+   *   30–90 days (research window)      → linear 1.0 → 0.4
+   *   90–365 days (background awareness) → linear 0.4 → 0.0
+   *   > 365 days (too far)              → 0.0
+   *   no electionDate                   → 0.0
+   *
+   * Captures the planning-doc's "3 weeks > 1 year" requirement and
+   * preserves a non-zero floor through the full research window so
+   * propositions show up before they hit the urgent 30-day band.
+   */
+  scoreElectionProximity(
+    proposition: RankableProposition,
+    now: Date = new Date(),
+  ): number {
+    if (!proposition.electionDate) return 0;
+    const daysUntil =
+      (proposition.electionDate.getTime() - now.getTime()) /
+      (1000 * 60 * 60 * 24);
+    if (daysUntil < 0) return 0;
+    if (daysUntil <= 30) return 1.0;
+    if (daysUntil <= 90) {
+      // 30 days → 1.0; 90 days → 0.4
+      return 1.0 - ((daysUntil - 30) / 60) * 0.6;
+    }
+    if (daysUntil <= 365) {
+      // 90 days → 0.4; 365 days → 0.0
+      return 0.4 - ((daysUntil - 90) / 275) * 0.4;
+    }
+    return 0;
+  }
+
+  /**
+   * Compute the full axis scores + composite. Pure function —
+   * deterministic given input + a clock. The clock is injectable so
+   * the election-proximity tests stay stable.
+   */
+  scoreProposition(
+    proposition: RankableProposition,
+    input: PropositionPersonalizationInputDto,
+    now: Date = new Date(),
+  ): { axisScores: PropositionAxisScoresModel; composite: number } {
+    const directMaterial = this.scoreDirectMaterial(proposition, input.flags);
+    const valuesAlignment = this.scoreValuesAlignment(
+      proposition,
+      input.interestTags,
+    );
+    const actionability = this.scoreElectionProximity(proposition, now);
+
+    const axisScores: PropositionAxisScoresModel = {
+      directMaterial,
+      valuesAlignment,
+      actionability,
+      indirectMaterial: 0,
+      coalitionSignal: 0,
+      counterfactual: 0,
+      noveltyRepetition: 0,
+    };
+
+    const composite =
+      directMaterial * AXIS_WEIGHTS.directMaterial +
+      valuesAlignment * AXIS_WEIGHTS.valuesAlignment +
+      actionability * AXIS_WEIGHTS.actionability;
+
+    return { axisScores, composite };
+  }
+}

--- a/apps/frontend/__tests__/accessibility/briefing-propositions.a11y.test.tsx
+++ b/apps/frontend/__tests__/accessibility/briefing-propositions.a11y.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * WCAG 2.2 AA Accessibility Tests for the Propositions Briefing
+ * section (#771).
+ *
+ * Scope is the per-card render (PropositionBriefingCard) since the
+ * shell + collapse semantics are exhaustively tested in
+ * BriefingSection.test.tsx and the full-page a11y is covered by
+ * the e2e/briefing.spec.ts axe scan. This file targets the new card
+ * surface specifically.
+ */
+
+import { render } from "@testing-library/react";
+import { axe, toHaveNoViolations } from "jest-axe";
+import "@testing-library/jest-dom";
+
+import { PropositionBriefingCard } from "@/components/briefing/propositions/PropositionBriefingCard";
+import type { RankedProposition } from "@/components/briefing/propositions/usePropositionsBriefing";
+import type { Proposition } from "@/lib/graphql/region";
+
+expect.extend(toHaveNoViolations);
+
+const baseProp: Proposition = {
+  id: "p-a11y-1",
+  externalId: "Prop 33",
+  title: "Local Rent Control Initiative",
+  summary: "Allows cities to adopt rent control on residential property.",
+  status: "PENDING",
+  electionDate: "2026-11-03T00:00:00Z",
+  analysisSummary: "Permits municipal rent caps on residential housing.",
+  yesOutcome: "Cities may pass rent control on properties built any year.",
+  noOutcome:
+    "Existing state law (Costa-Hawkins) continues to limit local rent control.",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const baseItem: RankedProposition = {
+  result: {
+    propositionId: "p-a11y-1",
+    relevanceScore: 0.65,
+    axisScores: {
+      directMaterial: 0.4,
+      valuesAlignment: 1.0,
+      actionability: 1.0,
+      indirectMaterial: 0,
+      coalitionSignal: 0,
+      counterfactual: 0,
+      noveltyRepetition: 0,
+    },
+    relevanceExplanation: null,
+  },
+  proposition: baseProp,
+};
+
+describe("PropositionBriefingCard — WCAG 2.2 AA", () => {
+  it("renders with no axe violations in the default state", async () => {
+    const { container } = render(<PropositionBriefingCard item={baseItem} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("renders with no axe violations when yes/no outcomes are absent", async () => {
+    const { container } = render(
+      <PropositionBriefingCard
+        item={{
+          ...baseItem,
+          proposition: {
+            ...baseProp,
+            yesOutcome: undefined,
+            noOutcome: undefined,
+          },
+        }}
+      />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("renders with no axe violations when only summary (no analysisSummary) is present", async () => {
+    const { container } = render(
+      <PropositionBriefingCard
+        item={{
+          ...baseItem,
+          proposition: { ...baseProp, analysisSummary: undefined },
+        }}
+      />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/frontend/__tests__/components/briefing/BriefingSection.test.tsx
+++ b/apps/frontend/__tests__/components/briefing/BriefingSection.test.tsx
@@ -1,6 +1,14 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { BriefingSection } from "@/components/briefing/BriefingSection";
+
+beforeEach(() => {
+  // Each test starts with a clean slate — collapse state is keyed on
+  // section slug and we don't want one test's toggle to leak into the
+  // next test's "should default to expanded" assertion.
+  window.localStorage.clear();
+});
 
 describe("BriefingSection", () => {
   it("renders the title + subtitle + children", () => {
@@ -61,5 +69,173 @@ describe("BriefingSection", () => {
       </BriefingSection>,
     );
     expect(screen.getByTestId("bills-icon")).toBeInTheDocument();
+  });
+
+  describe("collapsibility (S0 / #771)", () => {
+    it("defaults to expanded so children are visible on first paint", () => {
+      render(
+        <BriefingSection slug="bills" title="Bills" seeAllHref="/region/bills">
+          <p>body content</p>
+        </BriefingSection>,
+      );
+      expect(
+        screen.getByRole("button", { name: /collapse bills section/i }),
+      ).toHaveAttribute("aria-expanded", "true");
+      expect(screen.getByText("body content")).toBeVisible();
+    });
+
+    it("collapses on click and persists the choice to localStorage", async () => {
+      const user = userEvent.setup();
+      render(
+        <BriefingSection slug="bills" title="Bills" seeAllHref="/region/bills">
+          <p>body content</p>
+        </BriefingSection>,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /collapse bills section/i }),
+      );
+
+      // After collapse: button reports false, content is hidden, storage
+      // remembers the choice for next mount.
+      const toggle = screen.getByRole("button", {
+        name: /expand bills section/i,
+      });
+      expect(toggle).toHaveAttribute("aria-expanded", "false");
+      expect(screen.getByText("body content")).not.toBeVisible();
+      expect(
+        window.localStorage.getItem("briefing:section:bills:expanded"),
+      ).toBe("false");
+    });
+
+    it("restores collapsed state from localStorage on remount", async () => {
+      window.localStorage.setItem("briefing:section:bills:expanded", "false");
+      render(
+        <BriefingSection slug="bills" title="Bills" seeAllHref="/region/bills">
+          <p>body content</p>
+        </BriefingSection>,
+      );
+      // The useEffect that reads storage fires after mount; assert on
+      // the post-effect state by waiting for the expand-aria button.
+      expect(
+        await screen.findByRole("button", { name: /expand bills section/i }),
+      ).toHaveAttribute("aria-expanded", "false");
+      expect(screen.getByText("body content")).not.toBeVisible();
+    });
+
+    it("toggles back to expanded and persists the new state", async () => {
+      const user = userEvent.setup();
+      window.localStorage.setItem("briefing:section:reps:expanded", "false");
+      render(
+        <BriefingSection
+          slug="reps"
+          title="Reps"
+          seeAllHref="/region/representatives"
+        >
+          <p>body content</p>
+        </BriefingSection>,
+      );
+
+      const toggle = await screen.findByRole("button", {
+        name: /expand reps section/i,
+      });
+      await user.click(toggle);
+
+      expect(
+        screen.getByRole("button", { name: /collapse reps section/i }),
+      ).toHaveAttribute("aria-expanded", "true");
+      expect(
+        window.localStorage.getItem("briefing:section:reps:expanded"),
+      ).toBe("true");
+    });
+
+    it("surfaces the item count in the header when collapsed", async () => {
+      const user = userEvent.setup();
+      render(
+        <BriefingSection
+          slug="bills"
+          title="Bills"
+          seeAllHref="/region/bills"
+          itemCount={3}
+        >
+          <p>body</p>
+        </BriefingSection>,
+      );
+
+      // Expanded: count is hidden so the heading reads cleanly.
+      expect(screen.queryByText(/3 items/i)).not.toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole("button", { name: /collapse bills section/i }),
+      );
+
+      // Collapsed: the count appears so the header isn't information-free.
+      expect(screen.getByText(/3 items/i)).toBeInTheDocument();
+    });
+
+    it("survives a localStorage write failure without breaking the toggle", async () => {
+      // Private-mode Safari / blocked storage scenarios.
+      const setItem = jest
+        .spyOn(Storage.prototype, "setItem")
+        .mockImplementation(() => {
+          throw new Error("QuotaExceededError");
+        });
+      const user = userEvent.setup();
+      render(
+        <BriefingSection
+          slug="committees"
+          title="Committees"
+          seeAllHref="/region/committees"
+        >
+          <p>body</p>
+        </BriefingSection>,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /collapse committees section/i }),
+      );
+
+      // Toggle still flipped despite the storage write failure.
+      expect(
+        screen.getByRole("button", { name: /expand committees section/i }),
+      ).toHaveAttribute("aria-expanded", "false");
+      setItem.mockRestore();
+    });
+
+    it("uses different localStorage keys per slug so sections collapse independently", async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <BriefingSection
+            slug="bills"
+            title="Bills"
+            seeAllHref="/region/bills"
+          >
+            <p>bills body</p>
+          </BriefingSection>
+          <BriefingSection
+            slug="reps"
+            title="Reps"
+            seeAllHref="/region/representatives"
+          >
+            <p>reps body</p>
+          </BriefingSection>
+        </>,
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /collapse bills section/i }),
+      );
+
+      // Only bills collapsed; reps still expanded.
+      expect(screen.getByText("bills body")).not.toBeVisible();
+      expect(screen.getByText("reps body")).toBeVisible();
+      expect(
+        window.localStorage.getItem("briefing:section:bills:expanded"),
+      ).toBe("false");
+      expect(
+        window.localStorage.getItem("briefing:section:reps:expanded"),
+      ).toBeNull();
+    });
   });
 });

--- a/apps/frontend/__tests__/components/briefing/PropositionBriefingCard.test.tsx
+++ b/apps/frontend/__tests__/components/briefing/PropositionBriefingCard.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { PropositionBriefingCard } from "@/components/briefing/propositions/PropositionBriefingCard";
+import type { RankedProposition } from "@/components/briefing/propositions/usePropositionsBriefing";
+import type { Proposition } from "@/lib/graphql/region";
+
+const baseProp: Proposition = {
+  id: "p-1",
+  externalId: "Prop 33",
+  title: "Local Rent Control Initiative",
+  summary: "Allows cities to adopt rent control on residential property.",
+  status: "PENDING",
+  electionDate: "2026-11-03T00:00:00Z",
+  analysisSummary: "Permits municipal rent caps on residential housing.",
+  yesOutcome: "Cities may pass rent control on properties built any year.",
+  noOutcome:
+    "Existing state law (Costa-Hawkins) continues to limit local rent control.",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-01-01T00:00:00Z",
+};
+
+const baseItem: RankedProposition = {
+  result: {
+    propositionId: "p-1",
+    relevanceScore: 0.65,
+    axisScores: {
+      directMaterial: 0.4,
+      valuesAlignment: 1.0,
+      actionability: 1.0,
+      indirectMaterial: 0,
+      coalitionSignal: 0,
+      counterfactual: 0,
+      noveltyRepetition: 0,
+    },
+    relevanceExplanation: null,
+  },
+  proposition: baseProp,
+};
+
+describe("PropositionBriefingCard", () => {
+  it("returns null when the proposition row is missing (e.g. fan-out fetch failed)", () => {
+    const { container } = render(
+      <PropositionBriefingCard
+        item={{ result: baseItem.result, proposition: null }}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the title as a link to the proposition detail page", () => {
+    render(<PropositionBriefingCard item={baseItem} />);
+    const link = screen.getByRole("link", {
+      name: /local rent control initiative/i,
+    });
+    expect(link).toHaveAttribute("href", "/region/propositions/p-1");
+  });
+
+  it("renders the externalId and election date in the metadata line", () => {
+    render(<PropositionBriefingCard item={baseItem} />);
+    expect(screen.getByText(/Prop 33/)).toBeInTheDocument();
+    // i18n key uses {{date}} — we just assert the year appears so the
+    // test isn't locale-brittle.
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+
+  it("prefers analysisSummary over the raw summary when both exist", () => {
+    render(<PropositionBriefingCard item={baseItem} />);
+    expect(
+      screen.getByText(/permits municipal rent caps/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Allows cities to adopt rent control/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("falls back to summary when analysisSummary is absent", () => {
+    render(
+      <PropositionBriefingCard
+        item={{
+          ...baseItem,
+          proposition: { ...baseProp, analysisSummary: undefined },
+        }}
+      />,
+    );
+    expect(
+      screen.getByText(/Allows cities to adopt rent control/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the yes/no outcome dl when either side carries text", () => {
+    render(<PropositionBriefingCard item={baseItem} />);
+    expect(
+      screen.getByText(/cities may pass rent control/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Costa-Hawkins.*continues to limit/i),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the outcome dl when both yes/no are absent", () => {
+    render(
+      <PropositionBriefingCard
+        item={{
+          ...baseItem,
+          proposition: {
+            ...baseProp,
+            yesOutcome: undefined,
+            noOutcome: undefined,
+          },
+        }}
+      />,
+    );
+    // No "If yes" / "If no" labels render.
+    expect(screen.queryByText(/^If yes$/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^If no$/i)).not.toBeInTheDocument();
+  });
+
+  it("does NOT render endorsement chips in Phase 1 (regression guard for scope)", () => {
+    render(<PropositionBriefingCard item={baseItem} />);
+    // Endorsement copy uses "endorse" / "Sierra Club" / "NRA" patterns
+    // per the issue spec; none of those should appear in Phase 1.
+    expect(screen.queryByText(/sierra club/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/endors/i)).not.toBeInTheDocument();
+  });
+
+  it("exposes data-testid + data-proposition-id for e2e selectors", () => {
+    render(<PropositionBriefingCard item={baseItem} />);
+    const card = screen.getByTestId("proposition-briefing-card");
+    expect(card).toHaveAttribute("data-proposition-id", "p-1");
+  });
+
+  it("renders the relevance chip", () => {
+    render(<PropositionBriefingCard item={baseItem} />);
+    // Composite 0.65 → 65%
+    expect(screen.getByText(/65%/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/briefing/BriefingPage.tsx
+++ b/apps/frontend/components/briefing/BriefingPage.tsx
@@ -3,15 +3,15 @@
 import { BillsBriefingSection } from "./bills/BillsBriefingSection";
 import { BriefingPageHeader } from "./BriefingPageHeader";
 import { CommitteesBriefingPlaceholder } from "./placeholders/CommitteesBriefingPlaceholder";
-import { PropositionsBriefingPlaceholder } from "./placeholders/PropositionsBriefingPlaceholder";
+import { PropositionsBriefingSection } from "./propositions/PropositionsBriefingSection";
 import { RepsBriefingPlaceholder } from "./placeholders/RepsBriefingPlaceholder";
 
 /**
  * The authenticated home page. Composes the page header (with the
  * "Browse all civic data →" link to /region) and four BriefingSection
- * cards — Bills (the AC of #744) plus the three placeholder sections
- * for Reps, Committees, Propositions whose personalized variants land
- * via #769 / #770 / #771.
+ * cards — Bills (AC of #744) and Propositions (AC of #771), plus
+ * the two remaining placeholder sections for Reps + Committees whose
+ * personalized variants land via #769 / #770.
  *
  * Each section owns its own loading / empty / error / no-profile
  * branches so the page composes without a top-level Suspense boundary.
@@ -24,7 +24,7 @@ export function BriefingPage() {
         <BillsBriefingSection />
         <RepsBriefingPlaceholder />
         <CommitteesBriefingPlaceholder />
-        <PropositionsBriefingPlaceholder />
+        <PropositionsBriefingSection />
       </div>
     </main>
   );

--- a/apps/frontend/components/briefing/BriefingSection.tsx
+++ b/apps/frontend/components/briefing/BriefingSection.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import type { ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 interface BriefingSectionProps {
@@ -18,17 +18,33 @@ interface BriefingSectionProps {
   /** Override the default "See all →" label (i18n: briefing.section.seeAll). */
   readonly seeAllLabel?: string;
   /**
-   * `data-section` exposes the consumer's identity for e2e selectors
-   * and any future telemetry. Use the slug ("bills", "reps", etc.).
+   * `data-section` exposes the consumer's identity for e2e selectors,
+   * any future telemetry, AND the localStorage key that persists this
+   * section's collapse state. Use the slug ("bills", "reps", etc.).
    */
   readonly slug: string;
+  /**
+   * Optional count surfaced when the section is collapsed so the
+   * header isn't information-free. Sections with no count (e.g.
+   * placeholders) can omit it.
+   */
+  readonly itemCount?: number;
 }
 
 /**
+ * Local-storage key for the collapsed/expanded state of a section.
+ * Per-section so each card remembers its own state across reloads.
+ * Browser-scoped only; per-account persistence is a post-MVP follow-up.
+ */
+const storageKey = (slug: string) => `briefing:section:${slug}:expanded`;
+
+/**
  * Domain-agnostic shell for one card on the civic briefing home page.
- * Each personalized section (Bills now, Reps/Committees/Propositions in
- * #769/#770/#771) wraps its content in this so the four cards on the
- * home page share the same chrome — title row, body, see-all linkout.
+ * Each personalized section (Bills, Reps, Committees, Propositions)
+ * wraps its content in this so the four cards on the home page share
+ * the same chrome — title row, body, see-all linkout, and the
+ * expand/collapse toggle that lets users compress sections they don't
+ * want to scan.
  *
  * Per the issue, "See all" always points at the existing /region/*
  * surface so users can browse the unfiltered domain when the
@@ -42,16 +58,79 @@ export function BriefingSection({
   seeAllHref,
   seeAllLabel,
   slug,
+  itemCount,
 }: BriefingSectionProps) {
   const { t } = useTranslation("briefing");
+
+  // SSR-safe default: expanded. The client hydrates with the saved
+  // state on mount; one re-render cost on first paint, no hydration
+  // mismatch (server always emits "expanded").
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  /* eslint-disable react-hooks/set-state-in-effect -- localStorage
+     read must happen post-mount to avoid SSR hydration mismatch; the
+     setState is a one-shot reconcile when the persisted value differs
+     from the SSR default. Pattern matches useBillBriefing + other
+     post-hydration syncs in this app. */
+  useEffect(() => {
+    try {
+      const stored = window.localStorage.getItem(storageKey(slug));
+      if (stored === "false") setIsExpanded(false);
+    } catch {
+      // localStorage blocked (private-mode Safari, etc.) — fall back to
+      // the default-expanded behavior; user can still toggle in-session.
+    }
+  }, [slug]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const toggle = () => {
+    setIsExpanded((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(storageKey(slug), String(next));
+      } catch {
+        // see above — ignore write failures.
+      }
+      return next;
+    });
+  };
+
+  const contentId = `briefing-section-${slug}-content`;
+  const titleId = `briefing-section-${slug}-title`;
+  const ariaLabel = isExpanded
+    ? t("section.collapseAria", { title })
+    : t("section.expandAria", { title });
+
   return (
     <section
       data-section={slug}
-      aria-labelledby={`briefing-section-${slug}-title`}
+      aria-labelledby={titleId}
       className="bg-white dark:bg-gray-800 rounded-2xl shadow-[0_2px_8px_rgba(0,0,0,0.06)] dark:shadow-none dark:border dark:border-gray-700 overflow-hidden"
     >
-      <header className="flex items-start justify-between gap-4 px-6 pt-6">
-        <div className="flex items-start gap-3 min-w-0">
+      <header
+        className={`flex items-start justify-between gap-4 px-6 pt-6 ${
+          isExpanded ? "" : "pb-6"
+        }`}
+      >
+        <button
+          type="button"
+          onClick={toggle}
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+          aria-label={ariaLabel}
+          className="flex items-start gap-3 min-w-0 flex-1 text-left -mt-1 -mb-1 pt-1 pb-1 rounded focus:outline-none focus:ring-2 focus:ring-sage-400 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+        >
+          <span
+            aria-hidden="true"
+            className="text-gray-500 dark:text-gray-400 shrink-0 mt-1 transition-transform motion-reduce:transition-none"
+            style={{ transform: isExpanded ? "rotate(90deg)" : "rotate(0deg)" }}
+          >
+            {/* Right-pointing chevron — text-only to match the WhyThisPanel
+                pattern; no icon-library dependency. */}
+            <span className="inline-block w-3 text-xs leading-none font-bold">
+              ›
+            </span>
+          </span>
           {icon && (
             <span
               aria-hidden="true"
@@ -62,10 +141,15 @@ export function BriefingSection({
           )}
           <div className="min-w-0">
             <h2
-              id={`briefing-section-${slug}-title`}
+              id={titleId}
               className="text-xl font-semibold text-[#222222] dark:text-white"
             >
               {title}
+              {!isExpanded && typeof itemCount === "number" && (
+                <span className="ml-2 text-sm font-normal text-[#4d4d4d] dark:text-gray-300">
+                  ({t("section.itemCount", { count: itemCount })})
+                </span>
+              )}
             </h2>
             {subtitle && (
               <p className="text-sm text-[#4d4d4d] dark:text-gray-300 mt-0.5">
@@ -73,7 +157,7 @@ export function BriefingSection({
               </p>
             )}
           </div>
-        </div>
+        </button>
         <Link
           href={seeAllHref}
           className="text-sm font-medium text-[#5A7A6A] hover:text-[#2D4A3C] dark:text-sage-200 dark:hover:text-white shrink-0 mt-1 whitespace-nowrap"
@@ -81,7 +165,15 @@ export function BriefingSection({
           {seeAllLabel ?? t("section.seeAll")}
         </Link>
       </header>
-      <div className="px-6 py-5">{children}</div>
+      <div
+        id={contentId}
+        role="region"
+        aria-labelledby={titleId}
+        className="px-6 py-5"
+        hidden={!isExpanded}
+      >
+        {children}
+      </div>
     </section>
   );
 }

--- a/apps/frontend/components/briefing/README.md
+++ b/apps/frontend/components/briefing/README.md
@@ -28,11 +28,20 @@ BriefingPage
 ```
 
 `BriefingSection` is the unit of composition. It owns the section
-chrome (title, subtitle, optional icon, "See all →" link) and
-exposes `data-section={slug}` for e2e selectors. When #769/#770/#771
-ship, each replaces its placeholder body with a real
-`<XBriefingSection />` component matching the bills pattern — no
+chrome (title, subtitle, optional icon, "See all →" link, and the
+expand/collapse toggle that lets users compress sections they don't
+want to scan) and exposes `data-section={slug}` for e2e selectors.
+When #769/#770/#771 ship, each replaces its placeholder body with a
+real `<XBriefingSection />` component matching the bills pattern — no
 changes to the shell.
+
+**Collapse state** persists per-section in `localStorage`, keyed on
+the slug (`briefing:section:${slug}:expanded`). Default is expanded;
+the user's choice survives across reloads in the same browser.
+Per-account persistence (Supabase-synced preferences) is a post-MVP
+follow-up. The toggle is fully keyboard-accessible, respects
+`prefers-reduced-motion`, and shows an item count next to the title
+when the section is collapsed so a closed card isn't information-free.
 
 ## Where the data comes from
 

--- a/apps/frontend/components/briefing/bills/RelevanceChip.tsx
+++ b/apps/frontend/components/briefing/bills/RelevanceChip.tsx
@@ -29,8 +29,14 @@ export function RelevanceChip({ score, size = "sm" }: RelevanceChipProps) {
     size === "md"
       ? "px-3 py-1 text-sm font-semibold"
       : "px-2.5 py-0.5 text-xs font-semibold";
+  // `role="img"` legitimizes the `aria-label` on the span (without it,
+  // axe flags `aria-prohibited-attr` because a bare span doesn't admit
+  // ARIA labels). Screen readers announce the composed label as a
+  // single string — "Relevance 65%" — instead of reading the two inner
+  // spans separately.
   return (
     <span
+      role="img"
       className={`inline-flex items-center gap-1 rounded-full border ${sizeCls} ${tier}`}
       aria-label={`${t("whyThis.scoreLabel")} ${pct}%`}
     >

--- a/apps/frontend/components/briefing/bills/useBillBriefing.ts
+++ b/apps/frontend/components/briefing/bills/useBillBriefing.ts
@@ -128,8 +128,14 @@ export function useBillBriefing(limit: number): BillBriefingState {
     [feedResults, bills],
   );
 
-  const noProfile =
-    !prefetch.loading && (!flags || !interestTags || interestTags.length === 0);
+  // "No scoring inputs" guard — fires when prefetch resolved but the
+  // user has declared neither interest tags NOR any TRUE rankingFlags.
+  // Either one is sufficient for the ranker (axis 1 reads flags,
+  // axis 2 reads tags), so the noProfile nudge only makes sense when
+  // BOTH are empty. Kept in lockstep with the propositions hook.
+  const hasAnyFlag = !!flags && Object.values(flags).some((v) => v === true);
+  const hasAnyTag = !!interestTags && interestTags.length > 0;
+  const noProfile = !prefetch.loading && !hasAnyFlag && !hasAnyTag;
 
   const queryError = prefetch.error ?? feed.error;
   const loading =

--- a/apps/frontend/components/briefing/propositions/PropositionBriefingCard.tsx
+++ b/apps/frontend/components/briefing/propositions/PropositionBriefingCard.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+import { RelevanceChip } from "../bills/RelevanceChip";
+import { WhyThisPanel } from "../bills/WhyThisPanel";
+import type { RankedProposition } from "./usePropositionsBriefing";
+
+interface PropositionBriefingCardProps {
+  readonly item: RankedProposition;
+}
+
+/**
+ * One proposition row on the briefing surface (#771). Card-level
+ * structure mirrors `BillBriefingCard` so the page has a consistent
+ * visual rhythm; the per-row content differs because ballot measures
+ * carry yes/no outcomes + an explicit election date instead of a
+ * vote-action timeline.
+ *
+ * No hero variant — propositions surface fewer items per ballot
+ * (~3-10) than bills (~hundreds in flight), so a flat list of cards
+ * reads cleaner than promoting one to a hero block. If that calculus
+ * changes after onboarding-day data lands we can add a hero variant.
+ *
+ * Endorsement chips are intentionally absent in Phase 1 (Phase 2
+ * follow-up: requires the `PropositionEndorsement` data model that
+ * doesn't exist yet).
+ */
+export function PropositionBriefingCard({
+  item,
+}: PropositionBriefingCardProps) {
+  const { t, i18n } = useTranslation("briefing");
+  const { proposition, result } = item;
+  if (!proposition) return null;
+
+  // Prefer the AI-extracted plain-English summary when it landed;
+  // fall back to the raw scraped summary so the card never renders
+  // empty. The summary column itself is required at the schema layer
+  // so the fallback is virtually always defined.
+  const summary = proposition.analysisSummary ?? proposition.summary;
+  const electionDate = proposition.electionDate
+    ? new Date(proposition.electionDate)
+    : null;
+
+  return (
+    <article
+      className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4"
+      data-testid="proposition-briefing-card"
+      data-proposition-id={proposition.id}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <Link
+            href={`/region/propositions/${proposition.id}`}
+            className="block text-base font-semibold text-[#222222] dark:text-white hover:text-[#5A7A6A] dark:hover:text-sage-300 transition-colors line-clamp-2"
+          >
+            {proposition.title}
+          </Link>
+          <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+            {proposition.externalId}
+            {electionDate
+              ? ` · ${t("propositions.electionDate", {
+                  // Thread `i18n.language` so the rendered date matches
+                  // the surrounding i18next-translated copy rather than
+                  // defaulting to the browser locale (which may diverge
+                  // when a user has switched the in-app language).
+                  date: electionDate.toLocaleDateString(i18n.language, {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  }),
+                })}`
+              : ""}
+          </p>
+        </div>
+        <RelevanceChip score={result.relevanceScore} />
+      </div>
+
+      {summary && (
+        <p className="mt-2 text-sm text-[#4d4d4d] dark:text-gray-300 line-clamp-3">
+          {summary}
+        </p>
+      )}
+
+      {(proposition.yesOutcome || proposition.noOutcome) && (
+        <dl className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
+          {proposition.yesOutcome && (
+            <div className="rounded-md bg-sage-50 dark:bg-sage-900/30 border border-sage-200 dark:border-sage-700 p-2">
+              <dt className="font-semibold text-[#2D4A3C] dark:text-sage-200 uppercase tracking-wide text-[10px]">
+                {t("propositions.yesOutcome")}
+              </dt>
+              <dd className="text-[#222222] dark:text-gray-100 line-clamp-2 mt-0.5">
+                {proposition.yesOutcome}
+              </dd>
+            </div>
+          )}
+          {proposition.noOutcome && (
+            <div className="rounded-md bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700 p-2">
+              <dt className="font-semibold text-[#4d4d4d] dark:text-gray-300 uppercase tracking-wide text-[10px]">
+                {t("propositions.noOutcome")}
+              </dt>
+              <dd className="text-[#222222] dark:text-gray-100 line-clamp-2 mt-0.5">
+                {proposition.noOutcome}
+              </dd>
+            </div>
+          )}
+        </dl>
+      )}
+
+      <div className="mt-3">
+        <WhyThisPanel
+          axisScores={result.axisScores}
+          scopeId={proposition.id}
+          llmExplanation={result.relevanceExplanation}
+        />
+      </div>
+    </article>
+  );
+}

--- a/apps/frontend/components/briefing/propositions/PropositionsBriefingSection.tsx
+++ b/apps/frontend/components/briefing/propositions/PropositionsBriefingSection.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslation } from "react-i18next";
+import { BriefingSection } from "../BriefingSection";
+import { PropositionBriefingCard } from "./PropositionBriefingCard";
+import { usePropositionsBriefing } from "./usePropositionsBriefing";
+
+// Smaller default than bills — ballots typically carry 3-10 active
+// measures per cycle, not hundreds. Cap of 10 inside the service
+// matches the planning-doc "full ballot sized" upper bound.
+const FEED_LIMIT = 5;
+
+/**
+ * Personalized propositions section for the civic briefing home page
+ * (#771). Phase 1: heuristic 3-axis ranking, no LLM rerank, no
+ * endorsement chips (Phase 2 follow-up).
+ */
+export function PropositionsBriefingSection() {
+  const { t } = useTranslation("briefing");
+  const { loading, error, noProfile, empty, rankedPropositions } =
+    usePropositionsBriefing(FEED_LIMIT);
+
+  // Suppress the collapsed-state item count until the feed resolves —
+  // showing "(0 items)" while data is still in flight is misleading.
+  // Undefined hides the count entirely in the shell.
+  const itemCount = loading ? undefined : rankedPropositions.length;
+
+  const propIcon = (
+    <svg
+      className="w-6 h-6"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
+      />
+    </svg>
+  );
+
+  return (
+    <BriefingSection
+      slug="propositions"
+      title={t("propositions.title")}
+      subtitle={t("propositions.subtitle")}
+      seeAllHref="/region/propositions"
+      icon={propIcon}
+      itemCount={itemCount}
+    >
+      {noProfile && (
+        <div className="rounded-xl border border-dashed border-gray-300 dark:border-gray-600 p-4">
+          <p className="text-sm font-medium text-[#222222] dark:text-white">
+            {t("page.noProfileTitle")}
+          </p>
+          <p className="text-sm text-[#4d4d4d] dark:text-gray-300 mt-1">
+            {t("page.noProfileBody")}
+          </p>
+          <Link
+            href="/onboarding"
+            className="inline-block mt-2 text-sm font-medium text-[#5A7A6A] hover:text-[#2D4A3C] dark:text-sage-300 dark:hover:text-white"
+          >
+            {t("page.noProfileCta")}
+          </Link>
+        </div>
+      )}
+
+      {error && !noProfile && (
+        <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+          {error}
+        </p>
+      )}
+
+      {loading && !rankedPropositions.length && (
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <div
+              key={i}
+              className="animate-pulse h-24 rounded-xl bg-gray-100 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700"
+            />
+          ))}
+        </div>
+      )}
+
+      {empty && (
+        <p className="text-sm text-[#4d4d4d] dark:text-gray-300">
+          {t("propositions.empty")}
+        </p>
+      )}
+
+      {rankedPropositions.length > 0 && (
+        <div className="space-y-3">
+          {rankedPropositions.map((item) => (
+            <PropositionBriefingCard
+              key={item.result.propositionId}
+              item={item}
+            />
+          ))}
+        </div>
+      )}
+    </BriefingSection>
+  );
+}

--- a/apps/frontend/components/briefing/propositions/usePropositionsBriefing.ts
+++ b/apps/frontend/components/briefing/propositions/usePropositionsBriefing.ts
@@ -1,0 +1,169 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useApolloClient, useQuery } from "@apollo/client/react";
+import {
+  GET_PROPOSITION,
+  type Proposition,
+  type PropositionData,
+} from "@/lib/graphql/region";
+import {
+  GET_BRIEFING_PREFETCH,
+  stripTypename,
+  type BriefingPrefetchData,
+} from "@/lib/graphql/personalized-feed";
+import {
+  GET_MY_PERSONALIZED_PROPOSITION_FEED,
+  type PersonalizedPropositionFeedData,
+  type PersonalizedPropositionResult,
+  type PropositionPersonalizationInput,
+} from "@/lib/graphql/personalized-propositions";
+
+export interface RankedProposition {
+  readonly result: PersonalizedPropositionResult;
+  readonly proposition: Proposition | null;
+}
+
+export interface PropositionsBriefingState {
+  readonly loading: boolean;
+  readonly error: string | null;
+  /** True before the prefetch resolves (rare beyond first paint). */
+  readonly noProfile: boolean;
+  /** True after prefetch + feed resolve but the feed is empty. */
+  readonly empty: boolean;
+  readonly topicTags: readonly string[];
+  readonly rankedPropositions: readonly RankedProposition[];
+}
+
+/**
+ * Orchestrates the three-step propositions-briefing fetch (#771):
+ *   1. `myRankingFlags` + `mySignalProfile { interestTags }` — shared
+ *      with the bills section's prefetch query; Apollo's cache means
+ *      this is free when both sections mount together.
+ *   2. `myPersonalizedPropositionFeed(input, limit)` — chained,
+ *      requires #1.
+ *   3. `proposition(id)` for each returned propositionId — parallel;
+ *      details come from the region service (planning doc §6.3).
+ *
+ * Mirrors `useBillBriefing` exactly so the briefing-card layer stays
+ * consistent across sections. Federation refactor at #761 collapses
+ * the per-domain fan-out into a single subgraph hop.
+ */
+export function usePropositionsBriefing(
+  limit: number,
+): PropositionsBriefingState {
+  const client = useApolloClient();
+
+  const prefetch = useQuery<BriefingPrefetchData>(GET_BRIEFING_PREFETCH, {
+    fetchPolicy: "cache-and-network",
+  });
+
+  const flags = prefetch.data?.myRankingFlags;
+  const interestTags = prefetch.data?.mySignalProfile?.interestTags;
+  const input: PropositionPersonalizationInput | null = useMemo(() => {
+    if (!flags || !interestTags) return null;
+    // Strip Apollo's auto-added `__typename` before passing back as a
+    // GraphQL InputType. Same pattern as `useBillBriefing`.
+    return {
+      flags: stripTypename(flags),
+      interestTags: [...interestTags],
+    };
+  }, [flags, interestTags]);
+
+  const feed = useQuery<PersonalizedPropositionFeedData>(
+    GET_MY_PERSONALIZED_PROPOSITION_FEED,
+    {
+      variables: input ? { input, limit } : undefined,
+      skip: !input,
+      fetchPolicy: "cache-and-network",
+    },
+  );
+
+  const feedResults = feed.data?.myPersonalizedPropositionFeed;
+
+  const [propositions, setPropositions] = useState<
+    Map<string, Proposition | null>
+  >(new Map());
+  const [propsLoading, setPropsLoading] = useState(false);
+  const [propsError, setPropsError] = useState<string | null>(null);
+
+  /* eslint-disable react-hooks/set-state-in-effect -- Proposition
+     detail fan-out can't happen until the feed ids land, and Apollo
+     doesn't expose a hook-friendly way to fetch N independent queries
+     whose count is data-dependent. Same out-of-band pattern as
+     useBillBriefing. */
+  useEffect(() => {
+    if (!feedResults || feedResults.length === 0) return;
+    let cancelled = false;
+    setPropsLoading(true);
+    setPropsError(null);
+
+    Promise.all(
+      feedResults.map((r) =>
+        client
+          .query<PropositionData>({
+            query: GET_PROPOSITION,
+            variables: { id: r.propositionId },
+            fetchPolicy: "cache-first",
+          })
+          .then(
+            (res) => [r.propositionId, res.data?.proposition ?? null] as const,
+          ),
+      ),
+    )
+      .then((entries) => {
+        if (cancelled) return;
+        setPropositions(new Map(entries));
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setPropsError(
+          err instanceof Error
+            ? err.message
+            : "Failed to load proposition details",
+        );
+      })
+      .finally(() => {
+        if (!cancelled) setPropsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [feedResults, client]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const rankedPropositions: RankedProposition[] = useMemo(
+    () =>
+      (feedResults ?? []).map((r) => ({
+        result: r,
+        proposition: propositions.get(r.propositionId) ?? null,
+      })),
+    [feedResults, propositions],
+  );
+
+  // "No scoring inputs" guard — fires when prefetch resolved but the
+  // user has declared neither interest tags NOR any TRUE rankingFlags.
+  // Either one is sufficient for the ranker to score (axis 1 reads
+  // flags, axis 2 reads tags), so the noProfile nudge only makes
+  // sense when BOTH are empty. Single empty-inputs branch shared with
+  // the bills hook so the two stay in lockstep.
+  const hasAnyFlag = !!flags && Object.values(flags).some((v) => v === true);
+  const hasAnyTag = !!interestTags && interestTags.length > 0;
+  const noProfile = !prefetch.loading && !hasAnyFlag && !hasAnyTag;
+
+  const queryError = prefetch.error ?? feed.error;
+  const loading =
+    prefetch.loading || feed.loading || (!!feedResults && propsLoading);
+  const empty = !loading && (feedResults?.length ?? 0) === 0 && !noProfile;
+  const error = queryError?.message ?? propsError ?? null;
+
+  return {
+    loading,
+    error,
+    noProfile,
+    empty,
+    topicTags: interestTags ?? [],
+    rankedPropositions,
+  };
+}

--- a/apps/frontend/e2e/briefing-propositions.spec.ts
+++ b/apps/frontend/e2e/briefing-propositions.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Personalized propositions briefing section E2E (#771).
+ *
+ * Asserts the new section renders the real PropositionsBriefingSection
+ * (not the placeholder) for authed users, surfaces section-level state
+ * machinery (loading / empty / cards), and that the collapse-shell
+ * behavior from S0 works for this section specifically. Per-card
+ * content rendering is exhaustively covered in PropositionBriefingCard.test.tsx.
+ *
+ * Cross-section behaviors (header, navigation, WCAG) live in
+ * briefing.spec.ts so we don't duplicate that scaffolding here.
+ */
+import { test, expect } from "@playwright/test";
+import { setupAuthSession } from "./utils/test-helpers";
+
+test.describe("Civic briefing — Propositions section (#771)", () => {
+  test("renders the propositions section with the personalized shell, not the placeholder copy", async ({
+    page,
+  }) => {
+    await setupAuthSession(page);
+    await page.goto("/me/briefing");
+
+    const section = page.locator('[data-section="propositions"]');
+    await expect(section).toBeVisible();
+
+    // Section title from i18n key propositions.title
+    await expect(
+      section.getByRole("heading", { level: 2, name: /active propositions/i }),
+    ).toBeVisible();
+
+    // Placeholder copy SHOULD NOT appear — placeholder body lives at
+    // propositions.placeholder.body in the i18n bundle. If it shows,
+    // we accidentally regressed BriefingPage to mount the placeholder.
+    await expect(
+      section.getByText(/personalized proposition briefings are coming soon/i),
+    ).toHaveCount(0);
+  });
+
+  test("collapses and re-expands via the section toggle (S0 inherits here)", async ({
+    page,
+  }) => {
+    await setupAuthSession(page);
+    await page.goto("/me/briefing");
+
+    const section = page.locator('[data-section="propositions"]');
+    const toggle = section.getByRole("button", {
+      name: /collapse active propositions section/i,
+    });
+    await expect(toggle).toBeVisible();
+
+    await toggle.click();
+
+    // After collapse: aria-expanded flips, toggle label flips, the
+    // section content region is hidden from the a11y tree.
+    await expect(
+      section.getByRole("button", {
+        name: /expand active propositions section/i,
+      }),
+    ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("a card click navigates to /region/propositions/[id] when a card is present", async ({
+    page,
+  }) => {
+    await setupAuthSession(page);
+    await page.goto("/me/briefing");
+
+    const section = page.locator('[data-section="propositions"]');
+    await expect(section).toBeVisible();
+
+    const cards = section.locator('[data-testid="proposition-briefing-card"]');
+    const count = await cards.count();
+
+    // Test passes whether or not the seed has personalized matches —
+    // when cards render, we assert their link shape; when none render,
+    // we expect the empty-state copy. Both are valid AC outcomes.
+    if (count > 0) {
+      const firstCard = cards.first();
+      const titleLink = firstCard
+        .getByRole("link")
+        .filter({ hasNotText: /see all/i })
+        .first();
+      await expect(titleLink).toHaveAttribute(
+        "href",
+        /^\/region\/propositions\/[a-zA-Z0-9_-]+$/,
+      );
+    } else {
+      // Empty-state copy is from propositions.empty in i18n.
+      await expect(
+        section.getByText(/no active propositions match your interests/i),
+      ).toBeVisible();
+    }
+  });
+
+  test("does NOT render endorsement chips in Phase 1 (scope guard)", async ({
+    page,
+  }) => {
+    await setupAuthSession(page);
+    await page.goto("/me/briefing");
+
+    const section = page.locator('[data-section="propositions"]');
+    await expect(section).toBeVisible();
+
+    // Endorsement chips are Phase 2 of #771; their absence is a
+    // regression guard against accidentally enabling that UI before
+    // the data model lands.
+    await expect(section.getByText(/sierra club/i)).toHaveCount(0);
+    await expect(section.getByText(/\bendors/i)).toHaveCount(0);
+  });
+});

--- a/apps/frontend/e2e/briefing-propositions.spec.ts
+++ b/apps/frontend/e2e/briefing-propositions.spec.ts
@@ -71,9 +71,12 @@ test.describe("Civic briefing — Propositions section (#771)", () => {
     const cards = section.locator('[data-testid="proposition-briefing-card"]');
     const count = await cards.count();
 
-    // Test passes whether or not the seed has personalized matches —
-    // when cards render, we assert their link shape; when none render,
-    // we expect the empty-state copy. Both are valid AC outcomes.
+    // The section legitimately renders one of three states depending on
+    // the auth fixture's seed: cards (signals overlap with props), the
+    // "empty" copy (signals declared but no overlap), or the noProfile
+    // nudge (signals not yet declared). All three are valid AC outcomes;
+    // the test asserts the link shape when cards are present, and that
+    // one of the two empty-shape copies is shown when they aren't.
     if (count > 0) {
       const firstCard = cards.first();
       const titleLink = firstCard
@@ -85,10 +88,14 @@ test.describe("Civic briefing — Propositions section (#771)", () => {
         /^\/region\/propositions\/[a-zA-Z0-9_-]+$/,
       );
     } else {
-      // Empty-state copy is from propositions.empty in i18n.
-      await expect(
-        section.getByText(/no active propositions match your interests/i),
-      ).toBeVisible();
+      // Either propositions.empty ("No active propositions match…") OR
+      // page.noProfileTitle ("Tell us what matters to you"). Match
+      // either since the auth fixture's signal_profile state isn't
+      // guaranteed in this test.
+      const emptyOrNoProfile = section.getByText(
+        /no active propositions match your interests|tell us what matters to you/i,
+      );
+      await expect(emptyOrNoProfile).toBeVisible();
     }
   });
 

--- a/apps/frontend/e2e/briefing.spec.ts
+++ b/apps/frontend/e2e/briefing.spec.ts
@@ -76,7 +76,7 @@ test.describe("Civic briefing page", () => {
     ).toHaveAttribute("href", "/region/legislative-committees");
   });
 
-  test("Propositions placeholder See all → /region/propositions", async ({
+  test("Propositions section See all → /region/propositions (#771)", async ({
     page,
   }) => {
     await setupAuthed(page);

--- a/apps/frontend/lib/graphql/personalized-feed.ts
+++ b/apps/frontend/lib/graphql/personalized-feed.ts
@@ -82,12 +82,31 @@ export const GET_BRIEFING_PREFETCH = gql`
   }
 `;
 
-export interface AxisScores {
+/**
+ * Wire shape of the 7-axis relevance scores produced by the v1.0
+ * personalized ranker — shared between bills (#743/#745) and
+ * propositions (#771). Re-exported as `BriefingAxisScores` so domain
+ * modules can alias it without import-path coupling.
+ *
+ * Axes 4-7 are placeholder 0.0 in v1.0 (planning doc §5.1 follow-ups).
+ *
+ * NB: `actionability` carries different per-domain semantics — bills
+ * read it as "recent legislative activity / vote window", propositions
+ * read it as "election proximity". The wire field is shared so the
+ * frontend's `WhyThisPanel` can drive a single i18n key set across
+ * sections (`whyThis.axisActionability`). The per-domain interpretation
+ * lives in the respective backend scoring service.
+ */
+export interface BriefingAxisScores {
   /** Axis 1: does this change the user's money, rights, health, services? */
   directMaterial: number;
   /** Axis 2: does it advance or threaten priorities the user declared? */
   valuesAlignment: number;
-  /** Axis 3: is there a vote / comment window the user can affect now? */
+  /**
+   * Axis 3: bills → "is there a vote / comment window the user can
+   * affect now?"; propositions → election proximity. Same wire field
+   * for shared rendering, different per-domain semantics.
+   */
   actionability: number;
   // Axes 4-7 — placeholder 0.0 in v1.0 (planning doc §5.1 follow-ups)
   indirectMaterial: number;
@@ -95,6 +114,12 @@ export interface AxisScores {
   counterfactual: number;
   noveltyRepetition: number;
 }
+
+/**
+ * Bill-specific alias for `BriefingAxisScores`. Kept as a separate
+ * named export so existing imports of `AxisScores` continue to work.
+ */
+export type AxisScores = BriefingAxisScores;
 
 export interface PersonalizedBillResult {
   billId: string;

--- a/apps/frontend/lib/graphql/personalized-propositions.ts
+++ b/apps/frontend/lib/graphql/personalized-propositions.ts
@@ -1,0 +1,101 @@
+import { gql } from "@apollo/client";
+import type { BriefingAxisScores, RankingFlags } from "./personalized-feed";
+
+// ============================================
+// Personalized propositions feed (#771).
+//
+// Mirrors the bills feed (#743 / #744) for ballot measures. The
+// frontend reuses the `myRankingFlags` + `mySignalProfile { interestTags }`
+// prefetch from `personalized-feed.ts` — those signals power BOTH the
+// bills section and the propositions section, so there's no benefit
+// to re-fetching them per domain.
+//
+// `myPersonalizedPropositionFeed(input, limit)` from the knowledge
+// service returns ranked `PersonalizedPropositionResult[]` with
+// `propositionId`, `relevanceScore`, and the per-axis breakdown.
+// Proposition details (title, summary, election date, outcomes, …)
+// are resolved separately via region's existing `proposition(id)`
+// query (see GET_PROPOSITION in `region.ts`).
+//
+// v1.0 known shape: axes 1–3 (directMaterial / valuesAlignment /
+// actionability — propositions' axis 3 = election proximity) are
+// populated; axes 4–7 are placeholder 0.0 until follow-ups land.
+// `relevanceExplanation` is always null in Phase 1 — the LLM rerank
+// flow that powers bills (#745) isn't wired for props yet.
+// ============================================
+
+/**
+ * Proposition-specific alias for the shared `BriefingAxisScores`
+ * shape. Wire-identical to the bill `AxisScores` so card-level
+ * components (`WhyThisPanel`, `RelevanceChip`) accept both without
+ * structural casts. The per-domain axis-3 semantics (election
+ * proximity vs. legislative activity) are documented on the shared
+ * interface.
+ */
+export type PropositionAxisScores = BriefingAxisScores;
+
+export interface PersonalizedPropositionResult {
+  propositionId: string;
+  relevanceScore: number;
+  axisScores: PropositionAxisScores;
+  /**
+   * LLM-written one-sentence "why this matters to you" — placeholder
+   * for Phase 2 of #771 (would reuse the `llm-rerank-worker` infra
+   * shipped in #745 with a new prompt-service template). Always null
+   * in Phase 1; `WhyThisPanel` falls back to the heuristic axis
+   * explanation.
+   */
+  relevanceExplanation?: string | null;
+}
+
+export interface PersonalizedPropositionFeedData {
+  myPersonalizedPropositionFeed: PersonalizedPropositionResult[];
+}
+
+export interface PropositionPersonalizationInput {
+  flags: RankingFlags;
+  interestTags: string[];
+}
+
+export const GET_MY_PERSONALIZED_PROPOSITION_FEED = gql`
+  query MyPersonalizedPropositionFeed(
+    $input: PropositionPersonalizationInputDto!
+    $limit: Int!
+  ) {
+    myPersonalizedPropositionFeed(input: $input, limit: $limit) {
+      propositionId
+      relevanceScore
+      relevanceExplanation
+      axisScores {
+        directMaterial
+        valuesAlignment
+        actionability
+        indirectMaterial
+        coalitionSignal
+        counterfactual
+        noveltyRepetition
+      }
+    }
+  }
+`;
+
+/**
+ * Convenience: pulls the top-scoring axis so the heuristic
+ * `WhyThisPanel` can choose an i18n key. Same shape as `topAxisFor`
+ * in `personalized-feed.ts` — kept in this file so the propositions
+ * card can pass its (Proposition)AxisScores cleanly without a
+ * structural cast against the bill shape.
+ */
+export function topAxisForProposition(
+  scores: PropositionAxisScores,
+): keyof PropositionAxisScores {
+  const axes: (keyof PropositionAxisScores)[] = [
+    "directMaterial",
+    "valuesAlignment",
+    "actionability",
+  ];
+  return axes.reduce<keyof PropositionAxisScores>(
+    (best, axis) => ((scores[axis] ?? 0) > (scores[best] ?? 0) ? axis : best),
+    axes[0],
+  );
+}

--- a/apps/frontend/locales/en/briefing.json
+++ b/apps/frontend/locales/en/briefing.json
@@ -10,7 +10,11 @@
     "noProfileCta": "Complete onboarding →"
   },
   "section": {
-    "seeAll": "See all →"
+    "seeAll": "See all →",
+    "collapseAria": "Collapse {{title}} section",
+    "expandAria": "Expand {{title}} section",
+    "itemCount_one": "{{count}} item",
+    "itemCount_other": "{{count}} items"
   },
   "bills": {
     "title": "Bills moving this week",
@@ -38,7 +42,11 @@
   },
   "propositions": {
     "title": "Active propositions",
-    "subtitle": "Ballot measures in your jurisdictions, ranked by relevance + your trusted organizations.",
+    "subtitle": "Ballot measures in your jurisdictions, ranked by what matters to you.",
+    "empty": "No active propositions match your interests. Broaden your interests or check back closer to an election.",
+    "electionDate": "Election {{date}}",
+    "yesOutcome": "If yes",
+    "noOutcome": "If no",
     "placeholder": {
       "body": "Personalized proposition briefings are coming soon. Until then, browse all active ballot measures.",
       "comingSoonNote": "We'll show ranked props with trusted-org endorsements here once that signal pipeline ships."

--- a/apps/frontend/locales/es/briefing.json
+++ b/apps/frontend/locales/es/briefing.json
@@ -10,7 +10,11 @@
     "noProfileCta": "Completar incorporación →"
   },
   "section": {
-    "seeAll": "Ver todo →"
+    "seeAll": "Ver todo →",
+    "collapseAria": "Contraer sección {{title}}",
+    "expandAria": "Expandir sección {{title}}",
+    "itemCount_one": "{{count}} elemento",
+    "itemCount_other": "{{count}} elementos"
   },
   "bills": {
     "title": "Proyectos de ley esta semana",
@@ -38,7 +42,11 @@
   },
   "propositions": {
     "title": "Proposiciones activas",
-    "subtitle": "Medidas electorales en tus jurisdicciones, priorizadas por relevancia y por tus organizaciones de confianza.",
+    "subtitle": "Medidas electorales en tus jurisdicciones, priorizadas según lo que te importa.",
+    "empty": "Ninguna proposición activa coincide con tus intereses. Amplía tus intereses o vuelve a revisar cerca de una elección.",
+    "electionDate": "Elección {{date}}",
+    "yesOutcome": "Si sí",
+    "noOutcome": "Si no",
     "placeholder": {
       "body": "Los resúmenes personalizados de proposiciones llegarán pronto. Por ahora, explora todas las medidas electorales activas.",
       "comingSoonNote": "Mostraremos aquí proposiciones priorizadas con respaldos de organizaciones de confianza cuando esa señal esté lista."


### PR DESCRIPTION
## Summary

Ships the personalized Propositions section for the civic briefing home page (epic #740, issue #771). Replaces the placeholder card with a real `<PropositionsBriefingSection>` driven by a new heuristic 3-axis ranker in the knowledge service. The frontend mirrors the bills section pattern from #744 / PR #774 exactly — same shell, same WhyThisPanel disclosure, same RelevanceChip — for visual rhythm across the four briefing cards.

Also includes a **collapsible BriefingSection shell** improvement (separate commit) that all four sections (Bills, Reps, Committees, Propositions) inherit automatically: each section header has an expand/collapse toggle with localStorage-persisted state so users can compress sections they don't want to scan.

## Why this is Phase 1

The issue AC asks for **eight** behaviors, of which seven ship here. The eighth — **trusted-organization endorsement chips** ("Sierra Club: Yes • NRA: No" inline) — needs a `PropositionEndorsement` data model that doesn't exist yet, plus an ingest path. That's a Phase 2 follow-up that consolidates with reps endorsements (shared data shape). The frontend has no chip rendering in this PR, `trustedOrganizations` is not yet threaded through the DTO, and scoring axis 5 (`coalitionSignal`) returns a placeholder `0.0` ready to be populated when Phase 2 lands.

## What changed

### Commit 1 — `feat(frontend): collapsible BriefingSection shell + briefing i18n bundle`

- `BriefingSection.tsx` — expand/collapse toggle on the section header; per-section localStorage persistence (`briefing:section:${slug}:expanded`); `aria-expanded` + `aria-controls`; chevron rotates 90°; `prefers-reduced-motion` honored; collapsed header surfaces item count so closed cards aren't information-free
- 7 new BriefingSection collapse/persistence tests
- README updated to document the new shell capability
- EN + ES locale bundle update — section.* ARIA labels + propositions.* copy (i18n bundled atomically; splitting the JSON file gave no review value and broke the pre-commit test gate on commit 2's tests)

### Commit 2 — `feat(knowledge,frontend): personalized Propositions briefing section (#771)`

**New: knowledge service domain** (`apps/backend/src/apps/knowledge/src/domains/personalized-propositions/`)
- `PropositionScoringService` — 3-axis scoring (50% material via flag→keyword dictionary, 30% values via interest-tag substring match, 20% election proximity via piecewise distribution)
- `PersonalizedPropositionsService` — orchestrator; reads from `propositions`, scores each, returns top-N (default 5, capped at 10). Requires at least one personal signal match (axis 1 OR axis 2)
- `PersonalizedPropositionsResolver` — `myPersonalizedPropositionFeed(input, limit?)` GraphQL query
- DTO + result models (parallel to the bills domain); registered in knowledge `app.module.ts`

**New: frontend domain** (`apps/frontend/components/briefing/propositions/`)
- `PropositionsBriefingSection` — orchestrator with loading / error / empty / noProfile states
- `PropositionBriefingCard` — per-row component (title link, plain-language summary, yes/no outcomes dl, relevance chip, WhyThisPanel disclosure)
- `usePropositionsBriefing` hook — 3-step fetch (rankingFlags+interestTags → ranked feed → prop details)
- `lib/graphql/personalized-propositions.ts` — `GET_MY_PERSONALIZED_PROPOSITION_FEED` query + types
- `BriefingPage.tsx` replaces the placeholder with the real section

**Shared improvements** (incidental but worth noting)
- New shared `BriefingAxisScores` interface in `personalized-feed.ts`; bills' `AxisScores` and props' `PropositionAxisScores` are now type aliases for it. Removed an `as unknown as` cast in the prop card.
- `useBillBriefing` + `usePropositionsBriefing` use the same `noProfile` logic (fires only when **both** `interestTags` and `rankingFlags` are empty). Was: only checked `interestTags`.
- `RelevanceChip` gained `role="img"` so the `aria-label` doesn't trip the `aria-prohibited-attr` axe rule. Benefits bills + propositions cards.

## Review fixes applied before push (6 suggestions + 3 nitpicks)

| ID | Fix |
|---|---|
| S1 | Jurisdiction-filter gap documented as "Known limitation" on the service docstring; Phase 2 follow-up to file |
| S2 | `noProfile` checks flags AND tags emptiness in both hooks (kept in lockstep) |
| S3 | `stringLeaves` recursion bounded by `MAX_JSON_DEPTH=5` |
| S4 | Collapsed-state `itemCount` suppressed while feed is loading |
| S5 | Shared `BriefingAxisScores` interface; structural cast removed |
| S6 | Prisma `PROPOSITION_SELECT` hoisted to `as const satisfies Prisma.PropositionSelect`; `PropositionRow` derived via `Prisma.PropositionGetPayload` so SQL select and TS shape drift together |
| N7 | `Object.fromEntries(...) as unknown as ...` replaced with typed reducer; `escapeRegExp` helper extracted |
| N8 | Shared `BriefingAxisScores` documents axis-3 per-domain semantics (bills = vote window, props = election proximity) |
| N10 | `i18n.language` threaded into `Date.toLocaleDateString` so ES users get Spanish-formatted election dates |

Skipped: N9 (icon extraction — too broad), N11 (no change needed), N12 (post-MVP polish).

## Test plan

- [ ] CI passes (lint + test + build)
- [x] UAT smoke (validated this session):
  - [x] Knowledge service rebuilt; federation gateway exposes `myPersonalizedPropositionFeed` + new types (`PersonalizedPropositionResult`, `PropositionAxisScores`, `PropositionPersonalizationInputDto`)
  - [x] Frontend rebuilt; `/me/briefing` renders the four sections including Propositions
  - [x] User with no overlapping signals correctly sees the empty-state copy (UAT props are election-reform measures; user signals were housing/healthcare/justice)
  - [x] Section collapse/expand toggle works; localStorage persists across reload
  - [x] Collapsed-state focus ring no longer clipped by section `overflow-hidden` (fixed mid-session)
- [ ] Manual: register a user with `interestTags` overlapping ballot-measure topics and confirm the props rank correctly
- [ ] Playwright E2E: `briefing-propositions.spec.ts` (4 cases — render, collapse, navigation, no-endorsement-chips guard)
- [ ] a11y: `briefing-propositions.a11y.test.tsx` axe scans (3 card-render variants)

## Linked issues

- Closes #771
- Built on top of #744 (Civic Briefing post-auth landing — the briefing shell + page composition)
- Coordinates with #743 (relevance ranker pattern reused)
- Phase 2 follow-up to file: **trusted-org endorsement model + chips + scoring axis 5** (consolidates props + reps; shares the same `Endorsement` data shape)
- Phase 2 follow-up to file: **jurisdiction filter for propositions** (gated on local/county ballot-measure ingest)

## Migration / rollout notes

- **No DB migrations.** All new code reads from existing `Proposition` columns.
- **No new env vars** in this PR.
- New worker / new queues: none.
- Federation contract change: **additive** (new query + new types in knowledge subgraph). Gateway auto-composes; verified live via introspection.

## Test totals

- 23 PropositionScoringService unit tests
- 10 PersonalizedPropositionsService unit tests
- 4 PersonalizedPropositionsResolver unit tests
- 10 PropositionBriefingCard component tests
- 7 BriefingSection collapsibility tests
- 4 Playwright E2E cases
- 3 WCAG 2.2 AA axe scans

61 net new tests across 8 suites.

## Out of scope (Phase 2 candidates)

- Trusted-org endorsement chips (highest-value follow-up — fills the empty-state gap for users whose interest tags don't align with available props)
- Jurisdiction filtering (needs local/county ballot-measure ingest)
- LLM rerank for prop explanations (would reuse `llm-rerank-worker` from #745 with a new prompt-service template)
- Distinct empty-state messaging for "no scoring inputs" vs "no matches"

🤖 Generated with [Claude Code](https://claude.com/claude-code)