### PR TITLE
chore(postman): lean PROD (Node) env + CSRF seed fix + schema-drift sweep

### DIFF
--- a/postman/OpusPopuli-PROD.postman_environment.json
+++ b/postman/OpusPopuli-PROD.postman_environment.json
@@ -16,7 +16,7 @@
     },
     {
       "key": "supabase_anon_key",
-      "value": "PASTE_NODE_SUPABASE_ANON_KEY_HERE",
+      "value": "GET_FROM_NODE__docker_exec_opuspopuli-api_printenv_SUPABASE_ANON_KEY",
       "type": "secret",
       "enabled": true
     },

--- a/postman/OpusPopuli-PROD.postman_environment.json
+++ b/postman/OpusPopuli-PROD.postman_environment.json
@@ -1,0 +1,61 @@
+{
+  "id": "opus-populi-prod-node-env",
+  "name": "OpusPopuli - PROD (Node)",
+  "values": [
+    {
+      "key": "gateway_url",
+      "value": "http://opuspopuli-us-ca:8080",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "supabase_url",
+      "value": "http://opuspopuli-us-ca:8000",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "supabase_anon_key",
+      "value": "PASTE_NODE_SUPABASE_ANON_KEY_HERE",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "test_email",
+      "value": "admin@opuspopuli.local",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "test_password",
+      "value": "Admin1234!",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "csrf_token",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "access_token",
+      "value": "",
+      "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "sync_job_id",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    },
+    {
+      "key": "llm_rerank_job_id",
+      "value": "",
+      "type": "default",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/postman/OpusPopuli.postman_collection.json
+++ b/postman/OpusPopuli.postman_collection.json
@@ -89,9 +89,10 @@
             "method": "GET",
             "header": [{ "key": "apollo-require-preflight", "value": "true" }],
             "url": {
-              "raw": "{{gateway_url}}/api",
+              "raw": "{{gateway_url}}/api?query={__typename}",
               "host": ["{{gateway_url}}"],
-              "path": ["api"]
+              "path": ["api"],
+              "query": [{ "key": "query", "value": "{__typename}" }]
             }
           }
         },
@@ -267,7 +268,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "mutation LoginUser($input: LoginUserDto!) {\n  loginUser(loginUserDto: $input) {\n    accessToken\n    refreshToken\n    expiresIn\n  }\n}",
+                "query": "mutation LoginUser($input: LoginUserDto!) {\n  loginUser(loginUserDto: $input) {\n    accessToken\n    idToken\n    refreshToken\n  }\n}",
                 "variables": "{\n  \"input\": {\n    \"email\": \"{{test_email}}\",\n    \"password\": \"{{test_password}}\"\n  }\n}"
               }
             },
@@ -329,7 +330,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query {\n  getUsers {\n    id\n    email\n    firstName\n    lastName\n    role\n    createdAt\n  }\n}"
+                "query": "query {\n  getUsers {\n    id\n    email\n    firstName\n    lastName\n    created\n  }\n}"
               }
             },
             "url": {
@@ -348,7 +349,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query FindUser($email: String!) {\n  findUser(email: $email) {\n    id\n    email\n    firstName\n    lastName\n    role\n  }\n}",
+                "query": "query FindUser($email: String!) {\n  findUser(email: $email) {\n    id\n    email\n    firstName\n    lastName\n    created\n  }\n}",
                 "variables": "{\n  \"email\": \"{{test_email}}\"\n}"
               }
             },
@@ -372,7 +373,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query {\n  myProfile {\n    userId\n    displayName\n    bio\n    avatarUrl\n    region\n    timezone\n    language\n    updatedAt\n  }\n}"
+                "query": "query {\n  myProfile {\n    userId\n    displayName\n    bio\n    avatarUrl\n    timezone\n    preferredLanguage\n    locale\n    updatedAt\n  }\n}"
               }
             },
             "url": {
@@ -390,7 +391,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query {\n  myProfileCompletion {\n    completionPercentage\n    completedSteps\n    totalSteps\n    missingFields\n  }\n}"
+                "query": "query {\n  myProfileCompletion {\n    percentage\n    isComplete\n    suggestedNextSteps\n    coreFieldsComplete {\n      hasName\n      hasPhoto\n      hasAddress\n      hasCivic\n      hasDemographic\n    }\n  }\n}"
               }
             },
             "url": {
@@ -408,7 +409,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query {\n  myAddresses {\n    id\n    street\n    city\n    state\n    zipCode\n    country\n    isPrimary\n  }\n}"
+                "query": "query {\n  myAddresses {\n    id\n    addressLine1\n    city\n    state\n    postalCode\n    country\n    isPrimary\n  }\n}"
               }
             },
             "url": {
@@ -451,7 +452,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query Propositions($skip: Int!, $take: Int!) {\n  propositions(skip: $skip, take: $take) {\n    items {\n      id\n      title\n      status\n      dataType\n      sourceSystem\n    }\n    total\n    hasMore\n  }\n}",
+                "query": "query Propositions($skip: Int!, $take: Int!) {\n  propositions(skip: $skip, take: $take) {\n    items {\n      id\n      externalId\n      title\n      status\n      summary\n    }\n    total\n    hasMore\n  }\n}",
                 "variables": "{\n  \"skip\": 0,\n  \"take\": 10\n}"
               }
             },
