### PR TITLE
feat(infra): mirror prod credential pattern in UAT compose

### DIFF
--- a/docker-compose-uat.yml
+++ b/docker-compose-uat.yml
@@ -30,26 +30,48 @@ x-backend-env: &backend-env
   VERSION: 1.0.0
   OTEL_EXPORTER_OTLP_ENDPOINT: http://tempo:4318
   OTEL_TRACING_ENABLED: "true"
-  # RESEND_API_KEY is sourced from Supabase Vault at bootstrap (see issue #786).
-  # SECRETS_PROVIDER=supabase below activates the hydration step.
+  # ---- Credentials hydration ----------------------------------------------
+  # UAT mirrors the opuspopuli-node prod pattern: secrets live in macOS
+  # Keychain (managed by `create-op-node bootstrap --local-only --region
+  # uat`) and are exported into the launchd session via the LaunchAgent.
+  # Docker Desktop, launched by launchd, inherits them automatically.
+  #
+  # `${VAR:?msg}` form HARD-FAILS docker compose if the var is unset — we
+  # deliberately removed the old `your-super-secret-password` fallback,
+  # which silently downgraded to a known-weak credential when the
+  # operator's shell predated the LaunchAgent load.
+  #
+  # If you see "variable is not set," run:
+  #   create-op-node bootstrap --local-only --region uat
+  # then reopen your terminal so `docker compose` inherits the new env.
+  #
+  # RESEND_API_KEY + SUPABASE_ANON_KEY + REDIS_URL are still sourced from
+  # Supabase Vault at bootstrap (see issue #786) — SECRETS_PROVIDER=supabase
+  # below activates that hydration step.
+  # ------------------------------------------------------------------------
   RELATIONAL_DB_PROVIDER: postgres
   RELATIONAL_DB_HOST: opuspopuli-db
   RELATIONAL_DB_PORT: 5432
   RELATIONAL_DB_USERNAME: postgres
-  RELATIONAL_DB_PASSWORD: your-super-secret-password
+  RELATIONAL_DB_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required — run create-op-node bootstrap and reopen your shell}
   RELATIONAL_DB_DATABASE: postgres
-  DATABASE_URL: postgresql://postgres:your-super-secret-password@opuspopuli-db:5432/postgres
-  # SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY stay as env vars by necessity
-  # — they're required to reach Vault. All other secrets (including
-  # SUPABASE_ANON_KEY and REDIS_URL) are sourced from Vault at bootstrap.
-  # db-migrate auto-seeds the dev defaults; see docs/guides/secrets-management.md.
+  DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD}@opuspopuli-db:5432/postgres
+  # SUPABASE_URL stays a literal — it's the in-network address for the
+  # included docker-compose.yml's kong service. SUPABASE_SERVICE_ROLE_KEY
+  # is required to reach Vault during bootstrap.
   SUPABASE_URL: http://supabase-kong:8000
-  SUPABASE_SERVICE_ROLE_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.sF_hc5jg-YhscQGb00SNtjW3ZIyDlGIIQppgOLwHGiM
+  SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:?SUPABASE_SERVICE_ROLE_KEY is required — run create-op-node bootstrap}
   GATEWAY_CLIENT_ID: api-gateway
-  GATEWAY_HMAC_SECRET: integration-test-hmac-secret
-  API_KEYS: '{"api-gateway":"integration-test-hmac-secret"}'
-  JWT_SECRET: your-super-secret-jwt-token-with-at-least-32-characters
-  AUTH_JWT_SECRET: your-super-secret-jwt-token-with-at-least-32-characters
+  # GATEWAY_HMAC_SECRET + API_KEYS are platform-internal HMAC keys, not yet
+  # Keychain-managed (tracked in #811 — vault-first secrets refactor). Set
+  # via shell env or .env when running UAT; the dev-grade defaults below
+  # preserve the existing UAT workflow until #811 lands.
+  GATEWAY_HMAC_SECRET: ${GATEWAY_HMAC_SECRET:-integration-test-hmac-secret}
+  API_KEYS: ${API_KEYS:-'{"api-gateway":"integration-test-hmac-secret"}'}
+  JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required — run create-op-node bootstrap}
+  # AUTH_JWT_SECRET historically equals JWT_SECRET in dev/UAT — falls back
+  # to JWT_SECRET when not set independently.
+  AUTH_JWT_SECRET: ${AUTH_JWT_SECRET:-$JWT_SECRET}
   SECRETS_PROVIDER: supabase
   # SMTP_HOST default is inherited from docker-compose.yml (= inbucket).
   # To switch GoTrue to Resend SMTP for real magic-link delivery, set

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,17 @@
 #     SMTP_USER=resend
 #     SMTP_PASS=re_your_api_key
 #     SMTP_ADMIN_EMAIL=noreply@yourdomain.com
+#
+# Credential variable cascade:
+#   Supabase token env reads as `${SUPABASE_ANON_KEY:-${ANON_KEY:-<demo>}}`
+#   (and same for SERVICE_ROLE). Precedence:
+#     1. SUPABASE_ANON_KEY / SUPABASE_SERVICE_ROLE_KEY — exported by
+#        `create-op-node bootstrap` via launchd; used when running UAT
+#        (docker-compose-uat.yml) so base + app share the same tokens.
+#     2. ANON_KEY / SERVICE_ROLE_KEY — legacy var names, still honored.
+#     3. The hardcoded `eyJhbGciOiJIUzI1NiI…` JWTs — public Supabase demo
+#        tokens for `pnpm dev` fast iteration. NEVER use these in any
+#        environment exposed beyond localhost.
 
 networks:
   opuspopuli-network:
