### PR TITLE
test(frontend): deflake E2E tests + bump @opuspopuli/regions to ^1.0.70

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -87,7 +87,7 @@
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/queue-provider": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.68",
+    "@opuspopuli/regions": "^1.0.70",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/frontend/e2e/email.spec.ts
+++ b/apps/frontend/e2e/email.spec.ts
@@ -479,8 +479,11 @@ test.describe("Email History Page - Loading State", () => {
 
     await page.goto("/settings/email-history");
 
-    const skeletons = await page.locator(".animate-pulse").count();
-    expect(skeletons).toBeGreaterThan(0);
+    // Web-first assertion auto-retries until the skeleton appears during the
+    // 500ms mocked API delay. A one-shot `.count()` immediately after `goto`
+    // can sample before the skeleton renders (or after the delayed response
+    // already resolved it away), which flaked intermittently.
+    await expect(page.locator(".animate-pulse").first()).toBeVisible();
   });
 });
 

--- a/apps/frontend/e2e/home.spec.ts
+++ b/apps/frontend/e2e/home.spec.ts
@@ -57,6 +57,14 @@ test.describe("Home Page", () => {
   });
 
   test("should be accessible", async ({ page }) => {
+    // Wait for the page to finish rendering before scanning. axe on a
+    // mid-hydration DOM catches transient violations (unlabeled controls,
+    // duplicate ids during hydration) that resolve once settled — which
+    // flaked intermittently and recovered on retry.
+    await expect(
+      page.getByRole("heading", { name: /Know your ballot/i, level: 1 }),
+    ).toBeVisible();
+
     const results = await new AxeBuilder({ page })
       .withTags(["wcag2a", "wcag2aa", "wcag22aa"])
       .analyze();

--- a/apps/frontend/e2e/pwa.spec.ts
+++ b/apps/frontend/e2e/pwa.spec.ts
@@ -344,6 +344,12 @@ test.describe("PWA - Mobile Experience", () => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto("/login");
 
+    // Wait for the page's interactive buttons to render before enumerating.
+    // `goto` resolves on `load`, but the login form's buttons are client-
+    // rendered, so a one-shot `.all()` immediately after can race the render
+    // and find zero buttons (flaky: passed mobile-safari but failed tablet).
+    await expect(page.locator("button:visible").first()).toBeVisible();
+
     // Buttons should be at least 44x44 (iOS) or 48x48 (Android) for touch
     // Only check primary interactive buttons (not icon buttons or small controls)
     const buttons = await page.locator("button:visible").all();

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.69"
+    "@opuspopuli/regions": "^1.0.70"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.68
-        version: 1.0.68
+        specifier: ^1.0.70
+        version: 1.0.70
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -996,8 +996,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.69
-        version: 1.0.69
+        specifier: ^1.0.70
+        version: 1.0.70
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4999,12 +4999,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.68':
-    resolution: {integrity: sha512-gNk3Zbm1S7vaX/mazxzySss7wCHCWA7gx5DWRGCtUvXv/oJ1BIDOlT5A90Et9XRZ7BOUatYC9FHt0xWtUNgMcw==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.68/41a608bec17e2b313efac4250c7afe3ded29a5f6}
-    hasBin: true
-
-  '@opuspopuli/regions@1.0.69':
-    resolution: {integrity: sha512-hUEXPiScSmliOvMfAFN6pQkSMz466s5WHPHHdpI1uAH7qOejIGhK0CcRZLcJr4FcrFOkJsYImT85wgipKh4Z8w==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.69/ea789fd1b6ddfd47c90f313bd1a9bef3d8f66aa1}
+  '@opuspopuli/regions@1.0.70':
+    resolution: {integrity: sha512-k5kkvQcOlrdJXriJ7I7HolUPMlF3T70h59X8IFKupAkcwSA/b18PFsg04Nz0P0Zt9C0Baai1Nah1SFQ222Dm7A==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.70/f22a2ba4b110caa0bff87c067042179c9d9d07bd}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -16803,16 +16799,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.68':
-    dependencies:
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      chalk: 5.6.2
-      cheerio: 1.2.0
-      commander: 12.1.0
-      ollama: 0.6.3
-
-  '@opuspopuli/regions@1.0.69':
+  '@opuspopuli/regions@1.0.70':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)


### PR DESCRIPTION
Two independent changes (see the two commits):

## 1. `test(frontend)` — deflake three E2E tests (5e324e0)
E2E **shard 4** failed on `main` (CI run 29212405115): `1 failed, 3 flaky, 469 passed`. All the instability is one class of bug — asserting on the DOM immediately after navigation with a one-shot query, racing client render/hydration.

- **Hard failure** (all 3 attempts): `[tablet] pwa.spec.ts:343 › touch-friendly targets` — `expect(validButtonCount).toBeGreaterThan(0)` got `0`. Same test only flaked-and-recovered on `[mobile-safari]` in the same run → timing, not a product bug.
- **Flaky** (recovered on retry): `email.spec.ts:437 › loading skeleton`, `home.spec.ts:59 › should be accessible`.

Fix (behavior-preserving — same assertions, anchored to a settled DOM): wait for the first visible button before enumerating (pwa); one-shot `.count()` → web-first `toBeVisible()` (email); wait for the `h1` before axe (home).

## 2. `chore(deps)` — bump @opuspopuli/regions to ^1.0.70 (648f483)
Additive region config only (CA Senate + Secretary of State civics sources) — no code impact. Bumps **both** consumers: `apps/backend` and `packages/region-provider` (the latter loads the region JSON at runtime). Lockfile re-resolved (not just the `^`range) because the Dockerfiles install `--frozen-lockfile`. Verified: `regions@1.0.70` ×2, `1.0.69`/`1.0.68` gone.

## Validation
eslint clean; full pre-commit (`lint-staged && pnpm test`) + pre-push gate (coverage — backend 2188 tests green — jscpd, sonar, audit, Trivy, gitleaks, AI review + security review) both passed.