@@ -491,7 +492,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query Meetings($skip: Int!, $take: Int!) {\n  meetings(skip: $skip, take: $take) {\n    items {\n      id\n      title\n      date\n      location\n    }\n    total\n    hasMore\n  }\n}",
+                "query": "query Meetings($skip: Int!, $take: Int!) {\n  meetings(skip: $skip, take: $take) {\n    items {\n      id\n      title\n      scheduledAt\n      location\n    }\n    total\n    hasMore\n  }\n}",
                 "variables": "{\n  \"skip\": 0,\n  \"take\": 10\n}"
               }
             },
@@ -551,7 +552,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query CountyRepresentatives($countyRegionId: String!) {\n  countyRepresentatives(countyRegionId: $countyRegionId) {\n    id\n    name\n    title\n    district\n    party\n    phone\n    email\n    photoUrl\n    website\n  }\n}",
+                "query": "query CountyRepresentatives($countyRegionId: String!) {\n  countyRepresentatives(countyRegionId: $countyRegionId) {\n    id\n    name\n    chamber\n    district\n    party\n    photoUrl\n    contactInfo {\n      email\n      website\n    }\n  }\n}",
                 "variables": "{\n  \"countyRegionId\": \"california-sonoma\"\n}"
               }
             },
@@ -571,7 +572,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query {\n  myCountySupervisors {\n    id\n    name\n    title\n    district\n    party\n    phone\n    email\n    photoUrl\n    website\n  }\n}",
+                "query": "query {\n  myCountySupervisors {\n    id\n    name\n    chamber\n    district\n    party\n    photoUrl\n    contactInfo {\n      email\n      website\n    }\n  }\n}",
                 "variables": ""
               }
             },
@@ -1130,7 +1131,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query {\n  listFiles {\n    name\n    size\n    contentType\n    createdAt\n  }\n}"
+                "query": "query {\n  listFiles {\n    filename\n    size\n    status\n    createdAt\n  }\n}"
               }
             },
             "url": {
@@ -1148,7 +1149,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "mutation AnalyzeDocument($input: AnalyzeDocumentInput!) {\n  analyzeDocument(input: $input) {\n    documentId\n    analysisType\n    summary\n    confidence\n  }\n}",
+                "query": "mutation AnalyzeDocument($input: AnalyzeDocumentInput!) {\n  analyzeDocument(input: $input) {\n    analysis {\n      documentType\n      summary\n      keyPoints\n      provider\n      model\n    }\n    fromCache\n  }\n}",
                 "variables": "{\n  \"input\": {\n    \"documentId\": \"your-document-id\",\n    \"analysisType\": \"general\"\n  }\n}"
               }
             },
@@ -1168,7 +1169,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query {\n  petitionMapLocations {\n    locations {\n      documentId\n      latitude\n      longitude\n      title\n    }\n    total\n  }\n}"
+                "query": "query {\n  petitionMapLocations {\n    markers {\n      id\n      latitude\n      longitude\n      documentType\n      createdAt\n    }\n    totalCount\n    truncated\n  }\n}"
               }
             },
             "url": {
@@ -1191,7 +1192,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query SearchText($input: SearchInput!) {\n  searchText(input: $input) {\n    items {\n      content\n      score\n      metadata\n    }\n    total\n  }\n}",
+                "query": "query SearchText($input: SearchInput!) {\n  searchText(input: $input) {\n    results {\n      content\n      documentId\n      score\n    }\n    total\n    hasMore\n  }\n}",
                 "variables": "{\n  \"input\": {\n    \"query\": \"California water policy\",\n    \"limit\": 5\n  }\n}"
               }
             },
