### PR TITLE
feat(region): hide dead bills + Active/Inactive lifecycle toggle

### DIFF
--- a/apps/backend/__tests__/integration/region/region.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/region.integration.spec.ts
@@ -14,6 +14,7 @@ import {
   createContribution,
   createExpenditure,
   createIndependentExpenditure,
+  createBill,
   getDbService,
   graphqlRequest,
   assertNoErrors,
@@ -1365,6 +1366,178 @@ describe('Region Integration Tests', () => {
   // ==========================================
   // DATABASE CLEANUP
   // ==========================================
+
+  // ============================================
+  // GraphQL: bills lifecycle filter (#747)
+  // ============================================
+
+  describe('GraphQL: bills Query (#747 lifecycle)', () => {
+    /**
+     * Fixtures covering each canonical CA status string the helper
+     * categorises. Real DB writes, no mocks — per CLAUDE.md, the lifecycle
+     * filter must be exercised against the same Prisma where-clause path
+     * the runtime uses.
+     */
+    async function seedLifecycleCorpus(): Promise<void> {
+      // Active (currently moveable) — 2 rows across two active prefixes
+      await createBill({
+        billNumber: 'AB 100',
+        status: 'Active Bill - In Committee Process',
+        isActive: true,
+        isDead: false,
+      });
+      await createBill({
+        billNumber: 'AB 101',
+        status: 'Active Bill - In Floor Process',
+        isActive: true,
+        isDead: false,
+      });
+      // Passed/chaptered — signed into law, not dead but not active either
+      await createBill({
+        billNumber: 'AB 200',
+        status: 'Chaptered',
+        isActive: false,
+        isDead: false,
+      });
+      await createBill({
+        billNumber: 'AB 201',
+        status: 'Inactive Bill - Chaptered',
+        isActive: false,
+        isDead: false,
+      });
+      // Dead — vetoed, died, or moved to inactive file
+      await createBill({
+        billNumber: 'AB 300',
+        status: 'Inactive Bill - Died',
+        isActive: false,
+        isDead: true,
+      });
+      await createBill({
+        billNumber: 'AB 301',
+        status: 'Inactive Bill - Vetoed',
+        isActive: false,
+        isDead: true,
+      });
+      await createBill({
+        billNumber: 'AB 302',
+        status: 'Sen Inactive File - Assembly Bills',
+        isActive: false,
+        isDead: true,
+      });
+    }
+
+    const buildBillsQuery = (lifecycle?: 'ACTIVE' | 'INACTIVE' | 'ALL') => `
+      query {
+        bills(skip: 0, take: 50${lifecycle ? `, lifecycle: ${lifecycle}` : ''}) {
+          items {
+            id
+            billNumber
+            status
+            isActive
+            isDead
+          }
+          total
+          hasMore
+        }
+      }
+    `;
+
+    type BillsResult = {
+      bills: {
+        items: Array<{
+          id: string;
+          billNumber: string;
+          status: string | null;
+          isActive: boolean;
+          isDead: boolean;
+        }>;
+        total: number;
+        hasMore: boolean;
+      };
+    };
+
+    it('returns only the Active bucket by default (lifecycle defaults to ACTIVE)', async () => {
+      await seedLifecycleCorpus();
+
+      const result = await graphqlRequest<BillsResult>(buildBillsQuery());
+
+      assertNoErrors(result);
+      expect(result.data.bills.total).toBe(2);
+      expect(result.data.bills.items.map((b) => b.billNumber).sort()).toEqual([
+        'AB 100',
+        'AB 101',
+      ]);
+      result.data.bills.items.forEach((b) => {
+        expect(b.isActive).toBe(true);
+        expect(b.isDead).toBe(false);
+      });
+    });
+
+    it('returns chaptered + dead together for INACTIVE', async () => {
+      await seedLifecycleCorpus();
+
+      const result = await graphqlRequest<BillsResult>(
+        buildBillsQuery('INACTIVE'),
+      );
+
+      assertNoErrors(result);
+      expect(result.data.bills.total).toBe(5);
+      const numbers = result.data.bills.items.map((b) => b.billNumber).sort();
+      expect(numbers).toEqual([
+        'AB 200',
+        'AB 201',
+        'AB 300',
+        'AB 301',
+        'AB 302',
+      ]);
+      result.data.bills.items.forEach((b) => expect(b.isActive).toBe(false));
+    });
+
+    it('returns the full corpus for ALL', async () => {
+      await seedLifecycleCorpus();
+
+      const result = await graphqlRequest<BillsResult>(buildBillsQuery('ALL'));
+
+      assertNoErrors(result);
+      expect(result.data.bills.total).toBe(7);
+    });
+
+    it('exposes the partition invariant: no row is both isActive and isDead', async () => {
+      await seedLifecycleCorpus();
+
+      const result = await graphqlRequest<BillsResult>(buildBillsQuery('ALL'));
+
+      assertNoErrors(result);
+      result.data.bills.items.forEach((b) => {
+        expect(b.isActive && b.isDead).toBe(false);
+      });
+    });
+
+    it('bill(id) returns Inactive bills so deep links don’t 404', async () => {
+      const dead = await createBill({
+        billNumber: 'AB 999',
+        status: 'Inactive Bill - Died',
+        isActive: false,
+        isDead: true,
+      });
+
+      const result = await graphqlRequest<{
+        bill: { id: string; billNumber: string; isDead: boolean } | null;
+      }>(`
+        query {
+          bill(id: "${dead.id}") {
+            id
+            billNumber
+            isDead
+          }
+        }
+      `);
+
+      assertNoErrors(result);
+      expect(result.data.bill?.billNumber).toBe('AB 999');
+      expect(result.data.bill?.isDead).toBe(true);
+    });
+  });
 
   describe('Database cleanup', () => {
     it('should have clean database at start of each test', async () => {

--- a/apps/backend/__tests__/integration/utils/db-fixtures.ts
+++ b/apps/backend/__tests__/integration/utils/db-fixtures.ts
@@ -365,9 +365,10 @@ export interface CreateBillOptions {
   lastActionDate?: Date | null;
   aiSummary?: Prisma.InputJsonValue | null;
   aiSummaryVersion?: string | null;
-  /** Procedural lifecycle flags from #747. Defaulted to false so existing
-   *  fixtures keep the pre-#747 behavior; lifecycle tests pass them
-   *  explicitly. */
+  /** Procedural lifecycle flags from #747. Default: `isActive=true,
+   *  isDead=false` so existing fixtures produce rankable bills (the
+   *  personalized-feed filter requires isActive=true). #747's lifecycle
+   *  tests override these explicitly to exercise the dead/passed buckets. */
   isActive?: boolean;
   isDead?: boolean;
 }
@@ -403,8 +404,8 @@ export async function createBill(
       ...(options.aiSummaryVersion !== undefined && {
         aiSummaryVersion: options.aiSummaryVersion,
       }),
-      ...(options.isActive !== undefined && { isActive: options.isActive }),
-      ...(options.isDead !== undefined && { isDead: options.isDead }),
+      isActive: options.isActive ?? true,
+      isDead: options.isDead ?? false,
     },
   });
 }

--- a/apps/backend/__tests__/integration/utils/db-fixtures.ts
+++ b/apps/backend/__tests__/integration/utils/db-fixtures.ts
@@ -365,6 +365,11 @@ export interface CreateBillOptions {
   lastActionDate?: Date | null;
   aiSummary?: Prisma.InputJsonValue | null;
   aiSummaryVersion?: string | null;
+  /** Procedural lifecycle flags from #747. Defaulted to false so existing
+   *  fixtures keep the pre-#747 behavior; lifecycle tests pass them
+   *  explicitly. */
+  isActive?: boolean;
+  isDead?: boolean;
 }
 
 /**
@@ -398,6 +403,8 @@ export async function createBill(
       ...(options.aiSummaryVersion !== undefined && {
         aiSummaryVersion: options.aiSummaryVersion,
       }),
+      ...(options.isActive !== undefined && { isActive: options.isActive }),
+      ...(options.isDead !== undefined && { isDead: options.isDead }),
     },
   });
 }

--- a/apps/backend/region-schema.gql
+++ b/apps/backend/region-schema.gql
@@ -2,6 +2,137 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+type BillVote {
+  id: ID!
+  representativeName: String!
+  representativeId: String
+  chamber: String!
+  voteDate: DateTime!
+  position: String!
+  motionText: String
+  sourceUrl: String!
+}
+
+"""
+A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
+"""
+scalar DateTime
+
+type BillCoAuthor {
+  representativeId: ID
+  name: String!
+  coAuthorType: String
+}
+
+type BillFiscalImpact {
+  level: String!
+  summary: String!
+}
+
+type BillAiSummary {
+  plainEnglishSummary: String!
+  topics: [String!]!
+  whoItAffects: [String!]!
+  fiscalImpact: BillFiscalImpact!
+  stakeholderImpact: String!
+}
+
+type Bill {
+  id: ID!
+  externalId: String!
+  billNumber: String!
+  sessionYear: String!
+  measureTypeCode: String!
+  title: String!
+  subject: String
+  status: String
+  currentStageId: String
+  lastAction: String
+  lastActionDate: DateTime
+  fiscalImpact: String
+  fullTextUrl: String
+  authorId: String
+  authorName: String
+  sourceUrl: String!
+  extractedAt: DateTime!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+  votes: [BillVote!]!
+  coAuthors: [BillCoAuthor!]!
+  aiSummary: BillAiSummary
+  isDead: Boolean!
+  isActive: Boolean!
+}
+
+type PaginatedBills {
+  items: [Bill!]!
+  total: Int!
+  hasMore: Boolean!
+}
+
+type CivicText {
+  verbatim: String!
+  plainLanguage: String!
+  sourceUrl: String!
+}
+
+type CivicsChamber {
+  name: String!
+  abbreviation: String!
+  size: Float!
+  termYears: Float!
+  leadershipRoles: [String!]!
+  description: CivicText!
+}
+
+type CitizenAction {
+  verb: String!
+  label: CivicText!
+  url: String
+  urgency: String!
+}
+
+type CivicsLifecycleStage {
+  id: String!
+  name: CivicText!
+  shortDescription: CivicText!
+  longDescription: CivicText
+  statusStringPatterns: [String!]!
+  citizenAction: CitizenAction
+}
+
+type CivicsMeasureType {
+  code: String!
+  name: String!
+  chamber: String!
+  votingThreshold: String!
+  reachesGovernor: Boolean!
+  purpose: CivicText!
+  lifecycleStageIds: [String!]!
+}
+
+type CivicsGlossaryEntry {
+  term: String!
+  slug: String!
+  definition: CivicText!
+  longDefinition: CivicText
+  relatedTerms: [String!]!
+}
+
+type CivicsSessionScheme {
+  cadence: String!
+  namingPattern: String!
+  description: CivicText!
+}
+
+type CivicsBlock {
+  chambers: [CivicsChamber!]!
+  measureTypes: [CivicsMeasureType!]!
+  lifecycleStages: [CivicsLifecycleStage!]!
+  sessionScheme: CivicsSessionScheme
+  glossary: [CivicsGlossaryEntry!]!
+}
+
 type RegionInfoModel {
   id: String!
   name: String!
@@ -9,28 +140,94 @@ type RegionInfoModel {
   timezone: String!
   dataSourceUrls: [String!]
   supportedDataTypes: [DataType!]!
+  civics: CivicsBlock
 }
 
-"""Types of civic data available in the region"""
+"""Types of data available in the region"""
 enum DataType {
   PROPOSITIONS
   MEETINGS
   REPRESENTATIVES
+  CAMPAIGN_FINANCE
+  CIVICS
+  BILLS
+}
+
+type RegionPluginModel {
+  name: String!
+  displayName: String!
+  description: String
+  version: String!
+  enabled: Boolean!
+  parentRegionId: String
+  fipsCode: String
 }
 
 type SyncResultModel {
+  regionId: String!
   dataType: DataType!
   itemsProcessed: Float!
   itemsCreated: Float!
   itemsUpdated: Float!
+  itemsSkipped: Float!
   errors: [String!]!
   syncedAt: DateTime!
 }
 
-"""
-A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date-time format.
-"""
-scalar DateTime
+type ScheduledSyncJob {
+  id: ID!
+  pattern: String!
+  next: Float
+}
+
+type RegionSyncJob {
+  jobId: ID!
+  status: SyncJobStatus!
+  triggerSource: SyncTriggerSource!
+  regionId: String
+  dataTypes: [String!]!
+  enqueuedAt: DateTime!
+  startedAt: DateTime
+  finishedAt: DateTime
+  errorMessage: String
+  results: [SyncResultModel!]
+  elapsedMs: Float
+}
+
+"""Current state of an async region sync job"""
+enum SyncJobStatus {
+  QUEUED
+  RUNNING
+  SUCCEEDED
+  FAILED
+}
+
+"""What triggered the sync job"""
+enum SyncTriggerSource {
+  MANUAL
+  CRON
+  STARTUP
+  MANIFEST_READY
+}
+
+type PropositionAnalysisSectionModel {
+  heading: String!
+  startOffset: Int!
+  endOffset: Int!
+}
+
+type PropositionAnalysisClaimModel {
+  claim: String!
+  field: String!
+  sourceStart: Int!
+  sourceEnd: Int!
+  confidence: String
+}
+
+type ExistingVsProposedModel {
+  current: String!
+  proposed: String!
+}
 
 type PropositionModel {
   id: ID!
@@ -41,6 +238,17 @@ type PropositionModel {
   status: PropositionStatus!
   electionDate: DateTime
   sourceUrl: String
+  analysisSummary: String
+  keyProvisions: [String!]
+  fiscalImpact: String
+  yesOutcome: String
+  noOutcome: String
+  existingVsProposed: ExistingVsProposedModel
+  analysisSections: [PropositionAnalysisSectionModel!]
+  analysisClaims: [PropositionAnalysisClaimModel!]
+  analysisSource: String
+  analysisGeneratedAt: DateTime
+  lifecycleStageId: String
   createdAt: DateTime!
   updatedAt: DateTime!
 }
@@ -57,6 +265,34 @@ type PaginatedPropositions {
   items: [PropositionModel!]!
   total: Int!
   hasMore: Boolean!
+}
+
+type TopDonorModel {
+  donorName: String!
+  totalAmount: Float!
+  contributionCount: Int!
+}
+
+type CommitteeSummaryModel {
+  id: ID!
+  name: String!
+  totalRaised: Float!
+}
+
+type SidedFundingModel {
+  totalRaised: Float!
+  totalSpent: Float!
+  donorCount: Int!
+  committeeCount: Int!
+  topDonors: [TopDonorModel!]!
+  primaryCommittees: [CommitteeSummaryModel!]!
+}
+
+type PropositionFundingModel {
+  propositionId: ID!
+  asOf: DateTime!
+  support: SidedFundingModel!
+  oppose: SidedFundingModel!
 }
 
 type MeetingModel {
@@ -78,11 +314,32 @@ type PaginatedMeetings {
   hasMore: Boolean!
 }
 
+type OfficeModel {
+  name: String!
+  address: String
+  phone: String
+  fax: String
+}
+
 type ContactInfoModel {
   email: String
-  phone: String
-  address: String
   website: String
+  offices: [OfficeModel!]
+}
+
+type BioClaimModel {
+  sentence: String!
+  origin: String!
+  sourceField: String
+  sourceHint: String
+  confidence: String
+}
+
+type CommitteeAssignmentModel {
+  name: String!
+  role: String
+  url: String
+  legislativeCommitteeId: String
 }
 
 type RepresentativeModel {
@@ -91,9 +348,17 @@ type RepresentativeModel {
   name: String!
   chamber: String!
   district: String!
-  party: String!
+  party: String
   photoUrl: String
   contactInfo: ContactInfoModel
+  committees: [CommitteeAssignmentModel!]
+  committeesSummary: String
+  bio: String
+  bioSource: String
+  bioClaims: [BioClaimModel!]
+  activitySummary: String
+  activitySummaryGeneratedAt: DateTime
+  activitySummaryWindowDays: Float
   createdAt: DateTime!
   updatedAt: DateTime!
 }
@@ -104,16 +369,306 @@ type PaginatedRepresentatives {
   hasMore: Boolean!
 }
 
+type CommitteeModel {
+  id: ID!
+  externalId: String!
+  name: String!
+  type: String!
+  candidateName: String
+  candidateOffice: String
+  propositionId: String
+  party: String
+  status: String!
+  sourceSystem: String!
+  sourceUrl: String
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type PaginatedCommittees {
+  items: [CommitteeModel!]!
+  total: Int!
+  hasMore: Boolean!
+}
+
+type ContributionModel {
+  id: ID!
+  externalId: String!
+  committeeId: String!
+  donorName: String!
+  donorType: String!
+  donorEmployer: String
+  donorOccupation: String
+  donorCity: String
+  donorState: String
+  donorZip: String
+  amount: Float!
+  date: DateTime!
+  electionType: String
+  contributionType: String
+  sourceSystem: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type PaginatedContributions {
+  items: [ContributionModel!]!
+  total: Int!
+  hasMore: Boolean!
+}
+
+type ExpenditureModel {
+  id: ID!
+  externalId: String!
+  committeeId: String!
+  payeeName: String!
+  amount: Float!
+  date: DateTime!
+  purposeDescription: String
+  expenditureCode: String
+  candidateName: String
+  propositionTitle: String
+  supportOrOppose: String
+  sourceSystem: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type PaginatedExpenditures {
+  items: [ExpenditureModel!]!
+  total: Int!
+  hasMore: Boolean!
+}
+
+type IndependentExpenditureModel {
+  id: ID!
+  externalId: String!
+  committeeId: String!
+  committeeName: String!
+  candidateName: String
+  propositionTitle: String
+  supportOrOppose: String!
+  amount: Float!
+  date: DateTime!
+  electionDate: DateTime
+  description: String
+  sourceSystem: String!
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type PaginatedIndependentExpenditures {
+  items: [IndependentExpenditureModel!]!
+  total: Int!
+  hasMore: Boolean!
+}
+
+type LegislativeCommitteeModel {
+  id: ID!
+  externalId: String!
+  name: String!
+  chamber: String!
+  url: String
+  description: String
+  memberCount: Int!
+}
+
+type LegislativeCommitteeMemberModel {
+  representativeId: ID!
+  name: String!
+  role: String
+  party: String
+  photoUrl: String
+}
+
+type LegislativeCommitteeHearingModel {
+  id: ID!
+  title: String!
+  scheduledAt: DateTime!
+  agendaUrl: String
+}
+
+type LegislativeCommitteeDetailModel {
+  id: ID!
+  externalId: String!
+  name: String!
+  chamber: String!
+  url: String
+  description: String
+  memberCount: Int!
+  members: [LegislativeCommitteeMemberModel!]!
+  hearings: [LegislativeCommitteeHearingModel!]!
+  activitySummary: String
+  activitySummaryGeneratedAt: DateTime
+  activitySummaryWindowDays: Float
+  createdAt: DateTime!
+  updatedAt: DateTime!
+}
+
+type PaginatedLegislativeCommittees {
+  items: [LegislativeCommitteeModel!]!
+  total: Int!
+  hasMore: Boolean!
+}
+
+type LegislativeActionModel {
+  id: ID!
+  externalId: String!
+  body: String!
+  date: DateTime!
+  actionType: String!
+  position: String
+  text: String
+  passageStart: Int
+  passageEnd: Int
+  rawSubject: String
+  representativeId: ID
+  propositionId: ID
+  billId: ID
+  committeeId: ID
+  minutesId: ID!
+  minutesExternalId: String!
+}
+
+type RepresentativeActivityStatsModel {
+  presentSessionDays: Int!
+  totalSessionDays: Int!
+  absenceDays: Int!
+  amendments: Int!
+  committeeHearings: Int!
+  committeeReports: Int!
+  resolutions: Int!
+  votes: Int!
+  speeches: Int!
+}
+
+type PaginatedLegislativeActions {
+  items: [LegislativeActionModel!]!
+  total: Int!
+  hasMore: Boolean!
+}
+
+type CommitteeActivityStatsModel {
+  hearings: Int!
+  reports: Int!
+  amendments: Int!
+  distinctBills: Int!
+}
+
+type MinutesPassageModel {
+  actionId: ID!
+  minutesExternalId: String!
+  body: String!
+  date: DateTime!
+  sourceUrl: String!
+  passageStart: Int!
+  passageEnd: Int!
+  passageText: String!
+  sectionContext: String
+}
+
+type JurisdictionModel {
+  id: ID!
+  fipsCode: String
+  ocdId: String
+  name: String!
+  type: JurisdictionType!
+  level: JurisdictionLevel!
+  stateCode: String!
+  parent: JurisdictionModel
+}
+
+enum JurisdictionType {
+  STATE
+  CONGRESSIONAL_DISTRICT
+  STATE_SENATE_DISTRICT
+  STATE_ASSEMBLY_DISTRICT
+  COUNTY
+  CITY
+  SCHOOL_DISTRICT_UNIFIED
+  SCHOOL_DISTRICT_ELEMENTARY
+  SCHOOL_DISTRICT_HIGH
+  COMMUNITY_COLLEGE_DISTRICT
+  WATER_DISTRICT
+  FIRE_DISTRICT
+  TRANSIT_DISTRICT
+  SPECIAL_DISTRICT
+  COUNTY_SUPERVISOR_DISTRICT
+}
+
+enum JurisdictionLevel {
+  FEDERAL
+  STATE
+  COUNTY
+  MUNICIPAL
+  DISTRICT
+}
+
+type UserJurisdictionModel {
+  resolvedBy: String!
+  resolvedAt: DateTime!
+  jurisdiction: JurisdictionModel!
+}
+
 type Query {
   regionInfo: RegionInfoModel!
+  regionPlugins: [RegionPluginModel!]!
+  regionPluginByFipsCode(fipsCode: String!): RegionPluginModel
   propositions(skip: Int! = 0, take: Int! = 10): PaginatedPropositions!
   proposition(id: ID!): PropositionModel
+  propositionFunding(propositionId: ID!): PropositionFundingModel
   meetings(skip: Int! = 0, take: Int! = 10): PaginatedMeetings!
   meeting(id: ID!): MeetingModel
   representatives(skip: Int! = 0, take: Int! = 10, chamber: String): PaginatedRepresentatives!
   representative(id: ID!): RepresentativeModel
+  representativesByDistricts(congressionalDistrict: String, stateSenatorialDistrict: String, stateAssemblyDistrict: String, countyRegionId: String): [RepresentativeModel!]!
+  countyRepresentatives(countyRegionId: String!): [RepresentativeModel!]!
+  representativeActivityStats(id: ID!, sinceDays: Int): RepresentativeActivityStatsModel!
+  representativeActivity(id: ID!, actionTypes: [String!], includePresenceYes: Boolean, skip: Int, take: Int): PaginatedLegislativeActions!
+  minutesPassage(actionId: ID!): MinutesPassageModel
+  committeeActivityStats(committeeId: ID!, sinceDays: Int): CommitteeActivityStatsModel!
+  committeeActivity(committeeId: ID!, actionTypes: [String!], skip: Int, take: Int): PaginatedLegislativeActions!
+  billActivity(billId: ID!, actionTypes: [String!], skip: Int, take: Int): PaginatedLegislativeActions!
+  legislativeCommittees(skip: Int! = 0, take: Int! = 10, chamber: String, nameFilter: String): PaginatedLegislativeCommittees!
+  legislativeCommittee(id: ID!): LegislativeCommitteeDetailModel
+  committees(skip: Int! = 0, take: Int! = 10, sourceSystem: String): PaginatedCommittees!
+  committee(id: ID!): CommitteeModel
+  contributions(skip: Int! = 0, take: Int! = 10, committeeId: String, sourceSystem: String): PaginatedContributions!
+  contribution(id: ID!): ContributionModel
+  expenditures(skip: Int! = 0, take: Int! = 10, committeeId: String, sourceSystem: String): PaginatedExpenditures!
+  expenditure(id: ID!): ExpenditureModel
+  independentExpenditures(skip: Int! = 0, take: Int! = 10, committeeId: String, supportOrOppose: String, sourceSystem: String): PaginatedIndependentExpenditures!
+  independentExpenditure(id: ID!): IndependentExpenditureModel
+  bills(skip: Int! = 0, take: Int! = 10, measureTypeCode: String, sessionYear: String, authorId: ID, committeeId: ID, coAuthorId: ID, lifecycle: BillLifecycle = ACTIVE): PaginatedBills!
+  bill(id: ID!): Bill
+  myJurisdictions: [UserJurisdictionModel!]!
+  myCountySupervisors: [RepresentativeModel!]!
+  regionSyncJob(jobId: ID!): RegionSyncJob
+  recentRegionSyncJobs(limit: Int = 20): [RegionSyncJob!]!
+  scheduledSyncJobs: [ScheduledSyncJob!]!
+}
+
+"""
+Active = currently moveable; Inactive = passed/chaptered + dead; All = no filter (#747).
+"""
+enum BillLifecycle {
+  ACTIVE
+  INACTIVE
+  ALL
 }
 
 type Mutation {
-  syncRegionData(dataTypes: [DataType!]): [SyncResultModel!]!
+  regeneratePropositionAnalysis(id: ID!): PropositionModel
+  invalidateManifest(regionId: String!, sourceUrl: String!): Int!
+  updateRegionPlugin(name: String!, enabled: Boolean!): RegionPluginModel!
+  syncRegionData(dataTypes: [DataType!], depth: SyncDepth, regionId: String, maxReps: Int, maxBills: Int): RegionSyncJob!
+}
+
+"""
+STATE = top-level region only; COUNTY = all enabled sub-regions; ALL = both in one pass
+"""
+enum SyncDepth {
+  STATE
+  COUNTY
+  ALL
 }

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-feed/personalized-feed.service.spec.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-feed/personalized-feed.service.spec.ts
@@ -89,6 +89,17 @@ describe('PersonalizedFeedService', () => {
     });
   });
 
+  it('hard-includes only currently-moveable bills regardless of caller flag (#747)', async () => {
+    db.bill.findMany.mockResolvedValue([] as never);
+    await service.getFeedForUser(
+      'u-1',
+      { interestTags: [], flags: FLAGS_OFF },
+      5,
+    );
+    const call = db.bill.findMany.mock.calls[0][0]!;
+    expect(call.where).toMatchObject({ isActive: true });
+  });
+
   it('drops bills with null aiSummary even if returned by the query', async () => {
     db.bill.findMany.mockResolvedValue([mkBillRow('b-null', null)] as never);
     const result = await service.getFeedForUser(

--- a/apps/backend/src/apps/knowledge/src/domains/personalized-feed/personalized-feed.service.ts
+++ b/apps/backend/src/apps/knowledge/src/domains/personalized-feed/personalized-feed.service.ts
@@ -156,7 +156,12 @@ export class PersonalizedFeedService {
    */
   private async fetchRankableBills(): Promise<RankableBill[]> {
     const rows = await this.db.bill.findMany({
-      where: { aiSummary: { not: Prisma.DbNull } },
+      // Hard-include only currently-moveable bills (#747). The feed's value
+      // is "things you can act on now", so anything not actively progressing
+      // — chaptered/passed AND vetoed/died — destroys the user's trust in
+      // the ranking. Unlike the public `bills` resolver this filter is not
+      // toggle-able; the ranker only ever sees isActive=true bills.
+      where: { aiSummary: { not: Prisma.DbNull }, isActive: true },
       select: {
         id: true,
         lastActionDate: true,

--- a/apps/backend/src/apps/region/src/domains/bill-lifecycle.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/bill-lifecycle.spec.ts
@@ -1,0 +1,258 @@
+import {
+  isBillDead,
+  isBillActive,
+  BillLifecycleInput,
+  computeActiveCaSessionYears,
+} from './bill-lifecycle';
+
+const ctx = {
+  today: new Date(Date.UTC(2026, 4, 31)), // 2026-05-31
+  activeSessionYears: ['2025-2026'],
+};
+
+function bill(overrides: Partial<BillLifecycleInput> = {}): BillLifecycleInput {
+  return {
+    status: null,
+    currentStageId: null,
+    sessionYear: '2025-2026',
+    lastAction: null,
+    lastActionDate: null,
+    ...overrides,
+  };
+}
+
+describe('isBillDead', () => {
+  describe('terminal lifecycle stage', () => {
+    it('flags failed-passage as dead', () => {
+      expect(isBillDead(bill({ currentStageId: 'failed-passage' }), ctx)).toBe(
+        true,
+      );
+    });
+
+    it('does NOT flag chaptered as dead (passed ≠ dead)', () => {
+      expect(
+        isBillDead(
+          bill({ currentStageId: 'chaptered', sessionYear: '2023-2024' }),
+          ctx,
+        ),
+      ).toBe(false);
+    });
+
+    it('does not flag mid-pipeline stages', () => {
+      expect(isBillDead(bill({ currentStageId: 'first-committee' }), ctx)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('status string patterns', () => {
+    it.each([
+      ['Vetoed'],
+      ['Failed Deadline'],
+      ['Inactive File'],
+      ['Withdrawn'],
+      ['Failed Passage'],
+      ['Died'],
+      ['Inactive Bill - Died'], // CA verbatim form
+      ['Inactive Bill - Vetoed'], // CA verbatim form
+      ['Sen Inactive File - Assembly Bills'], // CA inactive-file variant
+    ])('flags %s', (status) => {
+      expect(isBillDead(bill({ status }), ctx)).toBe(true);
+    });
+
+    it.each([
+      ['Chaptered'],
+      ['Inactive Bill - Chaptered'], // CA verbatim form — passed, not dead
+      ['Active Bill - In Committee Process'],
+      ['Active Bill - Pending Referral'],
+    ])('does NOT flag live or chaptered status %s', (status) => {
+      expect(isBillDead(bill({ status }), ctx)).toBe(false);
+    });
+
+    it('is case-insensitive', () => {
+      expect(isBillDead(bill({ status: 'vetoed' }), ctx)).toBe(true);
+    });
+
+    it('does not flag unrelated statuses', () => {
+      expect(isBillDead(bill({ status: 'Active Bill - Engrossed' }), ctx)).toBe(
+        false,
+      );
+    });
+
+    it('does not flag when status is null', () => {
+      expect(isBillDead(bill({ status: null }), ctx)).toBe(false);
+    });
+  });
+
+  describe('veto override exception', () => {
+    it('does NOT flag a vetoed bill whose lastAction mentions an override', () => {
+      expect(
+        isBillDead(
+          bill({
+            status: 'Vetoed',
+            lastAction: 'Veto overridden by Assembly',
+          }),
+          ctx,
+        ),
+      ).toBe(false);
+    });
+
+    it('still flags a vetoed bill with no override action', () => {
+      expect(
+        isBillDead(
+          bill({
+            status: 'Vetoed',
+            lastAction: 'Vetoed by Governor',
+          }),
+          ctx,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('session expired', () => {
+    it('flags bills from a closed session', () => {
+      expect(isBillDead(bill({ sessionYear: '2023-2024' }), ctx)).toBe(true);
+    });
+
+    it('does not flag bills from the active session', () => {
+      expect(isBillDead(bill({ sessionYear: '2025-2026' }), ctx)).toBe(false);
+    });
+
+    it('does not flag chaptered bills from a closed session', () => {
+      expect(
+        isBillDead(
+          bill({ sessionYear: '2023-2024', currentStageId: 'chaptered' }),
+          ctx,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe('carryover guard', () => {
+    it('keeps a sessionYear-expired bill live if its lastActionDate is this year', () => {
+      // Two-year CA session: a bill labelled with a closed session label but
+      // with activity this year is a carryover and remains live.
+      expect(
+        isBillDead(
+          bill({
+            sessionYear: '2023-2024',
+            lastActionDate: new Date(Date.UTC(2026, 2, 1)),
+          }),
+          ctx,
+        ),
+      ).toBe(false);
+    });
+
+    it('does NOT save a bill with a terminal status, even with a same-year action date', () => {
+      // Hard signals (Vetoed/Died/etc.) win over the carryover heuristic —
+      // the carryover guard only protects against the soft session-expired
+      // rule, not against an authoritative dead status. Real-world: a bill
+      // that died on 2026-02-03 is still dead even though 2026 == today's
+      // year.
+      expect(
+        isBillDead(
+          bill({
+            status: 'Inactive Bill - Died',
+            lastActionDate: new Date(Date.UTC(2026, 1, 3)),
+          }),
+          ctx,
+        ),
+      ).toBe(true);
+    });
+
+    it('flags a closed-session bill whose last action was last year', () => {
+      expect(
+        isBillDead(
+          bill({
+            sessionYear: '2023-2024',
+            lastActionDate: new Date(Date.UTC(2025, 11, 15)),
+          }),
+          ctx,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe('default — clean active bill', () => {
+    it('returns false for a fresh active-session bill with no terminal signals', () => {
+      expect(
+        isBillDead(
+          bill({
+            status: 'Active Bill - In Committee Process',
+            currentStageId: 'first-committee',
+            lastActionDate: new Date(Date.UTC(2026, 4, 1)),
+          }),
+          ctx,
+        ),
+      ).toBe(false);
+    });
+  });
+});
+
+describe('isBillActive', () => {
+  it.each([
+    ['Active Bill - In Committee Process'],
+    ['Active Bill - Pending Referral'],
+    ['Active Bill - In Floor Process'],
+  ])('returns true for active prefix: %s', (status) => {
+    expect(isBillActive(bill({ status }), ctx)).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(
+      isBillActive(bill({ status: 'active bill - in committee process' }), ctx),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['Chaptered'],
+    ['Inactive Bill - Chaptered'],
+    ['Inactive Bill - Died'],
+    ['Inactive Bill - Vetoed'],
+    ['Sen Inactive File - Assembly Bills'],
+    ['Ordered to inactive file at the request of Senator Blakespear.'],
+  ])('returns false for inactive status %s', (status) => {
+    expect(isBillActive(bill({ status }), ctx)).toBe(false);
+  });
+
+  it('returns false for null status', () => {
+    expect(isBillActive(bill({ status: null }), ctx)).toBe(false);
+  });
+
+  it('does not flag a status that merely contains "active" elsewhere', () => {
+    // Defensive — only the leading-prefix counts, not the substring.
+    expect(
+      isBillActive(bill({ status: 'Inactive Bill - Active referral' }), ctx),
+    ).toBe(false);
+  });
+
+  it('returns false when the prefix matches but the bill is dead — partition invariant (#747)', () => {
+    // Stale "Active Bill - ..." status on an expired-session bill: prefix
+    // satisfies the substring rule, but isBillDead returns true via the
+    // session-expired path. isBillActive must defer to isBillDead so the
+    // 3-way partition stays airtight — no bill can be both active and dead.
+    expect(
+      isBillActive(
+        bill({
+          status: 'Active Bill - In Committee Process',
+          sessionYear: '2023-2024',
+          lastActionDate: new Date(Date.UTC(2024, 5, 1)),
+        }),
+        ctx,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('computeActiveCaSessionYears', () => {
+  it.each([
+    [new Date(Date.UTC(2025, 0, 1)), '2025-2026'],
+    [new Date(Date.UTC(2026, 5, 30)), '2025-2026'],
+    [new Date(Date.UTC(2026, 11, 31)), '2025-2026'],
+    [new Date(Date.UTC(2027, 0, 1)), '2027-2028'],
+    [new Date(Date.UTC(2028, 11, 31)), '2027-2028'],
+  ])('resolves %s → %s', (today, expected) => {
+    expect(computeActiveCaSessionYears(today)).toEqual([expected]);
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/bill-lifecycle.ts
+++ b/apps/backend/src/apps/region/src/domains/bill-lifecycle.ts
@@ -1,0 +1,178 @@
+/**
+ * Procedural lifecycle classification for bills (#747).
+ *
+ * Two booleans, computed at sync write time, partition the corpus
+ * into three phases that the UI and the personalized feed consume:
+ *
+ *   - isActive=true,  isDead=false → currently moveable; user can act
+ *   - isActive=false, isDead=false → passed/chaptered (signed into law)
+ *   - isActive=false, isDead=true  → vetoed, died, expired, etc.
+ *
+ * The bills-list Active/Inactive segmented toggle filters on isActive.
+ * The personalized feed (#743/#745) hard-includes isActive=true only
+ * — chaptered AND dead bills are equally unactionable in a "things you
+ * can do something about" surface. isDead is retained for the bill-
+ * detail banner (green vs amber) and admin/research callers.
+ *
+ * Design notes:
+ *
+ *   - **Pure**: no DB, no `Date.now()`. Caller passes `ctx.today`, so
+ *     both helpers stay deterministic and the backfill script + the
+ *     sync write path share one implementation.
+ *
+ *   - **Partition invariant**: `isBillActive` defers to `isBillDead` so
+ *     a stale "Active Bill - ..." status on an expired-session bill
+ *     can never satisfy both checks simultaneously.
+ *
+ *   - **Table-driven**: each dead-status signal is a row in
+ *     `DEAD_STATUS_PATTERNS`. Adding a new state-specific phrase (or
+ *     extending past CA) only touches the table — keeps cognitive
+ *     complexity well under the SonarCloud gate.
+ *
+ *   - **Carryover guard**: CA two-year sessions allow bills to revive
+ *     in year 2. The guard protects ONLY the soft session-expired
+ *     heuristic — it does not absorb a same-year terminal status (a
+ *     bill that died this year is still dead).
+ *
+ *   - **Re-evaluated on every sync**: helpers are deterministic, so
+ *     re-runs are no-ops until the source status changes. Real CA bills
+ *     don't un-die, so dead → active transitions don't happen in
+ *     practice — but the code doesn't artificially block them either,
+ *     which keeps recovery cheap if the source ever needs a re-import.
+ */
+
+export interface BillLifecycleInput {
+  status: string | null;
+  currentStageId: string | null;
+  sessionYear: string;
+  lastAction: string | null;
+  lastActionDate: Date | null;
+}
+
+export interface BillLifecycleContext {
+  /** Caller-supplied "now" so the function stays pure. */
+  today: Date;
+  /**
+   * sessionYear labels (e.g. ["2025-2026"]) considered still in-session.
+   * A bill whose sessionYear is NOT in this list and whose currentStageId
+   * is not the terminal `chaptered` stage is dead by the "session
+   * expired" rule.
+   */
+  activeSessionYears: string[];
+}
+
+/** Lifecycle stage IDs (from the civics data extracted into Bill.currentStageId)
+ *  that signal a bill is procedurally dead. `chaptered` means *passed* and is
+ *  NOT included — chaptered bills are enacted, not dead. */
+const DEAD_STAGE_IDS: ReadonlySet<string> = new Set(['failed-passage']);
+
+/** Regex patterns against the `status` column (covers both the LLM-
+ *  normalized short form and the verbatim leginfo string — older rows
+ *  may carry "Inactive Bill - Died" while newer ones carry "Died"). Each
+ *  row is a single canonical signal. Veto is handled separately because
+ *  an override in `lastAction` cancels it. */
+const DEAD_STATUS_PATTERNS: readonly RegExp[] = [
+  /died/i, // CA's canonical dead-bill marker ("Inactive Bill - Died")
+  /failed deadline/i, // missed the committee/floor cutoff
+  /inactive file/i, // moved to inactive file with no recall
+  /withdrawn/i, // withdrawn by author
+  /failed passage/i, // floor vote lost
+];
+
+const VETOED_PATTERN = /vetoed/i;
+/** Matches "override", "overrode", "overridden", "overriding" — the stem
+ *  `overrid` covers every conjugation we've seen in CA action history. */
+const OVERRIDE_PATTERN = /overrid/i;
+
+export function isBillDead(
+  bill: BillLifecycleInput,
+  ctx: BillLifecycleContext,
+): boolean {
+  // Hard terminal signals win unconditionally — a bill that died this year
+  // is still dead. The carryover guard only protects against the soft
+  // session-expired heuristic below it.
+  if (matchesDeadStage(bill)) return true;
+  if (matchesDeadStatus(bill)) return true;
+  if (isSessionExpired(bill, ctx) && !isCarryoverLive(bill, ctx)) return true;
+  return false;
+}
+
+function isCarryoverLive(
+  bill: BillLifecycleInput,
+  ctx: BillLifecycleContext,
+): boolean {
+  if (!bill.lastActionDate) return false;
+  return bill.lastActionDate.getUTCFullYear() === ctx.today.getUTCFullYear();
+}
+
+function matchesDeadStage(bill: BillLifecycleInput): boolean {
+  return !!bill.currentStageId && DEAD_STAGE_IDS.has(bill.currentStageId);
+}
+
+function matchesDeadStatus(bill: BillLifecycleInput): boolean {
+  if (!bill.status) return false;
+  if (DEAD_STATUS_PATTERNS.some((re) => re.test(bill.status!))) return true;
+  if (VETOED_PATTERN.test(bill.status)) {
+    // Veto + subsequent override = live again.
+    const overridden =
+      !!bill.lastAction && OVERRIDE_PATTERN.test(bill.lastAction);
+    return !overridden;
+  }
+  return false;
+}
+
+function isSessionExpired(
+  bill: BillLifecycleInput,
+  ctx: BillLifecycleContext,
+): boolean {
+  if (ctx.activeSessionYears.includes(bill.sessionYear)) return false;
+  // Chaptered bills from closed sessions are enacted, not dead.
+  if (bill.currentStageId === 'chaptered') return false;
+  return true;
+}
+
+/**
+ * CA two-year session label for the given date — e.g. 2026-05-31 → "2025-2026".
+ * Sessions start in odd-numbered years and run two calendar years. CA-only for
+ * now; when we add a second state with a different cadence, move this behind
+ * a region-config field.
+ */
+export function computeActiveCaSessionYears(today: Date): string[] {
+  const year = today.getUTCFullYear();
+  const startYear = year % 2 === 1 ? year : year - 1;
+  return [`${startYear}-${startYear + 1}`];
+}
+
+/**
+ * Returns true when the bill is *currently moveable* — the source has tagged
+ * it as actively progressing through the legislature (CA leginfo prefixes
+ * such bills with "Active Bill - ...") AND the bill is not procedurally
+ * dead. The dead-check seals the partition: a stale "Active Bill - ..."
+ * status on an expired-session bill (rare in real CA data, but possible
+ * with corrupt or pre-update rows) would otherwise satisfy both isActive
+ * and isDead. By gating on !isBillDead here, callers can rely on the
+ * 3-way partition invariant:
+ *
+ *   - isActive=true,  isDead=false → moveable (citizen can still influence)
+ *   - isActive=false, isDead=false → passed/chaptered (enacted law)
+ *   - isActive=false, isDead=true  → vetoed, died, expired, etc.
+ *   - isActive=true,  isDead=true  → impossible
+ *
+ * The bills-list "Active / Inactive" segmented toggle (#747) filters on
+ * isActive; the personalized feed hard-excludes anything with isActive=false
+ * (chaptered AND dead aren't actionable). isDead is retained for richer
+ * categorisation in admin/research surfaces.
+ */
+export function isBillActive(
+  bill: BillLifecycleInput,
+  ctx: BillLifecycleContext,
+): boolean {
+  if (!bill.status) return false;
+  if (!ACTIVE_STATUS_PATTERN.test(bill.status)) return false;
+  return !isBillDead(bill, ctx);
+}
+
+/** Matches the canonical CA leginfo "Active Bill - …" prefix. Anything that
+ *  doesn't begin with this prefix is treated as inactive — chaptered,
+ *  vetoed, died, withdrawn, inactive file, or unknown. */
+const ACTIVE_STATUS_PATTERN = /^active bill\b/i;

--- a/apps/backend/src/apps/region/src/domains/models/bill.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/bill.model.ts
@@ -1,4 +1,24 @@
-import { ObjectType, Field, ID, Int } from '@nestjs/graphql';
+import { ObjectType, Field, ID, Int, registerEnumType } from '@nestjs/graphql';
+
+/**
+ * Bills-list filter selector for the Active / Inactive segmented toggle
+ * (#747). Pairs with the `isActive` + `isDead` columns to partition the
+ * corpus into three lifecycle phases.
+ */
+export enum BillLifecycle {
+  /** isActive = true. Currently moveable bills only. Default for list/feed. */
+  ACTIVE = 'ACTIVE',
+  /** isActive = false. Chaptered (passed) and dead bills together. */
+  INACTIVE = 'INACTIVE',
+  /** No lifecycle filter — admin/research callers. */
+  ALL = 'ALL',
+}
+
+registerEnumType(BillLifecycle, {
+  name: 'BillLifecycle',
+  description:
+    'Active = currently moveable; Inactive = passed/chaptered + dead; All = no filter (#747).',
+});
 
 @ObjectType('BillVote')
 export class BillVoteModel {
@@ -153,6 +173,22 @@ export class BillModel {
    *  `{ skip: true }` (input was garbled / not-a-bill). See #741. */
   @Field(() => BillAiSummaryModel, { nullable: true })
   aiSummary?: BillAiSummaryModel;
+
+  /** Procedurally dead — vetoed without override, withdrawn, failed
+   *  deadline, inactive file, failed passage, or from a closed session
+   *  that did not enact. Pairs with `isActive` to give a 3-way partition.
+   *  The bill-detail resolver always returns the bill so deep links
+   *  don't 404. See #747. */
+  @Field()
+  isDead!: boolean;
+
+  /** Currently moveable — the source has tagged this bill as actively
+   *  progressing through the legislature ("Active Bill - ..."). Default
+   *  list/search and the personalized feed filter to isActive=true; the
+   *  Inactive segment of the bills-list toggle shows isActive=false
+   *  (chaptered + dead together). See #747. */
+  @Field()
+  isActive!: boolean;
 }
 
 @ObjectType('PaginatedBills')

--- a/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
@@ -8,6 +8,7 @@ import {
   createMockDbService,
   type MockDbClient,
 } from '@opuspopuli/relationaldb-provider/testing';
+import { BillLifecycle } from './models/bill.model';
 
 function createMockCache() {
   return {
@@ -1188,6 +1189,8 @@ describe('RegionQueryService — query methods', () => {
       extractedAt: new Date(),
       createdAt: new Date(),
       updatedAt: new Date(),
+      isDead: false,
+      isActive: true,
       votes: [],
       coAuthors: [],
     };
@@ -1275,6 +1278,89 @@ describe('RegionQueryService — query methods', () => {
       const result = await service.getBill('bill-1');
       expect(result?.aiSummary?.topics).toEqual(['housing', 'taxation']);
       expect(result?.aiSummary?.whoItAffects).toEqual(['renters', 'parents']);
+    });
+
+    it('exposes isDead and isActive on the mapped record', async () => {
+      mockDb.bill.findUnique.mockResolvedValue({
+        ...baseBillRow,
+        isDead: true,
+        isActive: false,
+        aiSummary: null,
+      } as never);
+      const result = await service.getBill('bill-1');
+      expect(result?.isDead).toBe(true);
+      expect(result?.isActive).toBe(false);
+    });
+  });
+
+  describe('getBills — lifecycle filter (#747)', () => {
+    beforeEach(() => {
+      mockDb.bill.findMany.mockResolvedValue([] as never);
+      mockDb.bill.count.mockResolvedValue(0 as never);
+    });
+
+    it('defaults to ACTIVE — adds isActive:true to the where clause', async () => {
+      await service.getBills(0, 10);
+      expect(mockDb.bill.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ isActive: true }),
+        }),
+      );
+      expect(mockDb.bill.count).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ isActive: true }),
+        }),
+      );
+    });
+
+    it('INACTIVE adds isActive:false (chaptered + dead together)', async () => {
+      await service.getBills(
+        0,
+        10,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        BillLifecycle.INACTIVE,
+      );
+      expect(mockDb.bill.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ isActive: false }),
+        }),
+      );
+    });
+
+    it('ALL omits any lifecycle clause', async () => {
+      await service.getBills(
+        0,
+        10,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        BillLifecycle.ALL,
+      );
+      const args = mockDb.bill.findMany.mock.calls[0][0] as {
+        where: Record<string, unknown>;
+      };
+      expect(args.where).not.toHaveProperty('isActive');
+      expect(args.where).not.toHaveProperty('isDead');
+    });
+
+    it('composes isActive:true with other filters', async () => {
+      await service.getBills(0, 10, 'AB', '2025-2026', 'author-1');
+      expect(mockDb.bill.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            isActive: true,
+            measureTypeCode: 'AB',
+            sessionYear: '2025-2026',
+            authorId: 'author-1',
+          }),
+        }),
+      );
     });
   });
 });

--- a/apps/backend/src/apps/region/src/domains/region-query.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.ts
@@ -34,12 +34,26 @@ import {
   BillCoAuthorModel,
   BillAiSummaryModel,
   PaginatedBillsModel,
+  BillLifecycle,
 } from './models/bill.model';
 
 import {
   mapPropositionRecord,
   type RepresentativeRecord,
 } from './region.service';
+
+/**
+ * Map the BillLifecycle GraphQL enum to the Prisma where-clause fragment
+ * that filters the `bills` table by lifecycle phase (#747). Returning an
+ * object literal lets callers spread the result into a wider where clause.
+ */
+function lifecycleClause(
+  lifecycle: BillLifecycle,
+): { isActive?: boolean } | Record<string, never> {
+  if (lifecycle === BillLifecycle.ACTIVE) return { isActive: true };
+  if (lifecycle === BillLifecycle.INACTIVE) return { isActive: false };
+  return {};
+}
 
 // ─── Local type aliases ───────────────────────────────────────────────────────
 
@@ -1133,8 +1147,13 @@ export class RegionQueryService {
     authorId?: string,
     committeeId?: string,
     coAuthorId?: string,
+    lifecycle: BillLifecycle = BillLifecycle.ACTIVE,
   ): Promise<PaginatedBillsModel> {
     const where = {
+      // ACTIVE → currently moveable only (partial index `bills_is_active_idx`).
+      // INACTIVE → chaptered + dead together. ALL → no lifecycle filter.
+      // See #747.
+      ...lifecycleClause(lifecycle),
       ...(measureTypeCode && { measureTypeCode }),
       ...(sessionYear && { sessionYear }),
       ...(authorId && { authorId }),
@@ -1204,6 +1223,8 @@ export class RegionQueryService {
     createdAt: Date;
     updatedAt: Date;
     aiSummary: Prisma.JsonValue | null;
+    isDead: boolean;
+    isActive: boolean;
     votes: {
       id: string;
       representativeName: string;
@@ -1241,6 +1262,8 @@ export class RegionQueryService {
       createdAt: b.createdAt,
       updatedAt: b.updatedAt,
       aiSummary: this.coerceBillAiSummary(b.aiSummary),
+      isDead: b.isDead,
+      isActive: b.isActive,
       votes: b.votes.map(
         (v): BillVoteModel => ({
           id: v.id,

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -48,6 +48,11 @@ import { LegislativeCommitteeService } from './legislative-committee.service';
 import { LegislativeCommitteeDescriptionGeneratorService } from './legislative-committee-description-generator.service';
 import { HostThrottle, fetchTextWithRetry } from './resilient-fetch';
 import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
+import {
+  isBillDead,
+  isBillActive,
+  computeActiveCaSessionYears,
+} from './bill-lifecycle';
 import { RegionInfoModel, DataTypeGQL } from './models/region-info.model';
 import { RegionCacheService } from './region-cache.service';
 import {
@@ -2319,21 +2324,40 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
         return 'failed';
       }
 
+      const resolvedCurrentStageId =
+        raw.currentStageId ??
+        this.resolveStageFromStatus(raw.status, stagePatterns);
+      const resolvedSessionYear = raw.sessionYear ?? sessionYear;
+      const resolvedLastActionDate = raw.lastActionDate
+        ? new Date(raw.lastActionDate as unknown as string)
+        : null;
+
+      // Snapshot now() once so both lifecycle helpers see the same moment —
+      // avoids a sub-millisecond drift between today and activeSessionYears.
+      const now = new Date();
+      const lifecycleInput = {
+        status: raw.status ?? null,
+        currentStageId: resolvedCurrentStageId,
+        sessionYear: resolvedSessionYear,
+        lastAction: raw.lastAction ?? null,
+        lastActionDate: resolvedLastActionDate,
+      };
+      const lifecycleCtx = {
+        today: now,
+        activeSessionYears: computeActiveCaSessionYears(now),
+      };
+
       const billData = {
         regionId,
         billNumber: raw.billNumber,
-        sessionYear: raw.sessionYear ?? sessionYear,
+        sessionYear: resolvedSessionYear,
         measureTypeCode,
         title: raw.title,
         subject: raw.subject ?? null,
         status: raw.status ?? null,
-        currentStageId:
-          raw.currentStageId ??
-          this.resolveStageFromStatus(raw.status, stagePatterns),
+        currentStageId: resolvedCurrentStageId,
         lastAction: raw.lastAction ?? null,
-        lastActionDate: raw.lastActionDate
-          ? new Date(raw.lastActionDate as unknown as string)
-          : null,
+        lastActionDate: resolvedLastActionDate,
         fiscalImpact: raw.fiscalImpact ?? null,
         fullTextUrl: raw.fullTextUrl ?? null,
         authorId: authorId ?? null,
@@ -2344,7 +2368,15 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
         // flag — whether the bill arrived here via the journal flag or the
         // weekly backstop, the LLM update is authoritative. See #689.
         needsStatusRecheck: false,
-        extractedAt: new Date(),
+        // Procedural lifecycle flags (#747). Computed at write time so list/
+        // search/feed queries don't re-evaluate the rules per row. The two
+        // booleans form a 3-way partition (active | passed/chaptered |
+        // dead); see bill-lifecycle.ts for the rules. Sync re-evaluates on
+        // each run — the helpers are deterministic, so re-runs are no-ops
+        // until the source status changes.
+        isDead: isBillDead(lifecycleInput, lifecycleCtx),
+        isActive: isBillActive(lifecycleInput, lifecycleCtx),
+        extractedAt: now,
       };
       const bill = await this.db.bill.upsert({
         where: { externalId },

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -78,7 +78,11 @@ import {
   PaginatedLegislativeActions,
   MinutesPassageModel,
 } from './models/legislative-action.model';
-import { BillModel, PaginatedBillsModel } from './models/bill.model';
+import {
+  BillModel,
+  PaginatedBillsModel,
+  BillLifecycle,
+} from './models/bill.model';
 import {
   JurisdictionModel,
   UserJurisdictionModel,
@@ -783,6 +787,10 @@ export class RegionResolver {
    * sessionYear, authorId, committeeId, or coAuthorId. Orders by
    * lastActionDate desc. Combining authorId with coAuthorId is AND-semantic
    * (rare; useful for "all bills this rep touched in any role"). See #594.
+   *
+   * `lifecycle` (#747) defaults to ACTIVE — currently moveable bills only.
+   * INACTIVE returns chaptered + dead together; ALL skips the filter for
+   * admin/research callers.
    */
   @Public()
   @Query(() => PaginatedBillsModel)
@@ -797,6 +805,13 @@ export class RegionResolver {
     committeeId?: string,
     @Args({ name: 'coAuthorId', type: () => ID, nullable: true })
     coAuthorId?: string,
+    @Args({
+      name: 'lifecycle',
+      type: () => BillLifecycle,
+      nullable: true,
+      defaultValue: BillLifecycle.ACTIVE,
+    })
+    lifecycle: BillLifecycle = BillLifecycle.ACTIVE,
   ): Promise<PaginatedBillsModel> {
     return this.regionService.getBills(
       skip,
@@ -806,6 +821,7 @@ export class RegionResolver {
       authorId,
       committeeId,
       coAuthorId,
+      lifecycle,
     );
   }
 

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -32,7 +32,11 @@ import { PaginatedCommittees } from './models/committee.model';
 import { PaginatedContributions } from './models/contribution.model';
 import { PaginatedExpenditures } from './models/expenditure.model';
 import { PaginatedIndependentExpenditures } from './models/independent-expenditure.model';
-import { BillModel, PaginatedBillsModel } from './models/bill.model';
+import {
+  BillModel,
+  PaginatedBillsModel,
+  BillLifecycle,
+} from './models/bill.model';
 import type { PropositionFunding } from './proposition-funding.service';
 import type {
   LegislativeCommitteeDetail,
@@ -541,6 +545,7 @@ export class RegionDomainService {
     authorId?: string,
     committeeId?: string,
     coAuthorId?: string,
+    lifecycle: BillLifecycle = BillLifecycle.ACTIVE,
   ): Promise<PaginatedBillsModel> {
     return this.queryService.getBills(
       skip,
@@ -550,6 +555,7 @@ export class RegionDomainService {
       authorId,
       committeeId,
       coAuthorId,
+      lifecycle,
     );
   }
 

--- a/apps/backend/src/apps/region/src/scripts/backfill-bill-is-dead.ts
+++ b/apps/backend/src/apps/region/src/scripts/backfill-bill-is-dead.ts
@@ -1,0 +1,118 @@
+/**
+ * One-off backfill: compute `Bill.isDead` and `Bill.isActive` for every
+ * existing bill using the same rules the sync write path uses (#747).
+ * Idempotent — re-runs are safe since both rules are deterministic.
+ *
+ * One-way transitions: dead bills stay dead; an inactive bill that becomes
+ * active again will be flipped back to true by the next sync (status string
+ * changes drive the transition). This script only needs to run once per
+ * region after deploy; ongoing hygiene happens via the regular sync.
+ *
+ * Usage:
+ *   pnpm --filter backend build:region
+ *   node dist/apps/region/src/scripts/backfill-bill-is-dead.js
+ *
+ * Optional flags (via env):
+ *   BACKFILL_IS_DEAD_REGION_ID=california  — limit to a single region.
+ *   BACKFILL_IS_DEAD_BATCH=200             — rows per page (default 200).
+ *   BACKFILL_IS_DEAD_DRY_RUN=1             — log decisions; skip writes.
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
+import { AppModule } from '../app.module';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import {
+  isBillDead,
+  isBillActive,
+  computeActiveCaSessionYears,
+} from '../domains/bill-lifecycle';
+
+const DEFAULT_BATCH = 200;
+
+async function main(): Promise<void> {
+  const logger = new Logger('backfill-bill-is-dead');
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'warn', 'error'],
+  });
+  try {
+    const db = app.get(DbService, { strict: false });
+    const regionId = process.env.BACKFILL_IS_DEAD_REGION_ID || undefined;
+    const batchSize =
+      Number(process.env.BACKFILL_IS_DEAD_BATCH) || DEFAULT_BATCH;
+    const dryRun = process.env.BACKFILL_IS_DEAD_DRY_RUN === '1';
+
+    const today = new Date();
+    const activeSessionYears = computeActiveCaSessionYears(today);
+
+    logger.log(
+      `Backfill starting: regionId=${regionId ?? 'ALL'} batch=${batchSize} dryRun=${dryRun} activeSessionYears=${activeSessionYears.join(',')}`,
+    );
+
+    let cursor: string | undefined;
+    let scanned = 0;
+    let flippedDead = 0;
+    let flippedActive = 0;
+
+    for (;;) {
+      const rows = await db.bill.findMany({
+        where: regionId ? { regionId } : undefined,
+        select: {
+          id: true,
+          status: true,
+          currentStageId: true,
+          sessionYear: true,
+          lastAction: true,
+          lastActionDate: true,
+          isDead: true,
+          isActive: true,
+        },
+        orderBy: { id: 'asc' },
+        take: batchSize,
+        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+      });
+      if (rows.length === 0) break;
+
+      // Per-row update — different bills may need different column
+      // combinations (dead-flip, active-flip, both, or both-cleared if the
+      // status changed mid-pipeline). updateMany is only safe for uniform
+      // payloads.
+      const lifecycleCtx = { today, activeSessionYears };
+      for (const row of rows) {
+        const dead = isBillDead(row, lifecycleCtx);
+        const active = isBillActive(row, lifecycleCtx);
+        const needsDead = dead !== row.isDead;
+        const needsActive = active !== row.isActive;
+        if (!needsDead && !needsActive) continue;
+        if (!dryRun) {
+          await db.bill.update({
+            where: { id: row.id },
+            data: {
+              ...(needsDead && { isDead: dead }),
+              ...(needsActive && { isActive: active }),
+            },
+          });
+        }
+        if (needsDead) flippedDead += 1;
+        if (needsActive) flippedActive += 1;
+      }
+
+      scanned += rows.length;
+      cursor = rows[rows.length - 1].id;
+      logger.log(
+        `Progress: scanned=${scanned} flippedDead=${flippedDead} flippedActive=${flippedActive} lastId=${cursor}`,
+      );
+    }
+
+    logger.log(
+      `Backfill complete: scanned=${scanned} flippedDead=${flippedDead} flippedActive=${flippedActive} dryRun=${dryRun}`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Backfill failed:', err);
+  process.exit(1);
+});

--- a/apps/backend/src/apps/region/src/scripts/backfill-bill-is-dead.ts
+++ b/apps/backend/src/apps/region/src/scripts/backfill-bill-is-dead.ts
@@ -26,9 +26,109 @@ import {
   isBillDead,
   isBillActive,
   computeActiveCaSessionYears,
+  type BillLifecycleContext,
 } from '../domains/bill-lifecycle';
 
 const DEFAULT_BATCH = 200;
+
+interface BackfillConfig {
+  regionId: string | undefined;
+  batchSize: number;
+  dryRun: boolean;
+  lifecycleCtx: BillLifecycleContext;
+}
+
+interface BackfillCounters {
+  scanned: number;
+  flippedDead: number;
+  flippedActive: number;
+}
+
+type LifecycleRow = {
+  id: string;
+  status: string | null;
+  currentStageId: string | null;
+  sessionYear: string;
+  lastAction: string | null;
+  lastActionDate: Date | null;
+  isDead: boolean;
+  isActive: boolean;
+};
+
+function loadConfig(): BackfillConfig {
+  const today = new Date();
+  return {
+    regionId: process.env.BACKFILL_IS_DEAD_REGION_ID || undefined,
+    batchSize: Number(process.env.BACKFILL_IS_DEAD_BATCH) || DEFAULT_BATCH,
+    dryRun: process.env.BACKFILL_IS_DEAD_DRY_RUN === '1',
+    lifecycleCtx: {
+      today,
+      activeSessionYears: computeActiveCaSessionYears(today),
+    },
+  };
+}
+
+async function fetchBatch(
+  db: DbService,
+  cfg: BackfillConfig,
+  cursor: string | undefined,
+): Promise<LifecycleRow[]> {
+  return db.bill.findMany({
+    where: cfg.regionId ? { regionId: cfg.regionId } : undefined,
+    select: {
+      id: true,
+      status: true,
+      currentStageId: true,
+      sessionYear: true,
+      lastAction: true,
+      lastActionDate: true,
+      isDead: true,
+      isActive: true,
+    },
+    orderBy: { id: 'asc' },
+    take: cfg.batchSize,
+    ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+  });
+}
+
+/**
+ * Decide which columns (if any) need flipping for the row. Returns null
+ * when both flags already match the helper output (no-op).
+ */
+function planRowUpdate(
+  row: LifecycleRow,
+  cfg: BackfillConfig,
+): { isDead?: boolean; isActive?: boolean } | null {
+  const dead = isBillDead(row, cfg.lifecycleCtx);
+  const active = isBillActive(row, cfg.lifecycleCtx);
+  const needsDead = dead !== row.isDead;
+  const needsActive = active !== row.isActive;
+  if (!needsDead && !needsActive) return null;
+  return {
+    ...(needsDead && { isDead: dead }),
+    ...(needsActive && { isActive: active }),
+  };
+}
+
+async function processBatch(
+  db: DbService,
+  cfg: BackfillConfig,
+  rows: LifecycleRow[],
+  counters: BackfillCounters,
+): Promise<void> {
+  // Per-row update — different bills may need different column combinations
+  // (dead-flip, active-flip, both, or no-op). updateMany is only safe for
+  // uniform payloads.
+  for (const row of rows) {
+    const update = planRowUpdate(row, cfg);
+    if (!update) continue;
+    if (!cfg.dryRun) {
+      await db.bill.update({ where: { id: row.id }, data: update });
+    }
+    if (update.isDead !== undefined) counters.flippedDead += 1;
+    if (update.isActive !== undefined) counters.flippedActive += 1;
+  }
+}
 
 async function main(): Promise<void> {
   const logger = new Logger('backfill-bill-is-dead');
@@ -37,75 +137,31 @@ async function main(): Promise<void> {
   });
   try {
     const db = app.get(DbService, { strict: false });
-    const regionId = process.env.BACKFILL_IS_DEAD_REGION_ID || undefined;
-    const batchSize =
-      Number(process.env.BACKFILL_IS_DEAD_BATCH) || DEFAULT_BATCH;
-    const dryRun = process.env.BACKFILL_IS_DEAD_DRY_RUN === '1';
-
-    const today = new Date();
-    const activeSessionYears = computeActiveCaSessionYears(today);
+    const cfg = loadConfig();
+    const counters: BackfillCounters = {
+      scanned: 0,
+      flippedDead: 0,
+      flippedActive: 0,
+    };
 
     logger.log(
-      `Backfill starting: regionId=${regionId ?? 'ALL'} batch=${batchSize} dryRun=${dryRun} activeSessionYears=${activeSessionYears.join(',')}`,
+      `Backfill starting: regionId=${cfg.regionId ?? 'ALL'} batch=${cfg.batchSize} dryRun=${cfg.dryRun} activeSessionYears=${cfg.lifecycleCtx.activeSessionYears.join(',')}`,
     );
 
     let cursor: string | undefined;
-    let scanned = 0;
-    let flippedDead = 0;
-    let flippedActive = 0;
-
     for (;;) {
-      const rows = await db.bill.findMany({
-        where: regionId ? { regionId } : undefined,
-        select: {
-          id: true,
-          status: true,
-          currentStageId: true,
-          sessionYear: true,
-          lastAction: true,
-          lastActionDate: true,
-          isDead: true,
-          isActive: true,
-        },
-        orderBy: { id: 'asc' },
-        take: batchSize,
-        ...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
-      });
+      const rows = await fetchBatch(db, cfg, cursor);
       if (rows.length === 0) break;
-
-      // Per-row update — different bills may need different column
-      // combinations (dead-flip, active-flip, both, or both-cleared if the
-      // status changed mid-pipeline). updateMany is only safe for uniform
-      // payloads.
-      const lifecycleCtx = { today, activeSessionYears };
-      for (const row of rows) {
-        const dead = isBillDead(row, lifecycleCtx);
-        const active = isBillActive(row, lifecycleCtx);
-        const needsDead = dead !== row.isDead;
-        const needsActive = active !== row.isActive;
-        if (!needsDead && !needsActive) continue;
-        if (!dryRun) {
-          await db.bill.update({
-            where: { id: row.id },
-            data: {
-              ...(needsDead && { isDead: dead }),
-              ...(needsActive && { isActive: active }),
-            },
-          });
-        }
-        if (needsDead) flippedDead += 1;
-        if (needsActive) flippedActive += 1;
-      }
-
-      scanned += rows.length;
+      await processBatch(db, cfg, rows, counters);
+      counters.scanned += rows.length;
       cursor = rows[rows.length - 1].id;
       logger.log(
-        `Progress: scanned=${scanned} flippedDead=${flippedDead} flippedActive=${flippedActive} lastId=${cursor}`,
+        `Progress: scanned=${counters.scanned} flippedDead=${counters.flippedDead} flippedActive=${counters.flippedActive} lastId=${cursor}`,
       );
     }
 
     logger.log(
-      `Backfill complete: scanned=${scanned} flippedDead=${flippedDead} flippedActive=${flippedActive} dryRun=${dryRun}`,
+      `Backfill complete: scanned=${counters.scanned} flippedDead=${counters.flippedDead} flippedActive=${counters.flippedActive} dryRun=${cfg.dryRun}`,
     );
   } finally {
     await app.close();

--- a/apps/frontend/app/region/bills/[id]/page.tsx
+++ b/apps/frontend/app/region/bills/[id]/page.tsx
@@ -67,6 +67,50 @@ function MeasureTypeBadge({ code }: { readonly code: string }) {
   );
 }
 
+/**
+ * Banner shown when the bill is no longer in the active legislative process
+ * (#747). Deep links to chaptered or dead bills still resolve so external
+ * citations don't 404, but the reader deserves a heads-up about the
+ * current state. Dead → amber warning; chaptered (signed into law) → green
+ * informational. Status + final-action date come straight from the DB
+ * columns the sync pipeline populates.
+ */
+function InactiveBillBanner({
+  isDead,
+  status,
+  lastActionDate,
+}: {
+  readonly isDead: boolean;
+  readonly status?: string;
+  readonly lastActionDate?: string;
+}) {
+  const finalAction = [
+    status,
+    lastActionDate ? formatDate(lastActionDate) : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  const tone = isDead
+    ? "border-amber-400 bg-amber-50 text-amber-900"
+    : "border-green-500 bg-green-50 text-green-900";
+  const headline = isDead
+    ? "This bill is no longer active."
+    : "This bill has been signed into law.";
+
+  return (
+    <div
+      role="status"
+      className={`mb-6 rounded-lg border-l-4 px-4 py-3 text-sm ${tone}`}
+    >
+      <span className="font-semibold">{headline}</span>
+      {finalAction && (
+        <span className="ml-1">Final status: {finalAction}.</span>
+      )}
+    </div>
+  );
+}
+
 function PositionBadge({ position }: { readonly position: string }) {
   const style = POSITION_STYLES[position] ?? POSITION_STYLES.no_vote;
   return (
@@ -591,6 +635,14 @@ export default function BillDetailPage() {
           {bill.title}
         </h1>
       </div>
+
+      {!bill.isActive && (
+        <InactiveBillBanner
+          isDead={bill.isDead}
+          status={bill.status}
+          lastActionDate={bill.lastActionDate}
+        />
+      )}
 
       <LayerNav layers={LAYERS} current={layer} onChange={setLayer} />
 

--- a/apps/frontend/app/region/bills/page.tsx
+++ b/apps/frontend/app/region/bills/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { useQuery } from "@apollo/client/react";
 import {
   GET_BILLS,
+  BillLifecycle,
   type BillsData,
   type BillsVars,
   type Bill,
@@ -34,6 +35,62 @@ function MeasureTypeBadge({ code }: { readonly code: string }) {
   );
 }
 
+/**
+ * One option in the Active/Inactive segmented filter. Uses the WAI-ARIA
+ * radio pattern (mutually-exclusive within a parent radiogroup) rather
+ * than the tabs pattern, since the buttons don't control tab panels.
+ * Focus ring matches the rest of the page's controls.
+ */
+function LifecycleOption({
+  value,
+  label,
+  selected,
+  onSelect,
+}: {
+  readonly value: BillLifecycle;
+  readonly label: string;
+  readonly selected: boolean;
+  readonly onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="radio"
+      aria-checked={selected}
+      data-value={value}
+      onClick={onSelect}
+      className={`px-3 py-1.5 rounded-md font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-sage-dark)] ${
+        selected
+          ? "bg-[var(--color-sage-dark)] text-white"
+          : "text-[#334155] hover:bg-gray-50"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * Per-card lifecycle pill. Active bills get no chip (cleaner default);
+ * chaptered (passed-into-law) bills get a Passed chip; dead bills get a
+ * Historical chip. Maps the isActive + isDead 3-way partition to a visual.
+ */
+function LifecycleChip({ bill }: { readonly bill: Bill }) {
+  if (bill.isActive) return null;
+  if (bill.isDead) {
+    return (
+      <span className="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-amber-800">
+        Historical
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-green-800">
+      Passed
+    </span>
+  );
+}
+
 function BillCard({ bill }: Readonly<{ bill: Bill }>) {
   return (
     <Link
@@ -48,6 +105,7 @@ function BillCard({ bill }: Readonly<{ bill: Bill }>) {
               {bill.billNumber}
             </span>
             <span className="text-xs text-slate-400">{bill.sessionYear}</span>
+            <LifecycleChip bill={bill} />
           </div>
           <h3 className="text-base font-semibold text-[#222222] line-clamp-2">
             {bill.title}
@@ -89,6 +147,12 @@ export default function BillsPage() {
     measureTypeCode: "",
     sessionYear: "",
   });
+  // Active/Inactive segmented toggle (#747). Default ACTIVE — currently
+  // moveable bills. INACTIVE shows chaptered + dead together with per-card
+  // Passed/Historical chips so users can still distinguish them.
+  const [lifecycle, setLifecycle] = useState<BillLifecycle>(
+    BillLifecycle.ACTIVE,
+  );
 
   // Honour deep-links from representative and committee detail pages
   const authorId = searchParams.get("authorId") ?? undefined;
@@ -106,6 +170,7 @@ export default function BillsPage() {
     ...(filters.sessionYear && { sessionYear: filters.sessionYear }),
     ...(authorId && { authorId }),
     ...(committeeId && { committeeId }),
+    lifecycle,
   };
 
   const { data, loading, error } = useQuery<BillsData, BillsVars>(GET_BILLS, {
@@ -166,6 +231,31 @@ export default function BillsPage() {
           Clear filters
         </button>
       )}
+
+      <div
+        role="radiogroup"
+        aria-label="Bill lifecycle filter"
+        className="ml-auto inline-flex rounded-lg border border-gray-200 bg-white p-0.5 text-sm"
+      >
+        <LifecycleOption
+          value={BillLifecycle.ACTIVE}
+          label="Active"
+          selected={lifecycle === BillLifecycle.ACTIVE}
+          onSelect={() => {
+            setLifecycle(BillLifecycle.ACTIVE);
+            setPage(0);
+          }}
+        />
+        <LifecycleOption
+          value={BillLifecycle.INACTIVE}
+          label="Inactive"
+          selected={lifecycle === BillLifecycle.INACTIVE}
+          onSelect={() => {
+            setLifecycle(BillLifecycle.INACTIVE);
+            setPage(0);
+          }}
+        />
+      </div>
     </div>
   );
 

--- a/apps/frontend/lib/apollo-client.ts
+++ b/apps/frontend/lib/apollo-client.ts
@@ -183,10 +183,28 @@ function createLink(): ApolloLink {
  */
 const cache = new InMemoryCache();
 
+/**
+ * LocalStorage namespace for the persisted Apollo cache. Bump the version
+ * suffix whenever a non-backward-compatible schema change ships so existing
+ * clients drop stale entries on next load rather than serving them while
+ * the network result arrives. See #747 (includeDead → BillLifecycle rename).
+ */
+const APOLLO_CACHE_KEY = "apollo-cache-persist-v2";
+const LEGACY_APOLLO_CACHE_KEYS = ["apollo-cache-persist"];
+
 // Initialize cache persistence for PWA offline support
 if (globalThis.window !== undefined) {
+  for (const legacyKey of LEGACY_APOLLO_CACHE_KEYS) {
+    try {
+      globalThis.localStorage.removeItem(legacyKey);
+    } catch {
+      // Storage may be unavailable (private mode, quota); the live cache
+      // still works without persistence — non-fatal.
+    }
+  }
   persistCache({
     cache,
+    key: APOLLO_CACHE_KEY,
     storage: new LocalStorageWrapper(globalThis.localStorage),
     maxSize: 1048576 * 5, // 5MB limit
     debug: process.env.NODE_ENV === "development",

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -1548,9 +1548,18 @@ export interface Bill {
   extractedAt: string;
   createdAt: string;
   updatedAt: string;
+  isDead: boolean;
+  isActive: boolean;
   votes: BillVote[];
   coAuthors: BillCoAuthor[];
   aiSummary?: BillAiSummary | null;
+}
+
+/** Mirrors the backend `BillLifecycle` enum (#747). */
+export enum BillLifecycle {
+  ACTIVE = "ACTIVE",
+  INACTIVE = "INACTIVE",
+  ALL = "ALL",
 }
 
 export interface PaginatedBills {
@@ -1575,6 +1584,8 @@ export interface BillsVars {
   authorId?: string;
   committeeId?: string;
   coAuthorId?: string;
+  /** Defaults to ACTIVE server-side when omitted. See #747. */
+  lifecycle?: BillLifecycle;
 }
 
 export interface BillIdVars {
@@ -1611,6 +1622,7 @@ export const GET_BILLS = gql`
     $authorId: ID
     $committeeId: ID
     $coAuthorId: ID
+    $lifecycle: BillLifecycle
   ) {
     bills(
       skip: $skip
@@ -1620,6 +1632,7 @@ export const GET_BILLS = gql`
       authorId: $authorId
       committeeId: $committeeId
       coAuthorId: $coAuthorId
+      lifecycle: $lifecycle
     ) {
       items {
         id
@@ -1637,6 +1650,8 @@ export const GET_BILLS = gql`
         authorName
         sourceUrl
         updatedAt
+        isDead
+        isActive
       }
       total
       hasMore
@@ -1668,6 +1683,8 @@ export const GET_BILL = gql`
       extractedAt
       createdAt
       updatedAt
+      isDead
+      isActive
       votes {
         ...BillVoteFields
       }

--- a/packages/relationaldb-provider/prisma/migrations/20260531000000_bill_is_dead/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260531000000_bill_is_dead/migration.sql
@@ -1,0 +1,18 @@
+-- Procedurally-dead flag for OpusPopuli/opuspopuli#747. Pairs with the
+-- sibling `is_active` column (added in the next migration) to give a 3-way
+-- partition of the bill corpus: active | passed/chaptered | dead.
+--
+-- Computed at sync write time from (status, currentStageId, sessionYear,
+-- lastAction, lastActionDate) by domains/bill-lifecycle.ts::isBillDead.
+-- Used by admin/research surfaces and the bill-detail banner; no list query
+-- filters on this column directly (the personalized feed + bills resolver
+-- both filter on `is_active` instead). A partial index would only earn its
+-- write amplification if a future query hit `WHERE is_dead = TRUE` at
+-- scale — none exists today.
+--
+-- Additive only — existing rows default to FALSE; the backfill script
+-- (apps/region/.../scripts/backfill-bill-is-dead.ts) flips the dead ones
+-- once after deploy in the same pass that sets is_active.
+
+ALTER TABLE "bills"
+  ADD COLUMN "is_dead" BOOLEAN NOT NULL DEFAULT FALSE;

--- a/packages/relationaldb-provider/prisma/migrations/20260531010000_bill_is_active/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260531010000_bill_is_active/migration.sql
@@ -1,0 +1,26 @@
+-- Currently-moveable flag for OpusPopuli/opuspopuli#747. Pairs with the
+-- earlier `is_dead` column to give a 3-way partition of the bill corpus:
+--
+--   is_active=TRUE,  is_dead=FALSE → moveable (citizen can still influence)
+--   is_active=FALSE, is_dead=FALSE → passed/chaptered (enacted law)
+--   is_active=FALSE, is_dead=TRUE  → vetoed, died, expired, etc.
+--
+-- The bills-list `Active / Inactive` segmented toggle filters on is_active;
+-- the personalized feed hard-excludes anything with is_active = FALSE (a
+-- chaptered bill isn't actionable either). Computed at sync write time by
+-- domains/bill-lifecycle.ts::isBillActive — true iff status starts with
+-- "Active Bill - ...".
+--
+-- Additive only — existing rows default to FALSE; the backfill script
+-- (apps/region/.../scripts/backfill-bill-is-dead.ts) now flips the live
+-- ones once after deploy in the same pass that sets is_dead.
+--
+-- Partial index on is_active = TRUE: the default bills-list filter and
+-- the ranker both want "active only", so PG can read the partial index
+-- directly. The is_active = FALSE case (Inactive segment) is exception
+-- traffic and tolerates a full scan.
+
+ALTER TABLE "bills"
+  ADD COLUMN "is_active" BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX "bills_is_active_idx" ON "bills" ("is_active") WHERE "is_active" = TRUE;

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -1309,6 +1309,19 @@ model Bill {
   aiSummaryVersion     String?   @map("ai_summary_version") @db.VarChar(20)
   aiSummaryGeneratedAt DateTime? @map("ai_summary_generated_at") @db.Timestamptz
 
+  /// Procedurally dead — vetoed without override, withdrawn, failed deadline,
+  /// inactive file, failed passage, OR from a closed session that did not
+  /// enact. Computed by domains/bill-lifecycle.ts at sync write time. One-
+  /// way transition: dead bills never re-animate. See #747.
+  isDead              Boolean   @default(false) @map("is_dead")
+  /// Currently moveable — the source has tagged the bill as actively
+  /// progressing (CA leginfo: status starts with "Active Bill - ..."). The
+  /// bills-list Active/Inactive segmented toggle filters on this column;
+  /// the personalized feed hard-excludes anything with isActive=false
+  /// (chaptered AND dead are both unactionable). Pairs with isDead to give
+  /// a 3-way partition: active | passed | dead. See #747.
+  isActive            Boolean   @default(false) @map("is_active")
+
   extractedAt DateTime @default(now()) @map("extracted_at") @db.Timestamptz
   createdAt   DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt   DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
@@ -1326,6 +1339,12 @@ model Bill {
   @@index([status])
   @@index([lastActionDate(sort: Desc)])
   @@index([needsStatusRecheck])
+  /// is_active partial index `bills_is_active_idx` (WHERE is_active = TRUE)
+  /// is defined in 20260531010000_bill_is_active/migration.sql — covers
+  /// the bills-list default + the personalized-feed hot path. Prisma can't
+  /// express partial-WHERE indexes natively. is_dead is uncovered by an
+  /// index — no query filters on it; it's used by the bill-detail banner
+  /// + admin surfaces only.
   @@map("bills")
 }
 


### PR DESCRIPTION
Closes #747.

## Summary

- New `Bill.isActive` + `Bill.isDead` columns computed at sync write time by a pure helper (`domains/bill-lifecycle.ts`). They form a 3-way partition: **active** (currently moveable) | **passed** (chaptered = signed into law) | **dead** (vetoed / died / inactive file / expired session).
- GraphQL `bills(... lifecycle: BillLifecycle = ACTIVE)` arg with three states: `ACTIVE`, `INACTIVE` (chaptered + dead), `ALL`. Single-bill `bill(id)` is unchanged so deep links still resolve for chaptered/dead bills.
- Personalized feed (`knowledge`) hard-includes only `isActive = true` — chaptered AND dead bills are equally unactionable in a "things you can act on now" surface, so neither reaches the ranker.
- Frontend: segmented Active/Inactive toggle on `/region/bills` (default Active, dark-sage `var(--color-sage-dark)` selected state, WAI-ARIA radiogroup semantics with focus ring). Per-card chips: nothing on Active, **Passed** (green) on chaptered, **Historical** (amber) on dead. Detail-page banner tones the message — *"This bill has been signed into law"* for chaptered, *"This bill is no longer active"* for dead.
- Apollo cache version bumped (`apollo-cache-persist-v2`) so existing clients drop stale `bills({includeDead: …})` entries from LocalStorage on first load after deploy.

## Why

CA produces ~2,000 bills per session; ~80% are non-moveable at any given moment (passed, vetoed, died, expired). Showing all of them by default pollutes every list view and would destroy trust in the personalized feed (epic #740) by surfacing bills the user can't act on. The 3-way partition lets the UI default to "what you can influence now" while keeping historical + passed bills one click away.

## Changes (high level)

| Area | Files |
|---|---|
| Lifecycle helper | `apps/backend/src/apps/region/src/domains/bill-lifecycle.{ts,spec.ts}` |
| Sync write path | `apps/backend/src/apps/region/src/domains/region-sync.service.ts` |
| Backfill script | `apps/backend/src/apps/region/src/scripts/backfill-bill-is-dead.ts` |
| GraphQL surface | `apps/backend/src/apps/region/src/domains/{models/bill.model.ts, region.resolver.ts, region.service.ts, region-query.service.ts}` |
| Ranker filter | `apps/backend/src/apps/knowledge/src/domains/personalized-feed/personalized-feed.service.ts` |
| Migrations | `packages/relationaldb-provider/prisma/migrations/20260531000000_bill_is_dead/`, `…010000_bill_is_active/` (both additive) + `schema.prisma` |
| Frontend | `apps/frontend/app/region/bills/{page.tsx, [id]/page.tsx}`, `lib/graphql/region.ts`, `lib/apollo-client.ts` |
| Integration tests | `apps/backend/__tests__/integration/region/region.integration.spec.ts`, `apps/backend/__tests__/integration/utils/db-fixtures.ts` |

## Test plan

- [ ] `pnpm --filter @opuspopuli/relationaldb-provider db:migrate` applies both new migrations without error
- [ ] `pnpm --filter backend test` — unit specs in scope:
  - [ ] `bill-lifecycle.spec.ts` — 46 cases incl. partition-invariant test
  - [ ] `region-query.service.spec.ts` — 4 new `lifecycle` filter cases
  - [ ] `personalized-feed.service.spec.ts` — `isActive: true` assertion
- [ ] `pnpm --filter backend test:integration --testNamePattern "747 lifecycle"` — 5/5 against real DB through live GraphQL
- [ ] Open `/region/bills` after backfill — default Active count matches `SELECT count(*) FROM bills WHERE is_active = true`; toggle to Inactive shows chaptered (Passed chip) + dead (Historical chip)
- [ ] Open a chaptered bill directly — green "Signed into law" banner above LayerNav
- [ ] Open a dead bill directly — amber "No longer active" banner above LayerNav
- [ ] Personalized feed / civic briefing — no chaptered or dead bills surface in top-N

## ⚠️ Deploy notes

### Worker rebuild gotcha

**All four backend services must be rebuilt + force-recreated together: `region`, `knowledge`, `api`, AND `region-worker`.**

The sync work that writes `Bill.isActive` / `Bill.isDead` runs inside `region-worker`, not the `region` service — they share the codebase but are separate Docker images. Recreating only `region` + `knowledge` + `api` leaves the worker on pre-#747 code, which silently writes `false` for both lifecycle columns on every bill ingestion. The Prisma client + DB columns still exist, so there's no error to alert you — bills just get the default `false` and disappear from the Active list.

**Recovery path** if this happens: rebuild + recreate `region-worker`, then re-run `backfill-bill-is-dead.ts` to fix any rows the stale worker wrote with default `false`s.

### Active-region hot-swap gotcha

The region service caches the active local plugin at startup by reading `region_plugins.enabled` once. If the `enabled` flag is toggled while the service is running (admin mutation, `cleanDatabase()` in integration tests, manual SQL), the change is **not** picked up until the next restart of `region` + `region-worker`. Symptom: `regionInfo` returns the Example fallback even after enabling California; `supportedDataTypes` drops `BILLS` + `CIVICS`. Restart both containers after re-enabling a region.

## Federation impact

Additive only:
- `Bill { isDead: Boolean!, isActive: Boolean! }` — non-nullable with DB defaults, safe for existing federation clients
- `bills(... lifecycle: BillLifecycle = ACTIVE)` — new optional arg with default. Existing callers omitting `lifecycle` continue to compile but now get filtered results (intentional behavior change; the frontend was the only consumer)
- `enum BillLifecycle { ACTIVE INACTIVE ALL }`

API Gateway recomposes on next startup; no breaking change.

## Related

- Epic: #740 (personalized bill feed)
- Depends on schema from: #741 (bill enrichment)
- Consumed by: #743 / #745 (ranking pipeline) — both updated in this PR to filter on `isActive: true`
- Follow-up infra chore: #796 (isolate integration tests from the dev DB — discovered while verifying this PR; flagged P1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)