### PR TITLE
chore(deps): bump @opuspopuli/regions to ^1.0.71 (CA reps district fix)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -87,7 +87,7 @@
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/queue-provider": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.70",
+    "@opuspopuli/regions": "^1.0.71",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.70"
+    "@opuspopuli/regions": "^1.0.71"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,8 +186,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.70
-        version: 1.0.70
+        specifier: ^1.0.71
+        version: 1.0.71
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -996,8 +996,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.70
-        version: 1.0.70
+        specifier: ^1.0.71
+        version: 1.0.71
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4999,8 +4999,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.70':
-    resolution: {integrity: sha512-k5kkvQcOlrdJXriJ7I7HolUPMlF3T70h59X8IFKupAkcwSA/b18PFsg04Nz0P0Zt9C0Baai1Nah1SFQ222Dm7A==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.70/f22a2ba4b110caa0bff87c067042179c9d9d07bd}
+  '@opuspopuli/regions@1.0.71':
+    resolution: {integrity: sha512-LdTEIOoliUg1tWgiGvAxHFB+R4Q38IyeAH4T1cMMglGBA5esQjhc0uy1VfN4w8CqMpYlfopowG7QE9ROo8h/mA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.71/505d649ceb4c36ddfd78692a2fc6d203bdfcdd03}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -16799,7 +16799,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.70':
+  '@opuspopuli/regions@1.0.71':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)


### PR DESCRIPTION
Bumps `@opuspopuli/regions` `1.0.70 → ^1.0.71` (both `apps/backend` and `packages/region-provider`, the runtime config loader) so the next image build bundles the CA representatives **district-selector fix** published in opuspopuli-regions#58 (fixes #57):
- Senate: static `district` mapping via `.page-members__district-num`.
- Assembly: verbatim `district` hint deriving from the `/assemblymembers/{N}` href.

Dockerfiles install `--frozen-lockfile`, so the lockfile is re-resolved to `1.0.71` (2 refs; 0 remaining at 1.0.70). Additive config only — no code change. Full pre-commit suite green.

**Merge AFTER the current bio-persist release** (#883) lands — this is queued to ride the *next* release so it doesn't disturb the in-flight develop→main promotion.

Closes #57 (once deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)