### PR TITLE
perf(region): generalize tryStatusOnlyRecheck — close silent-drift gap (#819)

### DIFF
--- a/apps/backend/__tests__/integration/region/status-recheck-coverage.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/status-recheck-coverage.integration.spec.ts
@@ -1,0 +1,373 @@
+/**
+ * Integration tests for the unconditional status-only re-check path (#819,
+ * generalizing #689).
+ *
+ * Complements the unit tests at
+ * `apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts` —
+ * those mock `DbService`, so they cover the gate logic but never exercise
+ * the actual Prisma writes or the BillSkipRecord-shape round-trip. These
+ * integration cases use the real `postgres_test` database to assert:
+ *
+ *   - the cheap parse fires for bills with `needsStatusRecheck=false`
+ *     (the silent-drift gap closure — the case Mechanism A used to skip)
+ *   - matching lastAction + lastActionDate persists no row mutation other
+ *     than the idempotent `needsStatusRecheck=false` clear
+ *   - any change to lastActionDate OR lastAction text returns `'fall-through'`
+ *     so the caller routes to the LLM extract path
+ *   - `forceStatusRecheck=true` short-circuits to `'fall-through'` without
+ *     even fetching the status page (operator override semantics)
+ *
+ * The HTTP fetcher is mocked — we don't want leginfo network IO in CI.
+ * The DB layer + the gate logic are real.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import {
+  PluginLoaderService,
+  PluginRegistryService,
+  type IRegionPlugin,
+} from '@opuspopuli/region-provider';
+import { RegionSyncService } from '../../../src/apps/region/src/domains/region-sync.service';
+import { RegionCacheService } from '../../../src/apps/region/src/domains/region-cache.service';
+import { REGION_CACHE } from '../../../src/apps/region/src/domains/region.tokens';
+import { cleanDatabase, disconnectDatabase, getDbService } from '../utils';
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const REGION_ID = 'california';
+
+/**
+ * Real-leginfo-shaped HTML. The status-page parser keys on:
+ *   - `<span id="lastAction" class="statusLabel">M/D/YY</span>` → lastActionDate
+ *   - first `<td scope="row">DATE</td><td>TEXT</td>` row → lastAction text
+ */
+function buildStatusHtml(opts: {
+  lastActionDate: string; // M/D/YY
+  lastAction: string;
+}): string {
+  return `
+    <span id="lastAction" class="statusLabel">${opts.lastActionDate}</span>
+    <table><tbody>
+      <tr><td scope="row">${opts.lastActionDate}</td><td>${opts.lastAction}</td></tr>
+    </tbody></table>
+  `;
+}
+
+function buildPlugin(): jest.Mocked<IRegionPlugin> {
+  return {
+    getName: jest.fn().mockReturnValue(REGION_ID),
+    getVersion: jest.fn().mockReturnValue('1.0.0'),
+    getRegionInfo: jest.fn().mockReturnValue({
+      id: REGION_ID,
+      name: 'California',
+      description: 'CA',
+      timezone: 'America/Los_Angeles',
+    }),
+    getSupportedDataTypes: jest.fn().mockReturnValue([]),
+    getDataSources: jest.fn().mockReturnValue([]),
+    initialize: jest.fn(),
+    healthCheck: jest.fn(),
+    destroy: jest.fn(),
+  } as unknown as jest.Mocked<IRegionPlugin>;
+}
+
+async function seedBill(
+  db: DbService,
+  overrides: Partial<{
+    id: string;
+    externalId: string;
+    billNumber: string;
+    status: string | null;
+    lastAction: string | null;
+    lastActionDate: Date | null;
+    needsStatusRecheck: boolean;
+  }> = {},
+): Promise<{
+  id: string;
+  externalId: string;
+  lastAction: string | null;
+  lastActionDate: Date | null;
+  needsStatusRecheck: boolean;
+  sourcePublishedAt: Date | null;
+}> {
+  const id = overrides.id ?? `bill-${Math.random().toString(36).slice(2, 10)}`;
+  const externalId = overrides.externalId ?? `ext-${id}`;
+  await db.bill.create({
+    data: {
+      id,
+      regionId: REGION_ID,
+      externalId,
+      billNumber: overrides.billNumber ?? 'AB 1',
+      sessionYear: '2025-2026',
+      measureTypeCode: 'AB',
+      title: 'A bill to test the unconditional status-only re-check.',
+      sourceUrl: `https://leginfo.legislature.ca.gov/faces/billStatusClient.xhtml?bill_id=${id}`,
+      status: overrides.status ?? null,
+      lastAction: overrides.lastAction ?? null,
+      lastActionDate: overrides.lastActionDate ?? null,
+      needsStatusRecheck: overrides.needsStatusRecheck ?? false,
+      isActive: true,
+      isDead: false,
+    },
+  });
+  return {
+    id,
+    externalId,
+    lastAction: overrides.lastAction ?? null,
+    lastActionDate: overrides.lastActionDate ?? null,
+    needsStatusRecheck: overrides.needsStatusRecheck ?? false,
+    sourcePublishedAt: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('tryStatusOnlyRecheck — integration (#819 silent-drift gap)', () => {
+  let service: RegionSyncService;
+  let db: DbService;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    db = await getDbService();
+  });
+
+  beforeEach(async () => {
+    await cleanDatabase();
+
+    const plugin = buildPlugin();
+    const mockRegistry = {
+      getActive: jest.fn().mockReturnValue(plugin),
+      getLocal: jest.fn().mockReturnValue(plugin),
+      getAll: jest
+        .fn()
+        .mockReturnValue([
+          { name: REGION_ID, instance: plugin, status: 'active' },
+        ]),
+    };
+    const mockLoader = { loadPlugin: jest.fn().mockResolvedValue(plugin) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RegionSyncService,
+        { provide: DbService, useValue: db },
+        { provide: PluginRegistryService, useValue: mockRegistry },
+        { provide: PluginLoaderService, useValue: mockLoader },
+        { provide: REGION_CACHE, useValue: { get: jest.fn(), set: jest.fn() } },
+        RegionCacheService,
+      ],
+    }).compile();
+
+    service = module.get<RegionSyncService>(RegionSyncService);
+
+    fetchSpy = jest
+      .spyOn(
+        service as unknown as {
+          fetchUrlText: (u: string) => Promise<string>;
+        },
+        'fetchUrlText',
+      )
+      .mockResolvedValue('');
+  });
+
+  afterEach(() => fetchSpy.mockRestore());
+
+  afterAll(async () => {
+    await disconnectDatabase();
+  });
+
+  // -----------------------------------------------------------------------
+  // Direct-call helpers
+  // -----------------------------------------------------------------------
+
+  type BillSkipRecord = {
+    id: string;
+    externalId: string;
+    sourcePublishedAt: Date | null;
+    lastAction: string | null;
+    lastActionDate: Date | null;
+    needsStatusRecheck: boolean;
+  };
+  type RecheckFn = (
+    statusUrl: string,
+    forceStatusRecheck: boolean,
+    existing: BillSkipRecord | undefined,
+  ) => Promise<'unchanged' | 'fall-through'>;
+
+  const callRecheck = (
+    statusUrl: string,
+    force: boolean,
+    existing: BillSkipRecord | undefined,
+  ): Promise<'unchanged' | 'fall-through'> =>
+    (
+      service as unknown as { tryStatusOnlyRecheck: RecheckFn }
+    ).tryStatusOnlyRecheck.bind(service)(statusUrl, force, existing);
+
+  // -----------------------------------------------------------------------
+  // Tests
+  // -----------------------------------------------------------------------
+
+  it('closes the silent-drift gap: unflagged bill + unchanged page → "unchanged" persists flag clear', async () => {
+    // The headline scenario #819 was filed to fix. Pre-#819 this bill
+    // would never have had the cheap parse run (needsStatusRecheck=false
+    // gated it out) — Mechanism B's text-page check would run instead,
+    // missing any status-only change. Post-#819 the cheap parse fires
+    // unconditionally; with the page matching DB state, we skip cleanly.
+    const seeded = await seedBill(db, {
+      lastAction: 'Chaptered by Secretary of State - Chapter 472.',
+      lastActionDate: new Date(Date.UTC(2025, 9, 9)),
+      needsStatusRecheck: false,
+    });
+    fetchSpy.mockResolvedValueOnce(
+      buildStatusHtml({
+        lastActionDate: '10/9/25',
+        lastAction: 'Chaptered by Secretary of State - Chapter 472.',
+      }),
+    );
+
+    const result = await callRecheck(
+      'https://leginfo.example/billStatusClient.xhtml?bill_id=x',
+      false,
+      seeded,
+    );
+
+    expect(result).toBe('unchanged');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    // Round-trip the flag clear through real Prisma — confirms the
+    // BillSkipRecord shape matches the model.
+    const row = await db.bill.findUniqueOrThrow({ where: { id: seeded.id } });
+    expect(row.needsStatusRecheck).toBe(false);
+    // Status, lastAction, lastActionDate are NOT mutated by the skip path —
+    // only the LLM-driven extract path writes those columns.
+    expect(row.lastAction).toBe(seeded.lastAction);
+    expect(row.lastActionDate?.toISOString()).toBe(
+      seeded.lastActionDate?.toISOString(),
+    );
+  });
+
+  it('catches a status-only change on an unflagged bill — newer lastActionDate → "fall-through"', async () => {
+    // The exact silent-drift scenario the issue's "Problem" section
+    // describes: a bill gets a new action without its text being
+    // republished. Mechanism B's text-page signal would NOT trigger.
+    // Mechanism A (post-#819) catches it because the status page's
+    // lastActionDate has moved.
+    const seeded = await seedBill(db, {
+      lastAction: 'Read first time.',
+      lastActionDate: new Date(Date.UTC(2026, 2, 1)),
+      needsStatusRecheck: false,
+    });
+    fetchSpy.mockResolvedValueOnce(
+      buildStatusHtml({
+        lastActionDate: '5/15/26',
+        lastAction: 'Amended in Committee on Health.',
+      }),
+    );
+
+    const result = await callRecheck(
+      'https://leginfo.example/billStatusClient.xhtml?bill_id=x',
+      false,
+      seeded,
+    );
+
+    expect(result).toBe('fall-through');
+
+    // DB row not touched by this path — the LLM-driven extract path that
+    // the caller routes to next is what actually updates the bill row.
+    // We just confirm the row is unchanged here so reviewers can see the
+    // separation of concerns.
+    const row = await db.bill.findUniqueOrThrow({ where: { id: seeded.id } });
+    expect(row.lastAction).toBe(seeded.lastAction);
+    expect(row.lastActionDate?.toISOString()).toBe(
+      seeded.lastActionDate?.toISOString(),
+    );
+    expect(row.needsStatusRecheck).toBe(false);
+  });
+
+  it('forceStatusRecheck=true bypasses the cheap parse (no fetch, no DB write)', async () => {
+    const seeded = await seedBill(db, {
+      lastAction: 'Held in Committee.',
+      lastActionDate: new Date(Date.UTC(2026, 4, 1)),
+      needsStatusRecheck: true,
+    });
+
+    const result = await callRecheck(
+      'https://leginfo.example/billStatusClient.xhtml?bill_id=x',
+      true,
+      seeded,
+    );
+
+    expect(result).toBe('fall-through');
+    // No HTTP, no DB write — caller goes directly to the LLM path which
+    // is what does the authoritative update.
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    const row = await db.bill.findUniqueOrThrow({ where: { id: seeded.id } });
+    expect(row.needsStatusRecheck).toBe(true);
+  });
+
+  it('clears needsStatusRecheck=true when the page matches stored values', async () => {
+    // The pre-#819 flag-driven path still works: journal-flagged bills
+    // get the flag cleared after a clean skip. The mechanism is just no
+    // longer gated on the flag for OTHER bills.
+    const seeded = await seedBill(db, {
+      lastAction: 'Approved by Governor.',
+      lastActionDate: new Date(Date.UTC(2025, 6, 14)),
+      needsStatusRecheck: true,
+    });
+    fetchSpy.mockResolvedValueOnce(
+      buildStatusHtml({
+        lastActionDate: '7/14/25',
+        lastAction: 'Approved by Governor.',
+      }),
+    );
+
+    const result = await callRecheck(
+      'https://leginfo.example/billStatusClient.xhtml?bill_id=x',
+      false,
+      seeded,
+    );
+
+    expect(result).toBe('unchanged');
+    const row = await db.bill.findUniqueOrThrow({ where: { id: seeded.id } });
+    expect(row.needsStatusRecheck).toBe(false);
+  });
+
+  it('falls through when fetch throws (defensive — never silently drifts on transport errors)', async () => {
+    const seeded = await seedBill(db, {
+      lastAction: 'Some action.',
+      lastActionDate: new Date(Date.UTC(2026, 1, 1)),
+    });
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+    const result = await callRecheck(
+      'https://leginfo.example/billStatusClient.xhtml?bill_id=x',
+      false,
+      seeded,
+    );
+
+    expect(result).toBe('fall-through');
+  });
+
+  it('falls through when leginfo markup drift breaks the regex parse', async () => {
+    const seeded = await seedBill(db, {
+      lastAction: 'Action.',
+      lastActionDate: new Date(Date.UTC(2026, 1, 1)),
+    });
+    fetchSpy.mockResolvedValueOnce(
+      '<html><body>no useful markup</body></html>',
+    );
+
+    const result = await callRecheck(
+      'https://leginfo.example/billStatusClient.xhtml?bill_id=x',
+      false,
+      seeded,
+    );
+
+    expect(result).toBe('fall-through');
+  });
+});

