### PR TITLE
fix(region): skip empty CivicsBlocks + stamp llm_model provenance (#874, #873)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/civics-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/civics-sync.service.spec.ts
@@ -29,6 +29,7 @@ describe('CivicsSyncService', () => {
     const mockPromptClient = createMock<PromptClientService>();
     const mockLlm = {
       generate: jest.fn(),
+      getModelName: jest.fn().mockReturnValue('qwen-test'),
     } as unknown as jest.Mocked<ILLMProvider>;
     const mockDb = createMock<DbService>();
 
@@ -126,6 +127,13 @@ describe('CivicsSyncService', () => {
     );
 
     expect(mockDb.civicsBlock.upsert).toHaveBeenCalledTimes(1);
+    // #873: the producing model is stamped for provenance on both paths.
+    expect(mockDb.civicsBlock.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ llmModel: 'qwen-test' }),
+        update: expect.objectContaining({ llmModel: 'qwen-test' }),
+      }),
+    );
     expect(result).toEqual({ processed: 1, created: 1, updated: 0 });
   });
 

--- a/apps/backend/src/apps/region/src/domains/civics-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/civics-sync.service.spec.ts
@@ -47,13 +47,103 @@ describe('CivicsSyncService', () => {
       >[0]['providers'],
     }).compile();
 
