### PR TITLE
feat(region): cascade enable/disable for region plugins (#886)

### DIFF
--- a/apps/backend/__tests__/integration/region/region.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/region.integration.spec.ts
@@ -1685,6 +1685,167 @@ describe('Region Integration Tests', () => {
     });
   });
 
+  // ============================================
+  // GraphQL: region plugin cascade (#886)
+  // ============================================
+
+  describe('Region plugin cascade enable/disable (#886)', () => {
+    /**
+     * Seeds a state parent (`california`, enabled) plus two county children
+     * that ship `enabled: false` and reference the parent via
+     * `parentRegionId === parent.name`. Mirrors the inaugural us-ca node,
+     * where all 58 counties register disabled under the enabled state.
+     */
+    async function seedCascadeHierarchy(): Promise<void> {
+      const db = await getDbService();
+      await db.regionPlugin.deleteMany({});
+      const countyConfig = (regionId: string) => ({
+        regionId,
+        regionName: regionId,
+        description: `${regionId} county plugin (test stub)`,
+        timezone: 'America/Los_Angeles',
+        stateCode: 'CA',
+        dataSources: [
+          {
+            url: `https://example.test/${regionId}-reps`,
+            dataType: 'representatives',
+            contentGoal: 'Test stub — extract county reps',
+          },
+        ],
+      });
+      await db.regionPlugin.createMany({
+        data: [
+          {
+            name: 'california',
+            displayName: 'California',
+            description: 'CA state plugin',
+            version: '1.0.0',
+            enabled: true,
+            config: {
+              regionId: 'california',
+              regionName: 'California',
+              description: 'CA state plugin (test stub)',
+              timezone: 'America/Los_Angeles',
+              stateCode: 'CA',
+              dataSources: [
+                {
+                  url: 'https://example.test/ca-bills',
+                  dataType: 'bills',
+                  contentGoal: 'Test stub — extract bills',
+                },
+              ],
+            },
+            parentRegionId: null,
+            fipsCode: '06',
+          },
+          {
+            name: 'california-sonoma',
+            displayName: 'Sonoma County',
+            description: 'Sonoma County plugin',
+            version: '1.0.0',
+            enabled: false,
+            config: countyConfig('california-sonoma'),
+            parentRegionId: 'california',
+            fipsCode: '06097',
+          },
+          {
+            name: 'california-marin',
+            displayName: 'Marin County',
+            description: 'Marin County plugin',
+            version: '1.0.0',
+            enabled: false,
+            config: countyConfig('california-marin'),
+            parentRegionId: 'california',
+            fipsCode: '06041',
+          },
+        ],
+      });
+    }
+
+    const cascadeMutation = (
+      name: string,
+      enabled: boolean,
+      cascade: boolean,
+    ) => `
+      mutation {
+        updateRegionPlugin(name: "${name}", enabled: ${enabled}, cascade: ${cascade}) {
+          name
+          enabled
+          cascadedCount
+        }
+      }
+    `;
+
+    async function childEnabledFlags(): Promise<boolean[]> {
+      const db = await getDbService();
+      const children = await db.regionPlugin.findMany({
+        where: { parentRegionId: 'california' },
+        orderBy: { name: 'asc' },
+        select: { enabled: true },
+      });
+      return children.map((c) => c.enabled);
+    }
+
+    it('cascade:true enable flips every county child to enabled and reports the count', async () => {
+      await seedCascadeHierarchy();
+
+      // Precondition: both counties start disabled.
+      expect(await childEnabledFlags()).toEqual([false, false]);
+
+      const result = await adminGraphqlRequest<{
+        updateRegionPlugin: { enabled: boolean; cascadedCount: number };
+      }>(cascadeMutation('california', true, true));
+      assertNoErrors(result);
+      expect(result.data.updateRegionPlugin.enabled).toBe(true);
+      expect(result.data.updateRegionPlugin.cascadedCount).toBe(2);
+
+      // Children are now enabled in the DB — a subsequent scoped/unscoped
+      // county sync (which filters on enabled: true) will pick them up.
+      expect(await childEnabledFlags()).toEqual([true, true]);
+    });
+
+    it('cascade:true disable shuts the whole subtree back off', async () => {
+      await seedCascadeHierarchy();
+      // Start from a fully-enabled subtree.
+      await adminGraphqlRequest(cascadeMutation('california', true, true));
+      expect(await childEnabledFlags()).toEqual([true, true]);
+
+      const result = await adminGraphqlRequest<{
+        updateRegionPlugin: { enabled: boolean; cascadedCount: number };
+      }>(cascadeMutation('california', false, true));
+      assertNoErrors(result);
+      expect(result.data.updateRegionPlugin.cascadedCount).toBe(2);
+      expect(await childEnabledFlags()).toEqual([false, false]);
+    });
+
+    it('default (no cascade) leaves children untouched — backward compatible', async () => {
+      await seedCascadeHierarchy();
+      const db = await getDbService();
+      // Precondition: children ship disabled from the seed.
+      expect(await childEnabledFlags()).toEqual([false, false]);
+      // Disable the parent WITHOUT cascade; children must stay as-seeded.
+      await db.regionPlugin.update({
+        where: { name: 'california' },
+        data: { enabled: false },
+      });
+
+      const result = await adminGraphqlRequest<{
+        updateRegionPlugin: { cascadedCount: number };
+      }>(`
+        mutation {
+          updateRegionPlugin(name: "california", enabled: true) {
+            name
+            cascadedCount
+          }
+        }
+      `);
+      assertNoErrors(result);
+      // No cascade requested → no descendants touched, count is 0.
+      expect(result.data.updateRegionPlugin.cascadedCount).toBe(0);
+      expect(await childEnabledFlags()).toEqual([false, false]);
+    });
+  });
+
   describe('Database cleanup', () => {
     it('should have clean database at start of each test', async () => {
       await createRepresentative({ name: 'Cleanup Test Rep' });

--- a/apps/backend/region-schema.gql
+++ b/apps/backend/region-schema.gql
@@ -161,6 +161,7 @@ type RegionPluginModel {
   enabled: Boolean!
   parentRegionId: String
   fipsCode: String
+  cascadedCount: Int
 }
 
 type SyncResultModel {
@@ -660,7 +661,7 @@ enum BillLifecycle {
 type Mutation {
   regeneratePropositionAnalysis(id: ID!): PropositionModel
   invalidateManifest(regionId: String!, sourceUrl: String!): Int!
-  updateRegionPlugin(name: String!, enabled: Boolean!): RegionPluginModel!
+  updateRegionPlugin(name: String!, enabled: Boolean!, cascade: Boolean = false): RegionPluginModel!
   syncRegionData(dataTypes: [DataType!], depth: SyncDepth, regionId: String, maxReps: Int, maxBills: Int): RegionSyncJob!
 }
 

--- a/apps/backend/src/apps/region/src/domains/models/region-info.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/region-info.model.ts
@@ -1,4 +1,4 @@
-import { ObjectType, Field, registerEnumType } from '@nestjs/graphql';
+import { ObjectType, Field, Int, registerEnumType } from '@nestjs/graphql';
 
 // ── Civics GQL types ─────────────────────────────────────────────────────────
 
@@ -228,6 +228,14 @@ export class RegionPluginModel {
 
   @Field({ nullable: true })
   fipsCode?: string;
+
+  /**
+   * Number of descendant plugins also toggled by a cascade mutation
+   * (`updateRegionPlugin(..., cascade: true)`). 0 when cascade was not
+   * requested or the target has no descendants. See #886.
+   */
+  @Field(() => Int, { nullable: true })
+  cascadedCount?: number;
 }
 
 /**

--- a/apps/backend/src/apps/region/src/domains/region-plugin.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-plugin.service.ts
@@ -206,29 +206,66 @@ export class RegionPluginService implements OnModuleInit {
   async setRegionPluginEnabled(
     name: string,
     enabled: boolean,
+    cascade = false,
   ): Promise<RegionPluginRow> {
-    const row = await this.db.regionPlugin.update({
-      where: { name },
-      data: { enabled },
-      select: {
-        name: true,
-        displayName: true,
-        description: true,
-        version: true,
-        enabled: true,
-        parentRegionId: true,
-        fipsCode: true,
-      },
-    });
+    const select = {
+      name: true,
+      displayName: true,
+      description: true,
+      version: true,
+      enabled: true,
+      parentRegionId: true,
+      fipsCode: true,
+    } as const;
+
+    // Optional cascade-down: also toggle every descendant. A child's
+    // `parentRegionId` equals its parent's `name`, so a single `updateMany`
+    // covers the current one-level (state → county) hierarchy. `federal` is
+    // excluded for symmetry with fetchLocalPluginConfigs — it never has a
+    // state parent. The primary update and the cascade run in ONE
+    // transaction so a partial failure can't leave the subtree half-toggled
+    // (the exact "partially-enabled state" risk #886 exists to remove).
+    let row: Prisma.RegionPluginGetPayload<{ select: typeof select }>;
+    let cascadedCount = 0;
+    if (cascade) {
+      const [updated, cascadeResult] = await this.db.$transaction([
+        this.db.regionPlugin.update({
+          where: { name },
+          data: { enabled },
+          select,
+        }),
+        this.db.regionPlugin.updateMany({
+          where: { parentRegionId: name, name: { not: 'federal' } },
+          data: { enabled },
+        }),
+      ]);
+      row = updated;
+      cascadedCount = cascadeResult.count;
+    } else {
+      // Default path: a single atomic row update — unchanged behavior.
+      row = await this.db.regionPlugin.update({
+        where: { name },
+        data: { enabled },
+        select,
+      });
+    }
+
     this.logger.log(
       `Region plugin "${name}" ${enabled ? 'enabled' : 'disabled'}`,
     );
+    if (cascade) {
+      this.logger.log(
+        `Cascade ${enabled ? 'enabled' : 'disabled'} ${cascadedCount} ` +
+          `descendant plugin(s) of "${name}"`,
+      );
+    }
     // Hot-swap the active plugin so the change takes effect immediately —
     // without this, the in-memory registry stays on whatever it loaded at
     // boot and `regionInfo` keeps returning the stale active region. See
-    // #796 for the failure mode this fixes.
+    // #796 for the failure mode this fixes. Runs after the (committed)
+    // cascade so the refresh sees the newly-toggled children.
     await this.refreshActiveLocalPlugin();
-    return toRegionPluginRow(row);
+    return { ...toRegionPluginRow(row), cascadedCount };
   }
 
   async invalidateManifest(

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
@@ -367,6 +367,98 @@ describe('RegionSyncService', () => {
     });
   });
 
+  describe('cascade enable/disable (#886)', () => {
+    // A parent row for the primary `update` to resolve to. `enabled` is
+    // overridden per-test to match the direction under test.
+    const parentRow = (enabled: boolean) =>
+      ({
+        name: 'california',
+        displayName: 'California',
+        description: null,
+        version: '1.0.0',
+        enabled,
+        parentRegionId: null,
+        fipsCode: '06',
+      }) as never;
+
+    it('cascade:true enable also enables every descendant via updateMany', async () => {
+      mockDb.regionPlugin.update.mockResolvedValue(parentRow(true));
+      mockDb.regionPlugin.updateMany.mockResolvedValue({ count: 58 } as never);
+
+      const result = await service.setRegionPluginEnabled(
+        'california',
+        true,
+        true,
+      );
+
+      // Descendants matched by parentRegionId === parent's name; federal is
+      // excluded for symmetry with fetchLocalPluginConfigs.
+      expect(mockDb.regionPlugin.updateMany).toHaveBeenCalledWith({
+        where: { parentRegionId: 'california', name: { not: 'federal' } },
+        data: { enabled: true },
+      });
+      expect(result.cascadedCount).toBe(58);
+    });
+
+    it('cascade:true disable also disables every descendant', async () => {
+      mockDb.regionPlugin.update.mockResolvedValue(parentRow(false));
+      mockDb.regionPlugin.updateMany.mockResolvedValue({ count: 58 } as never);
+
+      const result = await service.setRegionPluginEnabled(
+        'california',
+        false,
+        true,
+      );
+
+      expect(mockDb.regionPlugin.updateMany).toHaveBeenCalledWith({
+        where: { parentRegionId: 'california', name: { not: 'federal' } },
+        data: { enabled: false },
+      });
+      expect(result.cascadedCount).toBe(58);
+    });
+
+    it('cascade on a leaf (no descendants) is a no-op count of 0, not an error', async () => {
+      mockDb.regionPlugin.update.mockResolvedValue(parentRow(true));
+      mockDb.regionPlugin.updateMany.mockResolvedValue({ count: 0 } as never);
+
+      const result = await service.setRegionPluginEnabled(
+        'california-sonoma',
+        true,
+        true,
+      );
+
+      expect(result.cascadedCount).toBe(0);
+    });
+
+    it('default (no cascade) leaves single-row behavior unchanged — updateMany not called', async () => {
+      mockDb.regionPlugin.update.mockResolvedValue(parentRow(true));
+      mockDb.regionPlugin.updateMany.mockClear();
+
+      const result = await service.setRegionPluginEnabled('california', true);
+
+      expect(mockDb.regionPlugin.updateMany).not.toHaveBeenCalled();
+      expect(result.cascadedCount).toBe(0);
+    });
+
+    it('cascade write lands before the hot-swap refresh so children are picked up', async () => {
+      // Ordering guard: the cascade updateMany must run BEFORE the
+      // refreshActiveLocalPlugin() findMany, otherwise the single hot-swap
+      // would re-read the DB before the children were toggled.
+      mockDb.regionPlugin.update.mockResolvedValue(parentRow(true));
+      mockDb.regionPlugin.updateMany.mockResolvedValue({ count: 3 } as never);
+      mockDb.regionPlugin.updateMany.mockClear();
+      mockDb.regionPlugin.findMany.mockClear();
+
+      await service.setRegionPluginEnabled('california', true, true);
+
+      const updateManyOrder = (mockDb.regionPlugin.updateMany as jest.Mock).mock
+        .invocationCallOrder[0];
+      const findManyOrder = (mockDb.regionPlugin.findMany as jest.Mock).mock
+        .invocationCallOrder[0];
+      expect(updateManyOrder).toBeLessThan(findManyOrder);
+    });
+  });
+
   describe('syncAll', () => {
     it('should sync all data types from all plugins and return results', async () => {
       const results = await service.syncAll();

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -386,8 +386,13 @@ export class RegionSyncService implements OnModuleDestroy {
   async setRegionPluginEnabled(
     name: string,
     enabled: boolean,
+    cascade = false,
   ): Promise<RegionPluginRow> {
-    return this.regionPluginService.setRegionPluginEnabled(name, enabled);
+    return this.regionPluginService.setRegionPluginEnabled(
+      name,
+      enabled,
+      cascade,
+    );
   }
 
   /** Delegate — see RegionPluginService.invalidateManifest. */

--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -1244,4 +1244,46 @@ describe('RegionResolver', () => {
       expect(result.counts.failed).toBe(234);
     });
   });
+
+  describe('updateRegionPlugin (#886)', () => {
+    const pluginRow = {
+      name: 'california',
+      displayName: 'California',
+      version: '1.0.0',
+      enabled: true,
+      cascadedCount: 0,
+    };
+
+    it('forwards cascade=true to the service', async () => {
+      regionService.setRegionPluginEnabled.mockResolvedValue({
+        ...pluginRow,
+        cascadedCount: 58,
+      });
+
+      const result = await resolver.updateRegionPlugin(
+        'california',
+        true,
+        true,
+      );
+
+      expect(regionService.setRegionPluginEnabled).toHaveBeenCalledWith(
+        'california',
+        true,
+        true,
+      );
+      expect(result.cascadedCount).toBe(58);
+    });
+
+    it('forwards cascade=false (default single-row path) to the service', async () => {
+      regionService.setRegionPluginEnabled.mockResolvedValue(pluginRow);
+
+      await resolver.updateRegionPlugin('california', false, false);
+
+      expect(regionService.setRegionPluginEnabled).toHaveBeenCalledWith(
+        'california',
+        false,
+        false,
+      );
+    });
+  });
 });

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -918,8 +918,13 @@ export class RegionResolver {
   async updateRegionPlugin(
     @Args('name') name: string,
     @Args('enabled') enabled: boolean,
+    // Cascade-down: also toggle every descendant plugin (e.g. enable a whole
+    // state's counties in one call). Defaults false → unchanged single-row
+    // behavior. `cascadedCount` on the result reports how many were touched.
+    // See #886.
+    @Args('cascade', { defaultValue: false }) cascade: boolean,
   ): Promise<RegionPluginModel> {
-    return this.regionService.setRegionPluginEnabled(name, enabled);
+    return this.regionService.setRegionPluginEnabled(name, enabled, cascade);
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -65,6 +65,12 @@ export type RegionPluginRow = {
   enabled: boolean;
   parentRegionId?: string;
   fipsCode?: string;
+  /**
+   * Number of descendant plugins also updated by a cascade toggle
+   * (`setRegionPluginEnabled(..., cascade)`). Present only on the row
+   * returned by a cascade mutation; undefined on plain list/lookup rows.
+   */
+  cascadedCount?: number;
 };
 
 export function toRegionPluginRow(r: {
@@ -296,8 +302,9 @@ export class RegionDomainService {
   setRegionPluginEnabled(
     name: string,
     enabled: boolean,
+    cascade = false,
   ): Promise<RegionPluginRow> {
-    return this.syncService.setRegionPluginEnabled(name, enabled);
+    return this.syncService.setRegionPluginEnabled(name, enabled, cascade);
   }
 
   /**

--- a/docs/guides/region-provider.md
+++ b/docs/guides/region-provider.md
@@ -182,7 +182,29 @@ On startup, the service auto-discovers JSON config files and syncs them to the d
 UPDATE region_plugins SET enabled = true WHERE name = 'my-state';
 ```
 
-Only one local region can be enabled at a time. The federal plugin is always loaded alongside the active local plugin.
+Only one local region can be **active** at a time — the active region is the top-level state plugin (`parentRegionId: null`) that backs `regionInfo`. Its county sub-plugins (`parentRegionId` set) are separate rows that can be enabled independently and in bulk; they feed county-level syncs rather than becoming the active region. The federal plugin is always loaded alongside the active local plugin.
+
+#### Enabling via GraphQL (with cascade)
+
+Instead of raw SQL, admins toggle a plugin through the `updateRegionPlugin` mutation. County sub-plugins ship **`enabled: false`** and reference their state via `parentRegionId` (which equals the parent's `name` — e.g. `california-sonoma.parentRegionId = "california"`). To light up a whole state's counties in one call, pass `cascade: true`:
+
+```graphql
+mutation {
+  # Enable California AND every county under it (cascade descends one level).
+  updateRegionPlugin(name: "california", enabled: true, cascade: true) {
+    name
+    enabled
+    cascadedCount   # number of descendant plugins also toggled
+  }
+}
+```
+
+- `cascade: false` (the default) toggles only the named row — byte-for-byte the old single-row behavior. Backward compatible.
+- `cascade: true` also runs an `updateMany` over every row where `parentRegionId = <name>`, applying the **same** `enabled` value. It works in both directions: `enabled: false, cascade: true` shuts the whole state off.
+- `cascadedCount` reports how many descendants were touched (0 on a leaf plugin or when cascade is not requested).
+- Cascaded children are reflected in subsequent scoped and unscoped syncs — the region-worker re-reads enabled plugins from the DB before every sync run, and the region service hot-swaps its active plugin in the same call.
+
+Cascade currently descends exactly one level (state → county), matching the present hierarchy. There is intentionally **no parent-gate constraint** (enabling a child whose parent is disabled is not blocked) — see issue #886.
 
 ### Step 3: Restart and Sync
 


### PR DESCRIPTION
## Description

Region enabling was a flat, single-row toggle — onboarding a full state meant firing one `updateRegionPlugin` mutation per county (58 for CA), with no guarantee a child's parent was enabled. This adds an opt-in **cascade-down** so a single call lights up (or shuts off) an entire subtree.

`updateRegionPlugin(name: String!, enabled: Boolean!, cascade: Boolean = false): RegionPluginModel!`

- **`cascade: false`** (default) → unchanged single-row behavior. Backward compatible.
- **`cascade: true`** → also `updateMany` over every descendant (`parentRegionId = name`, `federal` excluded), in the **same `$transaction`** as the primary update so a partial failure can't leave a half-toggled subtree. Works both directions.
- The cascade write lands **before** `refreshActiveLocalPlugin()`, so the region-service hot-swap and the worker's pre-sync DB re-read both pick up toggled children.
- New nullable **`cascadedCount: Int`** surfaces how many descendants were touched.

No DB migration — uses the existing `parent_region_id` / `enabled` columns and their indexes.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #886

## Checklist

### Code Quality
- [x] My code follows the project's coding standards
- [x] I have run `pnpm lint` and fixed any issues
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for new functionality (if applicable)

### Documentation
- [x] I have updated relevant documentation (if applicable)
- [x] I have added JSDoc comments for new public APIs (if applicable)

### Accessibility
- [ ] UI changes meet WCAG 2.2 Level AA requirements (if applicable) — N/A (backend)
- [ ] I have tested with keyboard navigation (if applicable) — N/A

- [x] I confirm this PR contains platform code, not region-specific configuration

## Test Coverage

- **Unit** (`region-sync.service.spec.ts`): cascade enable, cascade disable, leaf no-op, default-no-cascade unchanged, and a write-ordering guard (cascade before refresh).
- **Resolver** (`region.resolver.spec.ts`): `cascade` forwarded in both directions.
- **Integration** (`region.integration.spec.ts`, real DB): cascade enable flips both CA counties + reports count, cascade disable shuts the subtree off, default path leaves children untouched.

## Additional Notes

- **Federation:** only the `region` subgraph SDL changed (`region-schema.gql` — additive: optional arg + nullable field). Composed at the gateway at runtime; backward compatible.
- **Out of scope** (per #886): parent-gate constraint and multi-level (state → county → city) cascade. The `updateMany` descends exactly one level, matching the current hierarchy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)