@@ -220,8 +231,8 @@ services:
       supabase-rest:
         condition: service_started
     environment:
-      ANON_KEY: ${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE}
-      SERVICE_KEY: ${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.sF_hc5jg-YhscQGb00SNtjW3ZIyDlGIIQppgOLwHGiM}
+      ANON_KEY: ${SUPABASE_ANON_KEY:-${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE}}
+      SERVICE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.sF_hc5jg-YhscQGb00SNtjW3ZIyDlGIIQppgOLwHGiM}}
       POSTGREST_URL: http://supabase-rest:3000
       PGRST_JWT_SECRET: ${JWT_SECRET:-your-super-secret-jwt-token-with-at-least-32-characters}
       DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD:-your-super-secret-password}@opuspopuli-db:5432/postgres
@@ -300,8 +311,8 @@ services:
       KONG_PLUGINS: request-transformer,cors,key-auth,acl,basic-auth
       KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
       KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
-      SUPABASE_ANON_KEY: ${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE}
-      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.sF_hc5jg-YhscQGb00SNtjW3ZIyDlGIIQppgOLwHGiM}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE}}
+      SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.sF_hc5jg-YhscQGb00SNtjW3ZIyDlGIIQppgOLwHGiM}}
       DASHBOARD_USERNAME: ${DASHBOARD_USERNAME:-supabase}
       DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD:-this_password_is_insecure_and_should_be_updated}
     volumes:
@@ -339,8 +350,8 @@ services:
       DEFAULT_PROJECT_NAME: ${STUDIO_DEFAULT_PROJECT:-opuspopuli}
       SUPABASE_URL: http://supabase-kong:8000
       SUPABASE_PUBLIC_URL: ${SUPABASE_PUBLIC_URL:-http://localhost:8000}
-      SUPABASE_ANON_KEY: ${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE}
-      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.sF_hc5jg-YhscQGb00SNtjW3ZIyDlGIIQppgOLwHGiM}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY:-${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.KR1jqUlyHtwAxCJf6B0QVoRpobrdPEv8ALnNJUlGxPE}}
+      SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-${SERVICE_ROLE_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImV4cCI6MTk4MzgxMjk5Nn0.sF_hc5jg-YhscQGb00SNtjW3ZIyDlGIIQppgOLwHGiM}}
       LOGFLARE_API_KEY: ${LOGFLARE_API_KEY:-your-logflare-api-key}
       LOGFLARE_URL: http://supabase-analytics:4000
       NEXT_PUBLIC_ENABLE_LOGS: "true"


### PR DESCRIPTION
## Summary

UAT was hardcoding `your-super-secret-password` and the public Supabase demo JWTs directly in `docker-compose-uat.yml`'s backend-env anchor. When UAT gets wired through the Tunnel for stakeholder validation, "UAT" would be running with well-known weak credentials that any GitHub-indexed search would surface — a real security regression vs the `opuspopuli-node` prod posture.

Aligns UAT with the [opuspopuli-node](https://github.com/OpusPopuli/opuspopuli-node/pull/5) template's Keychain-fed pattern, fed by [create-op-node](https://github.com/OpusPopuli/create-op-node/pull/19).

## What changed

**`docker-compose-uat.yml` — backend-env anchor:**
- `POSTGRES_PASSWORD`, `JWT_SECRET`, `SUPABASE_SERVICE_ROLE_KEY` now use the `${VAR:?msg}` form — UAT compose hard-fails with a bootstrap hint when env is missing, no silent downgrade to demo creds
- Bootstrap hint points to `create-op-node bootstrap --local-only --region uat`
- `AUTH_JWT_SECRET` cascades to `JWT_SECRET` (their relationship is dev-only identity; saves operators from setting two near-identical vars)
- Platform-internal HMAC keys (`GATEWAY_HMAC_SECRET`, `API_KEYS`) stay as fallback-OK until #811 (vault-first secrets refactor) lands

**`docker-compose.yml` — env var name harmonization:**
- `ANON_KEY` / `SERVICE_ROLE_KEY` env reads now cascade through `SUPABASE_ANON_KEY` / `SUPABASE_SERVICE_ROLE_KEY` first
- A UAT operator's Keychain-fed `SUPABASE_*` vars actually override the demo JWTs in the included base infra (previously the env var names didn't match, so the demos always won)
- Dev workflow with no env still falls back to the public demo JWTs — `pnpm dev` operators unaffected
- Added header comment documenting the precedence chain

## What did NOT change (deliberately)

Per the scope discussion: dev workflow (`docker-compose.yml` standalone for `pnpm dev`) keeps the demo credentials so contributors don't need `create-op-node` installed to run the stack. Only UAT (which mirrors prod's deployment posture) enforces Keychain-fed creds.

Image-version sync between opuspopuli base and the node template is **deferred to a separate validated PR** — kong 2→3, postgrest 12→14, and storage 1.11→1.60 are major bumps with config-schema changes that need their own validation pass.

## Test plan

- [ ] `docker compose -f docker-compose.yml config` succeeds with no env set (dev workflow preserved)
- [ ] `docker compose -f docker-compose-uat.yml config` hard-fails with `POSTGRES_PASSWORD is required — run create-op-node bootstrap` when env is missing
- [ ] After `create-op-node bootstrap --local-only --region uat`: reopen shell, `docker compose -f docker-compose-uat.yml up -d --build` brings the full UAT stack up using Keychain-fed creds
- [ ] All UAT services connect to Supabase auth/rest/storage successfully (no 401s vs the included demo-JWT base)
- [ ] Magic-link signup via Inbucket works end-to-end with the new tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)