@@ -1210,7 +1211,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "mutation AnswerQuery($input: QueryInput!) {\n  answerQuery(input: $input)\n}",
+                "query": "mutation AnswerQuery($input: QueryInput!) {\n  answerQuery(input: $input) {\n    answer\n    sourcedFrom\n  }\n}",
                 "variables": "{\n  \"input\": {\n    \"query\": \"What are the latest California ballot propositions?\"\n  }\n}"
               }
             },
@@ -1234,7 +1235,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query MyActivityLog($limit: Int!, $offset: Int!) {\n  myActivityLog(limit: $limit, offset: $offset) {\n    items {\n      action\n      details\n      createdAt\n      ipAddress\n    }\n    total\n  }\n}",
+                "query": "query MyActivityLog($limit: Int!, $offset: Int!) {\n  myActivityLog(limit: $limit, offset: $offset) {\n    items {\n      action\n      operationName\n      success\n      ipAddress\n      timestamp\n    }\n    total\n  }\n}",
                 "variables": "{\n  \"limit\": 20,\n  \"offset\": 0\n}"
               }
             },
@@ -1253,7 +1254,7 @@
             "body": {
               "mode": "graphql",
               "graphql": {
-                "query": "query {\n  mySessions {\n    items {\n      id\n      userAgent\n      ipAddress\n      createdAt\n      lastActiveAt\n      isRevoked\n    }\n    total\n  }\n}"
+                "query": "query {\n  mySessions {\n    items {\n      id\n      deviceName\n      browser\n      operatingSystem\n      city\n      region\n      isActive\n      isCurrent\n      lastActivityAt\n      createdAt\n      revokedAt\n    }\n    total\n  }\n}"
               }
             },
             "url": {

--- a/postman/README.md
+++ b/postman/README.md
@@ -42,12 +42,19 @@ host-scoped, so seeding on one host and mutating on another won't carry it.
 
 ### One secret to paste
 
-`supabase_anon_key` is per-node. On the node (unlocked-Keychain terminal):
+`supabase_anon_key` must match what **kong validates against** — the value the
+running gateway container actually uses. A wrong/placeholder value makes kong
+return `{"message":"Unauthorized","request_id":...}` on login (before gotrue
+ever checks the password). Read the authoritative value straight from the
+container (this is the source of truth — the Keychain copy can drift from what's
+actually running):
 ```bash
-security find-generic-password -s org.opuspopuli.<region> -a supabase-anon-key -w
+docker exec opuspopuli-api printenv SUPABASE_ANON_KEY
 ```
-(`<region>` = e.g. `us-ca`.) Change `test_password` only if the node was
-bootstrapped with a custom `SEED_ADMIN_PASSWORD`.
+(The anon key is public/non-secret, but it's not committed here — the pre-push
+secret scanner flags any JWT.)
+Change `test_password` only if the node was bootstrapped with a custom
+`SEED_ADMIN_PASSWORD`.
 
 ## Run order
 

--- a/postman/README.md
+++ b/postman/README.md
@@ -1,0 +1,73 @@
+# Postman — OpusPopuli Backend
+
+`OpusPopuli.postman_collection.json` drives the backend GraphQL API through the
+API Gateway. It's environment-agnostic — every request uses `{{gateway_url}}`,
+so the same collection runs against local dev or a deployed node by swapping the
+environment.
+
+## Environments
+
+| File | Target | `gateway_url` |
+|------|--------|---------------|
+| `OpusPopuli-UAT.postman_environment.json` | Local dev / UAT — all services on `localhost` | `http://localhost:3000` |
+| `OpusPopuli-PROD.postman_environment.json` | A deployed node (e.g. us-ca Studio) | `http://opuspopuli-us-ca:8080` |
+
+### Why PROD only has the gateway
+
+A **node publishes exactly one API surface to the network: the gateway** (and
+kong/Supabase, only so you can log in). Every microservice — users, documents,
+knowledge, region, the workers — runs *inside* the node's Docker network and is
+**not reachable from outside**. You talk to all of them through the federated
+gateway. So the PROD environment deliberately carries only:
+
+| Var | Purpose |
+|-----|---------|
+| `gateway_url` | the one API endpoint (GraphQL at `{{gateway_url}}/api`) |
+| `supabase_url` + `supabase_anon_key` | log in via Supabase Auth to get the admin JWT |
+| `test_email` / `test_password` | seeded admin (`admin@opuspopuli.local` / `Admin1234!`) |
+| `csrf_token`, `access_token`, `sync_job_id`, `llm_rerank_job_id` | set by scripts at runtime |
+
+> The per-service `*_url` variables and the individual **service** health-check
+> requests are **local-dev only** — on a node those ports don't exist. Use
+> **API Gateway - Health** on a node.
+
+### Set `gateway_url` for your node
+
+- **Local-only node** (Tailscale/LAN, no public tunnel): `http://<node-host>:8080`
+  — e.g. `http://opuspopuli-us-ca:8080` (Tailscale) or `http://192.168.4.25:8080` (LAN).
+- **Public / Cloudflare-Tunnel node**: `https://api.<your-domain>` (443, no port).
+
+Keep the **same host** across a whole run — the `csrf-token` cookie is
+host-scoped, so seeding on one host and mutating on another won't carry it.
+
+### One secret to paste
+
+`supabase_anon_key` is per-node. On the node (unlocked-Keychain terminal):
+```bash
+security find-generic-password -s org.opuspopuli.<region> -a supabase-anon-key -w
+```
+(`<region>` = e.g. `us-ca`.) Change `test_password` only if the node was
+bootstrapped with a custom `SEED_ADMIN_PASSWORD`.
+
+## Run order
+
+1. **Health Checks → API Gateway - Seed CSRF Token (run first!)** — seeds the
+   `csrf-token` cookie + `{{csrf_token}}` var (returns 200 via `{__typename}`).
+   The collection pre-request script then attaches `x-csrf-token` + the cookie
+   to every POST automatically.
+2. **Auth → Login via Supabase Auth (run this first!)** — logs in as the admin,
+   saving the JWT to `{{access_token}}` (the collection's `Bearer` auth).
+3. Now any request works. To scrape:
+   **Pipeline Jobs (Region Worker) → Sync — …** enqueues a `syncRegionData` job
+   (saves `{{sync_job_id}}`), then **Poll Job Status** tracks it.
+
+## Kicking off a scrape
+
+`syncRegionData(regionId, dataTypes, depth, maxReps, maxBills)` → `RegionSyncJob!`
+(admin + CSRF gated — both handled by the collection).
+
+- `regionId`: `"california"` (state). Enable it first if reported inactive:
+  **Region → Enable Region Plugin (Admin)** with `name: "california"`.
+- `dataTypes`: `PROPOSITIONS · MEETINGS · REPRESENTATIVES · CAMPAIGN_FINANCE · CIVICS · BILLS`
+- `depth`: `STATE · COUNTY · ALL`
+- Start small (low `maxReps`/`maxBills`) to validate the pipeline before a full pull.


### PR DESCRIPTION
Makes the Postman collection usable against a deployed node and brings every request back in sync with the current schema.

## Why
A node publishes **only the API Gateway** (+ kong for login) to the network — every microservice is internal. The existing `localhost:300x` multi-URL env is confusing for a node operator, and the collection had accumulated schema drift across the auxiliary folders.

## Changes
**New `OpusPopuli-PROD.postman_environment.json`** — only what a node needs: `gateway_url`, `supabase_url` + `supabase_anon_key`, admin creds, and the runtime vars (`csrf_token`, `access_token`, `sync_job_id`, `llm_rerank_job_id`). No per-service URLs.

**New `README.md`** — run order, the "a node only exposes the gateway" model, `gateway_url` per deployment mode (`http://<host>:8080` local-only vs `https://api.<domain>` tunnelled), and the one secret to paste.

**Collection:**
- **Seed CSRF Token** → `/api?query={__typename}` returns a clean **200** (was a 400 that still set the cookie but looked broken).
- **Schema-drift sweep**: validated all 42 operations against the live gateway schema with `graphql-js` (no execution) and fixed **17 drifted** queries — `User.role`→removed, `createdAt`→`created`, `Meeting.date`→`scheduledAt`, flat rep contact→`contactInfo { email website }`, `PetitionMapResult.locations`→`markers/totalCount`, `QueryResult` now selects subfields, etc. **All 42 now validate cleanly.**

Scraping path (Seed CSRF → Login via Supabase → `syncRegionData` → Poll) was already valid; verified end-to-end against the us-ca Studio (login → CSRF → admin `getUsers` returns data; `Forbidden` without the token).

## Validation
- `graphql-js` validate: 42/42 operations pass against the live schema.
- Collection JSON valid; diff is one line per changed query (no reformat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)