### PR TITLE
chore(infra): pull prod images from ghcr.io instead of building locally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,19 @@ jobs:
             dockerfile: apps/backend/docker/Dockerfile.knowledge
           - service: region
             dockerfile: apps/backend/docker/Dockerfile.region
+          # Async workers — same Dockerfile pattern, published so the prod
+          # compose can pull them instead of building locally on the Studio.
+          - service: region-worker
+            dockerfile: apps/backend/docker/Dockerfile.region-worker
+          - service: structural-analysis-worker
+            dockerfile: apps/backend/docker/Dockerfile.structural-analysis-worker
+          - service: llm-rerank-worker
+            dockerfile: apps/backend/docker/Dockerfile.llm-rerank-worker
+          # Migration runner — image name = compose service name (db-migrate).
+          # Shares Dockerfile.test-runner with the test/integration harness;
+          # the prod use case runs db-migrate.sh as its CMD.
+          - service: db-migrate
+            dockerfile: apps/backend/docker/Dockerfile.test-runner
 
     steps:
       - name: Checkout

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -5,20 +5,28 @@
 # Runs on the Mac Studio behind a Cloudflare Tunnel. Frontend is hosted on
 # Cloudflare Pages (not in this compose file).
 #
+# Image source: ghcr.io/opuspopuli/* — built and signed by .github/workflows/
+# release.yml on push to main. The Studio NEVER builds locally; it pulls
+# pre-built, cosign-signed images and runs them. `${TAG:-latest}` defaults to
+# the rolling latest tag; pin to a specific sha-prefixed tag for a hot-fix or
+# rollback (e.g. TAG=sha-abc1234 docker compose -f docker-compose-prod.yml ...).
+#
 # Architecture:
 #   - cloudflared: Encrypted tunnel to Cloudflare edge
-#   - NestJS microservices: API Gateway + 4 subgraph services
+#   - NestJS microservices: API Gateway + 4 subgraph services + 3 workers
 #   - Local PostgreSQL: AI scratch data (manifests, pipeline state, prompts)
-#   - Redis: Caching
+#   - Redis: BullMQ queue + caching
 #   - Observability: Prometheus + Loki + Grafana
 #   - Ollama: Runs NATIVELY on macOS (not Docker) for Metal GPU access
 #
-# User-facing data (users, documents, auth, storage) lives in Supabase Cloud.
-# Configure via .env.production (see .env.production.example).
+# Configure via .env.production (see .env.production.example). Runtime secrets
+# (RESEND_API_KEY, R2_*, FEC_API_KEY) come from the local Supabase Vault via
+# the hydration path in apps/backend/src/common/preflight.ts.
 #
 # Usage:
-#   docker compose -f docker-compose-prod.yml up -d --build
-#   docker compose -f docker-compose-prod.yml down
+#   docker compose -f docker-compose-prod.yml pull            # fetch new images
+#   docker compose -f docker-compose-prod.yml up -d           # start the stack
+#   docker compose -f docker-compose-prod.yml down            # stop (volumes kept)
 #   docker compose -f docker-compose-prod.yml logs -f api
 #
 # =============================================================================
@@ -161,11 +169,7 @@ services:
   # Database Migrations
   # ---------------------------------------------------------------------------
   db-migrate:
-    build:
-      context: .
-      dockerfile: apps/backend/docker/Dockerfile.test-runner
-      args:
-        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
+    image: ghcr.io/opuspopuli/db-migrate:${TAG:-latest}
     container_name: opuspopuli-prod-db-migrate
     environment:
       <<: *backend-env
@@ -188,11 +192,7 @@ services:
   # NestJS Microservices
   # ---------------------------------------------------------------------------
   users:
-    build:
-      context: .
-      dockerfile: apps/backend/docker/Dockerfile.users
-      args:
-        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
+    image: ghcr.io/opuspopuli/users:${TAG:-latest}
     container_name: opuspopuli-prod-users
     environment:
       <<: *backend-env
@@ -216,11 +216,7 @@ services:
           memory: 256M
 
   documents:
-    build:
-      context: .
-      dockerfile: apps/backend/docker/Dockerfile.documents
-      args:
-        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
+    image: ghcr.io/opuspopuli/documents:${TAG:-latest}
     container_name: opuspopuli-prod-documents
     environment:
       <<: *backend-env
@@ -244,11 +240,7 @@ services:
           memory: 256M
 
   knowledge:
-    build:
-      context: .
-      dockerfile: apps/backend/docker/Dockerfile.knowledge
-      args:
-        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
+    image: ghcr.io/opuspopuli/knowledge:${TAG:-latest}
     container_name: opuspopuli-prod-knowledge
     environment:
       <<: *backend-env
@@ -275,11 +267,7 @@ services:
           memory: 256M
 
   region:
-    build:
-      context: .
-      dockerfile: apps/backend/docker/Dockerfile.region
-      args:
-        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
+    image: ghcr.io/opuspopuli/region:${TAG:-latest}
     container_name: opuspopuli-prod-region
     environment:
       <<: *backend-env
@@ -306,11 +294,7 @@ services:
           memory: 256M
 
   region-worker:
-    build:
-      context: .
-      dockerfile: apps/backend/docker/Dockerfile.region-worker
-      args:
-        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
+    image: ghcr.io/opuspopuli/region-worker:${TAG:-latest}
     container_name: opuspopuli-prod-region-worker
     environment:
       <<: *backend-env
@@ -342,11 +326,7 @@ services:
           memory: 1G
 
   structural-analysis-worker:
-    build:
-      context: .
-      dockerfile: apps/backend/docker/Dockerfile.structural-analysis-worker
-      args:
-        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
+    image: ghcr.io/opuspopuli/structural-analysis-worker:${TAG:-latest}
     container_name: opuspopuli-prod-structural-analysis-worker
     environment:
       <<: *backend-env
@@ -375,11 +355,7 @@ services:
           memory: 512M
 
   llm-rerank-worker:
-    build:
-      context: .
-      dockerfile: apps/backend/docker/Dockerfile.llm-rerank-worker
-      args:
-        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
+    image: ghcr.io/opuspopuli/llm-rerank-worker:${TAG:-latest}
     container_name: opuspopuli-prod-llm-rerank-worker
     environment:
       <<: *backend-env
@@ -420,11 +396,7 @@ services:
           memory: 512M
 
   api:
-    build:
-      context: .
-      dockerfile: apps/backend/docker/Dockerfile.api
-      args:
-        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
+    image: ghcr.io/opuspopuli/api:${TAG:-latest}
     container_name: opuspopuli-prod-api
     environment:
       <<: *backend-env

