### PR TITLE
fix(infra): durable pgsodium key + resilient vault upsert (#791)

### DIFF
--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -16,3 +16,20 @@ secrets:
   - id: github-pat
     paths:
       - ".env"
+
+  # apps/backend/docker/scripts/db-migrate.sh seeds the well-known
+  # self-hosted Supabase demo anon JWT into Vault as a dev default
+  # (overridable via SEED_SUPABASE_ANON_KEY for hosted projects). This
+  # is the publicly documented Supabase demo value — meaningless without
+  # the matching demo pgsodium_secret_key that ships with the same
+  # self-hosted install. Not a secret in any operational sense. The same
+  # JWT lives unflagged in docker-compose-uat.yml as the
+  # SUPABASE_SERVICE_ROLE_KEY (trivy's YAML scanner accepts dev patterns
+  # there but the shell-script context triggers detection). See
+  # docs/guides/secrets-management.md and issue #792.
+  #
+  # Remove this entry if the dev-default JWT is ever moved out of this
+  # script (e.g., into docker-compose env passthrough).
+  - id: jwt-token
+    paths:
+      - "apps/backend/docker/scripts/db-migrate.sh"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,12 +49,24 @@ services:
       POSTGRES_DB: postgres
       JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters}
       JWT_EXP: ${JWT_EXP:-3600}
+      # pgsodium master key — read by the bind-mounted getkey script
+      # below. Default is a deterministic dev value; override with a real
+      # 32-byte hex secret for any environment that holds production data.
+      # Stable across container recreations, so vault.secrets entries
+      # remain decryptable on every `up -d --force-recreate`. See #791 and
+      # docs/guides/secrets-management.md.
+      PGSODIUM_ROOT_KEY: ${PGSODIUM_ROOT_KEY:-d2f294bd82c77492323d9a54692dff2ed274fcfd4665edbefe170c0112259443}
     volumes:
       - opuspopuli-db-data:/var/lib/postgresql/data
       # Custom init script to set passwords on Supabase roles
       # Named zz-* to run AFTER migrate.sh (z > m alphabetically)
       # postgres entrypoint ignores directories, so must mount as a file
       - ./supabase/init/99-set-passwords.sql:/docker-entrypoint-initdb.d/zz-set-passwords.sql:ro
+      # Override the image's pgsodium getkey script (which generates a
+      # random key on first start, INSIDE the container filesystem, and
+      # re-generates on every container recreation — wiping the vault).
+      # Our replacement reads PGSODIUM_ROOT_KEY from env. See #791.
+      - ./supabase/init/pgsodium_getkey_env.sh:/usr/lib/postgresql/bin/pgsodium_getkey.sh:ro
     networks:
       - opuspopuli-network
     healthcheck:

--- a/docs/guides/secrets-management.md
+++ b/docs/guides/secrets-management.md
@@ -267,12 +267,62 @@ The hydration policy when `SECRETS_PROVIDER=supabase` is that Vault is authorita
 
 ### `pgsodium_crypto_aead_det_decrypt_by_id: invalid ciphertext`
 
