### PR TITLE
chore(infra): test DB isolation + region active-plugin hot-swap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,8 +319,14 @@ jobs:
         env:
           # API gateway runs on port 4000 in E2E docker-compose
           API_GATEWAY_URL: http://localhost:4000
-          # Database connection for Prisma
+          # Database connection for Prisma. setup.ts derives the test DB
+          # URL by appending `_test` when INTEGRATION_DATABASE_URL is unset.
           DATABASE_URL: postgresql://postgres:your-super-secret-password@localhost:5432/postgres
+          # Match the secret the e2e backend services were started with —
+          # signAdminJwt() in utils/test-context.ts mints HS256 tokens
+          # with this key for admin-gated mutation tests (#796 hot-swap).
+          # Mirror of docker-compose-e2e.yml's AUTH_JWT_SECRET.
+          AUTH_JWT_SECRET: your-super-secret-jwt-token-with-at-least-32-characters
 
       - name: Build frontend
         run: pnpm --filter frontend build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,26 @@ Rules:
 - Unit tests (`*.spec.ts`) live co-located with the file they test.
 - Files excluded from coverage (don't add tests): `*.dto.ts`, `*.model.ts`, `*.module.ts`, `main.ts`, `bootstrap.ts`, `tracing.ts`, config files, migration scripts, seed scripts.
 
+### Integration test database isolation (#796)
+
+**Integration tests run against a dedicated `postgres_test` database, never the dev `postgres`.** The dev `postgres` DB holds your manually-synced bills, your user account, your enabled region plugins — losing that to a routine test run cost ~30 minutes of recovery per incident before this safeguard existed.
+
+How it works:
+- `apps/backend/.env` defines `INTEGRATION_DATABASE_URL` pointing at `postgres_test`
+- `apps/backend/__tests__/integration/setup.ts::bootstrapTestDatabase` runs once in `globalSetup`: creates `postgres_test` if missing (via `ensureTestDatabase()`), installs required extensions (postgis/pgvector/etc.), runs `prisma migrate deploy` against it, then swaps `process.env.DATABASE_URL` so every test worker inherits the test DB
+- `docker-compose-integration.yml` services use `postgres_test` for the same reason
+- `apps/backend/__tests__/integration/utils/db-cleanup.ts::cleanDatabase` calls `assertTestDatabase()` first, which **throws** if `DATABASE_URL` doesn't end in `_test` — belt-and-suspenders against accidental dev-DB wipes from future regressions
+
+**DO NOT**:
+- Remove the `assertTestDatabase()` guard
+- Point `INTEGRATION_DATABASE_URL` at the `postgres` database
+- Revert `docker-compose-integration.yml`'s `RELATIONAL_DB_DATABASE`/`DATABASE_URL` back to `postgres`
+- Write tests that go around `cleanDatabase()` directly via `db.someTable.deleteMany()` without calling `assertTestDatabase()` first
+
+#### Region active-plugin hot-swap — federal limitation
+
+`updateRegionPlugin` (and the recovery mutation `refreshActiveRegion`) re-load only the **local** plugin slot. The federal plugin keeps the `stateCode` resolution it picked up at boot. So if you flip from `california` (stateCode=CA) to a different state plugin live, the federal plugin's CA-shaped config placeholders remain in memory until a service restart. In practice the federal plugin almost never needs to change after boot, so this is a documented limitation, not a bug. If you do need federal to re-resolve, restart `region` + `region-worker`.
+
 ## SonarCloud quality gates
 
 - **Cognitive complexity ≤ 15** per function. Extract named helpers rather than nesting.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -106,6 +106,13 @@ RELATIONAL_DB_PASSWORD='your-super-secret-password'
 # Pool parameters are injected automatically at startup (see below)
 DATABASE_URL='postgresql://postgres:your-super-secret-password@localhost:5432/postgres'
 
+# Backend integration tests run against a DEDICATED database so they cannot
+# wipe the dev corpus. The globalSetup helper creates it lazily on first run
+# and swaps DATABASE_URL before any test worker boots. See #796 + the guard
+# in __tests__/integration/utils/db-cleanup.ts. DO NOT point this at the
+# dev `postgres` database.
+INTEGRATION_DATABASE_URL='postgresql://postgres:your-super-secret-password@localhost:5432/postgres_test'
+
 # Prisma Connection Pool Configuration
 # These are appended to DATABASE_URL as query parameters at startup.
 # PRISMA_CONNECTION_LIMIT=20    # Max connections per service (default: Prisma default ~num_cpus * 2 + 1)

--- a/apps/backend/__tests__/integration/region/region.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/region.integration.spec.ts
@@ -1539,6 +1539,115 @@ describe('Region Integration Tests', () => {
     });
   });
 
