### PR TITLE
fix(api): AuthGuard defers non-GraphQL contexts so REST /metrics isn't 403'd (#864)

### DIFF
--- a/apps/backend/src/common/guards/auth.guard.spec.ts
+++ b/apps/backend/src/common/guards/auth.guard.spec.ts
@@ -35,8 +35,9 @@ describe('AuthGuard', () => {
 
     (GqlExecutionContext.create as jest.Mock).mockReturnValue(mockGqlContext);
 
-    // Create a minimal ExecutionContext mock
+    // Create a minimal ExecutionContext mock (GraphQL context type)
     const context = {
+      getType: () => 'graphql',
       getHandler: jest.fn(),
       getClass: jest.fn(),
     } as unknown as ExecutionContext;
@@ -154,6 +155,7 @@ describe('AuthGuard', () => {
       (GqlExecutionContext.create as jest.Mock).mockReturnValue(mockGqlContext);
 
       return {
+        getType: () => 'graphql',
         getHandler: jest.fn(),
         getClass: jest.fn(),
       } as unknown as ExecutionContext;
@@ -221,6 +223,7 @@ describe('AuthGuard', () => {
 
       return {
         context: {
+          getType: () => 'graphql',
           getHandler: jest.fn(),
           getClass: jest.fn(),
         } as unknown as ExecutionContext,
@@ -308,6 +311,7 @@ describe('AuthGuard', () => {
       );
 
       const context = {
+        getType: () => 'graphql',
         getHandler: jest.fn(),
         getClass: jest.fn(),
       } as unknown as ExecutionContext;
@@ -361,6 +365,7 @@ describe('AuthGuard', () => {
       (GqlExecutionContext.create as jest.Mock).mockReturnValue(mockGqlContext);
 
       const context = {
+        getType: () => 'graphql',
         getHandler: jest.fn(),
         getClass: jest.fn(),
       } as unknown as ExecutionContext;
@@ -369,6 +374,26 @@ describe('AuthGuard', () => {
 
       // Should deny because request.user is null, ignoring spoofed headers.user
       expect(result).toBe(false);
+    });
+  });
+
+  describe('non-GraphQL (REST) routes (#864)', () => {
+    it('allows a REST request through without touching the GraphQL context', async () => {
+      // /metrics (Prometheus), /health, /api/csrf reach this global guard as an
+      // 'http' context. The guard governs GraphQL only, so it must defer to the
+      // REST layer — not 403 every scrape.
+      const context = {
+        getType: () => 'http',
+        getHandler: jest.fn(),
+        getClass: jest.fn(),
+      } as unknown as ExecutionContext;
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      // Must short-circuit BEFORE building a GraphQL context or checking @Public.
+      expect(GqlExecutionContext.create as jest.Mock).not.toHaveBeenCalled();
+      expect(mockReflector.getAllAndOverride).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/common/guards/auth.guard.ts
+++ b/apps/backend/src/common/guards/auth.guard.ts
@@ -6,7 +6,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { GqlExecutionContext } from '@nestjs/graphql';
+import { GqlExecutionContext, type GqlContextType } from '@nestjs/graphql';
 import { randomUUID } from 'node:crypto';
 import { isLoggedIn } from 'src/common/auth/jwt.strategy';
 import { IS_PUBLIC_KEY } from 'src/common/decorators/public.decorator';
@@ -54,6 +54,22 @@ export class AuthGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    // This guard governs GraphQL operations only (see class docstring). It is
+    // registered as a global APP_GUARD, so it also fires on the gateway's REST
+    // routes — /metrics (Prometheus scrape), /health, /api/csrf. Those are
+    // protected by CsrfMiddleware/AuthMiddleware and their own controllers; a
+    // non-GraphQL request has no GraphQL context or user, so the checks below
+    // would deny it — e.g. a 403 on every Prometheus scrape of /metrics. Defer
+    // to the REST layer for anything that isn't a GraphQL operation.
+    //
+    // NOTE: this keys off the execution-context TYPE, not the URL. Our GraphQL
+    // endpoint is `POST /api` (not /graphql); it executes in the 'graphql'
+    // context, so it does NOT short-circuit here and stays fully guarded. Only
+    // true REST requests ('http' context) are deferred. `/api/csrf` is REST.
+    if (context.getType<GqlContextType>() !== 'graphql') {
+      return true;
+    }
+
     // Check if the endpoint is marked as public
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),


### PR DESCRIPTION
Closes #864

## Problem
The api gateway logs ~6/min of `[ErrorSanitizer] … ForbiddenException: Forbidden resource` — one per Prometheus scrape. `GET /metrics` returns **403**, so api-gateway metrics are effectively un-scrapeable (its Grafana panels are blind) and the logs are noisy.

## Root cause
`AuthGuard` is documented as a guard for **GraphQL operations**, but it's registered as a global `APP_GUARD`, so it fires on **every** route including REST. For a non-GraphQL request it builds a `GqlExecutionContext` with no `req`/`user` and returns `false` → 403. The team already excluded `/metrics` from `CsrfMiddleware`/`AuthMiddleware` (`app.module.ts` `.exclude(...)`), but **middleware `.exclude()` does not apply to guards** — the exemption landed in the wrong layer.

## Fix
Short-circuit non-`graphql` execution contexts at the top of `canActivate`:
```ts
if (context.getType<GqlContextType>() !== 'graphql') return true;
```
Keys off the execution-context **type**, not the URL. Our GraphQL endpoint is `POST /api` (not `/graphql`) and executes in the `graphql` context, so it does **not** short-circuit and stays fully guarded. Only true REST (`http`) requests — `/metrics`, `/health*`, `/api/csrf` — are deferred to `CsrfMiddleware`/`AuthMiddleware` + their own controllers.

## Safety — verified on a live node
| Request | Context | Result |
|---|---|---|
| `GET /metrics` | `http` | was 403 → now deferred (public, as intended) |
| `POST /api { myScanHistory { total } }` *(no auth)* | `graphql` | still `Forbidden resource` via the Apollo query plan |

GraphQL authorization is unchanged; there's no REST route that relied on this GraphQL guard for protection (`AuthMiddleware` still guards `.forRoutes('*')`, its `.exclude()` list is minimal — `health*`, `metrics`). No `@Subscription` exists in the backend, so there's no WebSocket-graphql path to consider.

## Tests
- New: a `http`-context request returns `true` and short-circuits **before** building a GraphQL context or checking `@Public()`.
- Existing 22 guard tests updated to tag their mocks as `graphql` context (unchanged behavior). 23/23 pass, guard at 100% coverage.

## Deploy note
This lives in the `api` image — it quiets a running node only after `ghcr.io/opuspopuli/api` is rebuilt and re-pulled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)