### PR TITLE
chore(infra): extend Vault hydration + preflight refactor (#792)

### DIFF
--- a/apps/backend/docker/scripts/db-migrate.sh
+++ b/apps/backend/docker/scripts/db-migrate.sh
@@ -150,23 +150,59 @@ fi
 
 VAULT_FUNCTIONS_FILE="/usr/src/app/supabase/migrations/99_vault_functions.sql"
 PG_META_URL="${PG_META_URL:-http://supabase-meta:8080}"
-SEED_KEY="${SEED_SENSITIVE_PROFILE_ENCRYPTION_KEY:-jv4vjdDIE+PqHm0WunsG3K4gA882jyQnkFaU5AYtAnM=}"
+# Export SEED_* values so the child `node` process can read them via
+# `process.env`. Doing it this way instead of shell-interpolating into
+# the JS template avoids shell-quote fragility — a SEED value containing
+# a single quote, backslash, or `${` would break the JS at parse time.
+export SEED_VAULT_KEY="${SEED_SENSITIVE_PROFILE_ENCRYPTION_KEY:-jv4vjdDIE+PqHm0WunsG3K4gA882jyQnkFaU5AYtAnM=}"
+# Default to the well-known self-hosted Supabase dev JWT (anon role). Override
+# via SEED_SUPABASE_ANON_KEY when seeding a hosted Supabase project.
+export SEED_VAULT_ANON_KEY="${SEED_SUPABASE_ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE}"
+# Default points at the redis service-name in docker-compose.yml. Override
+# via SEED_REDIS_URL when the deploy uses a managed Redis (with auth).
+export SEED_VAULT_REDIS="${SEED_REDIS_URL:-redis://redis:6379}"
 
 if [ -f "$VAULT_FUNCTIONS_FILE" ] && [ -n "$SERVICE_ROLE_KEY" ]; then
+  # Export the platform vars too so the node script can read them
+  # cleanly from process.env.
+  export VAULT_FUNCTIONS_FILE PG_META_URL
+  export SEED_PGREST_URL="${SUPABASE_INTERNAL_URL}/rest/v1"
+  export SEED_SERVICE_KEY="${SERVICE_ROLE_KEY}"
+
   echo "=== Installing Supabase Vault RPC functions via pg-meta ==="
-  echo "=== Seeding SENSITIVE_PROFILE_ENCRYPTION_KEY via PostgREST RPC ==="
-  # Pass the file PATH to node — let it read the SQL directly so we
-  # don't try to escape arbitrary SQL into a shell-embedded JS string.
+  echo "=== Seeding bootstrap secrets via PostgREST RPC ==="
+  # All values come from process.env — no shell interpolation into JS.
   node -e "
 const fs = require('fs');
 const http = require('http');
 const { URL } = require('url');
 
-const pgMetaUrl = '${PG_META_URL}';
-const pgrestUrl = '${SUPABASE_INTERNAL_URL}/rest/v1';
-const serviceKey = '${SERVICE_ROLE_KEY}';
-const seedKey = '${SEED_KEY}';
-const vaultFnSql = fs.readFileSync('${VAULT_FUNCTIONS_FILE}', 'utf8');
+const pgMetaUrl = process.env.PG_META_URL;
+const pgrestUrl = process.env.SEED_PGREST_URL;
+const serviceKey = process.env.SEED_SERVICE_KEY;
+const vaultFnSql = fs.readFileSync(process.env.VAULT_FUNCTIONS_FILE, 'utf8');
+
+// Secrets with sensible dev defaults that the seed script can write
+// idempotently. Anything that needs a real per-deploy credential
+// (RESEND_API_KEY, SMTP_USER/PASS, R2_*, FEC_API_KEY) must be seeded
+// by the operator via SQL — see docs/guides/secrets-management.md.
+const seeds = [
+  {
+    name: 'SENSITIVE_PROFILE_ENCRYPTION_KEY',
+    value: process.env.SEED_VAULT_KEY,
+    description: 'AES-256-GCM key for users.SensitiveProfile T3 column encryption (#742). Local UAT dev value.',
+  },
+  {
+    name: 'SUPABASE_ANON_KEY',
+    value: process.env.SEED_VAULT_ANON_KEY,
+    description: 'Supabase anon-role JWT. Well-known dev default for self-hosted; override via SEED_SUPABASE_ANON_KEY for hosted projects (#792).',
+  },
+  {
+    name: 'REDIS_URL',
+    value: process.env.SEED_VAULT_REDIS,
+    description: 'BullMQ + cache Redis connection string. Defaults to local docker-compose redis service; override via SEED_REDIS_URL for managed Redis (#792).',
+  },
+];
 
 function request(method, urlStr, headers, body) {
   return new Promise((resolve, reject) => {
@@ -207,18 +243,28 @@ async function main() {
   // Give PostgREST a moment to pick up the new functions before the seed call
   await new Promise((r) => setTimeout(r, 1000));
 
-  // 3. Seed the secret via PostgREST RPC
+  // 3. Seed each bootstrap secret via PostgREST RPC. Per-secret error handling
+  //    so one failure (e.g. corrupted-ciphertext upsert on a pre-existing row)
+  //    doesn't abort the rest. Operator can recover manually per
+  //    docs/guides/secrets-management.md.
   const auth = { apikey: serviceKey, Authorization: 'Bearer ' + serviceKey };
-  const seedRes = await request('POST', pgrestUrl + '/rpc/vault_create_secret', auth,
-    JSON.stringify({
-      p_name: 'SENSITIVE_PROFILE_ENCRYPTION_KEY',
-      p_value: seedKey,
-      p_description: 'AES-256-GCM key for users.SensitiveProfile T3 column encryption (#742). Local UAT dev value.',
-    }));
-  if (seedRes.status >= 400) {
-    throw new Error('vault_create_secret RPC failed: ' + seedRes.status + ' ' + seedRes.body);
+  for (const seed of seeds) {
+    try {
+      const seedRes = await request('POST', pgrestUrl + '/rpc/vault_create_secret', auth,
+        JSON.stringify({
+          p_name: seed.name,
+          p_value: seed.value,
+          p_description: seed.description,
+        }));
+      if (seedRes.status >= 400) {
+        console.warn(seed.name + ' seed failed (non-fatal): ' + seedRes.status + ' ' + seedRes.body);
+      } else {
+        console.log(seed.name + ' seeded in vault');
+      }
+    } catch (err) {
+      console.warn(seed.name + ' seed threw (non-fatal):', err.message);
+    }
   }
-  console.log('SENSITIVE_PROFILE_ENCRYPTION_KEY seeded in vault');
 }
 
 main().catch((err) => { console.error('Vault seed failed (non-fatal):', err.message); });

--- a/apps/backend/src/api/src/main.ts
+++ b/apps/backend/src/api/src/main.ts
@@ -1,5 +1,4 @@
 import 'src/common/tracing'; // Must be first — OTel patches modules before they load
-import bootstrap from 'src/common/bootstrap';
-import { AppModule } from './app.module';
+import { runService } from 'src/common/preflight';
 
-bootstrap(AppModule, { portEnvVar: 'API_PORT' });
+runService(() => import('./app.module'), { portEnvVar: 'API_PORT' });

--- a/apps/backend/src/apps/documents/src/main.ts
+++ b/apps/backend/src/apps/documents/src/main.ts
@@ -1,5 +1,4 @@
 import 'src/common/tracing'; // Must be first — OTel patches modules before they load
-import bootstrap from 'src/common/bootstrap';
-import { AppModule } from './app.module';
+import { runService } from 'src/common/preflight';
 
-bootstrap(AppModule, { portEnvVar: 'DOCUMENTS_PORT' });
+runService(() => import('./app.module'), { portEnvVar: 'DOCUMENTS_PORT' });

--- a/apps/backend/src/apps/knowledge/src/main.ts
+++ b/apps/backend/src/apps/knowledge/src/main.ts
@@ -1,5 +1,4 @@
 import 'src/common/tracing'; // Must be first — OTel patches modules before they load
-import bootstrap from 'src/common/bootstrap';
-import { AppModule } from './app.module';
+import { runService } from 'src/common/preflight';
 
-bootstrap(AppModule, { portEnvVar: 'KNOWLEDGE_PORT' });
+runService(() => import('./app.module'), { portEnvVar: 'KNOWLEDGE_PORT' });

--- a/apps/backend/src/apps/region/src/main.ts
+++ b/apps/backend/src/apps/region/src/main.ts
@@ -1,7 +1,6 @@
 import 'src/common/tracing'; // Must be first — OTel patches modules before they load
 import { setGlobalHttpPool } from '@opuspopuli/common';
-import bootstrap from 'src/common/bootstrap';
-import { AppModule } from './app.module';
+import { runService } from 'src/common/preflight';
 
 // Configure the global undici dispatcher BEFORE any fetch calls fire.
 // Default undici headersTimeout is 300_000ms (5 min); civics-extraction
@@ -16,4 +15,4 @@ setGlobalHttpPool({
   bodyTimeoutMs: 1_350_000,
 });
 
-bootstrap(AppModule, { portEnvVar: 'REGION_PORT' });
+runService(() => import('./app.module'), { portEnvVar: 'REGION_PORT' });

--- a/apps/backend/src/apps/users/src/main.ts
+++ b/apps/backend/src/apps/users/src/main.ts
@@ -1,5 +1,4 @@
 import 'src/common/tracing'; // Must be first — OTel patches modules before they load
-import bootstrap from 'src/common/bootstrap';
-import { AppModule } from './app.module';
+import { runService } from 'src/common/preflight';
 
-bootstrap(AppModule, { portEnvVar: 'USERS_PORT' });
+runService(() => import('./app.module'), { portEnvVar: 'USERS_PORT' });

--- a/apps/backend/src/apps/workers/llm-rerank-worker/src/main.ts
+++ b/apps/backend/src/apps/workers/llm-rerank-worker/src/main.ts
@@ -2,7 +2,7 @@ import 'src/common/tracing';
 import { setGlobalHttpPool } from '@opuspopuli/common';
 import { NestFactory } from '@nestjs/core';
 import { Logger } from '@nestjs/common';
-import { LlmRerankWorkerModule } from './llm-rerank-worker.module';
+import { preflightAndLoad } from 'src/common/preflight';
 
 // Match region-worker: raise undici headersTimeout so slow Ollama
 // responses on large bill contexts don't cut off before our LLMError fires.
@@ -11,6 +11,10 @@ setGlobalHttpPool({ headersTimeoutMs: 1_350_000 });
 const logger = new Logger('LlmRerankWorker');
 
 async function bootstrap() {
+  const { LlmRerankWorkerModule } = await preflightAndLoad(
+    () => import('./llm-rerank-worker.module'),
+  );
+
   const app = await NestFactory.create(LlmRerankWorkerModule, {
     bufferLogs: true,
   });
@@ -21,4 +25,10 @@ async function bootstrap() {
   logger.log(`LLM rerank worker listening on port ${port}`);
 }
 
-bootstrap();
+bootstrap().catch((err: unknown) => {
+  logger.error(
+    `LLM rerank worker startup failed: ${err instanceof Error ? err.message : String(err)}`,
+    err instanceof Error ? err.stack : undefined,
+  );
+  process.exit(1);
+});

--- a/apps/backend/src/apps/workers/region-worker/src/main.ts
+++ b/apps/backend/src/apps/workers/region-worker/src/main.ts
@@ -2,7 +2,7 @@ import 'src/common/tracing';
 import { setGlobalHttpPool } from '@opuspopuli/common';
 import { NestFactory } from '@nestjs/core';
 import { Logger } from '@nestjs/common';
-import { RegionWorkerModule } from './region-worker.module';
+import { preflightAndLoad } from 'src/common/preflight';
 
 // Set undici headersTimeout before any fetch fires — default 300s would
 // cut off slow Ollama responses on large contexts before our LLMError fires.
@@ -11,6 +11,13 @@ setGlobalHttpPool({ headersTimeoutMs: 1_350_000 });
 const logger = new Logger('RegionWorker');
 
 async function bootstrap() {
+  // Vault → process.env hydration MUST run before the worker module is
+  // imported. ConfigModule.forRoot({validationSchema}) runs Joi validation
+  // synchronously at @Module-decorator evaluation time. See #786 / #792.
+  const { RegionWorkerModule } = await preflightAndLoad(
+    () => import('./region-worker.module'),
+  );
+
   const app = await NestFactory.create(RegionWorkerModule, {
     bufferLogs: true,
   });
@@ -21,4 +28,10 @@ async function bootstrap() {
   logger.log(`Region worker listening on port ${port}`);
 }
 
-bootstrap();
+bootstrap().catch((err: unknown) => {
+  logger.error(
+    `Region worker startup failed: ${err instanceof Error ? err.message : String(err)}`,
+    err instanceof Error ? err.stack : undefined,
+  );
+  process.exit(1);
+});

--- a/apps/backend/src/apps/workers/structural-analysis-worker/src/main.ts
+++ b/apps/backend/src/apps/workers/structural-analysis-worker/src/main.ts
@@ -1,11 +1,15 @@
 import 'src/common/tracing';
 import { NestFactory } from '@nestjs/core';
 import { Logger } from '@nestjs/common';
-import { StructuralAnalysisWorkerModule } from './structural-analysis-worker.module';
+import { preflightAndLoad } from 'src/common/preflight';
 
 const logger = new Logger('StructuralAnalysisWorker');
 
 async function bootstrap() {
+  const { StructuralAnalysisWorkerModule } = await preflightAndLoad(
+    () => import('./structural-analysis-worker.module'),
+  );
+
   const app = await NestFactory.create(StructuralAnalysisWorkerModule, {
     bufferLogs: true,
   });
@@ -19,4 +23,10 @@ async function bootstrap() {
   logger.log(`Structural analysis worker listening on port ${port}`);
 }
 
-bootstrap();
+bootstrap().catch((err: unknown) => {
+  logger.error(
+    `Structural analysis worker startup failed: ${err instanceof Error ? err.message : String(err)}`,
+    err instanceof Error ? err.stack : undefined,
+  );
+  process.exit(1);
+});

--- a/apps/backend/src/common/bootstrap.ts
+++ b/apps/backend/src/common/bootstrap.ts
@@ -9,20 +9,11 @@ import compression from 'compression';
 import { env } from 'process';
 
 import { ConfigService } from '@nestjs/config';
-import { hydrateEnvFromVault } from '@opuspopuli/secrets-provider';
 import { getHelmetOptions } from 'src/config/security-headers.config';
 import { getCorsConfig } from 'src/config/cors.config';
 import { GracefulShutdownService } from './services/graceful-shutdown.service';
 
 const logger = new Logger('Bootstrap');
-
-/**
- * Secrets sourced from Supabase Vault at bootstrap when
- * `SECRETS_PROVIDER=supabase`. Hydration runs before NestJS is
- * constructed so `@nestjs/config` factories see the Vault values.
- * Extended in follow-up PRs as more secrets migrate. See issue #786.
- */
-const VAULT_BACKED_SECRETS = ['RESEND_API_KEY'] as const;
 
 function setupSwagger(
   app: INestApplication,
@@ -48,11 +39,6 @@ export default async function bootstrap(
   options: BootstrapOptions = {},
 ): Promise<void> {
   const startTime = Date.now();
-
-  // Vault → process.env hydration must run before NestFactory.create()
-  // because @nestjs/config's registerAs factories read process.env at
-  // module-init time. See issue #786.
-  await hydrateEnvFromVault(VAULT_BACKED_SECRETS);
 
   const app = await NestFactory.create(AppModule);
   const configService = app.get<ConfigService>(ConfigService);

--- a/apps/backend/src/common/preflight.spec.ts
+++ b/apps/backend/src/common/preflight.spec.ts
@@ -1,0 +1,137 @@
+// Mock the secrets-provider hydration call so tests don't reach for a
+// real Vault. We assert call shape directly.
+jest.mock('@opuspopuli/secrets-provider', () => ({
+  hydrateEnvFromVault: jest.fn().mockResolvedValue(undefined),
+}));
+
+// Mock the shared bootstrap so runService doesn't actually spin up a
+// NestJS app — we only verify the wiring.
+jest.mock('./bootstrap', () => ({
+  __esModule: true,
+  default: jest.fn().mockResolvedValue(undefined),
+}));
+
+import { hydrateEnvFromVault } from '@opuspopuli/secrets-provider';
+import bootstrap from './bootstrap';
+import {
+  VAULT_BACKED_SECRETS,
+  preflightAndLoad,
+  runService,
+} from './preflight';
+
+const mockHydrate = hydrateEnvFromVault as jest.MockedFunction<
+  typeof hydrateEnvFromVault
+>;
+const mockBootstrap = bootstrap as jest.MockedFunction<typeof bootstrap>;
+
+describe('preflightAndLoad', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls hydrateEnvFromVault with the canonical VAULT_BACKED_SECRETS list', async () => {
+    const loader = jest.fn().mockResolvedValue({ ok: true });
+
+    await preflightAndLoad(loader);
+
+    expect(mockHydrate).toHaveBeenCalledTimes(1);
+    expect(mockHydrate).toHaveBeenCalledWith(VAULT_BACKED_SECRETS);
+  });
+
+  it('invokes the loader AFTER hydration completes (ordering enforced)', async () => {
+    const callOrder: string[] = [];
+    mockHydrate.mockImplementationOnce(async () => {
+      callOrder.push('hydrate');
+    });
+    const loader = jest.fn().mockImplementation(async () => {
+      callOrder.push('load');
+      return { ok: true };
+    });
+
+    await preflightAndLoad(loader);
+
+    expect(callOrder).toEqual(['hydrate', 'load']);
+  });
+
+  it("returns the loader's resolved value", async () => {
+    const expected = { AppModule: class FakeAppModule {} };
+    const loader = jest.fn().mockResolvedValue(expected);
+
+    await expect(preflightAndLoad(loader)).resolves.toBe(expected);
+  });
+
+  it('propagates loader rejection so callers can handle it', async () => {
+    const loader = jest.fn().mockRejectedValue(new Error('module load failed'));
+
+    await expect(preflightAndLoad(loader)).rejects.toThrow(
+      'module load failed',
+    );
+  });
+});
+
+describe('runService', () => {
+  let exitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Record process.exit() calls without throwing — the runService
+    // chain has nothing after exit() so silent no-op is fine, and a
+    // throw here would unhandled-reject inside .catch() and abort the
+    // test runner.
+    exitSpy = jest
+      .spyOn(process, 'exit')
+      .mockImplementation(() => undefined as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  const flushMicrotasks = () => new Promise((r) => setImmediate(r));
+
+  it('runs preflight then bootstrap with the loaded AppModule', async () => {
+    class FakeAppModule {}
+    const loader = jest.fn().mockResolvedValue({ AppModule: FakeAppModule });
+
+    runService(loader, { portEnvVar: 'TEST_PORT' });
+    await flushMicrotasks();
+
+    expect(mockHydrate).toHaveBeenCalledWith(VAULT_BACKED_SECRETS);
+    expect(mockBootstrap).toHaveBeenCalledWith(FakeAppModule, {
+      portEnvVar: 'TEST_PORT',
+    });
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('catches preflight errors and exits with code 1', async () => {
+    mockHydrate.mockRejectedValueOnce(new Error('vault unreachable'));
+    const loader = jest.fn();
+
+    runService(loader, { portEnvVar: 'TEST_PORT' });
+    await flushMicrotasks();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockBootstrap).not.toHaveBeenCalled();
+  });
+
+  it('catches loader errors and exits with code 1', async () => {
+    const loader = jest.fn().mockRejectedValue(new Error('module load failed'));
+
+    runService(loader, { portEnvVar: 'TEST_PORT' });
+    await flushMicrotasks();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(mockBootstrap).not.toHaveBeenCalled();
+  });
+
+  it('catches bootstrap errors and exits with code 1', async () => {
+    class FakeAppModule {}
+    const loader = jest.fn().mockResolvedValue({ AppModule: FakeAppModule });
+    mockBootstrap.mockRejectedValueOnce(new Error('NestFactory failed'));
+
+    runService(loader, { portEnvVar: 'TEST_PORT' });
+    await flushMicrotasks();
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/backend/src/common/preflight.ts
+++ b/apps/backend/src/common/preflight.ts
@@ -1,0 +1,103 @@
+import { Logger, Type } from '@nestjs/common';
+import { hydrateEnvFromVault } from '@opuspopuli/secrets-provider';
+import bootstrap from './bootstrap';
+
+const logger = new Logger('Preflight');
+
+/**
+ * Secrets sourced from Supabase Vault at bootstrap when
+ * `SECRETS_PROVIDER=supabase`. Hydration must run before any
+ * application module is loaded — `@nestjs/config`'s `forRoot()`
+ * runs Joi validation at the @Module-decorator evaluation step
+ * (synchronously, at file-import time), so any vault-managed
+ * secret in the validation schema must already be in `process.env`
+ * before the import statement executes.
+ *
+ * `preflightAndLoad()` enforces this ordering by running hydration
+ * first, then performing the AppModule import dynamically.
+ *
+ * `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are intentionally
+ * NOT in this list — they're required to reach Vault in the first
+ * place and stay as env vars by necessity.
+ *
+ * Internal cryptographic secrets (`JWT_SECRET`, `AUTH_JWT_SECRET`,
+ * `GATEWAY_HMAC_SECRET`, `API_KEYS`) are NOT in this list either —
+ * they need fail-fast behavior on missing-secret rather than the
+ * current tolerant warn-and-continue. Migration of those secrets
+ * requires extending the hydration mechanism with a strict mode.
+ *
+ * See issues #786 (mechanism), #792 (extended list + prod flip).
+ */
+export const VAULT_BACKED_SECRETS = [
+  'RESEND_API_KEY',
+  'SMTP_USER',
+  'SMTP_PASS',
+  'R2_ACCOUNT_ID',
+  'R2_ACCESS_KEY_ID',
+  'R2_SECRET_ACCESS_KEY',
+  'REDIS_URL',
+  'SUPABASE_ANON_KEY',
+  'FEC_API_KEY',
+] as const;
+
+/**
+ * Hydrates Vault-backed secrets into `process.env`, then invokes
+ * the provided loader to dynamically import the application or
+ * worker module. The dynamic import ensures the @Module decorator
+ * (and any synchronous validation it triggers) sees the hydrated
+ * environment.
+ *
+ * Usage from each service / worker `main.ts`:
+ *
+ * ```ts
+ * preflightAndLoad(() => import('./app.module')).then(({ AppModule }) =>
+ *   bootstrap(AppModule, { portEnvVar: 'USERS_PORT' }),
+ * );
+ * ```
+ */
+export async function preflightAndLoad<T>(
+  loader: () => Promise<T>,
+): Promise<T> {
+  await hydrateEnvFromVault(VAULT_BACKED_SECRETS);
+  return loader();
+}
+
+interface RunServiceOptions {
+  portEnvVar?: string;
+}
+
+/**
+ * Convenience wrapper for HTTP service `main.ts` entry points. Combines
+ * preflight + dynamic import + shared bootstrap into a single call.
+ *
+ * Catches and logs any startup failure (preflight error, module import
+ * error, NestJS bootstrap error) and exits the process so the failure
+ * mode is loud rather than a silent `unhandledRejection`.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import 'src/common/tracing';
+ * import { runService } from 'src/common/preflight';
+ *
+ * runService(() => import('./app.module'), { portEnvVar: 'USERS_PORT' });
+ * ```
+ *
+ * Workers have a more heterogeneous startup (custom port vars, custom
+ * undici pool config, distinct loggers) and use `preflightAndLoad`
+ * directly inside their own `bootstrap()` async function instead.
+ */
+export function runService(
+  loadAppModule: () => Promise<{ AppModule: Type<unknown> }>,
+  options: RunServiceOptions = {},
+): void {
+  preflightAndLoad(loadAppModule)
+    .then(({ AppModule }) => bootstrap(AppModule, options))
+    .catch((err: unknown) => {
+      logger.error(
+        `Service startup failed: ${err instanceof Error ? err.message : String(err)}`,
+        err instanceof Error ? err.stack : undefined,
+      );
+      process.exit(1);
+    });
+}

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -51,8 +51,16 @@ x-backend-env: &backend-env
   API_KEYS: ${API_KEYS}
   # OpenTelemetry distributed tracing
   OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318
-  # Secrets via env (not AWS)
-  SECRETS_PROVIDER: env
+  # Secrets via Supabase Vault. The hydration step in apps/backend/src/common/
+  # preflight.ts reads the secrets named in VAULT_BACKED_SECRETS and writes
+  # them into process.env before any AppModule is loaded. Vault values
+  # overwrite env when the vault secret is present; env values serve as
+  # fallback only when the vault secret is absent (used during incremental
+  # migration before each secret is seeded in the prod Supabase Cloud vault).
+  # Once a secret is seeded in vault, its env passthrough below becomes
+  # dead code and can be removed in a follow-up. See
+  # docs/guides/secrets-management.md and issues #786 / #792.
+  SECRETS_PROVIDER: supabase
   # Email
   RESEND_API_KEY: ${RESEND_API_KEY}
   SMTP_HOST: ${SMTP_HOST:-smtp.resend.com}

--- a/docker-compose-uat.yml
+++ b/docker-compose-uat.yml
@@ -39,21 +39,23 @@ x-backend-env: &backend-env
   RELATIONAL_DB_PASSWORD: your-super-secret-password
   RELATIONAL_DB_DATABASE: postgres
   DATABASE_URL: postgresql://postgres:your-super-secret-password@opuspopuli-db:5432/postgres
-  REDIS_URL: redis://redis:6379
+  # SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY stay as env vars by necessity
+  # — they're required to reach Vault. All other secrets (including
+  # SUPABASE_ANON_KEY and REDIS_URL) are sourced from Vault at bootstrap.
+  # db-migrate auto-seeds the dev defaults; see docs/guides/secrets-management.md.
   SUPABASE_URL: http://supabase-kong:8000
-  SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE
   SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.sF_hc5jg-YhscQGb00SNtjW3ZIyDlGIIQppgOLwHGiM
   GATEWAY_CLIENT_ID: api-gateway
   GATEWAY_HMAC_SECRET: integration-test-hmac-secret
   API_KEYS: '{"api-gateway":"integration-test-hmac-secret"}'
   JWT_SECRET: your-super-secret-jwt-token-with-at-least-32-characters
   AUTH_JWT_SECRET: your-super-secret-jwt-token-with-at-least-32-characters
-  # Resolve secrets via Supabase Vault (prod-matching pattern). The vault
-  # is seeded by db-migrate before any service starts. EncryptionService
-  # falls back to env if the vault read fails, so this stays robust.
   SECRETS_PROVIDER: supabase
-  SMTP_HOST: inbucket
-  SMTP_PORT: "2500"
+  # SMTP_HOST default is inherited from docker-compose.yml (= inbucket).
+  # To switch GoTrue to Resend SMTP for real magic-link delivery, set
+  # SMTP_HOST=smtp.resend.com (and SMTP_PORT=465) at shell time before
+  # `docker compose -f docker-compose-uat.yml up`. SMTP_USER/SMTP_PASS
+  # come from Vault. Inbucket remains the default.
   SMTP_ADMIN_EMAIL: noreply@opuspopuli.local
   FRONTEND_URL: http://localhost:3300
 
@@ -220,8 +222,8 @@ services:
       OLLAMA_REQUEST_TIMEOUT_MS: "600000"
       # AI Prompt Service for proprietary prompt templates
       PROMPT_SERVICE_URL: http://opuspopuli-prompts:3210
-      # FEC API key for federal campaign finance data
-      FEC_API_KEY: ${FEC_API_KEY:-}
+      # FEC_API_KEY (data.gov key) is sourced from Supabase Vault at bootstrap.
+      # See docs/guides/secrets-management.md for seeding instructions.
       PROMPT_SERVICE_API_KEY: dev-key-1
       # Disable automatic sync scheduler — trigger manually via GraphQL Playground
       REGION_SYNC_ENABLED: "false"

--- a/docs/guides/secrets-management.md
+++ b/docs/guides/secrets-management.md
@@ -69,6 +69,77 @@ SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 ```
 
+## Bootstrap-Time Vault Hydration
+
+When `SECRETS_PROVIDER=supabase`, a bootstrap step in the shared backend startup (`apps/backend/src/common/bootstrap.ts`) reads a fixed list of named secrets from Vault and writes them into `process.env` **before** NestJS is constructed. `@nestjs/config`'s `registerAs` factories read `process.env` at module-init time, so the hydration must run earlier — once it does, every existing `process.env.X` read in `config-provider` resolves to the Vault-backed value with zero per-module changes.
+
+### Policy when `SECRETS_PROVIDER=supabase`
+
+- **Vault is authoritative.** When a secret is present in Vault, its value overwrites any existing env value, and the overwrite is logged as a WARN (so operator mistakes are loud, not silent).
+- **Missing secrets are tolerated.** When a secret is not present in Vault, the existing env value (which may be empty) is left in place, and a WARN logs the gap. Service startup is not blocked — a partially-populated Vault during incremental migration won't crash the app.
+- **Per-secret timeout.** Each Vault lookup has a 10s deadline (`Promise.race`). A network partition cannot hang service startup indefinitely.
+- **Parallel reads.** The full secret list is hydrated concurrently with `Promise.all`.
+
+`SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` are required to reach Vault and therefore stay as env vars by necessity (chicken-and-egg).
+
+### Vault-Managed Secrets
+
+The current list lives in `apps/backend/src/common/bootstrap.ts` as `VAULT_BACKED_SECRETS`:
+
+| Secret | Auto-seeded by `db-migrate.sh`? | Notes |
+|---|---|---|
+| `RESEND_API_KEY` | ❌ operator | Resend HTTP API key for app emails |
+| `SMTP_USER` | ❌ operator | Resend SMTP relay username (literal `"resend"`) — only needed when `SMTP_HOST=smtp.resend.com` |
+| `SMTP_PASS` | ❌ operator | Resend API key for SMTP relay — only needed when flipping to Resend SMTP |
+| `R2_ACCOUNT_ID` | ❌ operator | Cloudflare R2 storage — only needed when `STORAGE_PROVIDER=cloudflare` |
+| `R2_ACCESS_KEY_ID` | ❌ operator | Same |
+| `R2_SECRET_ACCESS_KEY` | ❌ operator | Same |
+| `REDIS_URL` | ✅ defaults to `redis://redis:6379` | Override via `SEED_REDIS_URL` env at deploy time for managed Redis with auth |
+| `SUPABASE_ANON_KEY` | ✅ defaults to well-known self-hosted dev JWT | Override via `SEED_SUPABASE_ANON_KEY` for hosted Supabase projects |
+| `FEC_API_KEY` | ❌ operator | data.gov API key for federal campaign-finance data |
+| `SENSITIVE_PROFILE_ENCRYPTION_KEY` | ✅ defaults to deterministic dev key | Consumed by `EncryptionService` via per-consumer DI; override via `SEED_SENSITIVE_PROFILE_ENCRYPTION_KEY` |
+
+**`JWT_SECRET`, `AUTH_JWT_SECRET`, `GATEWAY_HMAC_SECRET`, and `API_KEYS` are intentionally NOT in this list.** They need fail-fast semantics on missing-secret rather than the current tolerant warn-and-continue. Migrating them requires extending the hydration mechanism with a strict mode — tracked as a future enhancement.
+
+### Seeding Operator-Required Secrets
+
+Use the idempotent `vault_create_secret` RPC (installed by `db-migrate`):
+
+```sql
+-- From Supabase Studio's SQL Editor, or psql against the project database
+SELECT public.vault_create_secret(
+  'RESEND_API_KEY',
+  're_your_real_key_here',
+  'Resend HTTP API key (sending-access scope)'
+);
+
+SELECT public.vault_create_secret(
+  'FEC_API_KEY',
+  'your_data_gov_api_key',
+  'data.gov / FEC API key for federal campaign-finance ingestion'
+);
+```
+
+For prod deploys, prefer setting `SEED_*` env vars on the `db-migrate` job so the seed values come from your deployment secrets and not from a manual SQL session.
+
+### Switching Magic-Link Delivery (Inbucket ↔ Resend)
+
+By default the local UAT stack routes magic links through Inbucket (the in-cluster email catcher). `docker-compose.yml` sets `GOTRUE_SMTP_HOST: ${SMTP_HOST:-inbucket}`, so without any override magic links land at http://localhost:9000 (Inbucket UI).
+
+To switch GoTrue to send real magic links via Resend SMTP:
+
+1. Seed `SMTP_USER` (literal `resend`) and `SMTP_PASS` (your Resend API key) in Vault — see the SQL example above.
+2. Restart the UAT stack with `SMTP_HOST` and `SMTP_PORT` overridden at shell time:
+
+```bash
+SMTP_HOST=smtp.resend.com SMTP_PORT=465 \
+  docker compose -f docker-compose-uat.yml up -d --force-recreate
+```
+
+3. Drop the override to switch back to Inbucket — no code change, no compose change.
+
+This keeps Inbucket as the friction-free default for local dev while making real Resend delivery a one-command toggle for end-to-end testing.
+
 ## Usage
 
 ### Dependency Injection (Recommended)
@@ -183,6 +254,25 @@ export { MySecretsProvider } from './providers/my-provider.js';
 
 - **EnvProvider**: Check that the environment variable is set
 - **SupabaseVaultProvider**: Check the secret exists in Supabase Vault
+
+### "N secret(s) requested but not found in Vault" at service startup
+
+This is the bootstrap-hydration helper noting that one or more entries in `VAULT_BACKED_SECRETS` aren't seeded yet. Service startup is **not** blocked — the existing env value (which may be empty) is left in place. Resolve by either:
+- Seeding the missing secret via `vault_create_secret` RPC (see "Seeding Operator-Required Secrets").
+- Removing the secret from `VAULT_BACKED_SECRETS` if it's no longer needed.
+
+### "Vault values overwrote existing env vars" at service startup
+
+The hydration policy when `SECRETS_PROVIDER=supabase` is that Vault is authoritative — when a Vault value differs from the existing env value, the env value is overwritten and the difference is logged loudly. This is intentional: env values for vault-managed secrets are a policy violation per CLAUDE.md and shouldn't be silently honored. To resolve, either remove the conflicting env var from compose, or update Vault to match.
+
+### `pgsodium_crypto_aead_det_decrypt_by_id: invalid ciphertext`
+
+The pgsodium master key has changed since the secret was encrypted — see issue [#791](https://github.com/OpusPopuli/opuspopuli/issues/791) for the durability investigation. Workaround for local dev:
+```sql
+DELETE FROM vault.secrets WHERE name = 'SECRET_NAME';
+SELECT vault.create_secret('value', 'SECRET_NAME', 'description');
+```
+The idempotent `vault_create_secret` RPC cannot recover from this state — tracked as [#789](https://github.com/OpusPopuli/opuspopuli/issues/789).
 
 ## API Reference
 


### PR DESCRIPTION
## Summary

- Extends `VAULT_BACKED_SECRETS` from 1 → 9 secrets: adds `SMTP_USER`, `SMTP_PASS`, `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `REDIS_URL`, `SUPABASE_ANON_KEY`, `FEC_API_KEY` alongside the existing `RESEND_API_KEY`. Removes the corresponding env declarations from `docker-compose-uat.yml` so Vault is the source of truth in UAT.
- **Architectural fix** that surfaced during testing: `ConfigModule.forRoot({validationSchema})` runs Joi validation at the @Module-decorator evaluation step (synchronously, at file-import time), so any vault-managed secret in the schema must already be in `process.env` *before* the import statement executes. PR #787's `bootstrap()`-time hydration was too late for `SUPABASE_ANON_KEY` (required by the schema). Introduces `apps/backend/src/common/preflight.ts` with `preflightAndLoad()` + `runService()` that hydrate Vault first, then dynamically import the AppModule. All 8 entry points (5 services + 3 workers) updated to use the new pattern.
- Flips `docker-compose-prod.yml` from `SECRETS_PROVIDER: env` to `supabase`. Env passthroughs are kept as fallback for secrets not yet seeded in the prod Supabase Cloud vault — Vault wins when present; env serves as fallback only when the vault secret is absent. Once a secret is seeded, its env passthrough becomes dead code and can be removed in a follow-up.
- Extends `db-migrate.sh` to auto-seed `SUPABASE_ANON_KEY` and `REDIS_URL` (alongside the existing `SENSITIVE_PROFILE_ENCRYPTION_KEY`). All three use well-known dev defaults with `SEED_*` env-var overrides for prod deploys. Refactored to pass values via `process.env` instead of shell-into-JS interpolation, eliminating shell-quote fragility.
- All entry points now have `.catch()` error handlers on the startup promise chain — preflight, module-load, or bootstrap failures exit with code 1 and a clear log line instead of becoming silent `unhandledRejection` warnings.
- Inbucket retention preserved: `SMTP_HOST` default in `docker-compose.yml` stays `inbucket`. To flip GoTrue to Resend SMTP for real magic-link delivery: `SMTP_HOST=smtp.resend.com SMTP_PORT=465 docker compose -f docker-compose-uat.yml up -d --force-recreate`. Documented in `docs/guides/secrets-management.md`.

Closes #792.

## How to test

End-to-end against a real local Vault:

1. Pull this branch and rebuild the full UAT stack:
   ```bash
   docker compose -f docker-compose-uat.yml up -d --force-recreate --build
   ```
2. Confirm all 8 backend containers reach healthy:
   ```bash
   docker ps --format '{{.Names}}\t{{.Status}}' | grep uat-
   ```
3. Check the hydration log on any service:
   ```bash
   docker logs opuspopuli-uat-users 2>&1 | grep -E '(Hydrated|VaultHydration)'
   ```
   Expect: `Hydrated 4 secret(s) from Vault: RESEND_API_KEY, REDIS_URL, SUPABASE_ANON_KEY, FEC_API_KEY` plus a WARN listing the 5 not-yet-seeded operator secrets (`SMTP_USER`, `SMTP_PASS`, `R2_*`).
4. Magic-link flow: confirm magic links still land in Inbucket (http://localhost:9000) — `SMTP_HOST` defaults to `inbucket`, behavior unchanged.

Unit tests:
- `pnpm --filter backend test src/common/preflight.spec.ts` — 8/8 pass (4 covering `preflightAndLoad` ordering/return/error propagation; 4 covering `runService` success + per-stage error handling + `process.exit(1)`).
- Full backend suite: 1916/1916 pass.

## ⚠️ Operational notes for prod deploy

- **Prod Supabase Cloud Vault must be seeded** with the new secrets before they're effective. Until then, the existing env passthroughs serve as fallback (Vault hydration logs a WARN per missing secret but startup is not blocked).
- **The pgsodium master-key durability issue (#791) escalated during this PR's testing** — a routine `docker compose up -d --build` invalidated every vault secret because the postgres container recreation reset pgsodium's master key. Recovery required manual `DELETE FROM vault.secrets` + re-seed (the `vault_create_secret` upsert can't recover from corrupted ciphertext per #789). **Strongly recommend prioritizing #791 + #789 before relying on Vault in production.**

## Out of scope

- **Internal cryptographic secrets** (`JWT_SECRET`, `AUTH_JWT_SECRET`, `GATEWAY_HMAC_SECRET`, `API_KEYS`) — these need fail-fast semantics on missing-secret rather than the tolerant warn-and-continue. Migration requires extending the hydration mechanism with a strict mode. Tracked as future enhancement.
- **Cleanup of per-consumer DI in `region-sync.service.ts` (FEC_API_KEY) and `encryption.service.ts` (SENSITIVE_PROFILE_ENCRYPTION_KEY)** — after bootstrap hydration, those secrets are also available via `process.env`, so the per-consumer Vault calls are redundant. Leave for a future refactor.
- **Prod compose env-passthrough removal** — kept as fallback for safety. A future PR after the prod vault is seeded can remove them.
- **Resolution of #789 / #791** — surfaced during testing but tracked separately as their own issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)