### PR TITLE
perf(llm): log Ollama generation throughput (tokens + tok/s) (#872)

### DIFF
--- a/packages/llm-provider/__tests__/ollama.provider.spec.ts
+++ b/packages/llm-provider/__tests__/ollama.provider.spec.ts
@@ -83,6 +83,52 @@ describe("OllamaLLMProvider", () => {
       );
     });
 
+    it("logs generation throughput as tokens + tok/s (#872)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            response: "hello world",
+            eval_count: 100,
+            eval_duration: 2_000_000_000, // 2s in ns → 50 tok/s
+            done: true,
+          }),
+      });
+
+      await provider.generate("Test prompt");
+
+      const { Logger } = jest.requireMock("@nestjs/common");
+      const results = (Logger as jest.Mock).mock.results as unknown as Array<{
+        value: { log: jest.Mock };
+      }>;
+      const logged = results
+        .flatMap((r) => r.value.log.mock.calls)
+        .map((c: unknown[]) => String(c[0]))
+        .join("\n");
+      expect(logged).toContain("100 tokens");
+      expect(logged).toContain("50.0 tok/s");
+    });
+
+    it("reports tok/s as n/a when the model omits eval_duration (#872)", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ response: "hi", eval_count: 5, done: true }),
+      });
+
+      await provider.generate("Test prompt");
+
+      const { Logger } = jest.requireMock("@nestjs/common");
+      const results = (Logger as jest.Mock).mock.results as unknown as Array<{
+        value: { log: jest.Mock };
+      }>;
+      const logged = results
+        .flatMap((r) => r.value.log.mock.calls)
+        .map((c: unknown[]) => String(c[0]))
+        .join("\n");
+      expect(logged).toContain("n/a tok/s");
+    });
+
     it("should pass generation options", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/packages/llm-provider/src/providers/ollama.provider.ts
+++ b/packages/llm-provider/src/providers/ollama.provider.ts
@@ -218,11 +218,22 @@ export class OllamaLLMProvider implements ILLMProvider {
         const data = (await response.json()) as {
           response?: string;
           eval_count?: number;
+          eval_duration?: number; // nanoseconds spent generating tokens
           done?: boolean;
         };
 
+        // Log generation throughput. Output volume (tokens), not context
+        // window or reasoning, is what governs latency here — surfacing
+        // tokens + tok/s makes perf regressions visible in one line
+        // instead of an ad-hoc benchmark. See #872.
+        const tokens = data.eval_count ?? 0;
+        const tokPerSec =
+          data.eval_duration && data.eval_duration > 0
+            ? ((tokens * 1e9) / data.eval_duration).toFixed(1)
+            : "n/a";
         this.logger.log(
-          `Generated ${data.response?.length || 0} chars with Ollama`,
+          `Generated ${data.response?.length || 0} chars ` +
+            `(${tokens} tokens, ${tokPerSec} tok/s) with Ollama`,
         );
 
         return {


### PR DESCRIPTION
## Summary

Repurposed #872 after measurement disproved its original premise.

An A/B on the us-ca node (qwen3.6:35b-a3b, ~5K-token prompt) showed the two proposed changes are **no-ops**:

| context setting | load | gen throughput |
|---|---|---|
| default (262144) | 4.1s | **75.2 tok/s** |
| `num_ctx=8192` | 3.8s | **75.2 tok/s** |

- **`num_ctx` cap → no measurable effect** (Ollama allocates the KV cache efficiently).
- **`think:false` is already the default AND already sent** (`ollama.provider.ts:200`) and is honored.

Latency is governed by **output token volume** at a flat ~75 tok/s: the 124s civics page = ~9,000 output tokens ÷ 75. The real fix (emit fewer tokens) lives in prompt-service (**#92**), and the faster-model-for-bulk lever in create-op-node #98.

## What this PR does

The one salvageable, genuinely-useful piece: **log generation throughput** in `OllamaLLMProvider.generate` — `eval_count` (tokens) + tok/s next to the existing char count, so future perf triage is one log line instead of an ad-hoc benchmark.

```
Generated 34883 chars (8721 tokens, 75.2 tok/s) with Ollama
```

Derives tok/s from Ollama's `eval_duration` (nanoseconds); falls back to `n/a` when the model omits it.

## Tests
2 new tests in `ollama.provider.spec.ts` (tok/s computed; `n/a` fallback). 26/26 pass; `tsc` build clean; full pre-commit suite green.

## Related
- prompt-service #92 (real output-size fix), create-op-node #98 (bulk model tiering), #869 (surfaced the pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)