### PR TITLE
fix(region): inject LLM_PROVIDER token into CivicsSyncService (#869)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/civics-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/civics-sync.service.spec.ts
@@ -1,0 +1,91 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { createMock } from '@golevelup/ts-jest';
+import { PromptClientService } from '@opuspopuli/prompt-client';
+import type { ILLMProvider } from '@opuspopuli/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+import {
+  CivicsSyncService,
+  type CivicsCrawlHelpers,
+  type CivicsProvider,
+} from './civics-sync.service';
+
+/**
+ * Regression coverage for #869: `llm` is an interface (`ILLMProvider`) and is
+ * therefore erased at runtime, so it must be injected by the explicit
+ * `'LLM_PROVIDER'` token that `LLMModule` provides. The original code declared
+ * `@Optional() private readonly llm?: ILLMProvider` WITHOUT `@Inject`, so
+ * NestJS resolved it to `undefined` and every civics sync silently no-op'd at
+ * the "requires PromptClient and LLM provider" guard — returning immediately
+ * with zero rows even when a region had civics data sources configured.
+ *
+ * These tests compile the service through a real DI container so the wiring
+ * (not just the guard logic) is exercised.
+ */
+describe('CivicsSyncService', () => {
+  const buildService = async (opts: { withLlm?: boolean } = {}) => {
+    const { withLlm = true } = opts;
+
+    const mockPromptClient = createMock<PromptClientService>();
+    const mockLlm = {
+      generate: jest.fn(),
+    } as unknown as jest.Mocked<ILLMProvider>;
+    const mockDb = createMock<DbService>();
+
+    const providers: unknown[] = [
+      CivicsSyncService,
+      { provide: DbService, useValue: mockDb },
+      { provide: PromptClientService, useValue: mockPromptClient },
+    ];
+    if (withLlm) {
+      providers.push({ provide: 'LLM_PROVIDER', useValue: mockLlm });
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: providers as Parameters<
+        typeof Test.createTestingModule
+      >[0]['providers'],
+    }).compile();
+
+    return { service: module.get(CivicsSyncService), mockLlm };
+  };
+
+  const makeHelpers = (): jest.Mocked<CivicsCrawlHelpers> => ({
+    fetchUrlText: jest.fn(),
+    htmlToReadableText: jest.fn(),
+    crawlCivicsUrls: jest.fn().mockResolvedValue([]),
+  });
+
+  it('receives the LLM provider via the LLM_PROVIDER token and gets past the guard (#869)', async () => {
+    const { service } = await buildService({ withLlm: true });
+    // A plugin whose dataSources are empty lets us stop right after the guard
+    // without any crawling — the assertion is simply that getDataSources IS
+    // consulted, which only happens once the llm/promptClient guard passes.
+    const getDataSources = jest.fn().mockReturnValue([]);
+    const plugin: CivicsProvider = {
+      getName: () => 'california',
+      getDataSources,
+    };
+
+    const result = await service.sync(plugin, makeHelpers());
+
+    // Under the injection bug, llm was undefined → guard short-circuited and
+    // getDataSources was NEVER called. Passing the guard proves the fix.
+    expect(getDataSources).toHaveBeenCalledWith(expect.anything());
+    expect(result).toEqual({ processed: 0, created: 0, updated: 0 });
+  });
+
+  it('no-ops when the LLM provider is absent (guard still protects a mis-wired node)', async () => {
+    const { service } = await buildService({ withLlm: false });
+    const getDataSources = jest.fn().mockReturnValue([]);
+    const plugin: CivicsProvider = {
+      getName: () => 'california',
+      getDataSources,
+    };
+
+    const result = await service.sync(plugin, makeHelpers());
+
+    expect(getDataSources).not.toHaveBeenCalled();
+    expect(result).toEqual({ processed: 0, created: 0, updated: 0 });
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/civics-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/civics-sync.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
 import {
   batchTransaction,
@@ -57,7 +57,12 @@ export class CivicsSyncService {
   constructor(
     private readonly db: DbService,
     @Optional() private readonly promptClient?: PromptClientService,
-    @Optional() private readonly llm?: ILLMProvider,
+    // ILLMProvider is an interface (erased at runtime), so there is no
+    // implicit injection token — NestJS resolves it by the explicit
+    // 'LLM_PROVIDER' token that LLMModule provides. Without @Inject here,
+    // @Optional() silently yields `undefined` and civics sync no-ops.
+    // Mirrors LlmGeneratorBase. See #869.
+    @Optional() @Inject('LLM_PROVIDER') private readonly llm?: ILLMProvider,
   ) {}
 
   async sync(


### PR DESCRIPTION
## Summary

Fixes #869. `CivicsSyncService` declared its LLM dependency as `@Optional() private readonly llm?: ILLMProvider` **without** `@Inject('LLM_PROVIDER')`. `ILLMProvider` is a TypeScript interface — erased at runtime — so NestJS had no token to resolve it, and `@Optional()` silently yielded `undefined`. The guard at the top of `sync()`:

```ts
if (!this.promptClient || !this.llm) {
  this.logger.warn('Civics sync requires PromptClient and LLM provider; skipping');
  return { processed: 0, created: 0, updated: 0 };
}
```

therefore short-circuited **every** civics run, returning zero rows before ever consulting the region plugin's `dataSources`.

**How it surfaced:** the 2026-07-12 from-scratch node acceptance test — the first real `CIVICS` scrape for `california` completed instantly with 0 rows despite the region having civics data sources configured.

## Fix

Add the explicit `@Inject('LLM_PROVIDER')` token (mirrors `LlmGeneratorBase` and `RegionSyncService`, and matches `LLMModule`'s `provide: "LLM_PROVIDER"`). `@Optional()` is retained so a node genuinely without an LLM still no-ops gracefully instead of failing to boot.

## Why civics was uniquely vulnerable

It was the only injection site combining all three risk factors:
1. a **bare class provider** (resolved by reflection, not a factory),
2. an **interface-typed** param (no implicit runtime token), and
3. **`@Optional()`** (turned the resolution miss into a *silent* `undefined` rather than a loud boot-time "can't resolve dependency").

Every other `LLM_PROVIDER` / `STORAGE_PROVIDER` / `EMAIL_PROVIDER` / `SECRETS_PROVIDER` / repository consumer either carries `@Inject` explicitly or is factory-wired (`useFactory` + `inject: [...]`, positional args need no token). Swept the entire backend + all 15 packages — CivicsSyncService was the only offender.

## Tests

New `civics-sync.service.spec.ts` compiles the service through a real `Test.createTestingModule` container (so it exercises actual DI resolution, not a hand-built instance):
- **positive** — with `LLM_PROVIDER` provided, `sync()` gets past the guard and consults `getDataSources` (fails under the old code, where `llm` was `undefined`).
- **negative** — without the token, the guard still no-ops (protects a legitimately mis-wired node).

Base + sonar eslint clean; full pre-commit test suite green.

## Deploy

Requires rebuilding + redeploying the `region-worker` image on the node, then re-queuing a `CIVICS` sync to confirm rows land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)