-The pgsodium master key has changed since the secret was encrypted — see issue [#791](https://github.com/OpusPopuli/opuspopuli/issues/791) for the durability investigation. Workaround for local dev:
-```sql
-DELETE FROM vault.secrets WHERE name = 'SECRET_NAME';
-SELECT vault.create_secret('value', 'SECRET_NAME', 'description');
+The pgsodium master key has changed since the secret was encrypted. This **shouldn't happen anymore** as of issue #791's fix: the `opuspopuli-db` service in `docker-compose.yml` mounts a custom getkey script (`supabase/init/pgsodium_getkey_env.sh`) that reads the master key from the `PGSODIUM_ROOT_KEY` env var instead of generating a random one inside the (ephemeral) container filesystem.
+
+If you see this error after pulling the fix:
+
+1. **You bypassed the env var** (unset, empty, or set to a different value than when the existing ciphertext was encrypted). Confirm via:
+   ```bash
+   docker exec opuspopuli-db sh -c 'echo "$PGSODIUM_ROOT_KEY"'
+   ```
+2. **You had vault entries before pulling the fix.** They were encrypted under the old random key, which the new env-driven key replaces. Recover by deleting + re-seeding:
+   ```sql
+   DELETE FROM vault.secrets WHERE name = 'SECRET_NAME';
+   SELECT vault.create_secret('value', 'SECRET_NAME', 'description');
+   ```
+   The idempotent `vault_create_secret` RPC cannot recover from this state on its own — tracked as [#789](https://github.com/OpusPopuli/opuspopuli/issues/789).
+3. **In production**, key rotation is a deliberate operation that needs vault re-encryption, not just a value change. Don't change `PGSODIUM_ROOT_KEY` on a live prod database without a documented rotation flow.
+
+## pgsodium Master-Key Management (#791)
+
+Supabase Vault is encrypted at rest with `pgsodium`. The `pgsodium` extension needs a 32-byte master key (the "root key") to derive the data-encryption keys it uses on `vault.secrets`. If that root key ever changes, every previously-encrypted ciphertext becomes permanently un-decryptable.
+
+### How it works in this repo
+
+- `opuspopuli-db`'s `docker-compose.yml` env block sets `PGSODIUM_ROOT_KEY` (64 hex chars, 32 bytes).
+- `supabase/init/pgsodium_getkey_env.sh` is bind-mounted over the image's default getkey script. It reads `PGSODIUM_ROOT_KEY` from env and `printf`s it (no trailing newline, matching the original format).
+- pgsodium's `pgsodium.getkey_script` GUC (set by the supabase/postgres image) already points at `/usr/lib/postgresql/bin/pgsodium_getkey.sh` — the mount overrides the file at that path, so no `postgresql.conf` changes are needed.
+- Result: the key is the same on every container start, regardless of `--force-recreate`. Vault entries survive container recreations.
+
+### Local dev default
+
+The default in `docker-compose.yml` is a deterministic 64-char hex value (`d2f29...259443`). Treat it like the well-known Supabase demo JWTs: a dev convenience, **not** a real secret. It only has meaning against your local postgres data dir.
+
+### Production override
+
+Set `PGSODIUM_ROOT_KEY` in the deploy environment to a real, durable 32-byte hex value. Recommended sources:
+- AWS KMS / GCP KMS — generate a key, export hex via KMS API at deploy time.
+- 1Password CLI / Vault by HashiCorp — pull at container-start.
+- Encrypted GitHub Actions secret + `gh secret set` — sufficient for low-risk deploys.
+
+**The key value must be durable.** Losing it means losing every vault secret. Back it up separately from the postgres volume.
+
+### Generating a new key for a fresh prod deploy
+
+```bash
+head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n'
 ```
-The idempotent `vault_create_secret` RPC cannot recover from this state — tracked as [#789](https://github.com/OpusPopuli/opuspopuli/issues/789).
+The output is 64 hex chars (no newline). Store it in your secret manager and pass into the container as `PGSODIUM_ROOT_KEY`.
+
+### Rotation (post-MVP)
+
+There's no built-in `pgsodium` rotation flow. Rotating the root key requires:
+1. Decrypt every `vault.secrets` row with the old key
+2. Re-encrypt every row with the new key
+3. Swap the env var
+4. Restart the postgres container
+
+This must be done atomically (within a postgres transaction or a maintenance window) to avoid mid-flight rows in an inconsistent state. Out of scope for current MVP work — track as a separate item if/when rotation is needed.
 
 ## API Reference
 

--- a/supabase/init/pgsodium_getkey_env.sh
+++ b/supabase/init/pgsodium_getkey_env.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# pgsodium getkey script — env-driven replacement for the supabase/postgres
+# image's default (which generates a random key inside the container
+# filesystem on first start and re-generates on every container recreation).
+#
+# Why this matters: the default behavior means every `docker compose up -d
+# --force-recreate --build opuspopuli-db` wipes the pgsodium master key,
+# rendering every prior `vault.secrets` ciphertext permanently un-decryptable
+# (pgsodium_crypto_aead_det_decrypt_by_id: invalid ciphertext). See issue
+# #791 — discovered during PR #793 testing.
+#
+# This script reads `PGSODIUM_ROOT_KEY` (64 hex chars = 32 bytes) from the
+# container environment and outputs it without a trailing newline, matching
+# the format the original script produced (head -c 32 /dev/urandom | od -t x1
+# | tr -d ' \n').
+#
+# Local UAT: PGSODIUM_ROOT_KEY defaults to a well-known dev value in
+# docker-compose.yml. Prod (Supabase Cloud) doesn't use this script — Supabase
+# manages key durability on the managed instance.
+#
+# Bind-mounted by docker-compose.yml over the image's
+# /usr/lib/postgresql/bin/pgsodium_getkey.sh — the postgres GUC
+# pgsodium.getkey_script (set in /etc/postgresql/postgresql.conf) already
+# points at that path, so no postgresql.conf changes are needed.
+
+set -euo pipefail
+
+if [[ -z "${PGSODIUM_ROOT_KEY:-}" ]]; then
+    echo "pgsodium_getkey_env: PGSODIUM_ROOT_KEY env var is not set." >&2
+    echo "pgsodium_getkey_env: This will cause pgsodium to fail to load." >&2
+    echo "pgsodium_getkey_env: Set PGSODIUM_ROOT_KEY (64 hex chars / 32 bytes) in docker-compose env." >&2
+    exit 1
+fi
+
+# Validate format: pgsodium expects exactly 32 bytes encoded as 64 hex
+# chars. A wrong length or non-hex value would fail later inside pgsodium
+# with a less actionable error.
+if ! [[ "$PGSODIUM_ROOT_KEY" =~ ^[0-9a-fA-F]{64}$ ]]; then
+    echo "pgsodium_getkey_env: PGSODIUM_ROOT_KEY must be exactly 64 hex chars (32 bytes)." >&2
+    echo "pgsodium_getkey_env: Got length=${#PGSODIUM_ROOT_KEY}. Generate one with:" >&2
+    echo "pgsodium_getkey_env:   head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \\n'" >&2
+    exit 1
+fi
+
+printf -- '%s' "$PGSODIUM_ROOT_KEY"

--- a/supabase/migrations/99_vault_functions.sql
+++ b/supabase/migrations/99_vault_functions.sql
@@ -84,10 +84,24 @@ BEGIN
   IF existing_id IS NULL THEN
     SELECT vault.create_secret(p_value, p_name, p_description) INTO result_id;
     RETURN result_id;
-  ELSE
+  END IF;
+
+  -- vault.update_secret internally reads the existing decrypted value
+  -- before writing, so a row with corrupted ciphertext (e.g. encrypted
+  -- under a previous pgsodium master key) makes the upsert fail without
+  -- writing the new value — the exact scenario where re-seeding is needed
+  -- most. Catch the failure, DELETE the unrecoverable row, and CREATE a
+  -- fresh one under the current master key. See issues #789 and #791.
+  BEGIN
     PERFORM vault.update_secret(existing_id, p_value, p_name, p_description);
     RETURN existing_id;
-  END IF;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE NOTICE 'vault_create_secret: update_secret failed for %, falling back to delete+create. SQLSTATE=% SQLERRM=%',
+      p_name, SQLSTATE, SQLERRM;
+    DELETE FROM vault.secrets WHERE id = existing_id;
+    SELECT vault.create_secret(p_value, p_name, p_description) INTO result_id;
+    RETURN result_id;
+  END;
 END;
 $$;
 


### PR DESCRIPTION
## Summary

The supabase/postgres image's default `pgsodium_getkey.sh` generates a random root key on first start, writes it to `/etc/postgresql-custom/pgsodium_root.key` **inside the container filesystem**, and re-generates a new one on every container recreation. Routine `docker compose up -d --force-recreate --build opuspopuli-db` wiped the pgsodium master key, leaving every prior `vault.secrets` ciphertext permanently un-decryptable. Discovered escalating from latent to dev-blocking during PR #793 testing.

**Pgsodium durability fix (#791):** Bind-mount `supabase/init/pgsodium_getkey_env.sh` over the image's getkey script. The replacement reads `PGSODIUM_ROOT_KEY` from the container env (set in `docker-compose.yml`) and outputs it via `printf -- '%s'`. The path the GUC already references is unchanged, so no `postgresql.conf` modifications are needed. The script validates the key is exactly 64 hex chars before emitting — wrong length or non-hex content fails fast with an actionable error instead of an opaque pgsodium load failure later. Local UAT uses a deterministic dev default (treated as a well-known-dev value, same intent as the Supabase demo JWTs); prod overrides via env from KMS/1Password/secret manager.

**Vault upsert recovery fix (#789):** Wrapped the `vault.update_secret` call in `vault_create_secret` in an EXCEPTION block. On any failure (notably the corrupted-ciphertext case where `update_secret` can't read the existing decrypted value before writing), the handler DELETEs the unrecoverable row and CREATEs a fresh one under the current master key. A `RAISE NOTICE` inside the handler logs `SQLSTATE` + `SQLERRM` so the recovery path is observable in postgres logs rather than silently triggering a destructive delete+create.

**Trivy suppression for the JWT in `db-migrate.sh`:** the well-known Supabase demo anon JWT (the same one that lives unflagged in `docker-compose-uat.yml`) was flagged by Trivy in the shell-script context, blocking PR #794. Added a narrow `.trivyignore.yaml` entry (`jwt-token` rule + specific path) with full justification, matching the existing `github-pat` pattern.

Closes #791. Closes #789.

## How to test

End-to-end on local UAT:

1. Pull this branch:
   ```bash
   git checkout fix/pgsodium-durability-791
   ```
2. **Pgsodium durability — the smoking gun:**
   ```bash
   # Baseline: snapshot vault state
   docker exec opuspopuli-db psql -U postgres -d postgres -c "SELECT name, LENGTH(decrypted_secret) AS len FROM vault.decrypted_secrets ORDER BY name;"

   # The previously-fatal operation
   docker compose -f docker-compose-uat.yml up -d --force-recreate --build opuspopuli-db

   # Verify: all entries still decrypt with identical lengths
   docker exec opuspopuli-db psql -U postgres -d postgres -c "SELECT name, LENGTH(decrypted_secret) AS len FROM vault.decrypted_secrets ORDER BY name;"
   ```
   Pre-fix: every entry would return `pgsodium_crypto_aead_det_decrypt_by_id: invalid ciphertext`. Post-fix: all entries identical to baseline.

3. **Full UAT stack rebuild** (confirms nothing else regresses):
   ```bash
   docker compose -f docker-compose-uat.yml up -d --force-recreate --build
   ```
   All 8 backend services + api gateway should reach healthy. `docker logs opuspopuli-uat-users | grep VaultHydration` should show 4 of 9 secrets hydrated (the operator-seeded ones we haven't seeded locally show as missing-and-tolerated).

4. **Key format validation:**
   ```bash
   # Short key — should exit non-zero with actionable error
   docker exec opuspopuli-db sh -c 'PGSODIUM_ROOT_KEY=abc /usr/lib/postgresql/bin/pgsodium_getkey.sh'
   ```

5. **Trivy suppression** verifies on the next CI run on this PR — `Trivy / JWT token` warning on `db-migrate.sh:160` should no longer appear.

## Migration notes for other devs

Anyone with an existing local vault from before this fix will need to delete + re-seed their vault entries once after pulling — their existing rows were encrypted under a random per-container key that's now replaced by the env-driven key. db-migrate auto-seeds `SUPABASE_ANON_KEY`, `REDIS_URL`, and `SENSITIVE_PROFILE_ENCRYPTION_KEY` on container start; operator-required secrets (`RESEND_API_KEY`, `FEC_API_KEY`, `SMTP_*`, `R2_*`) need manual SQL per `docs/guides/secrets-management.md`.

## Out of scope (tracked separately)

- **Automated test for the EXCEPTION-recovery path** of `vault_create_secret` — requires simulating ciphertext corruption (temp pgsodium key change), heavyweight setup, follow-up.
- **Trivy preemptive ignore for the dev `PGSODIUM_ROOT_KEY` value** — confirmed clean on current scan; will revisit if a future Trivy rule update flags it.
- **Pgsodium root-key rotation flow** — there's no built-in pgsodium rotation. Documented at the end of `docs/guides/secrets-management.md`; not needed for MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)