### PR TITLE
fix(region): persist generated representative bios (#881)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/bio-generator.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/bio-generator.service.spec.ts
@@ -1,8 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import { createMock } from '@golevelup/ts-jest';
+import { createMock, type DeepMocked } from '@golevelup/ts-jest';
 import { PromptClientService } from '@opuspopuli/prompt-client';
 import type { ILLMProvider, Representative } from '@opuspopuli/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
 
 import { BioGeneratorService } from './bio-generator.service';
 
@@ -10,6 +11,7 @@ describe('BioGeneratorService', () => {
   let service: BioGeneratorService;
   let promptClient: jest.Mocked<PromptClientService>;
   let llm: jest.Mocked<ILLMProvider>;
+  let db: DeepMocked<DbService>;
 
   const baseRep = (
     overrides: Partial<Representative> = {},
@@ -29,6 +31,7 @@ describe('BioGeneratorService', () => {
     service: BioGeneratorService;
     promptClient: jest.Mocked<PromptClientService>;
     llm: jest.Mocked<ILLMProvider>;
+    db: DeepMocked<DbService>;
   }> {
     const mockPromptClient = createMock<PromptClientService>();
     mockPromptClient.getDocumentAnalysisPrompt.mockResolvedValue({
@@ -45,12 +48,15 @@ describe('BioGeneratorService', () => {
       get: jest.fn((key: string) => configValues[key]),
     } as unknown as ConfigService;
 
+    const mockDb = createMock<DbService>();
+
     const providers = withDeps
       ? [
           BioGeneratorService,
           { provide: ConfigService, useValue: mockConfig },
           { provide: PromptClientService, useValue: mockPromptClient },
           { provide: 'LLM_PROVIDER', useValue: mockLlm },
+          { provide: DbService, useValue: mockDb },
         ]
       : [BioGeneratorService];
 
@@ -62,6 +68,7 @@ describe('BioGeneratorService', () => {
       service: module.get(BioGeneratorService),
       promptClient: mockPromptClient,
       llm: mockLlm,
+      db: mockDb,
     };
   }
 
@@ -84,6 +91,7 @@ describe('BioGeneratorService', () => {
       service = built.service;
       promptClient = built.promptClient;
       llm = built.llm;
+      db = built.db;
     });
 
     it('generates bios only for reps with empty bio', async () => {
@@ -107,6 +115,42 @@ describe('BioGeneratorService', () => {
       );
       expect(result[1].bioSource).toBe('ai-generated');
       expect(result[2].bioSource).toBe('ai-generated');
+    });
+
+    it('persists each generated bio back to the DB by externalId (#881)', async () => {
+      llm.generate.mockResolvedValue({
+        text: '{"bio": "Jane Smith represents District 5 in the California Senate."}',
+      } as Awaited<ReturnType<ILLMProvider['generate']>>);
+
+      const reps = [
+        baseRep({ externalId: 'sen-5' }),
+        baseRep({ externalId: 'sen-6', bio: '' }),
+      ];
+
+      await service.enrichBios(reps, undefined);
+
+      // Regression for #828: the mutated bios must be WRITTEN BACK, not just
+      // held in memory (the extraction dropped the persist, so a full reps
+      // sync produced 0 persisted bios). Two reps needed a bio → two writes.
+      expect(db.representative.update).toHaveBeenCalledTimes(2);
+      expect(db.representative.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { externalId: 'sen-5' },
+          data: expect.objectContaining({
+            bio: 'Jane Smith represents District 5 in the California Senate.',
+            bioSource: 'ai-generated',
+          }),
+        }),
+      );
+    });
+
+    it('does not write to the DB for reps that already have a bio (#881)', async () => {
+      const reps = [baseRep({ externalId: 'has-bio', bio: 'Existing bio.' })];
+
+      await service.enrichBios(reps, undefined);
+
+      expect(llm.generate).not.toHaveBeenCalled();
+      expect(db.representative.update).not.toHaveBeenCalled();
     });
 
     it('returns early when no reps need bios', async () => {

--- a/apps/backend/src/apps/region/src/domains/bio-generator.service.ts
+++ b/apps/backend/src/apps/region/src/domains/bio-generator.service.ts
@@ -5,6 +5,7 @@ import {
   type BioClaim,
   type Representative,
 } from '@opuspopuli/common';
+import { Prisma } from '@opuspopuli/relationaldb-provider';
 import { readOptionalPositiveInt, readPositiveInt } from './config-helpers';
 import { LlmGeneratorBase } from './llm-generator.base';
 
@@ -148,6 +149,7 @@ export class BioGeneratorService extends LlmGeneratorBase {
         // Persist the full claims array (#602). Undefined on tier-2
         // salvage since only the bio string survived parsing.
         rep.bioClaims = parsed.claims;
+        await this.persistBio(rep);
         return true;
       }
     } catch (error) {
@@ -156,6 +158,34 @@ export class BioGeneratorService extends LlmGeneratorBase {
       );
     }
     return false;
+  }
+
+  /**
+   * Write a freshly-generated bio back to the representative row. The rep was
+   * already upserted (keyed by externalId) in the sync's extract phase, so this
+   * persists the bio fields the generator just mutated in memory. The #828
+   * extraction of RepresentativesSyncService dropped the monolith's
+   * post-enrichBios upsert — without this write-back, generated bios are held
+   * only in memory and discarded (the whole reps sync produced 0 persisted
+   * bios). See #881.
+   */
+  private async persistBio(rep: Representative): Promise<void> {
+    if (!this.db) {
+      this.logger.warn(
+        `No DbService available — generated bio for ${rep.name} not persisted`,
+      );
+      return;
+    }
+    await this.db.representative.update({
+      where: { externalId: rep.externalId },
+      data: {
+        bio: rep.bio,
+        bioSource: rep.bioSource,
+        ...(rep.bioClaims
+          ? { bioClaims: rep.bioClaims as unknown as Prisma.InputJsonValue }
+          : {}),
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #881. `BioGeneratorService.enrichBios` generates AI bios and **mutates `rep.bio` / `rep.bioSource` / `rep.bioClaims` in memory, but never writes them back to the DB.** On the us-ca node, a full reps sync generated **120 bios (~15 min of qwen3.6 work) and persisted 0** — `bio`, `bio_claims`, `bio_source` all NULL for 0/120 reps; the `bio_generation` phase reports `0 updated`.

## Root cause — regression from `4b8a742` (#828 Step 3: extract RepresentativesSyncService)

Pre-#828, the monolith persisted after generation:
```ts
await this.bioGenerator.enrichBios(reps, ...);   // mutate in memory
await this.db.representative.upsert({ ... bio, bioSource, bioClaims ... });  // persist
```
The #828 extraction split rep upsert into Phase 2 `extract_and_upsert` (runs **before** bio-gen) and left Phase 4 `bio_generation` calling `enrichBios` with no write-back — the post-`enrichBios` upsert was not carried over. Hence *"worked in dev"* (the pre-#828 monolith) but not on current images.

## Fix

Add `persistBio()` to `BioGeneratorService`: after a successful generation, write the bio fields to the representative row by `externalId` (the `@unique` key the extract phase upserts on), via `this.db` (already available from `LlmGeneratorBase`). `@Optional` db is guarded; `bioClaims` is only set when present (tier-2 salvage doesn't clobber). Per-rep write keeps it crash-safe mid-batch.

## Tests

Two regression guards in `bio-generator.service.spec.ts` (now wiring a mock `DbService`):
- a generated bio triggers `db.representative.update({ where:{externalId}, data:{ bio, bioSource } })` — **fails without the fix** (0 calls);
- a rep that already has a bio is neither generated nor persisted.

28/28 in the suite; full pre-commit backend suite green; base + sonar lint clean.

## Related
- #882 (`manifest_ready` re-sync ignores `maxReps` — surfaced in the same test), opuspopuli-regions#57 (CA reps district selector). Found validating the 2026-07-13 fresh us-ca node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)