### PR TITLE
feat(infra): split Redis into dedicated queue and cache instances (#725)

### DIFF
--- a/apps/backend/src/common/preflight.ts
+++ b/apps/backend/src/common/preflight.ts
@@ -36,6 +36,10 @@ export const VAULT_BACKED_SECRETS = [
   'R2_ACCESS_KEY_ID',
   'R2_SECRET_ACCESS_KEY',
   'REDIS_URL',
+  // Dedicated app-cache Redis (#725). Optional: when unset, the cache falls
+  // back to REDIS_URL (see CacheFactory.getRedisUrlFromEnv). BullMQ always
+  // uses REDIS_URL regardless.
+  'REDIS_CACHE_URL',
   'SUPABASE_ANON_KEY',
   'FEC_API_KEY',
 ] as const;

--- a/docker-compose-uat.yml
+++ b/docker-compose-uat.yml
@@ -49,6 +49,10 @@ x-backend-env: &backend-env
   # Supabase Vault at bootstrap (see issue #786) — SECRETS_PROVIDER=supabase
   # below activates that hydration step.
   # ------------------------------------------------------------------------
+  # Dedicated app-cache Redis (#725) — in-network literal (not a secret),
+  # points at the redis-cache service from the included docker-compose.yml.
+  # BullMQ keeps using the vault-sourced REDIS_URL.
+  REDIS_CACHE_URL: redis://redis-cache:6379
   RELATIONAL_DB_PROVIDER: postgres
   RELATIONAL_DB_HOST: opuspopuli-db
   RELATIONAL_DB_PORT: 5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -417,9 +417,10 @@ services:
     ports:
       - "6379:6379"
     # noeviction required by BullMQ — allkeys-lru would evict job data under
-    # memory pressure. Conflicts with cache-as-LRU usage; see #725 for the
-    # production split into dedicated Redis instances.
-    command: redis-server --appendonly yes --maxmemory 256mb --maxmemory-policy noeviction
+    # memory pressure. Job data must never be silently dropped, so this
+    # instance has NO hard maxmemory (jobs are transient and bounded by the
+    # worker cadence). The app cache lives on redis-cache below (#725).
+    command: redis-server --appendonly yes --maxmemory-policy noeviction
     volumes:
       - redis-data:/data
     networks:
@@ -435,7 +436,37 @@ services:
       resources:
         limits:
           cpus: '0.5'
-          memory: 256M
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
+
+  # Redis (cache) — dedicated app-cache instance (#725). allkeys-lru so it
+  # evicts cold cache entries under memory pressure instead of failing writes
+  # (the opposite policy from the BullMQ queue instance above). Ephemeral: no
+  # appendonly / volume — cache data is disposable and re-derived from source.
+  # Backend reads it via REDIS_CACHE_URL (falls back to REDIS_URL when unset).
+  # Host-published on 6380 so `pnpm dev` on the host can target the split too.
+  redis-cache:
+    image: redis:7-alpine
+    container_name: opuspopuli-redis-cache
+    ports:
+      - "6380:6379"
+    command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
+    networks:
+      - opuspopuli-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512M
         reservations:
           cpus: '0.1'
           memory: 64M

--- a/packages/extraction-provider/__tests__/cache-factory.spec.ts
+++ b/packages/extraction-provider/__tests__/cache-factory.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * CacheFactory + FallbackCache unit tests.
+ *
+ * Covers the #725 Redis split: getRedisUrlFromEnv/getProviderFromEnv honoring
+ * REDIS_CACHE_URL with fallback to REDIS_URL, and FallbackCache auto-recovery
+ * (a transient primary outage must not pin the cache to memory permanently).
+ */
+
+import type { ICache } from "@opuspopuli/common";
+import { CacheFactory, FallbackCache } from "../src/cache/cache-factory";
+
+describe("CacheFactory env resolution (#725)", () => {
+  const original = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it("prefers REDIS_CACHE_URL over REDIS_URL for the cache", () => {
+    process.env.REDIS_URL = "redis://queue:6379";
+    process.env.REDIS_CACHE_URL = "redis://cache:6379";
+    expect(CacheFactory.getRedisUrlFromEnv()).toBe("redis://cache:6379");
+  });
+
+  it("falls back to REDIS_URL when REDIS_CACHE_URL is unset", () => {
+    delete process.env.REDIS_CACHE_URL;
+    process.env.REDIS_URL = "redis://queue:6379";
+    expect(CacheFactory.getRedisUrlFromEnv()).toBe("redis://queue:6379");
+  });
+
+  it("returns undefined when neither is set", () => {
+    delete process.env.REDIS_CACHE_URL;
+    delete process.env.REDIS_URL;
+    expect(CacheFactory.getRedisUrlFromEnv()).toBeUndefined();
+  });
+
+  it("selects the redis provider when either URL is present", () => {
+    delete process.env.REDIS_URL;
+    process.env.REDIS_CACHE_URL = "redis://cache:6379";
+    expect(CacheFactory.getProviderFromEnv()).toBe("redis");
+    delete process.env.REDIS_CACHE_URL;
+    process.env.REDIS_URL = "redis://queue:6379";
+    expect(CacheFactory.getProviderFromEnv()).toBe("redis");
+  });
+
+  it("selects the memory provider when neither URL is present", () => {
+    delete process.env.REDIS_CACHE_URL;
+    delete process.env.REDIS_URL;
+    expect(CacheFactory.getProviderFromEnv()).toBe("memory");
+  });
+});
+
+/** Minimal in-memory ICache whose get() can be toggled to throw. */
+class ControllableCache implements ICache<string> {
+  failing = false;
+  private store = new Map<string, string>();
+
+  async get(key: string): Promise<string | undefined> {
+    if (this.failing) throw new Error("primary down");
+    return this.store.get(key);
+  }
+  async set(key: string, value: string): Promise<void> {
+    if (this.failing) throw new Error("primary down");
+    this.store.set(key, value);
+  }
+  async has(key: string): Promise<boolean> {
+    if (this.failing) throw new Error("primary down");
+    return this.store.has(key);
+  }
+  async delete(key: string): Promise<boolean> {
+    if (this.failing) throw new Error("primary down");
+    return this.store.delete(key);
+  }
+  async clear(): Promise<void> {
+    this.store.clear();
+  }
+  get size(): number {
+    return this.store.size;
+  }
+  async keys(): Promise<string[]> {
+    return [...this.store.keys()];
+  }
+  async destroy(): Promise<void> {
+    this.store.clear();
+  }
+}
+
+describe("FallbackCache auto-recovery (#725)", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it("serves from fallback after the primary fails", async () => {
+    const primary = new ControllableCache();
+    const fallback = new ControllableCache();
+    const cache = new FallbackCache<string>(primary, fallback, 30_000);
+
+    primary.failing = true;
+    await cache.set("k", "v"); // fails on primary → routed to fallback
+    expect(cache.isUsingFallback()).toBe(true);
+    expect(await fallback.get("k")).toBe("v");
+  });
+
+  it("stays on fallback during the cooldown window", async () => {
+    const primary = new ControllableCache();
+    const fallback = new ControllableCache();
+    const cache = new FallbackCache<string>(primary, fallback, 30_000);
+
+    primary.failing = true;
+    await cache.get("k"); // trips fallback
+    primary.failing = false; // primary "recovers" immediately...
+
+    jest.advanceTimersByTime(10_000); // ...but only 10s elapse (< 30s cooldown)
+    const probe = jest.spyOn(primary, "get");
+    await cache.get("k");
+    expect(probe).not.toHaveBeenCalled(); // did not re-probe the primary yet
+    expect(cache.isUsingFallback()).toBe(true);
+  });
+
+  it("re-probes and recovers to the primary after the cooldown", async () => {
+    const primary = new ControllableCache();
+    const fallback = new ControllableCache();
+    const cache = new FallbackCache<string>(primary, fallback, 30_000);
+
+    primary.failing = true;
+    await cache.get("k"); // trips fallback
+    primary.failing = false;
+
+    jest.advanceTimersByTime(30_000); // cooldown elapsed
+    await cache.get("k"); // probes primary, which now succeeds
+    expect(cache.isUsingFallback()).toBe(false);
+  });
+});

