### PR TITLE
Release: : AuthGuard defers non-GraphQL contexts so REST /metrics isn't 403'd

### DIFF
--- a/apps/backend/src/common/guards/auth.guard.spec.ts
+++ b/apps/backend/src/common/guards/auth.guard.spec.ts
@@ -35,8 +35,9 @@ describe('AuthGuard', () => {
 
     (GqlExecutionContext.create as jest.Mock).mockReturnValue(mockGqlContext);
 
-    // Create a minimal ExecutionContext mock
+    // Create a minimal ExecutionContext mock (GraphQL context type)
     const context = {
+      getType: () => 'graphql',
       getHandler: jest.fn(),
       getClass: jest.fn(),
     } as unknown as ExecutionContext;
@@ -154,6 +155,7 @@ describe('AuthGuard', () => {
       (GqlExecutionContext.create as jest.Mock).mockReturnValue(mockGqlContext);
 
       return {
+        getType: () => 'graphql',
         getHandler: jest.fn(),
         getClass: jest.fn(),
       } as unknown as ExecutionContext;
@@ -221,6 +223,7 @@ describe('AuthGuard', () => {
 
       return {
         context: {
+          getType: () => 'graphql',
           getHandler: jest.fn(),
           getClass: jest.fn(),
         } as unknown as ExecutionContext,
@@ -308,6 +311,7 @@ describe('AuthGuard', () => {
       );
 
       const context = {
+        getType: () => 'graphql',
         getHandler: jest.fn(),
         getClass: jest.fn(),
       } as unknown as ExecutionContext;
@@ -361,6 +365,7 @@ describe('AuthGuard', () => {
       (GqlExecutionContext.create as jest.Mock).mockReturnValue(mockGqlContext);
 
       const context = {
+        getType: () => 'graphql',
         getHandler: jest.fn(),
         getClass: jest.fn(),
       } as unknown as ExecutionContext;
@@ -369,6 +374,26 @@ describe('AuthGuard', () => {
 
       // Should deny because request.user is null, ignoring spoofed headers.user
       expect(result).toBe(false);
+    });
+  });
+
+  describe('non-GraphQL (REST) routes (#864)', () => {
+    it('allows a REST request through without touching the GraphQL context', async () => {
+      // /metrics (Prometheus), /health, /api/csrf reach this global guard as an
+      // 'http' context. The guard governs GraphQL only, so it must defer to the
+      // REST layer — not 403 every scrape.
+      const context = {
+        getType: () => 'http',
+        getHandler: jest.fn(),
+        getClass: jest.fn(),
+      } as unknown as ExecutionContext;
+
+      const result = await guard.canActivate(context);
+
+      expect(result).toBe(true);
+      // Must short-circuit BEFORE building a GraphQL context or checking @Public.
+      expect(GqlExecutionContext.create as jest.Mock).not.toHaveBeenCalled();
+      expect(mockReflector.getAllAndOverride).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/backend/src/common/guards/auth.guard.ts
+++ b/apps/backend/src/common/guards/auth.guard.ts
@@ -6,7 +6,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { GqlExecutionContext } from '@nestjs/graphql';
+import { GqlExecutionContext, type GqlContextType } from '@nestjs/graphql';
 import { randomUUID } from 'node:crypto';
 import { isLoggedIn } from 'src/common/auth/jwt.strategy';
 import { IS_PUBLIC_KEY } from 'src/common/decorators/public.decorator';
@@ -54,6 +54,22 @@ export class AuthGuard implements CanActivate {
   ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    // This guard governs GraphQL operations only (see class docstring). It is
+    // registered as a global APP_GUARD, so it also fires on the gateway's REST
+    // routes — /metrics (Prometheus scrape), /health, /api/csrf. Those are
+    // protected by CsrfMiddleware/AuthMiddleware and their own controllers; a
+    // non-GraphQL request has no GraphQL context or user, so the checks below
+    // would deny it — e.g. a 403 on every Prometheus scrape of /metrics. Defer
+    // to the REST layer for anything that isn't a GraphQL operation.
+    //
+    // NOTE: this keys off the execution-context TYPE, not the URL. Our GraphQL
+    // endpoint is `POST /api` (not /graphql); it executes in the 'graphql'
+    // context, so it does NOT short-circuit here and stays fully guarded. Only
+    // true REST requests ('http' context) are deferred. `/api/csrf` is REST.
+    if (context.getType<GqlContextType>() !== 'graphql') {
+      return true;
+    }
+
     // Check if the endpoint is marked as public
     const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),


### PR DESCRIPTION
## Description

<!-- Provide a brief description of your changes -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Infrastructure/DevOps change

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

Fixes #

## Checklist

<!-- Mark completed items with an "x" -->

### Code Quality
- [ ] My code follows the project's coding standards
- [ ] I have run `pnpm lint` and fixed any issues
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added tests for new functionality (if applicable)

### Documentation
- [ ] I have updated relevant documentation (if applicable)
- [ ] I have added JSDoc comments for new public APIs (if applicable)

### Accessibility
- [ ] UI changes meet WCAG 2.2 Level AA requirements (if applicable)
- [ ] I have tested with keyboard navigation (if applicable)

### Architecture Reminder

> **Important**: This is the core platform repository.
>
> - **Platform improvements** (bug fixes, new features, providers) belong here
> - **Region configs** (JSON data source definitions) belong in [`opuspopuli-regions`](https://github.com/OpusPopuli/opuspopuli-regions)
>
> See [CONTRIBUTING.md](../CONTRIBUTING.md) for details.

- [ ] I confirm this PR contains platform code, not region-specific configuration

## Screenshots/Recordings

<!-- If applicable, add screenshots or recordings to demonstrate the change -->

## Additional Notes

<!-- Any additional context or notes for reviewers -->