--- a/apps/backend/__tests__/jest-integration.json
+++ b/apps/backend/__tests__/jest-integration.json
@@ -7,6 +7,9 @@
     "^.+\\.ts$": "ts-jest"
   },
   "transformIgnorePatterns": ["/node_modules/", "/dist/"],
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1"
+  },
   "globalSetup": "<rootDir>/__tests__/integration/setup.ts",
   "globalTeardown": "<rootDir>/__tests__/integration/teardown.ts",
   "testTimeout": 60000,

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
@@ -758,10 +758,19 @@ describe('RegionSyncService', () => {
     });
   });
 
-  describe('tryStatusOnlyRecheck — status-only re-check gate (#689)', () => {
+  describe('tryStatusOnlyRecheck — status-only re-check (#819 / #689)', () => {
     // Sample real-leginfo-shaped HTML; the parser path is covered by the
     // extractBillStatusFields tests above. These tests focus on the gate
-    // logic: when to read, when to fetch, when to clear the flag.
+    // logic: when to fetch, when to skip the LLM, when forceStatusRecheck
+    // bypasses, when to clear the flag.
+    //
+    // Post-#819: the cheap parse fires for every bill with a prior row,
+    // not just journal-flagged ones (`needsStatusRecheck=true`). The flag
+    // is no longer load-bearing for skip eligibility; it remains as
+    // documentation that the journal linker cited the bill. The
+    // `forceStatusRecheck` parameter's meaning flipped from "force the
+    // cheap parse to fire" to "bypass the cheap parse, force LLM
+    // re-extraction" — see the method docstring for context.
     const matchingHtml = `
       <span id="lastAction" class="statusLabel">10/09/25</span>
       <table><tbody>
@@ -782,7 +791,7 @@ describe('RegionSyncService', () => {
             needsStatusRecheck: boolean;
           }
         | undefined,
-    ) => Promise<'unchanged' | 'no-recheck-needed' | 'fall-through'>;
+    ) => Promise<'unchanged' | 'fall-through'>;
     const callRecheck = (svc: RegionSyncService) =>
       (
         svc as unknown as { tryStatusOnlyRecheck: Recheck }
@@ -806,6 +815,7 @@ describe('RegionSyncService', () => {
     });
 
     let fetchSpy: jest.SpyInstance;
+    let updateMock: jest.Mock;
 
     beforeEach(() => {
       fetchSpy = jest
@@ -816,11 +826,17 @@ describe('RegionSyncService', () => {
           'fetchUrlText',
         )
         .mockResolvedValue(matchingHtml);
+      // The 'unchanged' path clears the flag; spec'd by default to avoid
+      // touching the real `db` instance from the surrounding suite.
+      updateMock = jest.fn().mockResolvedValue({});
+      (service as unknown as { db: { bill: { update: jest.Mock } } }).db = {
+        bill: { update: updateMock },
+      };
     });
 
     afterEach(() => fetchSpy.mockRestore());
 
-    it('returns "fall-through" when bill is not in the DB map', async () => {
+    it('returns "fall-through" when bill is not in the DB map (brand-new bill, full extract)', async () => {
       const recheck = callRecheck(service);
       const result = await recheck(
         'https://x/billStatusClient.xhtml?bill_id=AB1',
@@ -831,54 +847,105 @@ describe('RegionSyncService', () => {
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('returns "no-recheck-needed" when flag is false and force is false (no fetch)', async () => {
+    // ─── New: the unflagged-path coverage that closes the silent-drift gap ──
+
+    it('fires for an unflagged bill (#819) — needsStatusRecheck=false + unchanged page → "unchanged" (no LLM)', async () => {
+      // The core gap-closing case. Pre-#819 this returned "no-recheck-needed"
+      // and the bill fell through to Mechanism B (sourcePublishedAt check),
+      // which silently missed status-only changes that didn't republish
+      // the bill text. Now the cheap parse runs for every bill with a
+      // prior row regardless of the flag.
       const recheck = callRecheck(service);
-      const result = await recheck('https://x/x.xhtml', false, mkExisting());
-      expect(result).toBe('no-recheck-needed');
+      const result = await recheck(
+        'https://x/x.xhtml',
+        false,
+        mkExisting({ needsStatusRecheck: false }),
+      );
+      expect(result).toBe('unchanged');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      // The clear-the-flag write still fires even on an already-false flag
+      // (idempotent; documents that the bill was checked this sync).
+      expect(updateMock).toHaveBeenCalledWith({
+        where: { id: 'bill-uuid' },
+        data: { needsStatusRecheck: false },
+      });
+    });
+
+    it('fires for an unflagged bill (#819) — needsStatusRecheck=false + changed lastActionDate → "fall-through" (LLM)', async () => {
+      const recheck = callRecheck(service);
+      const result = await recheck(
+        'https://x/x.xhtml',
+        false,
+        mkExisting({
+          needsStatusRecheck: false,
+          lastActionDate: new Date(Date.UTC(2024, 0, 1)),
+        }),
+      );
+      expect(result).toBe('fall-through');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires for an unflagged bill (#819) — needsStatusRecheck=false + changed lastAction text → "fall-through" (LLM)', async () => {
+      const recheck = callRecheck(service);
+      const result = await recheck(
+        'https://x/x.xhtml',
+        false,
+        mkExisting({
+          needsStatusRecheck: false,
+          lastAction: 'Some different action text',
+        }),
+      );
+      expect(result).toBe('fall-through');
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // ─── forceStatusRecheck semantics — flipped vs pre-#819 ─────────────────
+
+    it('forceStatusRecheck=true bypasses the cheap parse (does NOT fetch)', async () => {
+      // Operator override — "I don't trust DB state, force the LLM."
+      // Pre-#819 this forced the cheap parse to fire; post-#819 it skips
+      // the cheap parse entirely so the caller goes straight to the full
+      // extract path.
+      const recheck = callRecheck(service);
+      const result = await recheck('https://x/x.xhtml', true, mkExisting());
+      expect(result).toBe('fall-through');
       expect(fetchSpy).not.toHaveBeenCalled();
     });
 
-    it('fetches when forceStatusRecheck=true even if the flag is false', async () => {
-      const recheck = callRecheck(service);
-      await recheck('https://x/x.xhtml', true, mkExisting());
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('fetches when the flag is true even if force is false', async () => {
-      const recheck = callRecheck(service);
-      await recheck(
-        'https://x/x.xhtml',
-        false,
-        mkExisting({ needsStatusRecheck: true }),
-      );
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-    });
-
-    it('returns "fall-through" when fetch throws', async () => {
-      fetchSpy.mockRejectedValueOnce(new Error('503'));
-      const recheck = callRecheck(service);
-      const result = await recheck('https://x/x.xhtml', true, mkExisting());
-      expect(result).toBe('fall-through');
-    });
-
-    it('returns "fall-through" when the regex cannot parse the page', async () => {
-      fetchSpy.mockResolvedValueOnce(
-        '<html><body>no useful markup</body></html>',
-      );
-      const recheck = callRecheck(service);
-      const result = await recheck('https://x/x.xhtml', true, mkExisting());
-      expect(result).toBe('fall-through');
-    });
-
-    it('returns "unchanged" and clears the flag when page matches stored values', async () => {
-      const updateMock = jest.fn().mockResolvedValue({});
-      (service as unknown as { db: { bill: { update: jest.Mock } } }).db = {
-        bill: { update: updateMock },
-      };
+    it('forceStatusRecheck=true bypasses even when needsStatusRecheck=true', async () => {
       const recheck = callRecheck(service);
       const result = await recheck(
         'https://x/x.xhtml',
         true,
+        mkExisting({ needsStatusRecheck: true }),
+      );
+      expect(result).toBe('fall-through');
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    // ─── Existing-coverage retained ────────────────────────────────────────
+
+    it('returns "fall-through" when fetch throws (defensive — defer to LLM)', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('503'));
+      const recheck = callRecheck(service);
+      const result = await recheck('https://x/x.xhtml', false, mkExisting());
+      expect(result).toBe('fall-through');
+    });
+
+    it('returns "fall-through" when the regex cannot parse the page (markup drift)', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        '<html><body>no useful markup</body></html>',
+      );
+      const recheck = callRecheck(service);
+      const result = await recheck('https://x/x.xhtml', false, mkExisting());
+      expect(result).toBe('fall-through');
+    });
+
+    it('clears the needsStatusRecheck flag when the page matches and the flag was true', async () => {
+      const recheck = callRecheck(service);
+      const result = await recheck(
+        'https://x/x.xhtml',
+        false,
         mkExisting({ needsStatusRecheck: true }),
       );
       expect(result).toBe('unchanged');
@@ -892,7 +959,7 @@ describe('RegionSyncService', () => {
       const recheck = callRecheck(service);
       const result = await recheck(
         'https://x/x.xhtml',
-        true,
+        false,
         mkExisting({ lastAction: 'Different action' }),
       );
       expect(result).toBe('fall-through');
@@ -902,7 +969,7 @@ describe('RegionSyncService', () => {
       const recheck = callRecheck(service);
       const result = await recheck(
         'https://x/x.xhtml',
-        true,
+        false,
         mkExisting({ lastActionDate: new Date(Date.UTC(2024, 0, 1)) }),
       );
       expect(result).toBe('fall-through');
@@ -912,7 +979,7 @@ describe('RegionSyncService', () => {
       const recheck = callRecheck(service);
       const result = await recheck(
         'https://x/x.xhtml',
-        true,
+        false,
         mkExisting({ lastActionDate: null }),
       );
       expect(result).toBe('fall-through');

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -2119,8 +2119,11 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     const billId = this.safeBillIdFromUrl(url);
     const billNumber = billNumberFromExternalId(billId);
 
-    // Status-only re-check path (#689): flagged-by-linker or forced by
-    // weekly backstop. Unchanged → skip cheaply; otherwise fall through.
+    // Status-only re-check path (#819, generalizing #689): fires for every
+    // bill with a prior DB row, not just journal-flagged ones. Unchanged →
+    // skip cheaply (no LLM, just an `updated_at` touch); otherwise fall
+    // through to the full extract path. `forceStatusRecheck=true` bypasses
+    // the cheap parse and forces LLM re-extraction.
     if (billId) {
       const recheck = await this.tryStatusOnlyRecheck(
         url,
@@ -2742,11 +2745,30 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Status-only re-check for bills flagged by the journal linker or forced
-   * by the weekly backstop (#689). Compares lastActionDate + lastAction
-   * text (both LLM-stored verbatim) against the raw page; status is
-   * skipped because the LLM normalizes it ("Inactive Bill - Chaptered" →
-   * "Chaptered") and a raw comparison would false-positive every time.
+   * Status-only re-check for every bill with a prior DB row (#819,
+   * generalizing #689). Fetches the status page, parses lastAction +
+   * lastActionDate cheaply (no LLM), and skips the full extract path
+   * when neither has moved. The LLM-normalized `status` field is
+   * intentionally NOT compared — the LLM rewrites the raw leginfo
+   * status ("Inactive Bill - Chaptered" → "Chaptered") so a raw-vs-
+   * normalized comparison would false-positive every time.
+   *
+   * Coverage: pre-#819 this only fired for bills flagged by the
+   * journal linker (`needsStatusRecheck=true`) or the weekly backstop.
+   * Unflagged bills fell to the text-page `sourcePublishedAt` skip
+   * (Mechanism B) — which silently missed status-only changes (e.g.
+   * committee amendments) that didn't re-publish the bill text.
+   * Removing the flag gate closes that silent-drift gap; the existing
+   * `needsStatusRecheck` flag is retained as documentation (journal
+   * linker still sets it; the clear-after-skip path still clears it)
+   * but is no longer load-bearing for skip eligibility.
+   *
+   * `forceStatusRecheck` semantics: when true, bypass the cheap parse
+   * entirely and fall through to full LLM extraction. This is the
+   * operator override for "I don't trust DB state, re-extract from
+   * scratch." Pre-#819 the same flag meant "force the cheap parse to
+   * fire" — a subtle weaker guarantee since the cheap parse could
+   * still skip the LLM. The new semantics match the parameter name.
    *
    * Takes `existing` as a parameter to avoid a per-bill `findUnique` —
    * callers pre-load via `loadBillSkipMetadata` at sync start.
@@ -2755,11 +2777,10 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
     statusUrl: string,
     forceStatusRecheck: boolean,
     existing: BillSkipRecord | undefined,
-  ): Promise<'unchanged' | 'no-recheck-needed' | 'fall-through'> {
+  ): Promise<'unchanged' | 'fall-through'> {
     if (!existing) return 'fall-through'; // brand-new bill, full extraction
-    if (!forceStatusRecheck && !existing.needsStatusRecheck) {
-      return 'no-recheck-needed';
-    }
+    // Operator override — skip the cheap parse, force LLM re-extraction.
+    if (forceStatusRecheck) return 'fall-through';
 
     let html: string;
     try {
@@ -2786,7 +2807,7 @@ export class RegionSyncService implements OnModuleInit, OnModuleDestroy {
       return 'fall-through';
     }
 
-    // No material change. Clear the flag and skip.
+    // No material change. Clear the flag (idempotent on already-false) and skip.
     await this.db.bill.update({
       where: { id: existing.id },
       data: { needsStatusRecheck: false },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,9 @@
       "next@>=16.0.0 <16.2.6": ">=16.2.6",
       "@opentelemetry/auto-instrumentations-node@<0.75.0": ">=0.75.0",
       "@opentelemetry/sdk-node@<0.217.0": ">=0.217.0",
-      "@opentelemetry/exporter-prometheus@<0.217.0": ">=0.217.0"
+      "@opentelemetry/exporter-prometheus@<0.217.0": ">=0.217.0",
+      "@grpc/grpc-js": ">=1.14.4",
+      "joi": ">=18.2.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,8 @@ overrides:
   '@opentelemetry/auto-instrumentations-node@<0.75.0': '>=0.75.0'
   '@opentelemetry/sdk-node@<0.217.0': '>=0.217.0'
   '@opentelemetry/exporter-prometheus@<0.217.0': '>=0.217.0'
+  '@grpc/grpc-js': '>=1.14.4'
+  joi: '>=18.2.1'
 
 importers:
 
@@ -121,7 +123,7 @@ importers:
         version: 11.2.6(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)
       '@nestjs/terminus':
         specifier: ^11.0.0
-        version: 11.1.1(f5a43984b67a307728dba412c943137f)
+        version: 11.1.1(7c9ab35d39375dd0612d45986aa4f352)
       '@nestjs/throttler':
         specifier: ^6.5.0
         version: 6.5.0(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)
@@ -252,8 +254,8 @@ importers:
         specifier: ^5.0.0
         version: 5.10.1
       joi:
-        specifier: ^18.0.2
-        version: 18.1.1
+        specifier: '>=18.2.1'
+        version: 18.2.1
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.3
@@ -2823,8 +2825,8 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@grpc/grpc-js@1.14.3':
-    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+  '@grpc/grpc-js@1.14.4':
+    resolution: {integrity: sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==}
     engines: {node: '>=12.10.0'}
 
   '@grpc/proto-loader@0.8.0':
@@ -4269,7 +4271,7 @@ packages:
   '@nestjs/terminus@11.1.1':
     resolution: {integrity: sha512-Ssql79H+EQY/Wg108eJqN4NiNsO/tLrj+qbzOWSQUf2JE4vJQ2RG3WTqUOrYjfjWmVHD3+Ys0+azed7LSMKScw==}
     peerDependencies:
-      '@grpc/grpc-js': '*'
+      '@grpc/grpc-js': '>=1.14.4'
       '@grpc/proto-loader': '*'
       '@mikro-orm/core': '*'
       '@mikro-orm/nestjs': '*'
@@ -9120,8 +9122,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  joi@18.1.1:
-    resolution: {integrity: sha512-pJkBiPtNo+o0h19LfSvUN46Y5zY+ck99AtHwch9n2HqVLNRgP0ZMyIH8FRMoP+HV8hy/+AG99dXFfwpf83iZfQ==}
+  joi@18.2.1:
+    resolution: {integrity: sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==}
     engines: {node: '>= 20'}
 
   jose@4.15.9:
@@ -14540,7 +14542,7 @@ snapshots:
     dependencies:
       graphql: 16.13.2
 
-  '@grpc/grpc-js@1.14.3':
+  '@grpc/grpc-js@1.14.4':
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
@@ -15867,7 +15869,7 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.4
 
-  '@nestjs/terminus@11.1.1(f5a43984b67a307728dba412c943137f)':
+  '@nestjs/terminus@11.1.1(7c9ab35d39375dd0612d45986aa4f352)':
     dependencies:
       '@nestjs/common': 11.1.19(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       '@nestjs/core': 11.1.19(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)
@@ -15876,7 +15878,7 @@ snapshots:
       reflect-metadata: 0.2.2
       rxjs: 7.8.2
     optionalDependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@grpc/proto-loader': 0.8.0
       '@nestjs/typeorm': 11.0.0(@nestjs/common@11.1.19(class-transformer@0.5.1)(class-validator@0.14.4)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19)(reflect-metadata@0.2.2)(rxjs@7.8.2)(typeorm@0.3.28(better-sqlite3@12.8.0)(ioredis@5.10.1)(mysql2@3.20.0(@types/node@25.5.0))(pg@8.20.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))(typeorm-aurora-data-api-driver@3.0.2(@aws-sdk/client-rds-data@3.1019.0)))
       '@prisma/client': 7.6.0(prisma@7.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(better-sqlite3@12.8.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
@@ -16137,7 +16139,7 @@ snapshots:
 
   '@opentelemetry/exporter-logs-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
@@ -16167,7 +16169,7 @@ snapshots:
 
   '@opentelemetry/exporter-metrics-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/exporter-metrics-otlp-http': 0.217.0(@opentelemetry/api@1.9.1)
@@ -16206,7 +16208,7 @@ snapshots:
 
   '@opentelemetry/exporter-trace-otlp-grpc@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
@@ -16613,7 +16615,7 @@ snapshots:
 
   '@opentelemetry/otlp-grpc-exporter-base@0.217.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@grpc/grpc-js': 1.14.3
+      '@grpc/grpc-js': 1.14.4
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-exporter-base': 0.217.0(@opentelemetry/api@1.9.1)
@@ -22015,7 +22017,7 @@ snapshots:
   jiti@2.7.0:
     optional: true
 
-  joi@18.1.1:
+  joi@18.2.1:
     dependencies:
       '@hapi/address': 5.1.1
       '@hapi/formula': 3.0.2


### PR DESCRIPTION
## Summary

Closes a known silent-drift gap left over from #689. Net production change is **−3 LOC of logic** (one gate removed, one defensive guard kept). The remaining diff is documentation, tests, and a security override.

## Closes
- Closes #819

## The gap

Pre-this PR, two skip mechanisms ran during Phase 2:

- **Mechanism A** — `tryStatusOnlyRecheck` (#689): cheap status-page regex parse, compares `lastAction` + `lastActionDate` against DB, skips LLM if unchanged. **Gated on `existing.needsStatusRecheck === true`** (set by the journal linker or weekly backstop).
- **Mechanism B** — `checkBillSkipCondition` (#686): text-page `sourcePublishedAt` comparison, fires for every bill not handled by A.

A bill can get amended in committee (new `lastAction` + `lastActionDate` on the status page) without its full text being republished (`sourcePublishedAt` on the text page unchanged). If that bill isn't journal-cited, Mechanism A is gated out and Mechanism B silently skips the change. The status update is missed until the next text republish or journal flag.

Today's CA sync (job `8baa73c8`) hit a 91% skip rate on Phase 2 — most of that is Mechanism B doing the work for unflagged bills, hiding the gap.

## The fix

```diff
-  ): Promise<'unchanged' | 'no-recheck-needed' | 'fall-through'> {
+  ): Promise<'unchanged' | 'fall-through'> {
     if (!existing) return 'fall-through';
-    if (!forceStatusRecheck && !existing.needsStatusRecheck) {
-      return 'no-recheck-needed';
-    }
+    if (forceStatusRecheck) return 'fall-through';
```

The cheap status-page parse now fires for every bill with a prior DB row, not just journal-flagged ones. The text-page Mechanism B stays in place as belt-and-suspenders (evaluating its removal is a follow-up).

## Behavior change worth flagging for review

The `forceStatusRecheck` parameter's semantics are **tightened**, not preserved:
- **Pre-#819:** "force the cheap parse to fire" — the cheap parse could still skip the LLM if nothing had moved
- **Post-#819:** "bypass the cheap parse, route straight to LLM extraction"

Same operator intent ("force a re-extract"), tighter guarantee. The parameter name now matches what it does. No call sites needed updating because the existing operator-override use case ("I don't trust DB state, re-extract") gets a stronger guarantee than before.

## Test coverage

**Unit** (`region-sync.service.spec.ts`)
- 3 existing tests rewritten for the new semantics (the `'no-recheck-needed'` return value is gone, the flag is no longer load-bearing for skip eligibility)
- 3 new tests proving the silent-drift gap closure: unflagged bill + unchanged → `'unchanged'`; unflagged + dateChanged → `'fall-through'`; unflagged + textChanged → `'fall-through'`
- 2 new tests for the flipped `forceStatusRecheck` semantics
- Existing edge-case tests preserved (fetch throws, regex parse fails, lastAction text differs, lastActionDate differs, stored lastActionDate is null)

**Integration** (`status-recheck-coverage.integration.spec.ts` — new)
- 6 tests against `postgres_test` exercising:
  - The silent-drift gap closure end-to-end (unflagged bill → cheap parse fires → DB flag clear round-trips)
  - The status-only change detection (newer lastActionDate → fall-through)
  - The forceStatusRecheck bypass (no fetch, no DB write)
  - The flag-clear behavior when `needsStatusRecheck=true`
  - Defensive fall-through on fetch errors + markup-drift parse failures

## Real-world impact preview

Today's sync skipped 2,695 bills via Mechanism B. For any bill whose status moved without its text being republished, that skip was wrong (silent drift). The new path catches them at the cheap-parse layer before the LLM is invoked.

Expected post-deploy: Phase 2 skip rate stays around 85–90% (the status-page signal is a superset of the text-page signal, so most bills that skipped via B will skip via A instead). The drift gap is closed.

## Sequencing

- This PR's diff has **zero overlap** with the in-flight #827 (verified — different line ranges). Either can land first.
- This PR enables the #828 refactor cleanly — `tryStatusOnlyRecheck` is one of the methods that will move into `bills-sync/bill-extractor.service.ts` once #828 runs, and a clean post-#819 starting point makes the migration mechanical.
- The chore commit (`@grpc/grpc-js`, `joi` pnpm.overrides for CVE fixes) is included because the pre-push hook required it; if reviewers prefer it split out, happy to file as its own PR.

## Related

- #689 — predecessor; shipped the comparison logic, gated it on the flag
- #686 — Mechanism B (`sourcePublishedAt` skip)
- #823 / #827 — merged-LLM call (separate concern, Phase 6 not Phase 2)
- #828 — bounded-context refactor follow-up that absorbs `tryStatusOnlyRecheck` into `bill-extractor.service.ts`

## Test plan

- [ ] CI: lint + 2105-test backend suite + integration suite
- [ ] After merge: deploy region + region-worker, re-run a real CA sync, confirm Phase 2 skip rate stays ≥85% (correctness check — should NOT drop below) and `tracker.item('status-only matched')` counter rises for unflagged bills it previously didn't fire for
- [ ] Operator validation: run `syncRegionData` with `forceStatusRecheck=true` against one bill, confirm the LLM extract path runs (cheap parse bypassed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)