--- a/packages/extraction-provider/src/cache/cache-factory.ts
+++ b/packages/extraction-provider/src/cache/cache-factory.ts
@@ -106,18 +106,23 @@ export class CacheFactory {
    * Determine provider from environment
    */
   static getProviderFromEnv(): CacheProvider {
-    const redisUrl = process.env.REDIS_URL;
-    if (redisUrl) {
+    // Either the dedicated cache URL or the shared queue URL enables redis.
+    if (process.env.REDIS_CACHE_URL || process.env.REDIS_URL) {
       return "redis";
     }
     return "memory";
   }
 
   /**
-   * Get Redis URL from environment
+   * Get Redis URL for the application CACHE from environment.
+   *
+   * Prefers REDIS_CACHE_URL (the dedicated allkeys-lru cache instance, #725),
+   * falling back to REDIS_URL (the BullMQ noeviction instance) when it isn't
+   * set — so deployments that haven't split Redis yet keep working unchanged.
+   * BullMQ itself always reads REDIS_URL directly and is unaffected.
    */
   static getRedisUrlFromEnv(): string | undefined {
-    return process.env.REDIS_URL;
+    return process.env.REDIS_CACHE_URL ?? process.env.REDIS_URL;
   }
 
   /**
@@ -141,28 +146,54 @@ export class FallbackCache<T = string> implements ICache<T> {
   private readonly logger = new Logger(FallbackCache.name);
   private readonly primary: ICache<T>;
   private readonly fallback: ICache<T>;
+  private readonly retryAfterMs: number;
   private useFallback: boolean = false;
+  private lastFailureAt: number = 0;
 
-  constructor(primary: ICache<T>, fallback: ICache<T>) {
+  /**
+   * @param retryAfterMs once the primary has failed and we're serving from the
+   *   in-memory fallback, wait at least this long before probing the primary
+   *   again. Prevents a brief Redis outage from pinning the cache to memory
+   *   permanently (the old behavior required a manual resetToPrimary()).
+   */
+  constructor(primary: ICache<T>, fallback: ICache<T>, retryAfterMs = 30_000) {
     this.primary = primary;
     this.fallback = fallback;
+    this.retryAfterMs = retryAfterMs;
   }
 
   private async withFallback<R>(
     operation: () => Promise<R> | R,
     fallbackOperation: () => Promise<R> | R,
   ): Promise<R> {
-    if (this.useFallback) {
+    if (this.useFallback && !this.shouldProbePrimary()) {
       return fallbackOperation();
     }
 
     try {
-      return await operation();
+      const result = await operation();
+      if (this.useFallback) {
+        this.logger.log(
+          "Primary cache recovered, switching back from fallback",
+        );
+        this.useFallback = false;
+      }
+      return result;
     } catch (error) {
-      this.logger.warn(`Primary cache failed, switching to fallback: ${error}`);
-      this.useFallback = true;
+      if (!this.useFallback) {
+        this.logger.warn(
+          `Primary cache failed, switching to fallback: ${error}`,
+        );
+        this.useFallback = true;
+      }
+      this.lastFailureAt = Date.now();
       return fallbackOperation();
     }
+  }
+
+  /** True once the fallback cooldown has elapsed and it's time to re-probe. */
+  private shouldProbePrimary(): boolean {
+    return Date.now() - this.lastFailureAt >= this.retryAfterMs;
   }
 
   async get(key: string): Promise<T | undefined> {
@@ -228,9 +259,11 @@ export class FallbackCache<T = string> implements ICache<T> {
   }
 
   /**
-   * Reset to primary (for recovery)
+   * Reset to primary (for recovery). Rarely needed now that withFallback()
+   * auto-probes the primary after retryAfterMs; kept for explicit control.
    */
   resetToPrimary(): void {
     this.useFallback = false;
+    this.lastFailureAt = 0;
   }
 }


### PR DESCRIPTION
## Summary

BullMQ requires `noeviction` (queued jobs must never be silently dropped) while the app cache wants `allkeys-lru` (graceful memory-bounded eviction). A single shared Redis can't satisfy both — under real load, cache `SET`s start failing once the shared instance hits its cap. This splits them into two instances.

The change is **backward-compatible**: the cache prefers `REDIS_CACHE_URL` but falls back to `REDIS_URL`, so any deployment that hasn't split yet keeps working unchanged. BullMQ always reads `REDIS_URL` directly and is untouched.

## What changed

**Backend**
- `CacheFactory.getRedisUrlFromEnv()` prefers `REDIS_CACHE_URL`, falls back to `REDIS_URL`; `getProviderFromEnv()` treats either URL as "use redis".
- `FallbackCache` now auto-probes the primary after a cooldown (default 30s) so a transient Redis outage no longer pins the cache to the in-memory fallback permanently (previously required a manual `resetToPrimary()`).
- `REDIS_CACHE_URL` added to the Vault-hydration list in `preflight.ts` (optional).

**Compose**
- `docker-compose.yml`: new `redis-cache` service (`allkeys-lru`, 512MB, ephemeral, host-published `:6380`); queue `redis` now explicit `noeviction`, no hard cap.
- `docker-compose-uat.yml`: `REDIS_CACHE_URL` in-network literal so UAT mirrors prod topology.

The node prod compose half is in [opuspopuli-node#35](https://github.com/OpusPopuli/opuspopuli-node/pull/35).

## Tests

New `cache-factory.spec.ts` — env resolution (prefer `REDIS_CACHE_URL`, fall back, provider detection) + all three FallbackCache recovery states (fail → cooldown-hold → recover). Full `extraction-provider` unit suite: **138 pass**.

## Scope note

The `extraction-provider`'s own internal cache is intentionally out of scope — it resolves to memory today due to a separate `createConfigFromEnv` precedence bug, filed as #862 (fixing it flips it memory→Redis, a real behavior change to coordinate separately). The `REGION_CACHE` — the app cache #725 actually targets — is unaffected by that bug and correctly moves to `REDIS_CACHE_URL`.

## Rebuild on promote

Images that construct the app cache: `region`, `region-worker`, `structural-analysis-worker`, `llm-rerank-worker`.

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)