-    return { service: module.get(CivicsSyncService), mockLlm };
+    return {
+      service: module.get(CivicsSyncService),
+      mockLlm,
+      mockDb,
+      mockPromptClient,
+    };
   };
 
   const makeHelpers = (): jest.Mocked<CivicsCrawlHelpers> => ({
     fetchUrlText: jest.fn(),
     htmlToReadableText: jest.fn(),
     crawlCivicsUrls: jest.fn().mockResolvedValue([]),
+  });
+
+  /**
+   * Drive exactly one civics page end-to-end through `sync()` with the LLM
+   * returning `extractedJson`. Returns the sync result plus the db mock so a
+   * test can assert whether the block was persisted.
+   */
+  const drivePage = async (extractedJson: string) => {
+    const { service, mockLlm, mockDb, mockPromptClient } = await buildService();
+    mockPromptClient.getCivicsExtractionPrompt.mockResolvedValue({
+      promptText: 'prompt',
+      promptHash: 'hash',
+      promptVersion: '1.0.0',
+    } as never);
+    mockLlm.generate.mockResolvedValue({ text: extractedJson } as never);
+    (mockDb.civicsBlock.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const sourceUrl = 'https://www.assembly.ca.gov/resources/x';
+    const getDataSources = jest
+      .fn()
+      .mockReturnValue([
+        { url: sourceUrl, contentGoal: 'goal', category: 'Assembly' },
+      ]);
+    const plugin = {
+      getName: () => 'california',
+      getDataSources,
+    } as unknown as CivicsProvider;
+
+    const helpers: jest.Mocked<CivicsCrawlHelpers> = {
+      fetchUrlText: jest.fn().mockResolvedValue('<html/>'),
+      htmlToReadableText: jest.fn().mockReturnValue('readable text'),
+      crawlCivicsUrls: jest.fn().mockResolvedValue([sourceUrl]),
+    };
+
+    const result = await service.sync(plugin, helpers);
+    return { result, mockDb };
+  };
+
+  // ── #874: don't persist empty CivicsBlocks ────────────────────────────
+  const EMPTY_BLOCK = JSON.stringify({
+    chambers: [],
+    measureTypes: [],
+    lifecycleStages: [],
+    glossary: [],
+    sessionScheme: null,
+  });
+
+  it('skips the upsert when the extracted block has no civic content (#874)', async () => {
+    const { result, mockDb } = await drivePage(EMPTY_BLOCK);
+
+    expect(mockDb.civicsBlock.upsert).not.toHaveBeenCalled();
+    // A skipped page counts as neither processed nor created/updated.
+    expect(result).toEqual({ processed: 0, created: 0, updated: 0 });
+  });
+
+  it('persists a block that has any list content (#874)', async () => {
+    const { result, mockDb } = await drivePage(
+      JSON.stringify({
+        chambers: [{ name: 'Assembly' }],
+        measureTypes: [],
+        lifecycleStages: [],
+        glossary: [],
+        sessionScheme: null,
+      }),
+    );
+
+    expect(mockDb.civicsBlock.upsert).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ processed: 1, created: 1, updated: 0 });
+  });
+
+  it('persists a block whose only content is the session scheme (#874)', async () => {
+    // Mirrors real CA pages that yielded only sessionScheme — must NOT be
+    // treated as empty.
+    const { result, mockDb } = await drivePage(
+      JSON.stringify({
+        chambers: [],
+        measureTypes: [],
+        lifecycleStages: [],
+        glossary: [],
+        sessionScheme: { cadence: 'biennial' },
+      }),
+    );
+
+    expect(mockDb.civicsBlock.upsert).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ processed: 1, created: 1, updated: 0 });
   });
 
   it('receives the LLM provider via the LLM_PROVIDER token and gets past the guard (#869)', async () => {

--- a/apps/backend/src/apps/region/src/domains/civics-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/civics-sync.service.ts
@@ -186,7 +186,7 @@ export class CivicsSyncService {
     sourceUrl: string,
     ds: DataSourceConfig,
     helpers: CivicsCrawlHelpers,
-  ): Promise<'created' | 'updated' | 'failed'> {
+  ): Promise<'created' | 'updated' | 'failed' | 'skipped'> {
     if (!this.promptClient || !this.llm) return 'failed';
     try {
       const html = await helpers.fetchUrlText(sourceUrl);
@@ -229,6 +229,17 @@ export class CivicsSyncService {
           `Civics extraction: JSON.parse failed for ${sourceUrl}: ${(e as Error).message}`,
         );
         return 'failed';
+      }
+
+      // A page the crawler reached under the source's scope but that holds no
+      // civic content (e.g. dining services, records-request) extracts to a
+      // well-formed but entirely empty block. Persisting it creates a noise
+      // CivicsBlock, so skip the upsert entirely. See #874.
+      if (isEmptyCivicsExtraction(block)) {
+        this.logger.log(
+          `Civics extraction: no civic content on ${sourceUrl} — skipping empty block`,
+        );
+        return 'skipped';
       }
 
       const existing = await this.db.civicsBlock.findUnique({
@@ -357,4 +368,33 @@ function toJsonField(
   return value === undefined || value === null
     ? Prisma.DbNull
     : (value as Prisma.InputJsonValue);
+}
+
+/**
+ * True when an extracted civics block carries no civic content at all — every
+ * list field empty/absent and no session scheme. The crawler reaches non-civic
+ * utility pages under a source's scope (dining services, records requests),
+ * and the model faithfully returns an empty shell for them; persisting those
+ * as `civics_blocks` rows is pure noise. Callers skip the upsert. See #874.
+ */
+function isEmptyCivicsExtraction(block: {
+  chambers?: unknown;
+  measureTypes?: unknown;
+  lifecycleStages?: unknown;
+  sessionScheme?: unknown;
+  glossary?: unknown;
+}): boolean {
+  const isEmptyList = (v: unknown): boolean =>
+    !Array.isArray(v) || v.length === 0;
+  const isEmptyScheme =
+    block.sessionScheme == null ||
+    (typeof block.sessionScheme === 'object' &&
+      Object.keys(block.sessionScheme as Record<string, unknown>).length === 0);
+  return (
+    isEmptyList(block.chambers) &&
+    isEmptyList(block.measureTypes) &&
+    isEmptyList(block.lifecycleStages) &&
+    isEmptyList(block.glossary) &&
+    isEmptyScheme
+  );
 }

--- a/apps/backend/src/apps/region/src/domains/civics-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/civics-sync.service.ts
@@ -253,6 +253,10 @@ export class CivicsSyncService {
         lifecycleStages: toJsonField(block.lifecycleStages),
         sessionScheme: toJsonField(block.sessionScheme),
         glossary: toJsonField(block.glossary),
+        // Provenance: stamp which model produced this block, alongside
+        // promptHash/promptVersion, so re-ranking/re-extraction can tell what
+        // came from where. `llm` is non-null past the guard above. See #873.
+        llmModel: this.llm.getModelName(),
       };
 
       await this.db.civicsBlock.upsert({


### PR DESCRIPTION
## Summary

Fixes #874. The civics crawler reaches non-civic **utility pages** under a source's scope (dining services, records-request, hold-events, open-records-act). The extractor faithfully returns a well-formed but **entirely empty** block for them, and `extractAndUpsertPage` upserted **unconditionally** — so each such page created a noise `civics_blocks` row.

On the 2026-07-12 us-ca bring-up, **7 of 11** rows were empty shells (`chambers/measureTypes/lifecycleStages/glossary` all empty, `sessionScheme` null).

## Fix

Add an `isEmptyCivicsExtraction` guard. When all four list fields are empty/absent **and** there's no `sessionScheme`, skip the upsert (and its glossary write) and return `'skipped'` — an outcome the `sync()` Phase-2 loop **already** handled (the plumbing existed; the method just never returned it). Blocks whose only content is a `sessionScheme` are **preserved** — real CA pages (the glossary page, the follow-the-process page) produce exactly that shape.

Calibrated against live node data: the guard catches exactly the 7 empties and keeps the 4 real blocks.

## Tests

3 new tests drive a page end-to-end through `sync()` via a real DI container:
- empty block → `upsert` **not** called, result `{processed:0, created:0, updated:0}`
- any list content → persisted (`created`)
- `sessionScheme`-only → persisted (must not be treated as empty)

5/5 in the suite green; full pre-commit suite (2188) passed; base + sonar lint clean.

## Follow-up (not in this PR)

A one-time **backfill delete** of the existing empty rows must run **after** this image deploys to the node (deleting before deploy would let a re-sync on the old image recreate them). Tracked to run during the redeploy.

## Related
- #869 (civics DI fix — first surfaced this pipeline), #873 (llm_model provenance), opuspopuli-regions#55 (Assembly-only coverage). This PR is the noise-reduction half of "civics isn't complete"; #55 is the coverage half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)