--- a/docs/guides/container-verification.md
+++ b/docs/guides/container-verification.md
@@ -6,7 +6,7 @@ Opus Populi uses [Sigstore](https://www.sigstore.dev/) keyless signing to ensure
 
 When code is merged to `main`, the [release workflow](../../.github/workflows/release.yml) runs:
 
-1. **Build** — Docker images are built for each microservice (api, users, documents, knowledge, region)
+1. **Build** — Docker images are built for each microservice and async worker (`api`, `users`, `documents`, `knowledge`, `region`, `region-worker`, `structural-analysis-worker`, `llm-rerank-worker`, `db-migrate`). The `prompt-service` image is built by the [paired workflow in the `prompt-service` repo](https://github.com/OpusPopuli/prompt-service/blob/main/.github/workflows/release.yml).
 2. **Push** — Images are pushed to `ghcr.io/opuspopuli/<service>`
 3. **Sign** — Each image is signed using cosign with Sigstore keyless signing (GitHub Actions OIDC identity)
 4. **SBOM** — An SPDX SBOM is generated with syft and attached as a cosign attestation

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -267,35 +267,47 @@ Add this to your `.env.production` as `TUNNEL_TOKEN`.
 
 ### 8.1 Start Production Docker Compose
 
-Use the startup script, which verifies Ollama health before launching Docker:
+Production images are built and signed by the release workflow on push to `main`, then pulled from `ghcr.io/opuspopuli/*`. The Studio never builds locally.
+
+Use the startup script, which verifies Ollama health before pulling + launching:
 
 ```bash
-./scripts/start-prod.sh --build
+./scripts/start-prod.sh
 ```
 
-Or start manually (if Ollama is already verified):
+Or run the steps manually:
 
 ```bash
-docker compose -f docker-compose-prod.yml --env-file .env.production up -d --build
+docker compose -f docker-compose-prod.yml --env-file .env.production pull
+docker compose -f docker-compose-prod.yml --env-file .env.production up -d
+```
+
+To pin a specific build (rollback or hot-fix), set `TAG`:
+
+```bash
+TAG=sha-abc1234 docker compose -f docker-compose-prod.yml --env-file .env.production up -d
 ```
 
 This starts:
 
-| Container | Service | Port |
-|-----------|---------|------|
-| `opuspopuli-prod-cloudflared` | Cloudflare Tunnel daemon | (outbound only) |
-| `opuspopuli-prod-db` | Local PostgreSQL (AI scratch data) | 5432 (internal) |
-| `opuspopuli-prod-redis` | Redis cache | 6379 (internal) |
-| `opuspopuli-prod-db-migrate` | Database migrations (init, then exits) | - |
-| `opuspopuli-prod-users` | Users microservice | 8080 (internal) |
-| `opuspopuli-prod-documents` | Documents microservice | 8080 (internal) |
-| `opuspopuli-prod-knowledge` | Knowledge microservice | 8080 (internal) |
-| `opuspopuli-prod-region` | Region microservice | 8080 (internal) |
-| `opuspopuli-prod-api` | API Gateway (Apollo Federation) | 8080 (exposed) |
-| `opuspopuli-prod-prometheus` | Metrics collection | 9090 (internal) |
-| `opuspopuli-prod-loki` | Log aggregation | 3100 (internal) |
-| `opuspopuli-prod-promtail` | Log shipping | (internal) |
-| `opuspopuli-prod-grafana` | Dashboards | 3101 (localhost only) |
+| Container | Service | Port | Image |
+|-----------|---------|------|-------|
+| `opuspopuli-prod-cloudflared` | Cloudflare Tunnel daemon | (outbound only) | `cloudflare/cloudflared` |
+| `opuspopuli-prod-db` | Local PostgreSQL (AI scratch data) | 5432 (internal) | `pgvector/pgvector:pg16` |
+| `opuspopuli-prod-redis` | Redis cache + BullMQ queue | 6379 (internal) | `redis:7-alpine` |
+| `opuspopuli-prod-db-migrate` | Database migrations (init, then exits) | - | `ghcr.io/opuspopuli/db-migrate` |
+| `opuspopuli-prod-users` | Users microservice | 8080 (internal) | `ghcr.io/opuspopuli/users` |
+| `opuspopuli-prod-documents` | Documents microservice | 8080 (internal) | `ghcr.io/opuspopuli/documents` |
+| `opuspopuli-prod-knowledge` | Knowledge microservice | 8080 (internal) | `ghcr.io/opuspopuli/knowledge` |
+| `opuspopuli-prod-region` | Region microservice | 8080 (internal) | `ghcr.io/opuspopuli/region` |
+| `opuspopuli-prod-region-worker` | Region async worker (BullMQ) | 8080 (internal) | `ghcr.io/opuspopuli/region-worker` |
+| `opuspopuli-prod-structural-analysis-worker` | Structural analysis worker | 8080 (internal) | `ghcr.io/opuspopuli/structural-analysis-worker` |
+| `opuspopuli-prod-llm-rerank-worker` | Personalized-feed LLM rerank | 8080 (internal) | `ghcr.io/opuspopuli/llm-rerank-worker` |
+| `opuspopuli-prod-api` | API Gateway (Apollo Federation) | 8080 (exposed) | `ghcr.io/opuspopuli/api` |
+| `opuspopuli-prod-prometheus` | Metrics collection | 9090 (internal) | `prom/prometheus` |
+| `opuspopuli-prod-loki` | Log aggregation | 3100 (internal) | `grafana/loki` |
+| `opuspopuli-prod-promtail` | Log shipping | (internal) | `grafana/promtail` |
+| `opuspopuli-prod-grafana` | Dashboards | 3101 (localhost only) | `grafana/grafana` |
 
 ### 8.2 Verify Containers
 
@@ -405,14 +417,18 @@ See [Region Setup and Validation Guide](region-setup-and-validation-guide.md) fo
 
 ### 11.1 Updating the Application
 
+Production images publish to `ghcr.io/opuspopuli/*` on push to `main` (see `.github/workflows/release.yml`). On the Studio:
+
 ```bash
 cd opuspopuli
-git pull origin main
-pnpm install
-docker compose -f docker-compose-prod.yml up -d --build
+git pull origin main                                # picks up compose + bind-mount source changes
+docker compose -f docker-compose-prod.yml pull      # fetches new images from ghcr.io
+docker compose -f docker-compose-prod.yml up -d --remove-orphans
 ```
 
-For the frontend (if using Cloudflare Workers):
+No `pnpm install` or `docker compose build` runs on the Studio — the published image already contains the built artifacts.
+
+For the frontend (Cloudflare Pages):
 ```bash
 cd apps/frontend
 pnpm cf:deploy

--- a/docs/guides/docker-setup.md
+++ b/docs/guides/docker-setup.md
@@ -35,7 +35,8 @@ The project uses a layered Docker Compose architecture. Each environment-specifi
 docker-compose.yml                       ← Base infrastructure (Supabase, Redis, observability)
   ├── docker-compose-integration.yml     ← Integration testing (API on port 3000, test-runner)
   ├── docker-compose-e2e.yml             ← E2E testing (API on port 4000 for Playwright)
-  └── docker-compose-uat.yml             ← Manual UAT (LLM config, region sync disabled)
+  ├── docker-compose-uat.yml             ← Manual UAT (LLM config, region sync disabled)
+  └── docker-compose-prod.yml            ← Production (pulls signed images from ghcr.io)
 ```
 
 | File | When to Use | Command |
@@ -44,6 +45,9 @@ docker-compose.yml                       ← Base infrastructure (Supabase, Redi
 | `docker-compose-integration.yml` | Running integration tests | `pnpm test:integration:docker` |
 | `docker-compose-e2e.yml` | Running E2E tests with Playwright | `docker compose -f docker-compose-e2e.yml up -d --build` |
 | `docker-compose-uat.yml` | Manual region validation and UAT | `docker compose -f docker-compose-uat.yml up -d --build` |
+| `docker-compose-prod.yml` | Production deploy on the Mac Studio | `docker compose -f docker-compose-prod.yml pull && docker compose -f docker-compose-prod.yml up -d` |
+
+**Build vs pull:** the dev / integration / e2e / uat composes all build images locally so they exercise your current source. The prod compose **never** builds — it pulls pre-built, cosign-signed images from `ghcr.io/opuspopuli/*` (published by `.github/workflows/release.yml` on push to `main`). The Studio is a pure runtime host; no `pnpm install`, no `docker compose build`. See [`deployment.md`](deployment.md) and [`container-verification.md`](container-verification.md).
 
 ## Quick Start
 

--- a/docs/guides/mac-studio-bootstrap.md
+++ b/docs/guides/mac-studio-bootstrap.md
@@ -1,359 +1,404 @@
-# Mac Studio Bootstrap — From Unboxing to Live
+# Mac Studio Bootstrap — From Sealed Box to Live
 
-A single-pass runbook to take a brand-new Mac Studio from sealed box to a fully running Opus Populi node serving production traffic. Aimed at IT staff or first-time operators; assumes no prior familiarity with the codebase.
+Step-by-step to take a Mac Studio from first boot to serving production traffic at `api.opuspopuli.org`.
 
-**Audience:** IT, DevOps, the founder doing it themselves at 2am.
-**Scope:** Reference hardware (Mac Studio M4 Max, 128 GB) running the full stack: Ollama (native), the opuspopuli backend microservices, the prompt-service, the frontend, and the Cloudflare tunnel.
-**Time estimate:** 3–5 hours end-to-end if everything goes well. 1–2 of those hours are downloads (model weights, docker image base layers).
-**Out of scope:** Cloud VM deployment, Linux workstations, multi-region setups. See [`deployment.md`](deployment.md) for those.
+**Hardware:** Mac Studio M4 Max, 128 GB, 1 TB internal SSD + UPS.
+**Account:** `opuspopuli` (only account on the box).
+**Time:**
+- 5.5 h of step time (commands in sequence).
+- **10–14 h realistic** with first-time friction (LaunchAgent timing, rclone config, first restore drill).
+- **8–11 h to "live on the internet"** if Phase 10 observability is deferred.
+- Calendar: long Saturday + Sunday end-to-end, OR 3–4 evenings (4 h each).
+**MVP gate:** 2026-07-04 — 20 days of slack against an 8–11 h critical path.
 
-This guide intentionally **references** the topical guides ([`docker-setup.md`](docker-setup.md), [`ollama-setup.md`](ollama-setup.md), [`secrets-management.md`](secrets-management.md), etc.) instead of duplicating them. When you hit a section that says "see X for details," go read X — this runbook only covers the orchestration.
+## Decisions
 
----
-
-## Phase 0 — Pre-arrival checklist (do BEFORE the Mac arrives)
-
-These don't need the hardware. Do them in parallel with shipping so you're not blocked when the box lands.
-
-- [ ] **Apple ID** for the production machine (separate from anyone's personal account; bind to the org's shared inbox).
-- [ ] **GitHub access** — confirm an SSH key exists for whichever account will pull the three repos (`opuspopuli`, `prompt-service`, `opuspopuli-regions`). If using a deploy key, generate it now.
-- [ ] **Cloudflare tunnel** — provision via Terraform per [`deployment.md` §7](deployment.md#7-set-up-the-edge-proxy). Capture the tunnel token; it'll go into the Mac later.
-- [ ] **DNS records** for the public hostnames pointing at the Cloudflare tunnel.
-- [ ] **External secrets** — Resend API key, FEC API key, any other 3rd-party tokens. Stash them in 1Password or your secrets vault — see [`secrets-management.md`](secrets-management.md).
-- [ ] **Static IP / DHCP reservation** on the LAN side (Cloudflare tunnel doesn't need it but troubleshooting is much easier with a stable address).
-- [ ] **Hostname** decided (e.g., `opuspopuli-prod-01`).
-
-If any of these are missing when the hardware arrives, you'll stall mid-setup. Resolve them first.
-
----
-
-## Phase 1 — Hardware unboxing and macOS first-boot (~30 min)
-
-### 1.1 — Plug in
-
-Connect, in this order:
-
-1. Power
-2. Ethernet (preferred) or confirm Wi-Fi credentials in advance
-3. Display via HDMI or USB-C → DisplayPort
-4. USB keyboard + pointer (initial setup only; can go headless after)
-
-Apple's "monitor required for first boot" caveat is real — don't skip step 3.
-
-### 1.2 — Setup Assistant
-
-Walk through the macOS Setup Assistant:
-
-- **Region/keyboard** as appropriate.
-- **Network** — connect via Ethernet if available; Wi-Fi otherwise.
-- **Apple ID** — sign in with the production Apple ID from Phase 0. **Do not** use a personal account.
-- **Account name** — use `admin` or `opuspopuli-admin`. The username will become the home directory (`/Users/<name>`); pick something stable.
-- **Skip** Touch ID, Apple Pay, Siri, Screen Time, and the analytics opt-ins for the production machine.
-- **FileVault** — enable. Production data is on Supabase volumes, but your `.env` files and Cloudflare tunnel token will live on disk. Stash the recovery key in your secrets vault.
-- **iCloud Drive / Photos / Mail / Contacts / Calendar** — disable all. This is a server, not a desktop.
-
-### 1.3 — System settings to lock down
-
-After first boot, open **System Settings**:
-
-- **General → Software Update** — install all available updates, then enable automatic updates.
-- **Displays → Sleep** — Never. The Mac is a server; sleep kills running services.
-- **Energy** (under Battery on laptops; on Mac Studio it's **Energy**) — enable **"Start up automatically after a power failure"**. The `mac-studio-setup.sh` script also sets this via `pmset`, but verifying in the GUI catches edge cases on first run.
-- **Screen Lock** — set to require password immediately after sleep, but since sleep is disabled, this only matters for screen-locked-while-awake.
-- **Sharing**:
-  - **Remote Login (SSH)** — enable. Restrict to the admin user.
-  - **Screen Sharing** — enable for emergency GUI access. Restrict to admin user. Use a strong password.
-  - **File Sharing** — leave off.
-  - **Computer Name** — set to the hostname from Phase 0 (e.g., `opuspopuli-prod-01`). The local DNS name becomes `<hostname>.local`.
-- **Users & Groups → Login Options** — disable **automatic login** (FileVault requires it disabled anyway).
-
-### 1.4 — Verify network identity
-
-```bash
-hostname              # should match the Computer Name you set
-ipconfig getifaddr en0  # current IP — verify it matches your DHCP reservation
-ping -c 1 1.1.1.1     # confirm internet reachability
-```
+| Decision | Choice |
+|---|---|
+| Edge / TLS | Cloudflare Tunnel |
+| Frontend | Cloudflare Pages (already deploys via `pnpm cf:deploy`) |
+| Backend images | Built in GitHub Actions, pushed to `ghcr.io/opuspopuli/*`, Studio pulls — no local builds |
+| Container runtime | Docker Desktop — **never resize the disk image; size it 200 GB up front** |
+| Storage | Internal 1 TB SSD, Docker-managed named volumes |
+| Supabase | Self-hosted on the Studio (no Supabase Cloud) |
+| Email | Resend (DKIM on `opuspopuli.org`) |
+| Backups | Nightly `pg_dump -Fc` → Cloudflare R2, 30-day retention |
+| LLM | Local Ollama, `qwen3.5:9b` to start |
+| FileVault | Off (Secure Enclave still encrypts the SSD; trade is unattended boot) |
+| pgsodium key | 1Password `opuspopuli-prod-pgsodium-root-key`, mirrored locally at `/Users/opuspopuli/.config/opuspopuli/pgsodium_root_key` mode 0400 |
+| Out-of-band admin | Tailscale |
 
 ---
 
-## Phase 2 — Developer tooling (~30 min, mostly downloads)
+## Phase 1 — Workstation prep (≈ 1 h, no Studio needed)
 
-### 2.1 — Xcode Command Line Tools
+Do these from your laptop today.
 
-```bash
-xcode-select --install
-```
+1. **Apply Cloudflare prod Terraform** — creates Tunnel, DNS (`api.`, `grafana.`), R2 bucket.
+   ```bash
+   cd infra/cloudflare
+   terraform workspace select prod || terraform workspace new prod
+   terraform apply -var-file=environments/prod.tfvars
+   ```
 
-A GUI dialog appears; accept and let it run. Re-running the command shows `command line tools are already installed` once it's done.
+2. **Capture Tunnel token to 1Password** as `opuspopuli-prod-tunnel-token`.
+   ```bash
+   terraform output -raw tunnel_token
+   ```
 
-### 2.2 — Homebrew
+3. **R2 backup token** — Cloudflare dashboard → R2 → API tokens → scoped to `opuspopuli-prod-db-backups`, Object Read+Write only. Save to 1Password.
 
-```bash
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-```
+4. **Verify DNS + TLS** (origin will 530 until Phase 9):
+   ```bash
+   dig api.opuspopuli.org +short          # CNAME to *.cfargotunnel.com
+   curl -I https://api.opuspopuli.org     # HTTP/2 530
+   ```
 
-After install finishes it prints **two lines** to add Homebrew to the PATH — actually run them. Verify:
+5. **Resend DKIM** — add SPF + DKIM records on `opuspopuli.org` per Resend dashboard. Test-send to your inbox.
 
-```bash
-brew --version
-```
-
-### 2.3 — Core CLI tools
-
-```bash
-brew install git gh pnpm jq
-brew install --cask docker          # Docker Desktop
-```
-
-`pnpm` ships with corepack-enabled Node, so a separate Node install isn't needed for the workspace tools. If you need a freestanding Node for one-off scripts, `brew install fnm` and `fnm install --lts`.
-
-Open Docker Desktop once from `/Applications` so it can grant kernel extensions; accept the EULA. Then set:
-
-- **Settings → General → Start Docker Desktop when you sign in to your computer** — enable.
-- **Settings → Resources → Memory** — at least 16 GB. The region service alone reserves 6 GB during finance sync.
-- **Settings → Resources → Disk image size** — at least 200 GB.
-
-Verify:
-
-```bash
-docker --version && docker compose version
-```
-
-### 2.4 — GitHub auth
-
-```bash
-gh auth login
-```
-
-Pick HTTPS + browser flow, sign in with the production GitHub account. Then test:
-
-```bash
-gh repo view OpusPopuli/opuspopuli
-```
-
-If the account uses an SSH key instead, place it at `~/.ssh/id_ed25519` and `chmod 600` it.
+6. **Generate the pgsodium master key** (on laptop, not Studio):
+   ```bash
+   set +o history
+   head -c 32 /dev/urandom | od -A n -t x1 | tr -d ' \n'
+   ```
+   Save the 64-hex output to 1Password as `opuspopuli-prod-pgsodium-root-key`.
 
 ---
 
-## Phase 3 — Clone the three repos (~5 min)
+## Phase 2 — Studio first-boot (≈ 30 min, at the Studio)
+
+1. **Plug in:** power → Ethernet → display → USB keyboard.
+
+2. **Setup Assistant:**
+   - Apple ID: production account (not personal).
+   - Account name: **`opuspopuli`**.
+   - Skip Touch ID, Apple Pay, Siri, Screen Time, analytics.
+   - **FileVault: OFF.**
+   - Disable iCloud Drive / Photos / Mail / Contacts / Calendar.
+
+3. **System Settings:**
+   - General → Software Update → install all → Automatic: security responses **on**, macOS updates **off**.
+   - Displays → Sleep: Never.
+   - Energy → **Start up automatically after a power failure**.
+   - Lock Screen → require password immediately.
+   - Sharing → Remote Login (SSH) **on** (admin only); Screen Sharing **on** (admin only); File Sharing **off**; Computer Name **`opuspopuli-prod-01`**.
+   - Users & Groups → Login Options → automatic login **off**.
+
+4. **Verify:**
+   ```bash
+   hostname                              # opuspopuli-prod-01
+   ipconfig getifaddr en0
+   ping -c 1 1.1.1.1
+   sudo pmset -g | grep autorestart      # autorestart  1
+   ```
+
+---
+
+## Phase 3 — Dev tooling (≈ 45 min)
+
+1. **Xcode CLI tools:**
+   ```bash
+   xcode-select --install
+   ```
+
+2. **Homebrew:**
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+   Run the PATH lines it prints.
+
+3. **Core tools** (all MIT / Apache-2 — no GPL):
+   ```bash
+   brew install git gh pnpm jq cloudflared rclone
+   brew install --cask docker tailscale
+   ```
+
+4. **Docker Desktop config** — open once from `/Applications`, accept EULA, then:
+   - Settings → General → Start Docker Desktop when you sign in: **on**.
+   - Settings → Resources → Memory: **40 GB**, CPU: all cores.
+   - Settings → Resources → **Disk image size: 200 GB** (set this once and **never change it** — resizing wipes volumes).
+   ```bash
+   docker --version && docker compose version
+   ```
+
+5. **GitHub auth:**
+   ```bash
+   gh auth login
+   gh repo view OpusPopuli/opuspopuli   # smoke test
+   ```
+
+6. **Tailscale** — sign in, accept Studio as a node, enable SSH. Verify from laptop:
+   ```bash
+   tailscale ssh opuspopuli@opuspopuli-prod-01
+   ```
+
+7. **Ollama** (kick off downloads now, ~6 GB, comes back at Phase 7):
+   ```bash
+   brew install ollama
+   brew services start ollama
+   ollama pull qwen3.5:9b &
+   ollama pull nomic-embed-text &
+   ```
+
+---
+
+## Phase 4 — pgsodium key + LaunchAgent (≈ 20 min, load-bearing)
+
+1. **Materialize the key file** from 1Password:
+   ```bash
+   set +o history
+   mkdir -p /Users/opuspopuli/.config/opuspopuli
+   chmod 700 /Users/opuspopuli/.config/opuspopuli
+   printf '%s' '<paste-64-hex-from-1password>' > /Users/opuspopuli/.config/opuspopuli/pgsodium_root_key
+   chmod 400 /Users/opuspopuli/.config/opuspopuli/pgsodium_root_key
+   wc -c /Users/opuspopuli/.config/opuspopuli/pgsodium_root_key   # 64
+   ```
+
+2. **Author LaunchAgent** at `~/Library/LaunchAgents/org.opuspopuli.envloader.plist`:
+   ```xml
+   <?xml version="1.0" encoding="UTF-8"?>
+   <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+   <plist version="1.0">
+   <dict>
+     <key>Label</key><string>org.opuspopuli.envloader</string>
+     <key>ProgramArguments</key>
+     <array>
+       <string>/bin/sh</string>
+       <string>-c</string>
+       <string>launchctl setenv PGSODIUM_ROOT_KEY "$(cat /Users/opuspopuli/.config/opuspopuli/pgsodium_root_key)"; launchctl setenv TUNNEL_TOKEN "<paste-tunnel-token>"</string>
+     </array>
+     <key>RunAtLoad</key><true/>
+   </dict>
+   </plist>
+   ```
+   Load + verify:
+   ```bash
+   launchctl load ~/Library/LaunchAgents/org.opuspopuli.envloader.plist
+   # Log out and back in, then in a fresh shell:
+   echo ${PGSODIUM_ROOT_KEY:0:8}     # 8 hex chars
+   echo ${TUNNEL_TOKEN:0:8}          # 8 chars
+   ```
+
+3. **Prepare operator-secret seed SQL** at `/Users/opuspopuli/.config/opuspopuli/seed-operator-vault.sql` (mode 0400, source values from 1Password). Used at Phase 8.3.
+   ```sql
+   SELECT vault_create_secret('<resend_key>',  'RESEND_API_KEY',   'Resend');
+   SELECT vault_create_secret('<fec_key>',     'FEC_API_KEY',      'FEC');
+   SELECT vault_create_secret('<r2_account>',  'R2_ACCOUNT_ID',    'R2 account');
+   SELECT vault_create_secret('<r2_key>',      'R2_ACCESS_KEY_ID', 'R2 access');
+   SELECT vault_create_secret('<r2_secret>',   'R2_SECRET_ACCESS_KEY', 'R2 secret');
+   ```
+   **Do not commit.**
+
+---
+
+## Phase 5 — Clone opuspopuli (≈ 5 min, compose + bind-mount sources only)
+
+Backend + prompt-service images are pulled from `ghcr.io`, not built on the Studio. We still need a working tree of `opuspopuli` on disk for the compose files and the bind-mount sources (`supabase/init/`, `backup/scripts/`, `observability/`). Don't clone `prompt-service` or `opuspopuli-regions` — their code lives inside ghcr.io images.
 
 ```bash
-mkdir -p ~/Development/Opus
-cd ~/Development/Opus
+mkdir -p /Users/opuspopuli/Development/Opus
+cd /Users/opuspopuli/Development/Opus
 gh repo clone OpusPopuli/opuspopuli
-gh repo clone OpusPopuli/prompt-service
-gh repo clone OpusPopuli/opuspopuli-regions
 ```
 
-Confirm the layout:
-
+Then log in to ghcr.io so the next `docker compose pull` can authenticate:
 ```bash
-ls ~/Development/Opus
-# expected: opuspopuli  opuspopuli-regions  prompt-service
+gh auth token | docker login ghcr.io -u "$(gh api user --jq .login)" --password-stdin
 ```
-
-The opuspopuli `docker-compose-uat.yml` and the prompt-service compose both reference each other on the `prompt-service_default` Docker network — **the directory layout matters**, don't rename them.
 
 ---
 
-## Phase 4 — Run `mac-studio-setup.sh` (~30–60 min)
+## Phase 6 — Backup-restore drill (≈ 45 min, before any real data lands)
 
-The automation script handles Ollama, Docker auto-start verification, cloudflared, and the auto-restart-on-power-failure setting.
+Rehearse recovery before there's anything worth recovering.
 
-```bash
-cd ~/Development/Opus/opuspopuli
-chmod +x scripts/mac-studio-setup.sh
-./scripts/mac-studio-setup.sh
-```
+1. **Configure rclone for R2** at `~/.config/rclone/rclone.conf` (mode 0400) using the token from Phase 1.3.
 
-What this does (see the script source for specifics):
+2. **Stand up a throwaway DB + seed a tiny fixture.**
+   ```bash
+   cd /Users/opuspopuli/Development/Opus/opuspopuli
+   pnpm install
+   docker compose -f docker-compose-uat.yml up -d opuspopuli-db
+   # seed: one region, one user, ten bills
+   ```
 
-1. **Ollama (native macOS)** — installs and starts via launchd. Pulls the production model weights via [`scripts/setup-ollama.sh --prod`](../../scripts/setup-ollama.sh). Models are several GB each — this is the longest single step.
-2. **Docker** — verifies Docker Desktop is installed and running.
-3. **cloudflared** — installs and registers the tunnel as a launchd service. You'll be prompted for the tunnel token from Phase 0.
-4. **Auto-restart on power failure** — `sudo pmset -a autorestart 1`.
+3. **Backup → R2.**
+   ```bash
+   docker compose -f docker-compose-prod.yml -f docker-compose-backup.yml \
+                  --env-file .env.backup.prod \
+                  run --rm opuspopuli-backup /scripts/backup-db.sh
+   rclone copyto <local-dump-path> r2:opuspopuli-prod-db-backups/<filename>.dump.gz
+   rclone hashsum md5 r2:opuspopuli-prod-db-backups/<filename>.dump.gz   # compare to local md5sum
+   ```
 
-If any sub-step fails, the script exits non-zero. Re-run after fixing — it's idempotent.
+4. **Restore drill from R2** (simulate full Studio loss):
+   ```bash
+   docker compose down -v
+   docker compose -f docker-compose-uat.yml up -d opuspopuli-db
+   rclone copy r2:opuspopuli-prod-db-backups/<latest>.dump.gz /tmp/
+   docker compose ... run --rm opuspopuli-backup /scripts/restore-db.sh --full
+   ```
+   Time it. Target: **< 60 min**. Record RTO in `docs/site-notes/opuspopuli-prod-01.md`.
 
-Verify when it's done:
+5. **pgsodium key drill** — stash a wrong key file, restore from R2, watch `vault.secrets` reads fail. Proves the 1Password key is the only recovery path.
 
-```bash
-ollama list                         # production models present
-launchctl list | grep cloudflared   # tunnel daemon registered
-pmset -g | grep autorestart         # autorestart       1
-```
-
-For deeper Ollama tuning (GPU layers, num_parallel), see [`ollama-setup.md`](ollama-setup.md) and [`llm-configuration.md`](llm-configuration.md).
-
----
-
-## Phase 5 — Configure secrets (~15 min)
-
-The compose stack pulls some secrets from env vars and others from Supabase Vault. See [`secrets-management.md`](secrets-management.md) for the model.
-
-Minimum env vars to populate before bringing up the stack — drop them in `~/.opuspopuli.env` or wherever your secrets-manager workflow points to:
-
-```bash
-# External APIs
-FEC_API_KEY=...                # required for federal campaign-finance sync
-RESEND_API_KEY=...             # required for transactional email
-
-# Prompt-service auth (matches docker-compose API_KEYS env)
-PROMPT_SERVICE_API_KEY=dev-key-1   # OR your production key
-
-# Optional but recommended
-SUPABASE_VAULT_URL=...
-SUPABASE_VAULT_SERVICE_ROLE_KEY=...
-```
-
-If you're running the UAT compose for validation, the file at [`docker-compose-uat.yml`](../../docker-compose-uat.yml) ships with safe-default test keys — **do not** use that compose file for production traffic.
-
-For production, use [`docker-compose.yml`](../../docker-compose.yml) + the deployment-specific override per [`deployment.md` §6](deployment.md#6-configure-secrets-and-environment).
+6. **Reset:** `docker compose down -v`.
 
 ---
 
-## Phase 6 — Bring up the prompt-service first (~10 min)
+## Phase 7 — Ollama smoke (≈ 10 min)
 
-The opuspopuli backend depends on the prompt-service over the `prompt-service_default` Docker network, so this comes first.
-
-```bash
-cd ~/Development/Opus/prompt-service
-docker compose up -d --build
-```
-
-Apply migrations + seed prompts:
+Ollama downloads from Phase 3.7 should be done by now.
 
 ```bash
-docker compose exec <prompt-service-container-name> pnpm db:migrate deploy
-docker compose exec <prompt-service-container-name> pnpm db:seed
+ollama list                                # qwen3.5:9b + nomic-embed-text present
+curl http://localhost:11434/api/tags | jq '.models[].name'
+docker run --rm alpine sh -c 'apk add curl && curl http://host.docker.internal:11434/api/tags'
+# warm the model so first user request isn't a 90s cold start:
+curl -X POST http://localhost:11434/api/generate \
+     -d '{"model":"qwen3.5:9b","prompt":"hi","stream":false}'
 ```
-
-(Find the container name with `docker compose ps`.)
-
-Smoke test:
-
-```bash
-curl -s -X POST http://localhost:3210/api/render \
-  -H 'authorization: Bearer dev-key-1' \
-  -H 'content-type: application/json' \
-  -d '{"name":"document-analysis-representative-bio","inputs":{"TEXT":"test"}}' \
-  | jq '.promptText | length'
-```
-
-Expect a positive integer (the rendered prompt length). If you get a 401, the API key is wrong; 404 means the prompt isn't seeded.
 
 ---
 
-## Phase 7 — Bring up the opuspopuli stack (~15–30 min, mostly image build)
+## Phase 8 — Pull + start the stack (≈ 20 min)
 
-```bash
-cd ~/Development/Opus/opuspopuli
-pnpm install
-pnpm --filter @opuspopuli/relationaldb-provider db:generate
-docker compose -f docker-compose-uat.yml up -d --build
-```
+**Prerequisite:** `docker-compose-prod.yml` must reference `ghcr.io/opuspopuli/<service>` images instead of `build:` directives, and must include the prompt-service definitions (image, env, networks) so we don't need a separate prompt-service compose. This is a separate workstream tracked alongside the GitHub Actions deploy workflow.
 
-(Use the production compose instead of `-uat` once you're past validation. The flow is identical.)
+1. **Pull images.**
+   ```bash
+   cd /Users/opuspopuli/Development/Opus/opuspopuli
+   docker compose -f docker-compose-prod.yml -f docker-compose-backup.yml pull
+   ```
 
-Watch service health:
+2. **Bring up the stack.**
+   ```bash
+   docker compose -f docker-compose-prod.yml -f docker-compose-backup.yml up -d
+   ```
+   Watch `db-migrate` exit 0:
+   ```bash
+   docker compose logs -f db-migrate
+   ```
 
-```bash
-docker compose -f docker-compose-uat.yml ps
-docker compose -f docker-compose-uat.yml logs -f db-migrate region api
-```
+3. **Seed operator secrets** into the Vault using the SQL from Phase 4.3:
+   ```bash
+   docker compose exec opuspopuli-db psql -U postgres -d postgres \
+          < /Users/opuspopuli/.config/opuspopuli/seed-operator-vault.sql
+   ```
 
-Wait until `region` and `api` show `(healthy)` — typically 60–90 s after `db-migrate` finishes.
+4. **Smoke prompt-service** (now running inside the unified compose):
+   ```bash
+   curl -s -X POST http://localhost:3210/api/render \
+        -H 'authorization: Bearer dev-key-1' \
+        -H 'content-type: application/json' \
+        -d '{"name":"document-analysis-representative-bio","inputs":{"TEXT":"test"}}' \
+        | jq '.promptText | length'
+   ```
+   Expect a positive integer.
 
-For container-level troubleshooting see [`docker-setup.md`](docker-setup.md), [`docker-healthchecks.md`](docker-healthchecks.md), and [`container-resources.md`](container-resources.md).
+5. **Wait for healthy:**
+   ```bash
+   for port in 3000 3001 3002 3003 3004 3005 3210; do
+     printf "port %s: " $port
+     curl -fsS "http://localhost:$port/health" && echo
+   done
+   ```
+   All `{"status":"ok"}`.
 
----
-
-## Phase 8 — Bring up the frontend (~5 min)
-
-```bash
-cd ~/Development/Opus/opuspopuli
-docker compose -f docker-compose-frontend.yml up -d --build
-```
-
-The frontend image bakes in `next build` — first build takes 5–8 min; subsequent rebuilds with no source changes are cached.
-
----
-
-## Phase 9 — Smoke test the live stack (~10 min)
-
-### 9.1 — Health endpoints
-
-```bash
-for port in 3000 3001 3002 3003 3004 3210; do
-  printf "port %s: " $port
-  curl -fsS "http://localhost:$port/health" && echo
-done
-```
-
-All six should return `{"status":"ok"}`.
-
-### 9.2 — GraphQL
-
-```bash
-curl -s -X POST http://localhost:3000/api \
-  -H 'content-type: application/json' \
-  -H 'apollo-require-preflight: true' \
-  -d '{"query":"{ regionInfo { name supportedDataTypes } }"}' | jq
-```
-
-Expect the configured region's name and at least `[PROPOSITIONS, MEETINGS, REPRESENTATIVES, CAMPAIGN_FINANCE]`.
-
-### 9.3 — End-to-end via the frontend
-
-In a browser:
-
-1. Visit `https://<your-tunnel-hostname>` (or `http://<mac-hostname>.local:3300` on the LAN).
-2. Sign up + verify email through Inbucket at `http://localhost:54324` (UAT) or your real SMTP (prod).
-3. Add an address with full district info.
-4. Visit `/region` — both your Assemblymember and your Senator should appear under "My Representatives," and the Legislative Committees card should be visible.
-5. Click into a committee → all four layers (Snapshot/Members/Hearings/Deep Dive) render.
-
-### 9.4 — Trigger an initial sync
-
-GraphQL Playground at `http://localhost:3000/graphql` (or via curl with the auth header):
-
-```graphql
-mutation {
-  syncDataType(dataType: REPRESENTATIVES) { dataType processed created updated }
-}
-```
-
-Watch the region log — you should see `Legislative committee linker complete` and `Generated N/N legislative committee descriptions successfully`. See [`region-setup-and-validation-guide.md`](region-setup-and-validation-guide.md) for the full validation matrix.
+6. **Run ad-hoc backup** to verify R2 upload from the real stack:
+   ```bash
+   docker compose -f docker-compose-prod.yml -f docker-compose-backup.yml \
+                  run --rm opuspopuli-backup /scripts/backup-db.sh
+   wrangler r2 object list opuspopuli-prod-db-backups | head
+   ```
 
 ---
 
-## Phase 10 — Lock down + handoff (~30 min)
+## Phase 9 — Cloudflare Tunnel cutover (≈ 30 min, the visible moment)
 
-- [ ] Confirm cloudflared is reachable via the public hostname (`curl -I https://<hostname>` returns 200 from the frontend).
-- [ ] Confirm SSH from a remote workstation works: `ssh admin@opuspopuli-prod-01.local`.
-- [ ] Confirm screen sharing as a fallback.
-- [ ] Reboot the Mac and confirm everything comes back automatically:
-  - Ollama daemon
-  - Docker Desktop
-  - The compose stacks (Docker Desktop's autostart restarts the previously-running containers)
-  - cloudflared tunnel
-- [ ] Pull the FileVault recovery key into your secrets vault (you should already have it from Phase 1.3 — verify it's still there).
-- [ ] Document any deviation from this runbook in `docs/site-notes/<hostname>.md` so the next operator knows what's different.
-- [ ] Add the host to your monitoring (uptime checks, log aggregation) per [`observability.md`](observability.md) and [`distributed-tracing.md`](distributed-tracing.md).
+1. **Connect cloudflared.** Already defined in `docker-compose-prod.yml`; reads `TUNNEL_TOKEN` from launchd env (Phase 4.2).
+   ```bash
+   docker compose -f docker-compose-prod.yml up -d cloudflared
+   docker logs opuspopuli-prod-cloudflared --tail 50
+   # expect "Registered tunnel connection" from 2+ edge POPs
+   ```
+
+2. **Verify from off-LAN** (phone tethered, or a friend's laptop):
+   ```bash
+   curl -i https://api.opuspopuli.org/health     # HTTP/2 200, cf-cache-status header
+   curl -s -X POST https://api.opuspopuli.org/api \
+        -H 'content-type: application/json' \
+        -H 'apollo-require-preflight: true' \
+        -d '{"query":"{ regionInfo { name } }"}' | jq
+   ```
+
+3. **Point Cloudflare Pages at prod.** In Pages settings:
+   ```
+   NEXT_PUBLIC_GRAPHQL_URL=https://api.opuspopuli.org/api
+   ```
+   Deploy:
+   ```bash
+   cd apps/frontend
+   pnpm cf:deploy
+   ```
+
+4. **End-to-end browser check.** Visit `https://app.opuspopuli.org`. Sign up → magic link arrives via Resend → add address → `/region` page renders representatives + committees → click into a committee → all four layers render.
+
+---
+
+## Phase 10 — Observability + alerts (≈ 45 min)
+
+1. **Grafana behind Cloudflare Access.** Extend `infra/cloudflare/tunnel.tf` with an ingress rule for `grafana.opuspopuli.org` → `http://localhost:3101`. Apply. Add Cloudflare Access policy requiring login as your email.
+   ```bash
+   curl -I https://grafana.opuspopuli.org    # redirect to Access login
+   ```
+
+2. **Grafana alerts → Resend SMTP.** Grafana → Alerting → Notification channels.
+
+3. **External uptime monitor** — UptimeRobot or Better Stack free tier: `GET https://api.opuspopuli.org/health` every 1 min, page on 3 failures.
+
+4. **Smoke an alert:**
+   ```bash
+   docker compose stop knowledge
+   # wait 5 min, confirm email arrives
+   docker compose start knowledge
+   ```
+
+5. **Confirm `audit_logs` table is in nightly `pg_dump`.**
+
+---
+
+## Cold-restore rehearsal (≈ 4 h, optional, post-MVP if time-pressed)
+
+Run the entire bootstrap from Phase 2 onward against a second Mac (your dev MacBook works) using the R2 backup. The only honest RTO answer is what the rehearsal measures. Record in `docs/site-notes/cold-restore-runbook.md`.
 
 ---
 
 ## Troubleshooting
 
-| Symptom | Likely cause | Where to look |
+| Symptom | Cause | Fix |
 |---|---|---|
-| `db-migrate` exits non-zero | Migration SQL conflict or DB unreachable | [`database-migration.md`](database-migration.md) |
-| `region` keeps restarting (OOM) | Docker Desktop memory cap too low | Phase 2.3 — bump to 16 GB+ |
-| `network prompt-service_default not found` | Prompt-service stack not running | Phase 6 |
-| Frontend serves 404 from agenda links / stale data | Service worker cache | DevTools → Application → Service Workers → Unregister + Reload |
-| Ollama responses timing out | `OLLAMA_NUM_PARALLEL` mismatch with `BIO_GENERATOR_CONCURRENCY` | [`ollama-setup.md`](ollama-setup.md), [`llm-configuration.md`](llm-configuration.md) |
-| `apollo-require-preflight` request still 403s | NestJS CSRF middleware is also active | Use the in-browser fetch instead — same-origin cookies bypass both layers |
-| Cloudflare tunnel reports unhealthy | Token rotated or DNS not pointing at the tunnel | [`deployment.md` §7](deployment.md#7-set-up-the-edge-proxy) |
+| `db-migrate` exits non-zero | Migration SQL conflict, FK type drift vs `users.id` (TEXT) | `docker logs opuspopuli-e2e-db-migrate` |
+| Container OOMs (region, knowledge) | Docker memory cap too low | Settings → Resources → bump from 40 → 48 GB |
+| `network prompt-service_default not found` | prompt-service stack not running | Phase 8.1 |
+| Stale frontend after Pages deploy | Service worker cache | DevTools → Application → Service Workers → Unregister + Reload |
+| Ollama timeouts | `OLLAMA_NUM_PARALLEL` vs `BIO_GENERATOR_CONCURRENCY` mismatch | `docs/guides/ollama-setup.md` |
+| `apollo-require-preflight` 403 | NestJS CSRF on the path | Use in-browser fetch — same-origin cookies bypass |
+| Tunnel reports unhealthy | Token rotated or DNS not pointing at tunnel | Re-apply Terraform; reload LaunchAgent |
+| `vault.secrets` all error after restore | pgsodium key drift | Restore 1Password key to `/Users/opuspopuli/.config/opuspopuli/pgsodium_root_key`; relogin |
+| Stack doesn't come back after reboot | LaunchAgent didn't inject `PGSODIUM_ROOT_KEY` | `launchctl list | grep opuspopuli.envloader`; reload `.plist`; relogin |
+| Docker disk image full | Volumes accumulated | `docker system prune --volumes` (READ docs first); **never resize the disk image** — that wipes volumes |
 
-If you hit something not in the table, the topical guides under `docs/guides/` are the next stop. After that, the architecture docs under `docs/architecture/` explain the why.
+---
+
+## Critical files
+
+- `docker-compose-prod.yml` — base prod stack
+- `docker-compose-backup.yml` — nightly `pg_dump` overlay
+- `supabase/init/pgsodium_getkey_env.sh` — reads `PGSODIUM_ROOT_KEY` from env
+- `infra/cloudflare/tunnel.tf` — Tunnel ingress rules
+- `backup/scripts/backup-db.sh` — dump + verify
+- `apps/backend/src/common/bootstrap.ts` — `VAULT_BACKED_SECRETS` list
+- `~/Library/LaunchAgents/org.opuspopuli.envloader.plist` — boot-time env injection
+- `/Users/opuspopuli/.config/opuspopuli/pgsodium_root_key` — local mirror of the 1Password key (mode 0400)
+- `/Users/opuspopuli/.config/opuspopuli/seed-operator-vault.sql` — operator-secret seed SQL (mode 0400, not committed)

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
       "defu": ">=6.1.5",
       "axios": ">=1.15.0",
       "basic-ftp": ">=5.2.1",
+      "form-data": ">=4.0.6",
       "next@>=16.0.0 <16.2.6": ">=16.2.6",
       "@opentelemetry/auto-instrumentations-node@<0.75.0": ">=0.75.0",
       "@opentelemetry/sdk-node@<0.217.0": ">=0.217.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,7 @@ overrides:
   defu: '>=6.1.5'
   axios: '>=1.15.0'
   basic-ftp: '>=5.2.1'
+  form-data: '>=4.0.6'
   next@>=16.0.0 <16.2.6: '>=16.2.6'
   '@opentelemetry/auto-instrumentations-node@<0.75.0': '>=0.75.0'
   '@opentelemetry/sdk-node@<0.217.0': '>=0.217.0'
@@ -8158,8 +8159,8 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formdata-node@4.4.1:
@@ -8497,6 +8498,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   helmet@8.1.0:
@@ -14608,7 +14613,7 @@ snapshots:
     dependencies:
       '@types/node': 18.19.130
       extend: 3.0.2
-      form-data: 4.0.5
+      form-data: 4.0.6
       ibm-cloud-sdk-core: 5.4.9
       ts-node: 10.9.2(@types/node@18.19.130)(typescript@5.9.3)
     transitivePeerDependencies:
@@ -18121,7 +18126,7 @@ snapshots:
   '@types/node-fetch@2.6.13':
     dependencies:
       '@types/node': 25.8.0
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/node@18.19.130':
     dependencies:
@@ -18219,7 +18224,7 @@ snapshots:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 25.8.0
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/supercluster@7.1.3':
     dependencies:
@@ -18853,7 +18858,7 @@ snapshots:
   axios@1.16.1(debug@4.4.3):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -20001,7 +20006,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-shim-unscopables@1.1.0:
     dependencies:
@@ -20650,12 +20655,12 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   formdata-node@4.4.1:
@@ -20999,6 +21004,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
   helmet@8.1.0: {}
 
   help-me@3.0.0:
@@ -21127,7 +21136,7 @@ snapshots:
       dotenv: 16.6.1
       extend: 3.0.2
       file-type: 22.0.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
@@ -24443,7 +24452,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0

--- a/scripts/mac-studio-setup.sh
+++ b/scripts/mac-studio-setup.sh
@@ -1,114 +1,279 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # =============================================================================
-# Mac Studio M4 Max — Production Setup Script
-# =============================================================================
+# Mac Studio production bootstrap — idempotent, safe to re-run.
 #
-# Sets up the Mac Studio as the Opus Populi production server:
-#   1. Ollama (native macOS for Metal GPU acceleration)
-#   2. Docker Desktop
-#   3. cloudflared (Cloudflare tunnel client)
-#   4. macOS auto-restart on power failure
+# Automates Phases 3, 4, 5, 7, and 8-prep from
+# docs/guides/mac-studio-bootstrap.md.
 #
-# Prerequisites:
-#   - macOS with Apple Silicon (M4 Max)
-#   - Homebrew installed (https://brew.sh)
-#   - Cloudflare account with tunnel created (via Terraform)
+# Manual steps it CAN'T automate (it'll prompt you when you hit them):
+#   - Phase 2: macOS Setup Assistant + System Settings (GUI)
+#   - Phase 3.4: Docker Desktop GUI config (memory, disk image size)
+#   - Phase 3.5: `gh auth login` (browser flow)
+#   - Phase 3.6: Tailscale sign-in (menu bar)
+#   - Phase 4.1: paste the pgsodium key + tunnel token (read -s)
+#   - Phase 6: backup-restore drill (operational rehearsal)
+#   - Phase 9: off-LAN verification + Pages re-point + browser sign-up
 #
 # Usage:
 #   chmod +x scripts/mac-studio-setup.sh
 #   ./scripts/mac-studio-setup.sh
-#
 # =============================================================================
 
 set -euo pipefail
 
-echo "============================================"
-echo "  Opus Populi — Mac Studio Production Setup"
-echo "============================================"
-echo ""
+# ---------- helpers ----------
+log()     { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+fail()    { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+section() { printf '\n%s\n  %s\n%s\n' "============================================" "$*" "============================================"; }
+prompt()  { read -rp "→ $* [press Enter when done] " _; }
 
-# ---------------------------------------------------------------------------
-# 1. Ollama (Native macOS — NOT Docker)
-# ---------------------------------------------------------------------------
-echo "--- Setting up Ollama (production models) ---"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-"$SCRIPT_DIR/setup-ollama.sh" --prod
-echo ""
+# ---------- preflight ----------
+[[ "$(whoami)" == "opuspopuli" ]] || fail "run as 'opuspopuli' (got '$(whoami)')"
+[[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]] \
+  || fail "this script targets Apple Silicon macOS"
 
-# ---------------------------------------------------------------------------
-# 2. Docker Desktop
-# ---------------------------------------------------------------------------
-echo "--- Checking Docker ---"
-if command -v docker &> /dev/null; then
-    echo "Docker already installed: $(docker --version)"
+OPUS_HOME="/Users/opuspopuli"
+DEV_DIR="$OPUS_HOME/Development/Opus"
+CONFIG_DIR="$OPUS_HOME/.config/opuspopuli"
+KEY_FILE="$CONFIG_DIR/pgsodium_root_key"
+LAUNCH_AGENT="$OPUS_HOME/Library/LaunchAgents/org.opuspopuli.envloader.plist"
+
+# ============================================================================
+# Phase 3 — Dev tooling
+# ============================================================================
+section "Phase 3 — Dev tooling"
+
+if ! command -v brew >/dev/null 2>&1; then
+  log "Installing Homebrew..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+log "Homebrew: $(brew --version | head -1)"
+
+log "Installing CLI tools (idempotent)..."
+brew install git gh pnpm jq cloudflared rclone ollama
+
+log "Installing Docker Desktop + Tailscale..."
+brew install --cask docker tailscale
+
+cat <<'MANUAL'
+
+MANUAL STEPS — Docker Desktop:
+  1. Open Docker Desktop from /Applications, accept EULA.
+  2. Settings → General → "Start Docker Desktop when you sign in" ON.
+  3. Settings → Resources → Memory: 40 GB.
+  4. Settings → Resources → Disk image size: 200 GB.
+     ⚠️  NEVER resize this later — resizing wipes all volumes.
+
+MANUAL
+prompt "Docker Desktop config done"
+
+command -v docker >/dev/null 2>&1 || fail "docker not on PATH — restart shell"
+log "Docker: $(docker --version)"
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo
+  echo "MANUAL — GitHub auth (browser flow opens):"
+  gh auth login
+fi
+log "gh: signed in as $(gh api user --jq .login 2>/dev/null || echo unknown)"
+
+cat <<'MANUAL'
+
+MANUAL — Tailscale:
+  1. Open Tailscale from the menu bar.
+  2. Sign in to your tailnet.
+  3. Accept this Studio as a node.
+  4. Admin → Machines → enable SSH for this node.
+
+MANUAL
+prompt "Tailscale signed in"
+
+# ============================================================================
+# Phase 4 — pgsodium key + LaunchAgent
+# ============================================================================
+section "Phase 4 — pgsodium key + LaunchAgent"
+
+mkdir -p "$CONFIG_DIR"
+chmod 700 "$CONFIG_DIR"
+
+if [[ -s "$KEY_FILE" ]] && [[ "$(wc -c < "$KEY_FILE")" == "64" ]]; then
+  log "key file already present ($KEY_FILE, 64 bytes)"
 else
-    echo "Docker Desktop not found."
-    echo "Download and install from: https://www.docker.com/products/docker-desktop/"
-    echo ""
-    echo "After installing Docker Desktop:"
-    echo "  1. Open Docker Desktop → Settings → General"
-    echo "  2. Enable 'Start Docker Desktop when you sign in to your computer'"
-    echo "  3. Allocate at least 16GB memory (Settings → Resources)"
-    echo ""
+  echo
+  echo "Paste the 64-hex pgsodium key from 1Password"
+  echo "(opuspopuli-prod-pgsodium-root-key). Input is hidden."
+  read -rs -p "  key: " PGSODIUM_KEY
+  echo
+  [[ ${#PGSODIUM_KEY} -eq 64 ]] || fail "expected 64 hex chars, got ${#PGSODIUM_KEY}"
+  printf '%s' "$PGSODIUM_KEY" > "$KEY_FILE"
+  unset PGSODIUM_KEY
+  log "wrote $KEY_FILE"
+fi
+chmod 400 "$KEY_FILE"
+
+echo
+echo "Paste the Cloudflare Tunnel token from 1Password"
+echo "(opuspopuli-prod-tunnel-token). Input is hidden."
+echo "Press Enter alone to keep the existing token in the LaunchAgent."
+read -rs -p "  token: " TUNNEL_TOKEN
+echo
+
+mkdir -p "$(dirname "$LAUNCH_AGENT")"
+if [[ -n "$TUNNEL_TOKEN" ]]; then
+  cat > "$LAUNCH_AGENT" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.opuspopuli.envloader</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>launchctl setenv PGSODIUM_ROOT_KEY "\$(cat $KEY_FILE)"; launchctl setenv TUNNEL_TOKEN "$TUNNEL_TOKEN"</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+</dict>
+</plist>
+PLIST
+  unset TUNNEL_TOKEN
+  chmod 600 "$LAUNCH_AGENT"
+  log "wrote $LAUNCH_AGENT"
 fi
 
-# ---------------------------------------------------------------------------
-# 3. cloudflared
-# ---------------------------------------------------------------------------
-echo "--- Installing cloudflared ---"
-if command -v cloudflared &> /dev/null; then
-    echo "cloudflared already installed: $(cloudflared --version)"
+launchctl unload "$LAUNCH_AGENT" 2>/dev/null || true
+launchctl load "$LAUNCH_AGENT"
+launchctl setenv PGSODIUM_ROOT_KEY "$(cat "$KEY_FILE")"
+log "LaunchAgent loaded; env injected into current launchd session"
+log "verify in a NEW shell after relogin: echo \${PGSODIUM_ROOT_KEY:0:8}"
+
+cat <<'NEXT'
+
+MANUAL — operator-secret seed SQL (used at Phase 8.3):
+  Write /Users/opuspopuli/.config/opuspopuli/seed-operator-vault.sql (mode 0400)
+  containing vault_create_secret() calls for RESEND_API_KEY, FEC_API_KEY,
+  R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY.
+  See docs/guides/mac-studio-bootstrap.md Phase 4 step 3 for the SQL template.
+
+NEXT
+prompt "seed-operator-vault.sql in place (or skip if seeding later)"
+
+# ============================================================================
+# Phase 5 — Clone opuspopuli (compose + bind-mount sources only)
+# ============================================================================
+section "Phase 5 — Clone opuspopuli"
+
+# Images for backend services + prompt-service come from ghcr.io (built in CI,
+# pulled to the Studio). We still need a working tree of `opuspopuli` on disk
+# for:
+#   - docker-compose-prod.yml / docker-compose-backup.yml
+#   - supabase/init/pgsodium_getkey_env.sh   (bind-mounted into db)
+#   - backup/scripts/backup-db.sh             (bind-mounted into backup)
+#   - observability/*.yml + grafana/*        (bind-mounted into prom/grafana)
+#
+# We DO NOT clone prompt-service or opuspopuli-regions — prompt-service's image
+# comes from ghcr.io too (its compose definitions live inside opuspopuli's
+# docker-compose-prod.yml after the ghcr.io migration), and opuspopuli-regions
+# is baked into consumer images as an npm dependency.
+
+mkdir -p "$DEV_DIR"
+cd "$DEV_DIR"
+if [[ -d "opuspopuli/.git" ]]; then
+  log "opuspopuli already cloned"
 else
-    brew install cloudflared
-    echo "cloudflared installed successfully"
+  log "cloning opuspopuli..."
+  gh repo clone "OpusPopuli/opuspopuli"
 fi
 
-echo ""
-echo "cloudflared runs as a Docker container in docker-compose-prod.yml."
-echo "The TUNNEL_TOKEN is set via .env.production."
-echo ""
+# ============================================================================
+# Phase 7 — Ollama
+# ============================================================================
+section "Phase 7 — Ollama"
 
-# ---------------------------------------------------------------------------
-# 4. macOS Auto-Restart
-# ---------------------------------------------------------------------------
-echo "--- Configuring auto-restart ---"
-echo ""
-echo "MANUAL STEP REQUIRED:"
-echo "  System Settings → General → Startup & Shutdown"
-echo "  → Enable 'Start up automatically after a power failure'"
-echo ""
-echo "This ensures the Mac Studio restarts after a power outage."
-echo "Combined with Docker's 'restart: unless-stopped', all services"
-echo "will auto-recover."
-echo ""
+brew services start ollama >/dev/null 2>&1 || true
+for _ in 1 2 3 4 5; do
+  if curl -fsS http://localhost:11434/api/tags >/dev/null 2>&1; then break; fi
+  sleep 2
+done
+curl -fsS http://localhost:11434/api/tags >/dev/null \
+  || fail "Ollama not responding on :11434"
 
-# ---------------------------------------------------------------------------
-# Summary
-# ---------------------------------------------------------------------------
-echo "============================================"
-echo "  Setup Complete!"
-echo "============================================"
-echo ""
-echo "Next steps:"
-echo ""
-echo "  1. Copy environment template:"
-echo "     cp .env.production.example .env.production"
-echo ""
-echo "  2. Fill in .env.production with your values"
-echo "     (Supabase keys, JWT secrets, tunnel token)"
-echo ""
-echo "  3. Get the tunnel token from Terraform:"
-echo "     cd infra/cloudflare"
-echo "     terraform workspace select prod"
-echo "     terraform output -raw tunnel_token"
-echo ""
-echo "  4. Start the production stack (verifies Ollama health first):"
-echo "     ./scripts/start-prod.sh"
-echo ""
-echo "  5. Verify:"
-echo "     curl https://api.opuspopuli.org/health"
-echo ""
-echo "Recommended hardware:"
-echo "  - UPS: APC Back-UPS Pro 1500VA (~\$200)"
-echo "    Provides 15+ min runtime for Mac Studio + router/modem"
-echo ""
+for model in qwen3.5:9b nomic-embed-text; do
+  if ollama list 2>/dev/null | awk 'NR>1 {print $1}' | grep -qx "$model"; then
+    log "$model already pulled"
+  else
+    log "pulling $model (may take several minutes)..."
+    ollama pull "$model"
+  fi
+done
+
+log "warming qwen3.5:9b..."
+curl -s -X POST http://localhost:11434/api/generate \
+     -d '{"model":"qwen3.5:9b","prompt":"hi","stream":false}' >/dev/null
+log "Ollama ready"
+
+# verify host.docker.internal from inside a container
+docker run --rm alpine sh -c 'apk add --no-cache curl >/dev/null 2>&1 && curl -fsS http://host.docker.internal:11434/api/tags' >/dev/null \
+  && log "container → host.docker.internal:11434 OK" \
+  || log "WARN: containers can't reach Ollama via host.docker.internal — check Docker network settings"
+
+# ============================================================================
+# Phase 8 prep — docker login to ghcr.io
+# ============================================================================
+section "Phase 8 prep — ghcr.io login"
+
+# Backend + prompt-service images are pulled from ghcr.io, not built locally.
+# `gh auth token` gives us a PAT with packages:read scope (since gh signed in
+# above), which Docker can use to authenticate to ghcr.io.
+if gh auth token >/dev/null 2>&1; then
+  gh auth token | docker login ghcr.io -u "$(gh api user --jq .login)" --password-stdin
+  log "logged in to ghcr.io"
+else
+  log "WARN: gh not authenticated — run 'gh auth login' then re-run this script"
+fi
+
+# ============================================================================
+# Summary + next manual steps
+# ============================================================================
+cat <<DONE
+
+============================================
+  Bootstrap script complete.
+============================================
+
+✅ Automated:
+   - Homebrew + CLI tools + casks
+   - pgsodium key file (mode 0400) + LaunchAgent
+   - opuspopuli repo cloned to $DEV_DIR (compose + bind-mount sources)
+   - Ollama running, models pulled + warmed
+   - Docker logged in to ghcr.io
+
+⏭  Next (manual, from docs/guides/mac-studio-bootstrap.md):
+
+   1. Verify env in a NEW shell after re-login:
+        echo \${PGSODIUM_ROOT_KEY:0:8}   # 8 hex chars
+        echo \${TUNNEL_TOKEN:0:8}        # 8 chars
+
+   2. Phase 6 — backup-restore drill (60 min rehearsal).
+
+   3. PREREQUISITE — docker-compose-prod.yml must reference ghcr.io images:
+        Replace 'build:' blocks on api/users/documents/knowledge/region with
+          image: ghcr.io/opuspopuli/<service>:\${TAG:-latest}
+        Add prompt-service definitions (image, env, networks) if not already
+        merged into the prod compose.
+
+   4. Phase 8 — pull + start the stack:
+        cd $DEV_DIR/opuspopuli
+        docker compose -f docker-compose-prod.yml -f docker-compose-backup.yml \\
+          pull
+        docker compose -f docker-compose-prod.yml -f docker-compose-backup.yml \\
+          up -d
+
+   5. Phase 8.3 — seed operator vault:
+        docker compose exec opuspopuli-db psql -U postgres -d postgres \\
+          < $CONFIG_DIR/seed-operator-vault.sql
+
+   6. Phase 9 — Tunnel cutover + Pages re-point + off-LAN verify.
+
+DONE

--- a/scripts/start-prod.sh
+++ b/scripts/start-prod.sh
@@ -9,8 +9,10 @@
 # Usage:
 #   ./scripts/start-prod.sh                        # defaults to .env.production
 #   ./scripts/start-prod.sh --env-file .env.staging
-#   ./scripts/start-prod.sh --skip-pull             # skip model pull check
-#   ./scripts/start-prod.sh --build                 # force rebuild containers
+#   ./scripts/start-prod.sh --skip-pull             # skip Ollama model pull check
+#   ./scripts/start-prod.sh --build                 # rebuild from source (rare —
+#                                                  # default pulls signed images
+#                                                  # from ghcr.io/opuspopuli/*)
 #
 # =============================================================================
 
@@ -175,7 +177,8 @@ if [[ ! -f "$ENV_FILE" ]]; then
   exit 1
 fi
 
-docker compose -f docker-compose-prod.yml --env-file "$ENV_FILE" up -d $BUILD_FLAG
+docker compose -f docker-compose-prod.yml --env-file "$ENV_FILE" pull
+docker compose -f docker-compose-prod.yml --env-file "$ENV_FILE" up -d --remove-orphans $BUILD_FLAG
 
 echo ""
 echo "============================================"

--- a/scripts/verify-images.sh
+++ b/scripts/verify-images.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 # Configuration
 # ---------------------------------------------------------------------------
 REGISTRY="ghcr.io/opuspopuli"
-SERVICES=(api users documents knowledge region)
+SERVICES=(api users documents knowledge region region-worker structural-analysis-worker llm-rerank-worker db-migrate)
 CERT_IDENTITY_REGEXP="https://github\\.com/OpusPopuli/opuspopuli/\\.github/workflows/release\\.yml@.*"
 CERT_OIDC_ISSUER="https://token.actions.githubusercontent.com"
 
@@ -60,7 +60,9 @@ while [[ $# -gt 0 ]]; do
       echo "Usage: $0 [--service <name>] [--sbom <name>] [--tag <tag>]"
       echo ""
       echo "Options:"
-      echo "  --service <name>   Verify a single service (api|users|documents|knowledge|region)"
+      echo "  --service <name>   Verify a single service"
+      echo "                     (api|users|documents|knowledge|region|region-worker|"
+      echo "                      structural-analysis-worker|llm-rerank-worker|db-migrate)"
       echo "  --sbom <name>      Show SBOM for a service"
       echo "  --tag <tag>        Image tag to verify (default: latest)"
       echo ""


### PR DESCRIPTION
## Summary

The Mac Studio that will host production is an app host, not a CI host — it should pull pre-built, cosign-signed images and run them, never `pnpm install` or `docker compose build`. `release.yml` already published 5 backend images; this extends the matrix to all 9 services compose runs (3 async workers + `db-migrate`, which shares the `test-runner` Dockerfile) and flips `docker-compose-prod.yml` from `build:` to `image: ghcr.io/opuspopuli/<svc>:${TAG:-latest}`.

**Pairs with prompt-service [chore(infra): publish image to ghcr.io + add prod compose overlay #88](https://github.com/OpusPopuli/prompt-service/pull/88)** — together they give the Studio a uniform pull-from-registry deploy story.

## What ships

### Release workflow
- `.github/workflows/release.yml` — added 4 matrix entries:
  - `region-worker`
  - `structural-analysis-worker`
  - `llm-rerank-worker`
  - `db-migrate` (image name = compose service name; shares `Dockerfile.test-runner`)

### docker-compose-prod.yml
- 9 `build:` blocks → `image: ghcr.io/opuspopuli/<svc>:${TAG:-latest}` references
- Header comment rewritten to reflect pull-and-run model + `TAG=sha-…` rollback pattern
- Container table in `docs/guides/deployment.md` expanded to show image source per container

### Mac Studio bootstrap (collapsed from earlier OrbStack/external-drive plan)
- `docs/guides/mac-studio-bootstrap.md` (400 lines) — Docker Desktop on internal SSD, ghcr.io pull at Phase 8, step-by-step with copy-pasteable commands per phase
- `scripts/mac-studio-setup.sh` — idempotent bootstrap: brew installs, GUI config prompts, pgsodium key file + LaunchAgent generation, opuspopuli repo clone (config-source only — no `pnpm install`), ghcr.io login, Ollama pulls

### Docs + scripts touched to match the new model
- `docs/guides/deployment.md` §8 + §11.1 — `pull && up -d`, 9-image container table, rollback example, no `pnpm install` on Studio
- `docs/guides/container-verification.md` — service list expanded to 9 + cross-link to prompt-service `release.yml`
- `docs/guides/docker-setup.md` — added `docker-compose-prod.yml` to file tree + build-vs-pull explainer
- `scripts/verify-images.sh` — `SERVICES=` array extended to 9, help text updated
- `scripts/start-prod.sh` — runs `docker compose pull` before `up -d`; `--build` flag re-described as the rare local-build escape hatch

### Unrelated CVE fix (folded in to clear the pre-push gate)
- `package.json` — `pnpm.overrides` entry for `form-data: ">=4.0.6"` to clear GHSA-hmw2-7cc7-3qxx (transitive via `@apollo/gateway > @types/node-fetch`). Pre-existing on `develop`; surfaced as a HIGH on this branch's pre-push pipeline.

## What's NOT changed
- `docker-compose.yml`, `docker-compose-uat.yml`, `docker-compose-e2e.yml`, `docker-compose-integration.yml` — all still build locally (dev / test stacks need to exercise current source).
- `apps/backend/Dockerfile.*` — unchanged.
- Frontend — already deploys via Cloudflare Pages.

## Caveat to expect

The first push to `main` after this lands triggers a ~15-minute build of the 4 newly-added matrix entries (`region-worker`, `structural-analysis-worker`, `llm-rerank-worker`, `db-migrate`). During that window, anyone running `docker compose -f docker-compose-prod.yml pull` will hit "image not found" for those four. Nothing in production consumes the compose yet, so the window is harmless.

## Test plan

- [ ] CI lint + test + build pass on this PR
- [ ] After `develop → main` promotion merges, verify the 4 new images appear in https://github.com/orgs/OpusPopuli/packages and are cosign-signed
- [ ] Run `./scripts/verify-images.sh` to confirm all 9 verify cleanly
- [ ] On the Mac Studio (post-bootstrap): `docker compose -f docker-compose-prod.yml pull && docker compose -f docker-compose-prod.yml up -d` succeeds, all 9 services reach `(healthy)`, `:8080/health` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)