### PR TITLE
feat(infra): containerized DB backup + restore (#220)

### DIFF
--- a/.env.backup.example
+++ b/.env.backup.example
@@ -1,0 +1,86 @@
+# ============================================================
+# Backup overlay configuration
+#
+# Consumed by: docker-compose-backup.yml
+#
+# Setup:
+#   1. Copy this file: cp .env.backup.example .env.backup
+#   2. Edit the values for your environment (paths differ by host)
+#   3. Reference it via --env-file when bringing up the overlay:
+#
+#        docker compose -f docker-compose-uat.yml \
+#                       -f docker-compose-backup.yml \
+#                       --env-file .env.backup \
+#                       up -d opuspopuli-backup
+#
+# See docs/guides/backup-recovery.md for the full operator guide.
+# ============================================================
+
+# ─────────────────────────────────────────────────────────────
+# REQUIRED
+# ─────────────────────────────────────────────────────────────
+
+# Host filesystem path where the bind-mounted /backups directory
+# lives in the container. Snapshot files written here survive
+# `docker compose down -v` (because it's host-side, not a docker
+# volume). The 2026-06-06 docker disk image resize incident is the
+# reason this MUST be a host path, NOT a docker named volume.
+#
+# Examples:
+#   Local dev (external SSD):  /Volumes/OpusPopuli/Development/db-backups
+#   Mac Studio production:     /Users/opuspopuli/backups
+#   Mac Studio external drive: /Volumes/Backups/opuspopuli
+#
+# The directory must exist and be writable by the user running
+# docker. Create it before starting the overlay:
+#   mkdir -p /Volumes/OpusPopuli/Development/db-backups
+BACKUPS_DIR_HOST=/Volumes/OpusPopuli/Development/db-backups
+
+# Schema-version tag baked into snapshot filenames so restore can
+# detect drift between snapshot-time and restore-time schema. Should
+# be set to the git SHA of the deployed code. Typical pattern:
+#
+#   GIT_SHA=$(git rev-parse HEAD)
+#
+# Falls back to "unknown" if unset, but unknown means restore can't
+# warn about schema drift — set this in any environment that runs
+# scheduled backups.
+GIT_SHA=
+
+# ─────────────────────────────────────────────────────────────
+# RECOMMENDED (have sensible defaults but worth setting per env)
+# ─────────────────────────────────────────────────────────────
+
+# How many days of snapshots to keep. The daily run deletes anything
+# older after a successful backup.
+#
+#   Local dev:   7    (external SSD has space; quick iteration)
+#   UAT:         14   (longer historical for regression triage)
+#   Production:  30   (more recovery headroom; storage is cheap)
+RETENTION_DAYS=7
+
+# Timezone for the daily 03:00 schedule. supercronic respects TZ
+# and computes the next fire time accordingly. Set to the timezone
+# the operations team works in.
+TZ=America/Los_Angeles
+
+# ─────────────────────────────────────────────────────────────
+# OPTIONAL (defaults usually correct)
+# ─────────────────────────────────────────────────────────────
+
+# Lock-wait behavior for ad-hoc runs that overlap the scheduled
+# backup. `true` blocks until the scheduled run finishes; `false`
+# fails fast with a "skipped:lock_held" log line. Default `true` —
+# better to wait than to silently skip a manual backup.
+# BACKUP_LOCK_WAIT=true
+
+# supercronic version to install in the image. Bump here to upgrade
+# without editing the Dockerfile. SHA1 pin is in the Dockerfile.
+# SUPERCRONIC_VERSION=v0.2.31
+
+# Override the postgres connection target. Defaults match the
+# opuspopuli-db service in docker-compose.yml. Change only for
+# non-standard deployments (e.g. external postgres).
+# BACKUP_PGHOST=opuspopuli-db
+# BACKUP_PGUSER=postgres
+# BACKUP_PGDATABASE=postgres

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,0 +1,41 @@
+# Backup service for the opuspopuli stack.
+#
+# Pinned to the SAME image tag as the production DB so that pg_dump /
+# pg_restore versions are guaranteed to match the server. The 17.x
+# series introduced format-version changes in custom dumps; using a
+# different pg_dump major than the server would silently produce
+# files the server can't restore.
+FROM supabase/postgres:17.6.1.091
+
+# supercronic — minimal-deps cron replacement we use as the in-container
+# scheduler. Single static Go binary, logs jobs to stdout (so
+# `docker logs opuspopuli-backup` shows scheduler activity directly,
+# no syslog forwarding gymnastics).
+#
+# Build args isolate version + checksum so they can be bumped via
+# compose --build-arg without editing this file. Pin to a known SHA
+# to detect tampering of the upstream binary.
+ARG SUPERCRONIC_VERSION=v0.2.31
+ARG SUPERCRONIC_ARCH=linux-amd64
+ARG SUPERCRONIC_SHA1=fb4242e9d28528a76b70d878dbf69fe8d94ba7d2
+
+ADD https://github.com/aptible/supercronic/releases/download/${SUPERCRONIC_VERSION}/supercronic-${SUPERCRONIC_ARCH} /usr/local/bin/supercronic
+RUN echo "${SUPERCRONIC_SHA1}  /usr/local/bin/supercronic" | sha1sum -c - \
+    && chmod +x /usr/local/bin/supercronic
+
+# Bake the scripts into the image so it works standalone. The compose
+# bind-mount over /scripts lets us iterate on script content without
+# rebuilds during local development.
+COPY scripts /scripts
+COPY crontab /crontab
+COPY entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /scripts/*.sh /entrypoint.sh
+
+# flock, gzip, find, date are already in the base image.
+
+# Default UID is the postgres image's `postgres` user; we keep that
+# rather than rooting so file ownership on the bind-mounted /backups
+# matches expected non-privileged ownership on the host.
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/backup/README.md
+++ b/backup/README.md
@@ -1,0 +1,186 @@
+# `backup/` — opuspopuli backup service
+
+Container image, scripts, and supercronic schedule for the daily
+PostgreSQL backup that runs alongside every opuspopuli environment.
+
+**Operator-facing guide**: see [`docs/guides/backup-recovery.md`](../docs/guides/backup-recovery.md)
+for setup, ad-hoc commands, and restore procedures.
+
+**Compose**: see [`docker-compose-backup.yml`](../docker-compose-backup.yml)
+for the overlay that pulls this image into a running stack.
+
+**Env vars**: see [`.env.backup.example`](../.env.backup.example) for
+the contract between this service and the host environment.
+
+This README documents the contents of the directory for anyone
+adding or modifying the backup service itself.
+
+---
+
+## Contents
+
+| Path | Role |
+|------|------|
+| `Dockerfile` | Builds the backup container. Inherits from `supabase/postgres:17.6.1.091` so `pg_dump` / `pg_restore` versions exactly match the production server. Installs supercronic as the in-container scheduler. |
+| `entrypoint.sh` | Container entrypoint. Dispatches between **scheduler mode** (no args → supercronic + crontab) and **one-shot mode** (args → exec args). Ad-hoc invocations use one-shot. |
+| `crontab` | supercronic-format schedule. Currently a single line: daily 03:00 backup. Edit here to change the schedule for all environments at once. |
+| `scripts/backup-db.sh` | The daily backup. `pg_dump --format=custom` piped through `gzip -9` into a host bind-mounted directory. Atomic rename via `.partial`, cross-mode `flock`, JSON-structured log lines, configurable retention. |
+| `scripts/restore-db.sh` | Operator-triggered restore. Two modes (`--quick` and `--full`) for schema-match vs schema-drift cases. Takes the same lock as backup-db.sh so a scheduled backup can't race a restore. |
+
+## How the pieces fit together
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Host filesystem                                                 │
+│                                                                  │
+│    ${BACKUPS_DIR_HOST}/                                          │
+│    ├── opuspopuli-db-<sha>-<ts>.dump.gz   ← scheduled or ad-hoc  │
+│    ├── opuspopuli-db-<sha>-<ts>.dump.gz                          │
+│    ├── backup.log                          ← JSON lines, append  │
+│    └── .backup.lock                        ← flock file          │
+└──────────────────────────────────────────────────────────────────┘
+                        ▲
+                        │ bind-mount → /backups
+                        │
+┌─────────────────── opuspopuli-backup container ──────────────────┐
+│                                                                  │
+│   entrypoint.sh                                                  │
+│      │                                                           │
+│      ├── no args ─→  supercronic /crontab                        │
+│      │                  │                                        │
+│      │                  └── fires `/scripts/backup-db.sh` daily  │
+│      │                                                           │
+│      └── argv  ─→  exec argv                                     │
+│                       └── `/scripts/backup-db.sh` (ad-hoc)       │
+│                       └── `/scripts/restore-db.sh ...` (restore) │
+│                                                                  │
+└──────────────────────────────────────────────────────────────────┘
+                        │
+                        │ docker network: opuspopuli-network
+                        ▼
+                 opuspopuli-db (postgres)
+```
+
+## Design decisions worth knowing before you change anything
+
+### Base image is pinned to the production DB image
+
+`FROM supabase/postgres:17.6.1.091` (not generic `postgres:17-alpine`).
+This guarantees `pg_dump` and `pg_restore` versions exactly match the
+server. PostgreSQL custom-format dumps are not forward-compatible
+across major-version mismatches; downgrade-side bugs are silent and
+costly. If you bump the DB image version anywhere else in the stack,
+bump it here too.
+
+### Backups land on a host bind mount, never a docker named volume
+
+The 2026-06-06 incident: a Docker Desktop disk image resize wiped
+every docker named volume, including the prod database. If backups
+had lived in a named volume the same operation would have wiped
+them too. Bind-mounting to a host filesystem path (or external
+drive) means backups survive any docker volume operation.
+
+The `${BACKUPS_DIR_HOST:?...}` compose syntax fails the `up` command
+loudly if the var isn't set — this is intentional, to surface
+operator misconfiguration immediately.
+
+### Scripts are baked into the image AND bind-mounted
+
+The Dockerfile `COPY scripts /scripts` (image has its own copy) AND
+the compose file binds `./backup/scripts:/scripts:ro` (overrides
+with the on-disk version at runtime). This means:
+
+- **Production**: image is self-contained, can run without the repo present
+- **Development**: edits to scripts take effect on container restart
+  without a rebuild
+
+The compose-side bind mount wins at runtime, so dev iteration is
+fast and prod is hermetic.
+
+### supercronic chosen over stock cron
+
+- Logs job output to stdout — `docker logs opuspopuli-backup` shows
+  the scheduler activity directly, no syslog forwarding gymnastics
+- Single static binary, no PAM/syslog dependencies
+- Built-in `--lock` flag (we use `flock` in the script for the same
+  effect, but the option exists)
+- Sane PID 1 signal handling — `docker compose stop` is clean
+
+### Cross-mode flock between backup-db.sh and restore-db.sh
+
+Both scripts `flock -x` on `${BACKUPS_DIR}/.backup.lock`. This means:
+- Two concurrent backup runs serialize (or fail fast with
+  `BACKUP_LOCK_WAIT=false`)
+- A restore blocks scheduled backups while it's in progress
+- A scheduled backup at 03:00 won't fire mid-restore
+
+### `--full` restore doesn't auto-migrate
+
+After a `--full` restore, the schema is at the snapshot's git_sha,
+not necessarily current head. If they differ, the script prints
+the follow-up `db-migrate` command for the operator to run rather
+than trying to do it itself.
+
+The reason: invoking docker exec from inside this container to run
+the migrate container requires mounting the docker socket, which is
+a privilege escalation surface we don't want for a backup service.
+Better to keep the operator in the loop for the schema-bump step.
+
+## Adding a new scheduled job
+
+If you ever want to add a second scheduled task (e.g. a separate
+audit-log dump):
+
+1. Add a new script to `scripts/`
+2. Add a line to `crontab` referencing it
+3. Rebuild the image; deploy via `docker compose up -d --build`
+
+The image is small enough that rebuilds are quick. Don't try to
+reuse the same script for multiple schedules — keep one
+script-per-purpose for clarity.
+
+## Bumping supercronic
+
+The version + SHA1 are build args in the Dockerfile. To bump:
+
+```bash
+# Fetch the new SHA1
+curl -sL https://github.com/aptible/supercronic/releases/download/<NEW_VERSION>/supercronic-linux-amd64 | sha1sum
+
+# Update SUPERCRONIC_VERSION and SUPERCRONIC_SHA1 in Dockerfile,
+# then rebuild and verify
+docker compose -f docker-compose-uat.yml \
+               -f docker-compose-backup.yml \
+               build --no-cache opuspopuli-backup
+```
+
+The SHA1 pin is a supply-chain safeguard — if upstream is ever
+compromised, the build will fail loud at install time.
+
+## Why no R2 sync yet
+
+Deferred to a follow-up issue. Two reasons:
+
+1. Vault-first secrets refactor (#811) isn't done; R2 creds would
+   need to be available cleanly to the container, and threading
+   them through env vars before #811 is finished introduces tech
+   debt that we'd have to unwind later.
+2. R2 sync turns this from a single-service into a two-step pipeline
+   (snapshot → upload), which adds failure modes (network, R2 quota,
+   credential expiry) worth thinking about in their own design pass.
+
+Until then, manual off-site copies (Time Machine, `rclone` cron from
+the host, or a one-off `aws s3 cp`) cover the geographic-redundancy
+gap.
+
+## Why no encryption yet
+
+The DB currently contains civic public data only. Once we onboard
+real users with PII, the snapshot file contains personal data
+that the unencrypted-at-rest snapshot doesn't protect adequately.
+Adding pg_dump encryption (or wrapping with `age` / `gpg`) at that
+point is straightforward — it's a single pipe step in `backup-db.sh`
+and a matching pipe in `restore-db.sh`.
+
+For MVP launch, encryption is documented as a known gap in the
+operator guide and tracked for v1.1.

--- a/backup/crontab
+++ b/backup/crontab
@@ -1,0 +1,5 @@
+# supercronic crontab — fired in the container's TZ (set via the
+# TZ env var in docker-compose.yml; default America/Los_Angeles).
+#
+# m h dom mon dow command
+0 3 * * * /scripts/backup-db.sh

--- a/backup/entrypoint.sh
+++ b/backup/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Container entrypoint. Two roles, picked by argv:
+#
+#   No args     → scheduler mode: supercronic reads /crontab and fires
+#                  jobs at the scheduled times.
+#
+#   Any args    → one-shot mode: exec the args. This is how operators
+#                  trigger ad-hoc runs:
+#                    docker compose run --rm opuspopuli-backup \
+#                        /scripts/backup-db.sh
+#                    docker compose run --rm opuspopuli-backup \
+#                        /scripts/restore-db.sh --quick /backups/...
+set -euo pipefail
+
+if [[ $# -gt 0 ]]; then
+  exec "$@"
+fi
+
+echo "{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"event\":\"scheduler_start\",\"crontab\":\"$(cat /crontab | tr '\n' ';' | sed 's/"/\\"/g')\"}"
+
+# -passthrough-logs streams scheduled job stdout/stderr through
+# supercronic to container stdout, so backup-db.sh's JSON log lines
+# surface in `docker logs opuspopuli-backup`.
+exec /usr/local/bin/supercronic -passthrough-logs /crontab

--- a/backup/scripts/backup-db.sh
+++ b/backup/scripts/backup-db.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Daily PostgreSQL backup for the opuspopuli stack.
+#
+# Modes:
+#   - Scheduled: invoked by supercronic per /crontab (daily, 03:00 in TZ)
+#   - Ad-hoc:    docker compose run --rm opuspopuli-backup /scripts/backup-db.sh
+#
+# Output:    opuspopuli-db-<git_sha>-<UTC_timestamp>.dump.gz in $BACKUPS_DIR
+# Retention: deletes files older than $RETENTION_DAYS (default 7)
+#
+# Concurrency: takes a flock on $BACKUPS_DIR/.backup.lock so scheduled +
+# ad-hoc runs never overlap. Ad-hoc blocks until the scheduled run
+# finishes (set BACKUP_LOCK_WAIT=false to fail fast instead).
+#
+# Exit codes:
+#   0  ok
+#   1  pg_dump or gzip failed
+#   3  $BACKUPS_DIR not writable
+#   (retention-prune failures are non-fatal — logged, not propagated)
+
+set -euo pipefail
+
+BACKUPS_DIR="${BACKUPS_DIR:-/backups}"
+LOCK_FILE="${BACKUPS_DIR}/.backup.lock"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+LOCK_WAIT="${BACKUP_LOCK_WAIT:-true}"
+GIT_SHA="${GIT_SHA:-unknown}"
+
+log_json() {
+  local line
+  line="{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"event\":\"backup\",$1}"
+  echo "${line}"
+  echo "${line}" >> "${BACKUPS_DIR}/backup.log" 2>/dev/null || true
+}
+
+# 1. Validate destination is writable before touching the DB.
+if [[ ! -w "${BACKUPS_DIR}" ]]; then
+  log_json "\"status\":\"error\",\"reason\":\"dest_not_writable\",\"dir\":\"${BACKUPS_DIR}\""
+  exit 3
+fi
+
+# 2. Acquire the cross-mode lock. Scheduled + ad-hoc share it.
+flock_opts="-x"
+[[ "${LOCK_WAIT}" == "false" ]] && flock_opts="-xn"
+exec 9>"${LOCK_FILE}"
+if ! flock ${flock_opts} 9; then
+  log_json "\"status\":\"skipped\",\"reason\":\"lock_held\""
+  exit 0
+fi
+
+# 3. Compute snapshot filename. Atomic rename pattern via .partial.
+TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+FILENAME="opuspopuli-db-${GIT_SHA}-${TIMESTAMP}.dump.gz"
+TMP_DUMP="${BACKUPS_DIR}/.${FILENAME}.partial"
+FINAL_PATH="${BACKUPS_DIR}/${FILENAME}"
+ERR_FILE="${BACKUPS_DIR}/.backup.lasterr"
+START_MS="$(date +%s%3N)"
+
+cleanup() {
+  rm -f "${TMP_DUMP}"
+}
+trap cleanup EXIT
+
+# 4. pg_dump (custom format) → gzip → partial file. PG* vars in env.
+#    --compress=0 hands raw bytes to gzip -9 instead of pg_dump's
+#    internal compressor — gzip -9 produces ~5% smaller archives.
+if ! pg_dump --format=custom --no-owner --no-acl --compress=0 2> "${ERR_FILE}" \
+     | gzip -9 > "${TMP_DUMP}"; then
+  STDERR_TRUNCATED="$(tr '\n' ' ' < "${ERR_FILE}" 2>/dev/null | head -c 500 | sed 's/"/\\"/g')"
+  log_json "\"status\":\"error\",\"reason\":\"pg_dump_or_gzip_failed\",\"stderr\":\"${STDERR_TRUNCATED}\""
+  exit 1
+fi
+
+mv "${TMP_DUMP}" "${FINAL_PATH}"
+BYTES="$(stat -c%s "${FINAL_PATH}" 2>/dev/null || stat -f%z "${FINAL_PATH}")"
+DURATION_MS=$(( $(date +%s%3N) - START_MS ))
+
+# 5. Prune snapshots older than retention window. Failures non-fatal.
+PURGED=0
+PURGE_LIST="$(mktemp)"
+if find "${BACKUPS_DIR}" -maxdepth 1 -name 'opuspopuli-db-*.dump.gz' \
+   -type f -mtime "+${RETENTION_DAYS}" -print -delete > "${PURGE_LIST}" 2>/dev/null; then
+  PURGED=$(wc -l < "${PURGE_LIST}" | tr -d ' ')
+else
+  log_json "\"status\":\"warn\",\"reason\":\"retention_prune_failed\""
+fi
+rm -f "${PURGE_LIST}"
+
+# 6. Success log. Both stdout (docker logs) and appended to backup.log.
+log_json "\"status\":\"ok\",\"file\":\"${FILENAME}\",\"bytes\":${BYTES},\"duration_ms\":${DURATION_MS},\"git_sha\":\"${GIT_SHA}\",\"retention_days\":${RETENTION_DAYS},\"retention_purged\":${PURGED}"

--- a/backup/scripts/restore-db.sh
+++ b/backup/scripts/restore-db.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Restore the postgres database from an opuspopuli pg_dump snapshot.
+#
+# Two modes, picked by the operator based on whether the snapshot's
+# schema git_sha matches the current code's schema:
+#
+#   --quick  (fast path)
+#     Assumes the snapshot's schema is identical to the current head.
+#     Runs `pg_restore --clean --if-exists` in place. Fast.
+#     Use when restoring from a snapshot taken against the same git SHA
+#     as the currently-deployed code.
+#
+#   --full   (drift-safe path)
+#     Drops + recreates the target DB, then pg_restores schema + data
+#     from the dump. If the snapshot's git_sha is older than current,
+#     the script prints the follow-up `db-migrate` command to bring the
+#     schema forward to current head.
+#
+# Usage:
+#   docker compose run --rm opuspopuli-backup /scripts/restore-db.sh \
+#       --quick /backups/opuspopuli-db-<sha>-<ts>.dump.gz [--yes]
+#   docker compose run --rm opuspopuli-backup /scripts/restore-db.sh \
+#       --full  /backups/opuspopuli-db-<sha>-<ts>.dump.gz [--yes]
+#
+# Concurrency: takes the same flock as backup-db.sh so a scheduled
+# backup can't land on a half-restored DB.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<EOF
+Usage: restore-db.sh (--quick | --full) <snapshot.dump.gz> [--yes]
+
+  --quick   pg_restore --clean --if-exists; assumes schemas match
+  --full    drop + recreate target DB, then pg_restore schema + data
+  --yes     skip the destructive-action confirmation prompt
+
+Snapshot filename shape: opuspopuli-db-<git_sha>-<timestamp>.dump.gz
+EOF
+  exit 64
+}
+
+MODE=""
+SNAPSHOT=""
+ASSUME_YES=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --quick) MODE="quick"; shift ;;
+    --full)  MODE="full";  shift ;;
+    --yes)   ASSUME_YES=true; shift ;;
+    -h|--help) usage ;;
+    -*) echo "Unknown flag: $1" >&2; usage ;;
+    *)  [[ -n "${SNAPSHOT}" ]] && { echo "Multiple snapshot files passed" >&2; usage; }
+        SNAPSHOT="$1"; shift ;;
+  esac
+done
+
+[[ -z "${MODE}" || -z "${SNAPSHOT}" ]] && usage
+[[ ! -f "${SNAPSHOT}" ]] && { echo "Snapshot not found: ${SNAPSHOT}" >&2; exit 1; }
+
+BACKUPS_DIR="${BACKUPS_DIR:-/backups}"
+LOCK_FILE="${BACKUPS_DIR}/.backup.lock"
+TARGET_DB="${PGDATABASE:-postgres}"
+TARGET_HOST="${PGHOST:-opuspopuli-db}"
+CURRENT_SHA="${GIT_SHA:-unknown}"
+
+# Pull the snapshot's git_sha out of the filename for drift detection.
+SNAPSHOT_BASENAME="$(basename "${SNAPSHOT}")"
+SNAPSHOT_SHA="$(echo "${SNAPSHOT_BASENAME}" | sed -nE 's/^opuspopuli-db-([^-]+)-[0-9TZ]+\.dump\.gz$/\1/p')"
+[[ -z "${SNAPSHOT_SHA}" ]] && SNAPSHOT_SHA="unknown"
+
+cat >&2 <<EOF
+Restore plan:
+  Snapshot file   : ${SNAPSHOT_BASENAME}
+  Snapshot git_sha: ${SNAPSHOT_SHA}
+  Current git_sha : ${CURRENT_SHA}
+  Mode            : ${MODE}
+  Target DB       : ${TARGET_DB}@${TARGET_HOST}
+
+  This will DESTROY all data currently in ${TARGET_DB}.
+
+EOF
+
+# Quick-mode + sha mismatch is operator-error-prone. Warn loudly.
+if [[ "${MODE}" == "quick" && "${SNAPSHOT_SHA}" != "${CURRENT_SHA}" && \
+      "${SNAPSHOT_SHA}" != "unknown" && "${CURRENT_SHA}" != "unknown" ]]; then
+  cat >&2 <<EOF
+WARNING: snapshot git_sha (${SNAPSHOT_SHA}) does not match current (${CURRENT_SHA}).
+         --quick assumes the schemas are identical. If they're not, the
+         restore will leave the DB in an inconsistent state. Consider
+         --full instead.
+
+EOF
+fi
+
+if [[ "${ASSUME_YES}" != "true" ]]; then
+  read -r -p "Proceed? (yes/no): " REPLY
+  [[ "${REPLY}" != "yes" ]] && { echo "Aborted." >&2; exit 0; }
+fi
+
+# Cross-mode lock — blocks backups while we restore.
+exec 9>"${LOCK_FILE}"
+if ! flock -x 9; then
+  echo "Failed to acquire restore lock" >&2
+  exit 1
+fi
+
+START_MS="$(date +%s%3N)"
+
+log_json() {
+  local line
+  line="{\"ts\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"event\":\"restore\",$1}"
+  echo "${line}"
+  echo "${line}" >> "${BACKUPS_DIR}/backup.log" 2>/dev/null || true
+}
+
+case "${MODE}" in
+  quick)
+    if ! gunzip -c "${SNAPSHOT}" | pg_restore --clean --if-exists \
+         --no-owner --no-acl --dbname="${TARGET_DB}" --exit-on-error; then
+      log_json "\"status\":\"error\",\"mode\":\"quick\",\"snapshot\":\"${SNAPSHOT_BASENAME}\""
+      exit 1
+    fi
+    ;;
+
+  full)
+    # Postgres can't drop a database you're connected to, so issue the
+    # DDL against `template1`. Terminate any other connections first so
+    # the DROP DATABASE doesn't block on stragglers.
+    if ! PGDATABASE="template1" psql -v ON_ERROR_STOP=1 <<SQL
+SELECT pg_terminate_backend(pid)
+  FROM pg_stat_activity
+  WHERE datname = '${TARGET_DB}' AND pid <> pg_backend_pid();
+DROP DATABASE IF EXISTS "${TARGET_DB}";
+CREATE DATABASE "${TARGET_DB}";
+SQL
+    then
+      log_json "\"status\":\"error\",\"mode\":\"full\",\"phase\":\"drop_create\",\"snapshot\":\"${SNAPSHOT_BASENAME}\""
+      exit 1
+    fi
+
+    if ! gunzip -c "${SNAPSHOT}" | pg_restore \
+         --no-owner --no-acl --dbname="${TARGET_DB}" --exit-on-error; then
+      log_json "\"status\":\"error\",\"mode\":\"full\",\"phase\":\"pg_restore\",\"snapshot\":\"${SNAPSHOT_BASENAME}\""
+      exit 1
+    fi
+
+    # Schema-drift advisory — operator follow-up.
+    if [[ "${SNAPSHOT_SHA}" != "${CURRENT_SHA}" && \
+          "${SNAPSHOT_SHA}" != "unknown" && "${CURRENT_SHA}" != "unknown" ]]; then
+      cat >&2 <<EOF
+
+Restore complete. NOTE: snapshot git_sha (${SNAPSHOT_SHA}) is older
+than current (${CURRENT_SHA}). Apply Prisma migrations to bring the
+schema forward to current head:
+
+    docker compose -f docker-compose-uat.yml run --rm db-migrate
+
+EOF
+    fi
+    ;;
+esac
+
+DURATION_MS=$(( $(date +%s%3N) - START_MS ))
+log_json "\"status\":\"ok\",\"mode\":\"${MODE}\",\"snapshot\":\"${SNAPSHOT_BASENAME}\",\"snapshot_sha\":\"${SNAPSHOT_SHA}\",\"current_sha\":\"${CURRENT_SHA}\",\"duration_ms\":${DURATION_MS}"

--- a/docker-compose-backup.yml
+++ b/docker-compose-backup.yml
@@ -1,0 +1,97 @@
+# Backup overlay for the opuspopuli stack.
+#
+# Single env-agnostic compose file used in every environment (local
+# dev, UAT, Mac Studio production). Env-specific values flow through
+# env vars / .env files — see .env.backup.example for the contract.
+#
+# Brought up as an overlay alongside whichever app stack is running:
+#
+#   Local dev:
+#     docker compose -f docker-compose.yml \
+#                    -f docker-compose-backup.yml \
+#                    --env-file .env.backup \
+#                    up -d opuspopuli-backup
+#
+#   UAT:
+#     docker compose -f docker-compose-uat.yml \
+#                    -f docker-compose-backup.yml \
+#                    --env-file .env.backup \
+#                    up -d opuspopuli-backup
+#
+#   Mac Studio production:
+#     docker compose -f docker-compose-prod.yml \
+#                    -f docker-compose-backup.yml \
+#                    --env-file .env.backup.prod \
+#                    up -d opuspopuli-backup
+#
+# Ad-hoc commands use the same overlay, swapping `up -d` for `run --rm`:
+#
+#   Manual backup (works even if the scheduler container is down):
+#     docker compose -f docker-compose-uat.yml \
+#                    -f docker-compose-backup.yml \
+#                    --env-file .env.backup \
+#                    run --rm opuspopuli-backup /scripts/backup-db.sh
+#
+#   Restore (quick — assumes schema matches snapshot):
+#     docker compose -f docker-compose-uat.yml \
+#                    -f docker-compose-backup.yml \
+#                    --env-file .env.backup \
+#                    run --rm opuspopuli-backup \
+#                    /scripts/restore-db.sh --quick \
+#                    /backups/opuspopuli-db-<sha>-<ts>.dump.gz
+#
+# See docs/guides/backup-recovery.md for the full operator guide.
+
+services:
+  opuspopuli-backup:
+    build:
+      context: ./backup
+      dockerfile: Dockerfile
+      args:
+        SUPERCRONIC_VERSION: ${SUPERCRONIC_VERSION:-v0.2.31}
+    container_name: opuspopuli-backup
+    depends_on:
+      opuspopuli-db:
+        condition: service_healthy
+    environment:
+      # DB connection — defaults match opuspopuli-db across all envs.
+      PGHOST: ${BACKUP_PGHOST:-opuspopuli-db}
+      PGUSER: ${BACKUP_PGUSER:-postgres}
+      PGPASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      PGDATABASE: ${BACKUP_PGDATABASE:-postgres}
+      # Schema version tag baked into snapshot filenames so restore can
+      # detect drift between snapshot-time and restore-time code.
+      GIT_SHA: ${GIT_SHA:-unknown}
+      # Where the container writes snapshots — bind-mounted from host.
+      BACKUPS_DIR: /backups
+      # How many days of snapshots to retain. Older files are deleted
+      # by the daily run after a successful pg_dump.
+      RETENTION_DAYS: ${RETENTION_DAYS:-7}
+      # Cron timezone — 03:00 in this TZ is when the scheduled backup
+      # fires. supercronic respects the TZ env var.
+      TZ: ${TZ:-America/Los_Angeles}
+      # If true, ad-hoc runs block waiting for the scheduled run to
+      # finish. If false, they fail fast when the lock is held.
+      BACKUP_LOCK_WAIT: ${BACKUP_LOCK_WAIT:-true}
+    volumes:
+      # Host path holding the snapshots. The :? syntax fails the
+      # `compose up` command at start time with a clear error if
+      # the var isn't set — surfaces operator misconfiguration
+      # immediately rather than silently bind-mounting an anonymous
+      # volume that would vanish on container teardown.
+      - ${BACKUPS_DIR_HOST:?BACKUPS_DIR_HOST must be set — see .env.backup.example}:/backups
+      # Scripts bind-mounted read-only from the repo so iteration
+      # during development doesn't require a container rebuild.
+      # Production deployments can omit this and rely on the baked-in
+      # copy from the image (the Dockerfile COPYs the same files).
+      - ./backup/scripts:/scripts:ro
+    networks:
+      - opuspopuli-network
+    restart: unless-stopped
+
+# Reuses the existing opuspopuli-network defined by the main compose
+# file. Declared as external so this overlay does not create a
+# duplicate network when brought up alongside an existing stack.
+networks:
+  opuspopuli-network:
+    external: true

--- a/docs/guides/backup-recovery.md
+++ b/docs/guides/backup-recovery.md
@@ -1,0 +1,382 @@
+# Backup and Recovery
+
+This guide covers the daily backup and disaster recovery procedures
+for the opuspopuli PostgreSQL database. It assumes you have a
+running opuspopuli stack — see [Getting Started](./getting-started.md)
+for stack setup.
+
+## Architecture overview
+
+A dedicated `opuspopuli-backup` container runs alongside the main
+stack as an overlay. It uses an in-container scheduler (supercronic)
+to fire a daily `pg_dump` at 03:00 (operator timezone) and writes
+gzipped custom-format snapshots to a host filesystem path you choose.
+
+The overlay is environment-agnostic — the same `docker-compose-backup.yml`
+file works against local dev, UAT, and Mac Studio production. Only
+the values in `.env.backup` differ per environment.
+
+```
+opuspopuli-backup container
+   ├── supercronic (scheduler) — fires daily at 03:00
+   ├── scripts/backup-db.sh    — pg_dump + gzip + retention
+   ├── scripts/restore-db.sh   — operator-triggered restore
+   └── bind mount → ${BACKUPS_DIR_HOST}/  (snapshots live here)
+```
+
+## One-time setup (per environment)
+
+### 1. Create the backup destination directory
+
+The directory must exist on the host and be writable by the user
+running docker.
+
+```bash
+# Local dev — typically the external SSD
+mkdir -p /Volumes/OpusPopuli/Development/db-backups
+
+# Mac Studio production
+mkdir -p /Users/opuspopuli/backups
+```
+
+### 2. Configure environment variables
+
+```bash
+cp .env.backup.example .env.backup
+$EDITOR .env.backup
+```
+
+Required variables:
+
+| Variable | What to set |
+|----------|-------------|
+| `BACKUPS_DIR_HOST` | The directory you just created |
+| `GIT_SHA` | Output of `git rev-parse HEAD` (lets restore detect schema drift) |
+
+Recommended:
+
+| Variable | Local dev | UAT | Production |
+|----------|-----------|-----|------------|
+| `RETENTION_DAYS` | `7` | `14` | `30` |
+| `TZ` | `America/Los_Angeles` | `America/Los_Angeles` | `America/Los_Angeles` |
+
+See [`.env.backup.example`](../../.env.backup.example) for the full
+contract including optional overrides.
+
+### 3. Bring up the backup service
+
+The overlay is brought up alongside whichever app stack is already
+running. The command pattern is the same across environments — only
+the app-stack compose file changes.
+
+```bash
+# Local dev (against the default docker-compose.yml)
+docker compose -f docker-compose.yml \
+               -f docker-compose-backup.yml \
+               --env-file .env.backup \
+               up -d opuspopuli-backup
+
+# UAT
+docker compose -f docker-compose-uat.yml \
+               -f docker-compose-backup.yml \
+               --env-file .env.backup \
+               up -d opuspopuli-backup
+
+# Mac Studio production
+docker compose -f docker-compose-prod.yml \
+               -f docker-compose-backup.yml \
+               --env-file .env.backup.prod \
+               up -d opuspopuli-backup
+```
+
+Verify the scheduler started:
+
+```bash
+docker logs opuspopuli-backup
+# Expected first line:
+# {"ts":"...","event":"scheduler_start","crontab":"0 3 * * * /scripts/backup-db.sh;"}
+```
+
+The backup service is now running. The first scheduled snapshot
+will fire at 03:00 in the configured timezone.
+
+## Daily automated backup
+
+The scheduler runs `backup-db.sh` once per day at 03:00 in
+`${TZ}`. Each run:
+
+1. Acquires a `flock` on `${BACKUPS_DIR_HOST}/.backup.lock` (prevents
+   overlap with ad-hoc backups or restores)
+2. Runs `pg_dump --format=custom --no-owner --no-acl` against
+   `opuspopuli-db`, piping through `gzip -9` to a `.partial` file
+3. Atomically renames the `.partial` → final filename:
+   `opuspopuli-db-<git_sha>-<UTC_timestamp>.dump.gz`
+4. Deletes snapshots older than `RETENTION_DAYS`
+5. Appends a structured JSON log line to both container stdout AND
+   `${BACKUPS_DIR_HOST}/backup.log`
+
+### Watching the daily run
+
+```bash
+# Live scheduler output (no other noise)
+docker logs -f opuspopuli-backup
+
+# History (queryable with jq)
+tail -f /Volumes/OpusPopuli/Development/db-backups/backup.log | jq -c .
+
+# Recent successful backups
+jq -c 'select(.status == "ok") | {ts, file, bytes, duration_ms}' \
+   /Volumes/OpusPopuli/Development/db-backups/backup.log | tail -7
+```
+
+### What success looks like
+
+```json
+{
+  "ts": "2026-06-08T10:00:00Z",
+  "event": "backup",
+  "status": "ok",
+  "file": "opuspopuli-db-8b0cb16-20260608T100000Z.dump.gz",
+  "bytes": 3852177,
+  "duration_ms": 4129,
+  "git_sha": "8b0cb16",
+  "retention_days": 7,
+  "retention_purged": 1
+}
+```
+
+### What failure looks like
+
+```json
+{
+  "ts": "2026-06-08T10:00:00Z",
+  "event": "backup",
+  "status": "error",
+  "reason": "pg_dump_or_gzip_failed",
+  "stderr": "..."
+}
+```
+
+Other reasons you might see: `dest_not_writable` (host directory
+permissions changed), `lock_held` (a previous run is still in
+flight — usually self-resolving), `retention_prune_failed`
+(non-fatal; backup itself succeeded, retention sweep didn't).
+
+## Ad-hoc backup (on demand)
+
+Run a backup outside the scheduled time — useful right before risky
+operations, immediately after a meaningful sync completes, or for a
+"snapshot what we have right now" moment:
+
+```bash
+docker compose -f docker-compose-uat.yml \
+               -f docker-compose-backup.yml \
+               --env-file .env.backup \
+               run --rm opuspopuli-backup /scripts/backup-db.sh
+```
+
+This shares the same lock as the scheduled run. By default it
+blocks until any in-flight scheduled backup finishes. To fail
+fast instead, set `BACKUP_LOCK_WAIT=false` in `.env.backup`.
+
+The resulting snapshot lands in the same `${BACKUPS_DIR_HOST}`
+directory with the same naming shape as scheduled runs — there's
+no distinction once written.
+
+## Restore
+
+> **Restore is destructive.** It drops all data currently in the
+> target database and replaces it with the snapshot's contents.
+> Both modes prompt for confirmation unless `--yes` is passed.
+
+### Pick a mode
+
+| Mode | When to use | Behavior |
+|------|-------------|----------|
+| `--quick` | Snapshot's `git_sha` matches your current code | `pg_restore --clean --if-exists` in place |
+| `--full` | Snapshot is older than current code (schema may have drifted) | Drop + recreate DB, restore from snapshot, operator runs migrations afterward |
+
+The script extracts the snapshot's `git_sha` from the filename and
+warns you if it doesn't match `${GIT_SHA}` from the env. When in
+doubt, use `--full`.
+
+### `--quick` restore (matching schema)
+
+```bash
+docker compose -f docker-compose-uat.yml \
+               -f docker-compose-backup.yml \
+               --env-file .env.backup \
+               run --rm opuspopuli-backup \
+               /scripts/restore-db.sh --quick \
+               /backups/opuspopuli-db-8b0cb16-20260608T100000Z.dump.gz
+```
+
+Behind the scenes: `gunzip | pg_restore --clean --if-exists` against
+the current database. Existing tables get cleared row-by-row before
+the restore data lands. Fast — typically under a minute for a
+sub-GB snapshot.
+
+### `--full` restore (schema may have drifted)
+
+```bash
+docker compose -f docker-compose-uat.yml \
+               -f docker-compose-backup.yml \
+               --env-file .env.backup \
+               run --rm opuspopuli-backup \
+               /scripts/restore-db.sh --full \
+               /backups/opuspopuli-db-1d4e5f2-20260520T100000Z.dump.gz
+```
+
+Behind the scenes:
+1. Terminate all other connections to the target DB
+2. `DROP DATABASE` + `CREATE DATABASE` (against `template1`)
+3. `gunzip | pg_restore` schema + data into the empty target
+
+If the snapshot's git_sha is older than current, the script prints
+a follow-up command for you to bring the schema forward:
+
+```bash
+docker compose -f docker-compose-uat.yml run --rm db-migrate
+```
+
+Run that after the restore completes. New columns added in
+migrations since the snapshot was taken will get their defaults;
+any data backfills required by migrations must be re-applied
+manually.
+
+### Skipping confirmation prompts
+
+For scripted use (e.g. an automated regression test that round-trips
+backups), add `--yes`:
+
+```bash
+... run --rm opuspopuli-backup \
+    /scripts/restore-db.sh --quick --yes /backups/...
+```
+
+## Verification checklist (after restore)
+
+Sanity-check the restored DB before resuming app traffic:
+
+```bash
+# 1. Container connects to the DB
+docker exec opuspopuli-db psql -U postgres -d postgres -c "SELECT 1;"
+
+# 2. Row counts look reasonable
+docker exec opuspopuli-db psql -U postgres -d postgres -c "
+  SELECT 'representatives' AS t, COUNT(*) FROM representatives
+  UNION ALL SELECT 'bills', COUNT(*) FROM bills
+  UNION ALL SELECT 'meetings', COUNT(*) FROM meetings;"
+
+# 3. Latest content recency matches the snapshot's age
+docker exec opuspopuli-db psql -U postgres -d postgres -c "
+  SELECT MAX(updated_at) FROM bills;"
+
+# 4. The schema matches what you expect
+#    For --full restores against an older snapshot, this should
+#    match the snapshot's git_sha BEFORE you run migrations.
+docker exec opuspopuli-db psql -U postgres -d postgres -c "
+  SELECT version FROM _prisma_migrations ORDER BY started_at DESC LIMIT 1;"
+```
+
+## Disaster recovery — full machine loss
+
+This guide covers the database side. For total machine loss (Mac
+Studio fails, lost in transit, etc.):
+
+1. **Acquire replacement hardware** — Mac Studio or equivalent
+2. **Install macOS + Docker Desktop** to a usable state
+3. **Restore the latest snapshot** from off-site backup (currently
+   manual; R2 sync is a deferred feature)
+4. **Clone the repo + check out the appropriate branch**
+5. **Restore `.env` files** from your secrets vault (see [`auth-security.md`](./auth-security.md))
+6. **Bring up the stack** per [Getting Started](./getting-started.md)
+7. **Run a `--full` restore** of the snapshot against the fresh DB
+8. **Apply any migrations** post-snapshot if needed
+
+The bottleneck in this flow is step 3 (off-site retrieval) — see
+the "What's NOT yet automated" section below.
+
+## What's NOT backed up and why
+
+| Data | Why not | What to do if you need it back |
+|------|---------|--------------------------------|
+| Redis | Cache layer; rebuilds from DB on first read | Nothing — it self-heals |
+| Ollama models | Re-downloadable from registry | `ollama pull qwen3.5:9b` |
+| Build cache, node_modules | Reproducible from lockfile | `pnpm install` |
+| Docker images | Reproducible from `docker compose build` | Rebuild |
+| `.env` files | Secrets; should be in a vault, never in git | Restore from secrets manager |
+| Cloudflare R2 objects | R2 itself provides 11 nines durability | No action needed |
+
+## What's NOT yet automated (known gaps)
+
+| Gap | Why deferred | Tracking |
+|-----|--------------|----------|
+| R2 off-site sync of snapshots | Gated on Vault-first secrets refactor (#811) so the credential path stays clean | Will file follow-up after #220 lands |
+| At-rest encryption of snapshots | Civic data is currently public; encryption matters once real-user PII lands | v1.1 |
+| Backup-restore round-trip integration test in CI | Separate scope; needs CI Postgres harness | v1.1 |
+| Multi-tier retention (weekly + monthly tiers) | Daily-only is sufficient at current DB size + retention window | File if disk pressure emerges |
+| Time Machine setup automation | Out of scope for a code repository; document operationally | N/A |
+
+## Troubleshooting
+
+### "BACKUPS_DIR_HOST must be set" at `docker compose up`
+
+You forgot to pass `--env-file .env.backup`, OR `.env.backup` doesn't
+define `BACKUPS_DIR_HOST`, OR the value is empty. This is a fail-fast
+guard, not a mysterious bug. Fix the env var.
+
+### Scheduled backup never fires
+
+Check the scheduler is alive:
+
+```bash
+docker ps --filter "name=opuspopuli-backup"
+docker logs opuspopuli-backup | grep scheduler_start
+```
+
+If the container's `Status` shows `Restarting`, look at logs for the
+crash reason. Most common: bind-mount path doesn't exist on host
+(create it), or `POSTGRES_PASSWORD` doesn't match what the DB expects.
+
+### Snapshot files are owned by root on host
+
+The supabase/postgres image runs as the `postgres` user, but bind-mount
+file ownership reflects the container UID, not your host UID. On Mac
+this is usually invisible because the Docker Desktop volume sharing
+remaps UIDs. On Linux hosts you may need `chown` after each snapshot
+or to run the container as your host UID.
+
+### `--full` restore says "snapshot git_sha is older than current"
+
+Expected. After the restore completes, the message tells you to run:
+
+```bash
+docker compose -f docker-compose-uat.yml run --rm db-migrate
+```
+
+That brings the schema forward from snapshot-era to current-head.
+Any data backfills in those migrations need manual review.
+
+### "lock_held" in scheduler logs
+
+A previous run is still in flight, OR a stale lockfile exists.
+Check process state:
+
+```bash
+docker exec opuspopuli-backup pgrep -af pg_dump
+```
+
+If no `pg_dump` is running, remove the stale lockfile:
+
+```bash
+rm /Volumes/OpusPopuli/Development/db-backups/.backup.lock
+```
+
+## See also
+
+- [`backup/README.md`](../../backup/README.md) — developer-facing details about the backup service itself
+- [`docker-compose-backup.yml`](../../docker-compose-backup.yml) — the overlay definition
+- [`.env.backup.example`](../../.env.backup.example) — env var contract
+- [Database Migration guide](./database-migration.md) — for the migration step in `--full` restores
+- [Docker Setup guide](./docker-setup.md) — for general stack troubleshooting


### PR DESCRIPTION
## Summary

Containerized daily PostgreSQL backup + restore service. The 2026-06-06 docker disk image resize wiped every named volume including the prod database; the only surviving snapshot was a week-old `pg_dump` from May 31. The currently-running bills sync (25+ hours of LLM-bound work on a parent branch) would be brutal to lose. This adds the daily backup discipline that was missing.

- **Single env-agnostic compose overlay** (`docker-compose-backup.yml`) — same file works against local dev, UAT, and Mac Studio production; env-specific values via `.env.backup`. Pattern mirrors `docker-compose-frontend.yml`.
- **In-container scheduler** (supercronic) — fires daily at 03:00 in `${TZ}`, logs to stdout so `docker logs opuspopuli-backup` shows scheduler activity directly.
- **Restore script with `--quick` / `--full` modes** — quick path for matching git_sha, full path (drop+recreate+restore) for schema drift, with the documented `db-migrate` follow-up.

## Status

**Opened as draft pending smoke test tomorrow.** Files are written and the scripts pass `bash -n` syntax checks; the compose file validates under `docker compose config` with `.env.backup.example`. What's NOT yet done:

- [ ] Build the image and verify the scheduler starts (`docker logs opuspopuli-backup` should emit `scheduler_start` JSON line)
- [ ] Ad-hoc backup test — fire `backup-db.sh` manually, verify a `.dump.gz` lands in the host directory with the expected filename shape
- [ ] Round-trip restore test against `postgres_test` — backup → drop test DB → `--quick` restore → assert row counts match

Marking ready-for-review once those three pass.

## What changed

### `backup/` directory (new)
- `Dockerfile` — inherits from `supabase/postgres:17.6.1.091` (production DB image) so `pg_dump` / `pg_restore` versions exactly match the server. SHA1-pinned supercronic install for supply-chain safeguard.
- `entrypoint.sh` — dispatches between scheduler mode (no args → supercronic) and one-shot mode (args → exec args, used by `docker compose run --rm`).
- `crontab` — single line: daily 03:00 backup.
- `scripts/backup-db.sh` — `pg_dump --format=custom --no-owner --no-acl | gzip -9` with atomic rename, cross-mode flock, JSON structured logs, configurable retention.
- `scripts/restore-db.sh` — `--quick` and `--full` modes with confirmation prompt + schema-drift detection via git_sha embedded in filename.
- `README.md` — developer-facing docs for anyone modifying the service.

### Overlay + env
- `docker-compose-backup.yml` — env-agnostic, `${BACKUPS_DIR_HOST:?...}` fails fast if the var isn't set.
- `.env.backup.example` — every required + optional var documented with per-environment guidance.

### Operator docs
- `docs/guides/backup-recovery.md` — setup, scheduled run, ad-hoc backup, both restore modes, verification checklist, disaster recovery, troubleshooting, deferred-feature list.

## Key design decisions (called out for review)

1. **Bind mount to host, not docker named volume** — exactly the failure mode 2026-06-06 demonstrated. The `${BACKUPS_DIR_HOST:?...}` syntax surfaces operator misconfiguration immediately rather than silently creating an anonymous volume.
2. **Base image pinned to production DB image** — `pg_dump` custom-format dumps aren't forward-compatible across major versions; mismatched binaries silently produce restores the server can't load.
3. **Scripts both COPYed AND bind-mounted** — image self-contained for production, hot-reload for dev iteration. Compose-side bind mount wins at runtime.
4. **Cross-mode flock between backup and restore** — restore blocks scheduled backups while it's in progress; backup-vs-backup overlap is handled by `BACKUP_LOCK_WAIT` (default block-and-wait).
5. **`--full` deliberately doesn't auto-migrate** — invoking docker exec from inside the backup container would require mounting the docker socket, which is a privilege escalation surface we don't want on a backup service. Operator runs `db-migrate` as a separate step; script prints the command.
6. **Daily-only retention, 7 days default** — earlier conversation considered weekly + monthly tiers and incremental backups; rejected for v1 since DB size is small at MVP scale. Tracked as "file follow-up if disk pressure emerges."

## Deferred (will file follow-up issues after merge)

| Item | Why deferred |
|---|---|
| R2 off-site sync of snapshots | Gated on #811 Vault-first secrets refactor so the credential path stays clean |
| At-rest encryption of snapshots | Civic data is currently public; matters once real-user PII lands |
| Backup-restore round-trip integration test in CI | Separate scope, needs CI Postgres harness |
| Multi-tier retention (weekly + monthly) | Daily-only is sufficient at current DB size + retention window |

## Test plan

- [x] All shell scripts pass `bash -n` syntax check
- [x] `docker compose -f docker-compose-uat.yml -f docker-compose-backup.yml --env-file .env.backup.example config` parses cleanly
- [x] Without `--env-file`, compose fails fast with `BACKUPS_DIR_HOST must be set` (`:?` guard works)
- [x] supercronic SHA1 fetched and pinned (`fb4242e9d28528a76b70d878dbf69fe8d94ba7d2`)
- [ ] Image builds (`docker compose ... build opuspopuli-backup`)
- [ ] Scheduler container starts and emits `scheduler_start` JSON log line
- [ ] Ad-hoc backup produces `opuspopuli-db-{sha}-{ts}.dump.gz` in `${BACKUPS_DIR_HOST}`
- [ ] Backup file lands on host filesystem via bind mount (verifiable by `ls` on host)
- [ ] Retention sweep deletes files older than `RETENTION_DAYS` (via `touch -d 30daysago` on a test file)
- [ ] `--quick` restore round-trips against `postgres_test` with matching row counts
- [ ] `--full` restore drops + recreates + restores cleanly

## Related

- Closes #220
- Memory note `[[complete-data-pg-dump]]` — the "snapshot once bills sync finishes" plan that triggered this
- Memory note `[[docker-disk-image-resize-destroys-volumes]]` — the 2026-06-06 incident
- Will file follow-ups for R2 sync + encryption + CI integration test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