+  // ============================================
+  // GraphQL: region plugin hot-swap (#796)
+  // ============================================
+
+  describe('Region plugin hot-swap (#796)', () => {
+    /**
+     * Seeds two local region plugin rows. We mark `california` disabled
+     * initially so the service boot fell back to whatever else was
+     * enabled (the integration stack seeds `example` enabled by default).
+     */
+    async function seedRegionPlugins(): Promise<void> {
+      const db = await getDbService();
+      await db.regionPlugin.deleteMany({});
+      await db.regionPlugin.createMany({
+        data: [
+          {
+            name: 'california',
+            displayName: 'California',
+            description: 'CA state plugin',
+            version: '1.0.0',
+            enabled: false,
+            config: { stateCode: 'CA' },
+            parentRegionId: null,
+            fipsCode: '06',
+          },
+          {
+            name: 'example',
+            displayName: 'Example Region',
+            description: 'Test fallback',
+            version: '0.0.0',
+            enabled: true,
+            config: {},
+            parentRegionId: null,
+            fipsCode: null,
+          },
+        ],
+      });
+    }
+
+    const updateRegionPluginMutation = (name: string, enabled: boolean) => `
+      mutation {
+        updateRegionPlugin(name: "${name}", enabled: ${enabled}) {
+          name
+          enabled
+        }
+      }
+    `;
+
+    const regionInfoQuery = `
+      query { regionInfo { id name supportedDataTypes } }
+    `;
+
+    const refreshActiveRegionMutation = `
+      mutation { refreshActiveRegion }
+    `;
+
+    it('updateRegionPlugin makes regionInfo reflect the new active region without a service restart', async () => {
+      await seedRegionPlugins();
+
+      // Enable california via the admin mutation — this should hot-swap.
+      const updateResult = await graphqlRequest<{
+        updateRegionPlugin: { name: string; enabled: boolean };
+      }>(updateRegionPluginMutation('california', true));
+      assertNoErrors(updateResult);
+      expect(updateResult.data.updateRegionPlugin.enabled).toBe(true);
+
+      // Same process — no container restart. regionInfo should now report
+      // California, not the previously-active Example fallback.
+      const infoResult = await graphqlRequest<{
+        regionInfo: {
+          id: string;
+          name: string;
+          supportedDataTypes: string[];
+        };
+      }>(regionInfoQuery);
+      assertNoErrors(infoResult);
+      expect(infoResult.data.regionInfo.id).toBe('california');
+      expect(infoResult.data.regionInfo.supportedDataTypes).toEqual(
+        expect.arrayContaining(['BILLS', 'CIVICS']),
+      );
+    });
+
+    it('refreshActiveRegion recovers from out-of-band region_plugins changes', async () => {
+      await seedRegionPlugins();
+
+      // Simulate the out-of-band edit (manual SQL / a test that bypasses
+      // the admin mutation): flip california on directly via Prisma.
+      const db = await getDbService();
+      await db.regionPlugin.update({
+        where: { name: 'california' },
+        data: { enabled: true },
+      });
+
+      // Without refresh, the in-memory pointer would still be Example.
+      // refreshActiveRegion forces a re-read.
+      const refreshResult = await graphqlRequest<{
+        refreshActiveRegion: boolean;
+      }>(refreshActiveRegionMutation);
+      assertNoErrors(refreshResult);
+      expect(refreshResult.data.refreshActiveRegion).toBe(true);
+
+      const infoResult = await graphqlRequest<{
+        regionInfo: { id: string };
+      }>(regionInfoQuery);
+      assertNoErrors(infoResult);
+      expect(infoResult.data.regionInfo.id).toBe('california');
+    });
+  });
+
   describe('Database cleanup', () => {
     it('should have clean database at start of each test', async () => {
       await createRepresentative({ name: 'Cleanup Test Rep' });

--- a/apps/backend/__tests__/integration/region/region.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/region.integration.spec.ts
@@ -17,6 +17,7 @@ import {
   createBill,
   getDbService,
   graphqlRequest,
+  adminGraphqlRequest,
   assertNoErrors,
 } from '../utils';
 
@@ -1599,14 +1600,16 @@ describe('Region Integration Tests', () => {
       await seedRegionPlugins();
 
       // Enable california via the admin mutation — this should hot-swap.
-      const updateResult = await graphqlRequest<{
+      // updateRegionPlugin is @Roles(Role.Admin), so we mint an admin JWT.
+      const updateResult = await adminGraphqlRequest<{
         updateRegionPlugin: { name: string; enabled: boolean };
       }>(updateRegionPluginMutation('california', true));
       assertNoErrors(updateResult);
       expect(updateResult.data.updateRegionPlugin.enabled).toBe(true);
 
       // Same process — no container restart. regionInfo should now report
-      // California, not the previously-active Example fallback.
+      // California, not the previously-active Example fallback. regionInfo
+      // itself is public, so the unauthenticated request still works.
       const infoResult = await graphqlRequest<{
         regionInfo: {
           id: string;
@@ -1633,8 +1636,8 @@ describe('Region Integration Tests', () => {
       });
 
       // Without refresh, the in-memory pointer would still be Example.
-      // refreshActiveRegion forces a re-read.
-      const refreshResult = await graphqlRequest<{
+      // refreshActiveRegion forces a re-read. The mutation is admin-gated.
+      const refreshResult = await adminGraphqlRequest<{
         refreshActiveRegion: boolean;
       }>(refreshActiveRegionMutation);
       assertNoErrors(refreshResult);

--- a/apps/backend/__tests__/integration/region/region.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/region.integration.spec.ts
@@ -1561,7 +1561,32 @@ describe('Region Integration Tests', () => {
             description: 'CA state plugin',
             version: '1.0.0',
             enabled: false,
-            config: { stateCode: 'CA' },
+            // Minimum-valid DeclarativeRegionConfig: regionId + dataSources
+            // are required by PluginLoaderService.loadPlugin (it throws
+            // otherwise, and initLocalPlugins falls through to the example
+            // fallback — which is why earlier runs of these hot-swap tests
+            // saw regionInfo.id stuck at 'example'). The two data sources
+            // back the test assertion that supportedDataTypes contains
+            // BILLS + CIVICS.
+            config: {
+              regionId: 'california',
+              regionName: 'California',
+              description: 'CA state plugin (test stub)',
+              timezone: 'America/Los_Angeles',
+              stateCode: 'CA',
+              dataSources: [
+                {
+                  url: 'https://example.test/ca-bills',
+                  dataType: 'bills',
+                  contentGoal: 'Test stub — extract bills',
+                },
+                {
+                  url: 'https://example.test/ca-civics',
+                  dataType: 'civics',
+                  contentGoal: 'Test stub — extract civics',
+                },
+              ],
+            },
             parentRegionId: null,
             fipsCode: '06',
           },
@@ -1571,7 +1596,16 @@ describe('Region Integration Tests', () => {
             description: 'Test fallback',
             version: '0.0.0',
             enabled: true,
-            config: {},
+            // Same minimum-valid shape — without regionId + dataSources the
+            // loader rejects this row and the test loses its boot-time
+            // "example is active" precondition.
+            config: {
+              regionId: 'example',
+              regionName: 'Example Region',
+              description: 'Test fallback',
+              timezone: 'UTC',
+              dataSources: [],
+            },
             parentRegionId: null,
             fipsCode: null,
           },

--- a/apps/backend/__tests__/integration/setup.ts
+++ b/apps/backend/__tests__/integration/setup.ts
@@ -1,9 +1,55 @@
 import { execSync } from 'node:child_process';
 import { config } from 'dotenv';
 import { resolve } from 'node:path';
+import { ensureTestDatabase } from './utils/test-db-bootstrap';
 
 // Load environment variables from .env file (only needed when running from host)
 config({ path: resolve(__dirname, '../../.env') });
+
+/**
+ * Workspace package that owns the Prisma schema + migrations. We shell out
+ * to its bin so we get the locally-pinned Prisma 5 client (the root has a
+ * Prisma 7 binary that doesn't understand this schema). See #796.
+ */
+const RELATIONALDB_PROVIDER_PACKAGE = '@opuspopuli/relationaldb-provider';
+
+/**
+ * Swap DATABASE_URL to point at `postgres_test`, create the DB if it doesn't
+ * exist, and apply pending migrations. Runs once per `pnpm test:integration`
+ * invocation, before any worker process imports the Prisma client. Pairs
+ * with the `assertTestDatabase` guard in utils/db-cleanup.ts — together
+ * they make it impossible for integration tests to touch the dev DB.
+ */
+async function bootstrapTestDatabase(): Promise<void> {
+  const integrationUrl = process.env.INTEGRATION_DATABASE_URL;
+  if (!integrationUrl) {
+    throw new Error(
+      'INTEGRATION_DATABASE_URL is not set. Copy the value from ' +
+        'apps/backend/.env.example into apps/backend/.env. See #796.',
+    );
+  }
+  if (!/\/[A-Za-z0-9_]*_test([?#/]|$)/.test(integrationUrl)) {
+    throw new Error(
+      'INTEGRATION_DATABASE_URL must end in a *_test database name to be ' +
+        'eligible for cleanDatabase() — refusing to bootstrap. ' +
+        `Got: ${integrationUrl}`,
+    );
+  }
+  await ensureTestDatabase();
+  // Swap BEFORE any test worker imports the Prisma client. Every downstream
+  // import (DbService, helpers, the assertTestDatabase guard) reads this
+  // value at module load time.
+  process.env.DATABASE_URL = integrationUrl;
+
+  // execSync inherits process.env, which we just updated above. No need
+  // to pass `env:` explicitly — that path collides with the dotenv-loaded
+  // PORT (number) vs. ProcessEnv (string) type expectations.
+  execSync(
+    `pnpm --filter ${RELATIONALDB_PROVIDER_PACKAGE} exec prisma migrate deploy`,
+    { stdio: ['ignore', 'pipe', 'pipe'] },
+  );
+  console.log('✓ postgres_test bootstrapped + migrations applied');
+}
 
 interface ServiceConfig {
   name: string;
@@ -56,6 +102,10 @@ async function checkService(service: ServiceConfig): Promise<boolean> {
 }
 
 export default async function globalSetup() {
+  // Bootstrap the isolated test database BEFORE anything else so every
+  // downstream module sees DATABASE_URL pointed at postgres_test. See #796.
+  await bootstrapTestDatabase();
+
   const services = getServiceConfigs();
 
   // When running inside Docker, skip docker compose check

--- a/apps/backend/__tests__/integration/setup.ts
+++ b/apps/backend/__tests__/integration/setup.ts
@@ -14,6 +14,30 @@ config({ path: resolve(__dirname, '../../.env') });
 const RELATIONALDB_PROVIDER_PACKAGE = '@opuspopuli/relationaldb-provider';
 
 /**
+ * Derive a `*_test` database URL from a base DATABASE_URL by appending
+ * `_test` to the database-name segment of the URL path. Used as a CI
+ * fallback when INTEGRATION_DATABASE_URL isn't explicitly set — the
+ * GitHub Actions runner has DATABASE_URL set on the workflow but doesn't
+ * have apps/backend/.env (gitignored), so the explicit-env-only path
+ * fails CI even though the test DB can be derived deterministically.
+ *
+ * Local dev still sets INTEGRATION_DATABASE_URL explicitly (in the
+ * gitignored .env) and this fallback never fires there. The
+ * `_test`-suffix guard at the caller (and assertTestDatabase in
+ * utils/db-cleanup.ts) still enforces the safety invariant: nothing
+ * touches a database without `_test` in its name.
+ */
+function deriveTestDatabaseUrl(dbUrl: string): string {
+  const url = new URL(dbUrl);
+  const dbName = url.pathname.replace(/^\//, '');
+  if (dbName.endsWith('_test')) {
+    return dbUrl;
+  }
+  url.pathname = `/${dbName}_test`;
+  return url.toString();
+}
+
+/**
  * Swap DATABASE_URL to point at `postgres_test`, create the DB if it doesn't
  * exist, and apply pending migrations. Runs once per `pnpm test:integration`
  * invocation, before any worker process imports the Prisma client. Pairs
@@ -21,11 +45,24 @@ const RELATIONALDB_PROVIDER_PACKAGE = '@opuspopuli/relationaldb-provider';
  * they make it impossible for integration tests to touch the dev DB.
  */
 async function bootstrapTestDatabase(): Promise<void> {
-  const integrationUrl = process.env.INTEGRATION_DATABASE_URL;
+  let integrationUrl = process.env.INTEGRATION_DATABASE_URL;
   if (!integrationUrl) {
-    throw new Error(
-      'INTEGRATION_DATABASE_URL is not set. Copy the value from ' +
-        'apps/backend/.env.example into apps/backend/.env. See #796.',
+    // CI fallback: derive from DATABASE_URL by appending `_test` to the
+    // database name. Lets the workflow set only DATABASE_URL without
+    // needing a second env var for the test-DB suffix. Local dev still
+    // sets INTEGRATION_DATABASE_URL explicitly. See #796.
+    const dbUrl = process.env.DATABASE_URL;
+    if (!dbUrl) {
+      throw new Error(
+        'Neither INTEGRATION_DATABASE_URL nor DATABASE_URL is set. ' +
+          'Set INTEGRATION_DATABASE_URL explicitly (see apps/backend/.env.example), ' +
+          'or set DATABASE_URL so the test URL can be derived with a "_test" suffix. ' +
+          'See #796.',
+      );
+    }
+    integrationUrl = deriveTestDatabaseUrl(dbUrl);
+    console.log(
+      `INTEGRATION_DATABASE_URL not set; derived from DATABASE_URL → ${integrationUrl.replace(/:[^:@]+@/, ':***@')}`,
     );
   }
   if (!/\/[A-Za-z0-9_]*_test([?#/]|$)/.test(integrationUrl)) {

--- a/apps/backend/__tests__/integration/utils/db-cleanup.ts
+++ b/apps/backend/__tests__/integration/utils/db-cleanup.ts
@@ -22,6 +22,14 @@ export async function getDbService(): Promise<DbService> {
  * Cleans all data from the database.
  * Should be called in beforeEach() to ensure test isolation.
  *
+ * Refuses to run unless DATABASE_URL points at a `*_test` database — this
+ * is the safety primitive for OpusPopuli/opuspopuli#796. Before this guard
+ * existed, every `pnpm test:integration` run wiped the dev DB (~30 min
+ * recovery loop per run). If the guard fires unexpectedly, check
+ * `apps/backend/.env`'s `INTEGRATION_DATABASE_URL` and that
+ * `globalSetup` is swapping `DATABASE_URL` to it — do NOT remove the
+ * guard.
+ *
  * @example
  * ```typescript
  * describe('User tests', () => {
@@ -36,8 +44,30 @@ export async function getDbService(): Promise<DbService> {
  * ```
  */
 export async function cleanDatabase(): Promise<void> {
+  assertTestDatabase();
   const db = await getDbService();
   await db.cleanDatabase();
+}
+
+/**
+ * Throws if the in-process DATABASE_URL doesn't end in a `_test` database
+ * name. Belt-and-suspenders against accidentally pointing the integration
+ * suite at the dev DB. Exported so callers that go around cleanDatabase()
+ * (e.g. raw db.bill.deleteMany in a future test) can opt into the same
+ * guard.
+ */
+export function assertTestDatabase(): void {
+  const url = process.env.DATABASE_URL;
+  // `_test` followed by start-of-query, fragment, trailing slash, or end of
+  // string. Trailing slash isn't valid Postgres, but tolerating it makes
+  // the guard robust against URL-builder noise.
+  if (!url || !/\/[A-Za-z0-9_]*_test([?#/]|$)/.test(url)) {
+    throw new Error(
+      `cleanDatabase() refused: DATABASE_URL must point at a *_test database. ` +
+        `Got: ${url ?? '<unset>'}. ` +
+        `This guard protects the dev DB — see OpusPopuli/opuspopuli#796.`,
+    );
+  }
 }
 
 /**

--- a/apps/backend/__tests__/integration/utils/index.ts
+++ b/apps/backend/__tests__/integration/utils/index.ts
@@ -99,6 +99,9 @@ export {
   // GraphQL request functions (through API Gateway)
   graphqlRequest,
   authenticatedGraphqlRequest,
+  // Admin-auth helpers for @Roles(Role.Admin) resolvers
+  signAdminJwt,
+  adminGraphqlRequest,
   // Direct service access (bypasses gateway - for debugging)
   directServiceRequest,
   // CSRF token management

--- a/apps/backend/__tests__/integration/utils/test-context.ts
+++ b/apps/backend/__tests__/integration/utils/test-context.ts
@@ -210,6 +210,58 @@ export async function authenticatedGraphqlRequest<T = unknown>(
 }
 
 /**
+ * Mint an HS256 JWT for an admin user, suitable for hitting resolvers
+ * gated by `@Roles(Role.Admin)`. Matches the payload shape that the
+ * backend's `JwtStrategy.validate()` expects (sub / email /
+ * app_metadata.roles).
+ *
+ * Reads `AUTH_JWT_SECRET` from process.env — the same value the running
+ * backend services were started with. In docker-compose-e2e.yml that's
+ * the well-known dev secret; in local dev it's whatever's in
+ * apps/backend/.env. If the env var is missing, throws so the test
+ * fails loudly rather than producing an invalid token.
+ *
+ * Returns the bearer token string. Pass to `authenticatedGraphqlRequest`.
+ */
+export function signAdminJwt(
+  options: { userId?: string; email?: string } = {},
+): string {
+  // Lazy-require so non-auth-using tests don't pay the import cost.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const jwt = require('jsonwebtoken') as typeof import('jsonwebtoken');
+  const secret = process.env.AUTH_JWT_SECRET;
+  if (!secret) {
+    throw new Error(
+      'AUTH_JWT_SECRET is not set; cannot sign an admin JWT for the test. ' +
+        'Ensure docker-compose-e2e.yml or apps/backend/.env provides it.',
+    );
+  }
+  const payload = {
+    sub: options.userId ?? 'integration-test-admin',
+    email: options.email ?? 'admin@opuspopuli.local',
+    app_metadata: { roles: ['admin'] },
+    user_metadata: { department: '', clearance: '' },
+  };
+  return jwt.sign(payload, secret, {
+    algorithm: 'HS256',
+    expiresIn: '1h',
+  });
+}
+
+/**
+ * Convenience wrapper for admin-only mutations: signs a fresh admin JWT
+ * and routes through `authenticatedGraphqlRequest`. Use for `@Roles(Role.Admin)`
+ * resolvers like `updateRegionPlugin`, `refreshActiveRegion`,
+ * `invalidateManifest`, `syncRegionData`.
+ */
+export async function adminGraphqlRequest<T = unknown>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<{ data?: T; errors?: Array<{ message: string }> }> {
+  return authenticatedGraphqlRequest<T>(query, variables, signAdminJwt());
+}
+
+/**
  * Makes a GraphQL request directly to a microservice (bypasses API Gateway).
  * Uses HMAC authentication. Useful for debugging or isolated service testing.
  *

--- a/apps/backend/__tests__/integration/utils/test-db-bootstrap.ts
+++ b/apps/backend/__tests__/integration/utils/test-db-bootstrap.ts
@@ -1,0 +1,110 @@
+/**
+ * Lazy `postgres_test` database bootstrap for the backend integration suite
+ * (#796). Existing local containers were initialised before
+ * `supabase/init/01-create-test-db.sql` existed, so this helper creates the
+ * test database on first run if it isn't already there. Postgres doesn't
+ * support `CREATE DATABASE IF NOT EXISTS`, hence the explicit `pg_database`
+ * check.
+ *
+ * Called from `globalSetup` so it runs once per `pnpm test:integration`
+ * invocation, well before any worker process imports the Prisma client.
+ *
+ * Why a fresh `pg` client and not the Prisma client: this runs BEFORE we
+ * point DATABASE_URL at the test DB, so we need a temporary admin
+ * connection to the default `postgres` database to issue the CREATE.
+ */
+
+import { Client } from 'pg';
+
+const ADMIN_DB_NAME = 'postgres';
+const TEST_DB_NAME = 'postgres_test';
+
+/**
+ * Extensions required by the application schema. Postgres extensions are
+ * per-database, so a freshly-created `postgres_test` needs them installed
+ * before `prisma migrate deploy` runs (the schema declares geography
+ * columns, vectors, uuid generators, etc.). Mirrors what the supabase
+ * docker init scripts install into the default `postgres` DB.
+ *
+ * `supabase_vault` is best-effort — it may not be available on every
+ * Postgres image (e.g. plain `postgres:17` in CI), so failure to install
+ * it is logged but not fatal. Tests that depend on vault should mock the
+ * vault layer or skip on non-supabase images.
+ */
+const REQUIRED_EXTENSIONS = [
+  'pgcrypto',
+  'pg_trgm',
+  'postgis',
+  'uuid-ossp',
+  'vector',
+  'supabase_vault',
+] as const;
+
+function getAdminUrl(): string {
+  const adminUrl = process.env.DATABASE_URL;
+  if (!adminUrl) {
+    throw new Error(
+      'ensureTestDatabase: DATABASE_URL must be set so we know how to connect ' +
+        'to the admin Postgres instance before creating the test DB.',
+    );
+  }
+  return adminUrl;
+}
+
+/**
+ * Ensure `postgres_test` exists and has every extension the application
+ * schema depends on (postgis, pgvector, etc.). No-op if already present.
+ * Returns the connection URL to the test DB so the caller can swap
+ * `DATABASE_URL`.
+ */
+export async function ensureTestDatabase(): Promise<string> {
+  const adminUrl = getAdminUrl();
+  await createDatabaseIfMissing(adminUrl);
+  const testDbUrl = adminUrl.replace(
+    new RegExp(`/${ADMIN_DB_NAME}([?#]|$)`),
+    `/${TEST_DB_NAME}$1`,
+  );
+  await installExtensions(testDbUrl);
+  return testDbUrl;
+}
+
+async function createDatabaseIfMissing(adminUrl: string): Promise<void> {
+  const client = new Client({ connectionString: adminUrl });
+  try {
+    await client.connect();
+    const result = await client.query(
+      'SELECT 1 FROM pg_database WHERE datname = $1',
+      [TEST_DB_NAME],
+    );
+    if (result.rowCount === 0) {
+      // `CREATE DATABASE` can't be parameterized; the name is a hardcoded
+      // identifier, so safe to interpolate. Don't expose this helper to
+      // anything that takes user input.
+      await client.query(`CREATE DATABASE ${TEST_DB_NAME}`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+async function installExtensions(testDbUrl: string): Promise<void> {
+  const client = new Client({ connectionString: testDbUrl });
+  try {
+    await client.connect();
+    for (const ext of REQUIRED_EXTENSIONS) {
+      // Identifier is from the hardcoded REQUIRED_EXTENSIONS list, so safe
+      // to interpolate. `IF NOT EXISTS` makes this idempotent across runs.
+      try {
+        await client.query(`CREATE EXTENSION IF NOT EXISTS "${ext}"`);
+      } catch (err) {
+        // Best-effort — extensions like supabase_vault aren't available on
+        // every Postgres image. Vault-dependent tests should mock the
+        // vault layer on those images.
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`  (skipped extension "${ext}": ${msg})`);
+      }
+    }
+  } finally {
+    await client.end();
+  }
+}

--- a/apps/backend/docker/scripts/db-migrate.sh
+++ b/apps/backend/docker/scripts/db-migrate.sh
@@ -15,6 +15,27 @@ PGHOST="${RELATIONAL_DB_HOST:-opuspopuli-db}"
 PGUSER="${RELATIONAL_DB_USERNAME:-postgres}"
 PGDB="${RELATIONAL_DB_DATABASE:-postgres}"
 
+# Ensure the target database exists before running migrations. Required for
+# the integration compose stack (#796) where DATABASE_URL points at
+# `postgres_test`, which may not yet exist on a developer's local install.
+# Postgres has no `CREATE DATABASE IF NOT EXISTS`, hence the conditional.
+# Skips quietly for the production-shaped `postgres` database, which is
+# created by the Postgres image itself.
+if [ "$PGDB" != "postgres" ]; then
+  echo "Ensuring database \"$PGDB\" exists..."
+  EXISTS=$(psql -h "$PGHOST" -U "$PGUSER" -d postgres -tA -c \
+    "SELECT 1 FROM pg_database WHERE datname='$PGDB'")
+  if [ "$EXISTS" != "1" ]; then
+    psql -h "$PGHOST" -U "$PGUSER" -d postgres -c "CREATE DATABASE \"$PGDB\""
+  fi
+  echo "Installing required extensions into \"$PGDB\"..."
+  for ext in pgcrypto pg_trgm postgis uuid-ossp vector supabase_vault; do
+    psql -h "$PGHOST" -U "$PGUSER" -d "$PGDB" -v ON_ERROR_STOP=0 -c \
+      "CREATE EXTENSION IF NOT EXISTS \"$ext\"" || \
+      echo "  (skipped $ext — not installed in this Postgres image)"
+  done
+fi
+
 echo "Running Prisma migrate deploy..."
 npx prisma migrate deploy
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -144,6 +144,7 @@
     "@types/node": "^25.0.1",
     "@types/passport": "^1.0.16",
     "@types/passport-jwt": "^4.0.1",
+    "@types/pg": "^8.20.0",
     "@types/supertest": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
@@ -237,6 +237,106 @@ describe('RegionSyncService', () => {
     });
   });
 
+  describe('active-plugin hot-swap (#796)', () => {
+    it('re-queries region_plugins and swaps the active local plugin on refresh', async () => {
+      mockDb.regionPlugin.findMany.mockClear();
+      mockRegistry.unregister.mockClear();
+
+      await service.refreshActiveLocalPlugin();
+
+      // Re-reads the enabled rows
+      expect(mockDb.regionPlugin.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { enabled: true, name: { not: 'federal' } },
+        }),
+      );
+      // Tears the slot down before re-init
+      expect(mockRegistry.unregister).toHaveBeenCalled();
+    });
+
+    it('setRegionPluginEnabled triggers a hot-swap after the DB update', async () => {
+      mockDb.regionPlugin.update.mockResolvedValue({
+        name: 'california',
+        displayName: 'California',
+        description: null,
+        version: '1.0.0',
+        enabled: true,
+        parentRegionId: null,
+        fipsCode: '06',
+      } as never);
+      mockDb.regionPlugin.findMany.mockClear();
+
+      await service.setRegionPluginEnabled('california', true);
+
+      // The findMany after the update is the refresh — proves the in-memory
+      // pointer hot-swaps without a service restart.
+      expect(mockDb.regionPlugin.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { enabled: true, name: { not: 'federal' } },
+        }),
+      );
+    });
+
+    it('throws when no local plugin is available after refresh', async () => {
+      mockRegistry.getLocal.mockReturnValueOnce(undefined);
+
+      await expect(service.refreshActiveLocalPlugin()).rejects.toThrow(
+        /No local region plugin available/,
+      );
+    });
+
+    it('setRegionPluginEnabled triggers a hot-swap when disabling a plugin', async () => {
+      // Same shape as the enable test — proves the refresh fires regardless
+      // of direction, not just when enabled flips true.
+      mockDb.regionPlugin.update.mockResolvedValue({
+        name: 'california',
+        displayName: 'California',
+        description: null,
+        version: '1.0.0',
+        enabled: false,
+        parentRegionId: null,
+        fipsCode: '06',
+      } as never);
+      mockDb.regionPlugin.findMany.mockClear();
+      mockRegistry.unregister.mockClear();
+
+      await service.setRegionPluginEnabled('california', false);
+
+      expect(mockRegistry.unregister).toHaveBeenCalled();
+      expect(mockDb.regionPlugin.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { enabled: true, name: { not: 'federal' } },
+        }),
+      );
+    });
+
+    it('back-to-back toggles end in the state of the last call', async () => {
+      // Two rapid awaits — the in-memory state after the second resolve
+      // should reflect the second call's enabled value, not the first. This
+      // smoke-tests that the refresh doesn't have an order-of-operations
+      // bug where the first refresh's tail races with the second's head.
+      mockDb.regionPlugin.update.mockResolvedValue({
+        name: 'california',
+        displayName: 'California',
+        description: null,
+        version: '1.0.0',
+        enabled: true,
+        parentRegionId: null,
+        fipsCode: '06',
+      } as never);
+      // Clear the boot-time refresh that beforeEach() already triggered.
+      mockRegistry.unregister.mockClear();
+      mockDb.regionPlugin.findMany.mockClear();
+
+      await service.setRegionPluginEnabled('california', false);
+      await service.setRegionPluginEnabled('california', true);
+
+      // Two toggles → two unregister + two findMany cycles.
+      expect(mockRegistry.unregister).toHaveBeenCalledTimes(2);
+      expect(mockDb.regionPlugin.findMany).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('syncAll', () => {
     it('should sync all data types from all plugins and return results', async () => {
       const results = await service.syncAll();

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -280,7 +280,43 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
   async onModuleInit(): Promise<void> {
     await this.resolveApiKeysFromVault();
     await this.syncRegionConfigs();
+    const { localConfigRow, allLocalConfigRows } =
+      await this.fetchLocalPluginConfigs();
 
+    const stateCode = (
+      localConfigRow?.config as Record<string, unknown> | undefined
+    )?.stateCode as string | undefined;
+
+    await this.initFederalPlugin(stateCode);
+    await this.reloadActiveLocalPlugin(allLocalConfigRows, localConfigRow);
+  }
+
+  /**
+   * Re-read the `region_plugins` table and swap the in-memory active local
+   * plugin to match. Called from `setRegionPluginEnabled` (so admin toggles
+   * take effect without a service restart) and from the public
+   * `refreshActiveLocalPlugin` recovery mutation. See #796 for the failure
+   * mode this prevents.
+   *
+   * Federal plugin is NOT refreshed here — if the toggled plugin changed
+   * the federal `stateCode`, the federal placeholders will still hold the
+   * boot-time value. That's a known limitation; restart the service if
+   * federal needs to re-resolve.
+   */
+  async refreshActiveLocalPlugin(): Promise<void> {
+    const { localConfigRow, allLocalConfigRows } =
+      await this.fetchLocalPluginConfigs();
+    await this.reloadActiveLocalPlugin(allLocalConfigRows, localConfigRow);
+  }
+
+  private async fetchLocalPluginConfigs(): Promise<{
+    localConfigRow: { config: unknown } | undefined;
+    allLocalConfigRows: {
+      name: string;
+      config: unknown;
+      parentRegionId: string | null;
+    }[];
+  }> {
     const allLocalConfigRows = await this.db.regionPlugin.findMany({
       where: { enabled: true, name: { not: 'federal' } },
     });
@@ -290,12 +326,30 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     const localConfigRow =
       allLocalConfigRows.find((r) => !r.parentRegionId) ??
       allLocalConfigRows[0];
+    return { localConfigRow, allLocalConfigRows };
+  }
 
-    const stateCode = (
-      localConfigRow?.config as Record<string, unknown> | undefined
-    )?.stateCode as string | undefined;
+  private async reloadActiveLocalPlugin(
+    allLocalConfigRows: {
+      name: string;
+      config: unknown;
+      parentRegionId: string | null;
+    }[],
+    localConfigRow: { config: unknown } | undefined,
+  ): Promise<void> {
+    // Tear down the existing local registry before re-init so we never
+    // re-register the same plugin name twice (registerLocal would internally
+    // destroy and replace, but draining first keeps the logs honest).
+    //
+    // Concurrency: between this unregister() and the initLocalPlugins()
+    // below, the local plugin slot is empty. Any reader of
+    // `regionService.getRegionInfo()` (or any sync job started in that
+    // window) will see no active plugin and throw. Probability is low —
+    // refresh fires only on admin toggles or the recovery mutation, neither
+    // of which is in a hot path. If concurrent admin toggles ever become a
+    // real concern, swap to a build-then-atomic-swap pattern.
+    await this.pluginRegistry.unregister();
 
-    await this.initFederalPlugin(stateCode);
     await this.initLocalPlugins(allLocalConfigRows);
 
     const localPlugin = this.pluginRegistry.getLocal();
@@ -318,7 +372,7 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
       (p) => new RegExp(p, 'i'),
     );
     this.logger.log(
-      `RegionSyncService initialized — local: ${this.regionService.getProviderName()} (${info.name}), ` +
+      `RegionSyncService active plugin: ${this.regionService.getProviderName()} (${info.name}), ` +
         `federal: ${this.pluginRegistry.getFederal() ? 'loaded' : 'not loaded'}`,
     );
   }
@@ -508,6 +562,11 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     this.logger.log(
       `Region plugin "${name}" ${enabled ? 'enabled' : 'disabled'}`,
     );
+    // Hot-swap the active plugin so the change takes effect immediately —
+    // without this, the in-memory registry stays on whatever it loaded at
+    // boot and `regionInfo` keeps returning the stale active region. See
+    // #796 for the failure mode this fixes.
+    await this.refreshActiveLocalPlugin();
     return toRegionPluginRow(row);
   }
 

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -916,6 +916,22 @@ export class RegionResolver {
     return this.regionService.setRegionPluginEnabled(name, enabled);
   }
 
+  /**
+   * Force a re-read of `region_plugins` and hot-swap the active local
+   * plugin in memory. Recovery mutation for cases where the DB changed
+   * out of band — e.g. integration tests, manual SQL — and the in-memory
+   * active region drifted from the table. The normal `updateRegionPlugin`
+   * mutation now triggers this automatically; only call this directly
+   * when the table changed without going through the mutation. See #796.
+   */
+  @Mutation(() => Boolean)
+  @UseGuards(AuthGuard)
+  @Roles(Role.Admin)
+  async refreshActiveRegion(): Promise<boolean> {
+    await this.regionService.refreshActiveLocalPlugin();
+    return true;
+  }
+
   @Mutation(() => RegionSyncJobModel)
   @UseGuards(AuthGuard)
   @Roles(Role.Admin)

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -301,6 +301,16 @@ export class RegionDomainService {
     return this.syncService.setRegionPluginEnabled(name, enabled);
   }
 
+  /**
+   * Re-read `region_plugins` and hot-swap the active local plugin. Setup
+   * for the admin recovery mutation (#796): if the table was changed out
+   * of band (manual SQL, integration tests cleaning up, etc.) the in-
+   * memory active region drifts. This forces a re-sync.
+   */
+  refreshActiveLocalPlugin(): Promise<void> {
+    return this.syncService.refreshActiveLocalPlugin();
+  }
+
   listRegionPlugins(): Promise<RegionPluginRow[]> {
     return this.syncService.listRegionPlugins();
   }

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -29,8 +29,16 @@ x-backend-env: &backend-env
   RELATIONAL_DB_PORT: 5432
   RELATIONAL_DB_USERNAME: postgres
   RELATIONAL_DB_PASSWORD: your-super-secret-password
-  RELATIONAL_DB_DATABASE: postgres
-  DATABASE_URL: postgresql://postgres:your-super-secret-password@opuspopuli-db:5432/postgres
+  # E2E backend services target `postgres_test` so they share a database with
+  # the integration test workers (globalSetup pins to postgres_test, either
+  # explicitly via INTEGRATION_DATABASE_URL or by deriving from DATABASE_URL).
+  # Without this, tests write fixtures to postgres_test and backend services
+  # read empty results from `postgres` — manifesting as 0-count totals and
+  # 'Cannot return null for non-nullable Query.findUser' errors. Mirrors the
+  # docker-compose-integration.yml setup; db-migrate creates the database via
+  # the conditional CREATE-IF-NOT-EXISTS block in db-migrate.sh. See #796.
+  RELATIONAL_DB_DATABASE: postgres_test
+  DATABASE_URL: postgresql://postgres:your-super-secret-password@opuspopuli-db:5432/postgres_test
   REDIS_URL: redis://redis:6379
   SUPABASE_URL: http://supabase-kong:8000
   SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -25,8 +25,12 @@ x-backend-env: &backend-env
   RELATIONAL_DB_PORT: 5432
   RELATIONAL_DB_USERNAME: postgres
   RELATIONAL_DB_PASSWORD: your-super-secret-password
-  RELATIONAL_DB_DATABASE: postgres
-  DATABASE_URL: postgresql://postgres:your-super-secret-password@opuspopuli-db:5432/postgres
+  # Integration stack targets `postgres_test` so it can't wipe dev state.
+  # The test-runner's globalSetup bootstraps the DB before any service
+  # connects. Pairs with the cleanDatabase() guard in db-cleanup.ts.
+  # See OpusPopuli/opuspopuli#796. DO NOT revert to `postgres`.
+  RELATIONAL_DB_DATABASE: postgres_test
+  DATABASE_URL: postgresql://postgres:your-super-secret-password@opuspopuli-db:5432/postgres_test
   REDIS_URL: redis://redis:6379
   SUPABASE_URL: http://supabase-kong:8000
   SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,9 @@ importers:
       '@types/passport-jwt':
         specifier: ^4.0.1
         version: 4.0.1
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
       '@types/supertest':
         specifier: ^6.0.2
         version: 6.0.3
@@ -6037,6 +6040,9 @@ packages:
 
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
+
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -18121,7 +18127,6 @@ snapshots:
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
-    optional: true
 
   '@types/nodemailer@7.0.11':
     dependencies:
@@ -18153,11 +18158,17 @@ snapshots:
 
   '@types/pg-pool@2.0.7':
     dependencies:
-      '@types/pg': 8.15.6
+      '@types/pg': 8.20.0
 
   '@types/pg@8.15.6':
     dependencies:
       '@types/node': 25.8.0
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 25.9.1
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 

--- a/supabase/init/01-create-test-db.sql
+++ b/supabase/init/01-create-test-db.sql
@@ -1,0 +1,12 @@
+-- Create the `postgres_test` database used by the backend integration suite.
+-- Pairs with apps/backend/__tests__/integration/utils/test-db-bootstrap.ts,
+-- which lazily creates the same DB at first test run for already-initialised
+-- containers (this script only runs on fresh installs).
+--
+-- See OpusPopuli/opuspopuli#796 for the full design rationale. Reverting this
+-- so integration tests target the main `postgres` database WILL wipe dev
+-- state — there is a guard in cleanDatabase() that throws against any DB
+-- whose name doesn't end in `_test`.
+
+SELECT 'CREATE DATABASE postgres_test'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'postgres_test')\gexec


### PR DESCRIPTION
Closes #796.

## Summary

Two related fixes from the same incident discovered during #747 verification — every `pnpm test:integration` run was wiping dev state, and admin region toggles didn't take effect until a service restart. Each incident cost ~30 min of recovery. This PR closes both.

### Part A — Test DB isolation

- New `postgres_test` database, created lazily by `ensureTestDatabase()` from `globalSetup` (existing containers) and by `supabase/init/01-create-test-db.sql` (fresh containers)
- Required extensions (postgis, pgvector, etc.) installed on first run; `supabase_vault` is best-effort so non-supabase Postgres images still pass
- `globalSetup` swaps `process.env.DATABASE_URL` to the test DB before any worker imports the Prisma client; runs `prisma migrate deploy` against it
- **New `cleanDatabase()` guard** (`assertTestDatabase`) throws if `DATABASE_URL` doesn't end in a `*_test` database — belt-and-suspenders against future regressions reintroducing the dev-DB wipe
- `docker-compose-integration.yml` switched to `postgres_test`; `db-migrate.sh` creates the DB + installs extensions before the prisma migrate step (so the docker-only flow also works on existing dev installs)

### Part B — Region active-plugin hot-swap

- `setRegionPluginEnabled` now calls `refreshActiveLocalPlugin()` after the DB update — admin toggles take effect in-memory immediately, no service restart needed
- New admin `refreshActiveRegion` mutation for the out-of-band-change recovery case (manual SQL, integration tests cleaning up, etc.)
- Boot path refactored: `onModuleInit` and the hot-swap share one `reloadActiveLocalPlugin()` helper. Behaviour-preserving at boot (verified by all pre-existing region unit tests)
- Federal plugin is **intentionally not refreshed** — `stateCode` placeholders resolved at boot stay until restart. Documented in CLAUDE.md and the JSDoc

## Why

Yesterday's session ran the same loop ~3 times:
1. Sync 10 bills → 2. Verify UI → 3. Run integration tests → 4. Lose user account / bills / region_plugins → 5. Re-recover for 30 min → 6. Goto 1

Every cycle traced back to one design hole (integration tests sharing the dev DB) and one in-memory caching bug (active-region pointer set at boot only). Fixing them together unblocks the next dev who runs an integration test with valuable dev state.

## Test plan

- [x] **`pnpm jest src/apps/region/src/domains/region-sync.service.spec.ts`** — 60/60 region-sync specs incl. 5 new hot-swap specs (enable, disable, recovery, missing plugin, back-to-back toggles)
- [x] **Full `pnpm test:integration` against dev stack**: 48 failures via GraphQL round-trip (expected — gateway services still point at dev DB on the host workflow; the post-#796 path is the integration compose stack), and **0 rows changed in the dev DB**
- [x] **Live verification**: restarted region container clean with the refactored `onModuleInit`; `regionInfo` returns California, `refreshActiveRegion` mutation present in the federated schema with `@Roles(Role.Admin)` guard active (returns 403 without admin context)
- [x] **Guard regression test**: walked the regex through all the expected URL shapes (`/postgres` rejected, `/postgres_test`, `/postgres_test?ssl=1`, `/postgres_test/`, `/postgres_test#foo`, `/postgres_testing` rejected, `/analytics_test` accepted)

To exercise the full integration suite the right way (the post-#796 supported flow):
```bash
docker compose -f docker-compose-integration.yml --profile test run test-runner
```

## The central safety claim

Pre/post snapshots of the dev `postgres` database after running the full integration suite from this branch:

```
PRE:  bills=251 users=1 region_plugins_enabled=3 representatives=45
POST: bills=251 users=1 region_plugins_enabled=3 representatives=45
```

Identical. The guard works.

## Federation impact

Additive only:
- New `refreshActiveRegion: Boolean!` admin mutation

API Gateway recomposes on next startup; no breaking change.

## Deploy notes

- **Existing local containers**: the supabase init script (`01-create-test-db.sql`) only runs on fresh containers. Existing installs will hit `ensureTestDatabase()` from `globalSetup` (host workflow) or the new `db-migrate.sh` logic (docker workflow). No manual action required.
- **CI**: the `INTEGRATION_DATABASE_URL` env var needs to be set (or `apps/backend/.env` populated from `.env.example`). The post-#796 invocation is `docker compose -f docker-compose-integration.yml --profile test run test-runner` — unchanged from before, but now targets the isolated DB.
- **The `assertTestDatabase` guard is permanent armor**. If anyone tries to revert the test DB routing later, every integration run aborts cleanly with a pointer back to this PR.

## Related

- Discovered 2026-06-01 during #747 post-review verification (the PR that introduced the integration tests that surfaced the failure)
- Pairs with the deploy-notes section of #747's PR, which documented both gotchas as workarounds. After this lands, those workarounds are no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)