### PR TITLE
perf(region): parallelize votes phase + fix maxTokens truncation (#892, #894)

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -209,6 +209,17 @@ REDIS_URL='redis://localhost:6379'
 # is too short for the largest full-text bills (~4.4% aborted without this).
 # BILL_ENRICHMENT_REQUEST_TIMEOUT_MS=120000
 
+# Bill votes (Phase 3, votes_only) throughput tuning (#892).
+# Concurrency default 1 == serial (one page fetch + LLM extract per bill,
+# ~18s each; a full-corpus backfill is ~25h serial). Raising it ONLY helps
+# if the Ollama server also accepts parallel requests — set
+# OLLAMA_NUM_PARALLEL >= this, or app-level parallelism just queues
+# server-side for zero speedup. Note the page fetches still pass through
+# the shared per-host throttle (~1 req/sec), so fetches stagger even as the
+# LLM extractions run in parallel — the ~18s extraction is the bottleneck
+# this parallelizes, not the fetch.
+# BILL_VOTES_CONCURRENCY=1
+
 # ============================================================
 # Security Configuration
 # ============================================================

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -219,6 +219,12 @@ REDIS_URL='redis://localhost:6379'
 # LLM extractions run in parallel — the ~18s extraction is the bottleneck
 # this parallelizes, not the fetch.
 # BILL_VOTES_CONCURRENCY=1
+# Max output tokens for votes extraction; default 8000 (#894). A large
+# roll-call (an 80-member chamber x multiple motions) overran the prior
+# 4000 cap -> truncated JSON -> ~33% of bills silently lost votes. Raise
+# further if the phase summary shows extraction-empty/extraction-unparseable.
+# A per-source DataSourceConfig.llmMaxTokens still overrides this.
+# BILL_VOTES_MAX_TOKENS=8000
 
 # ============================================================
 # Security Configuration

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
@@ -769,6 +769,80 @@ describe('RegionSyncService', () => {
         expect(res.outcome).toBe('fetch-failed');
         fetchSpy.mockRestore();
       });
+
+      it('returns extraction-empty when the LLM output has no JSON object (truncation) (#894)', async () => {
+        // Truncated mid-object → no balanced {…} → extractJsonObjectSlice
+        // returns undefined. This is the dominant maxTokens-truncation shape.
+        setProviders('{"votes": [{"chamber": "Assembly", "members": [');
+        mockDb.bill.findUnique.mockResolvedValue({ id: 'bill-uuid' } as never);
+        const fetchSpy = stubFetch();
+
+        const res = await internals().extractVotesOnlyPage(
+          'california',
+          VOTES_URL,
+          ds,
+          repIndex,
+        );
+        expect(res.outcome).toBe('extraction-empty');
+        expect(mockDb.billVote.createMany).not.toHaveBeenCalled();
+        fetchSpy.mockRestore();
+      });
+
+      it('returns extraction-unparseable when a balanced slice is invalid JSON (#894)', async () => {
+        // Balanced braces but invalid contents → slice returned, JSON.parse
+        // throws → distinct from the empty case.
+        setProviders('{"votes": [1 2 3]}');
+        mockDb.bill.findUnique.mockResolvedValue({ id: 'bill-uuid' } as never);
+        const fetchSpy = stubFetch();
+
+        const res = await internals().extractVotesOnlyPage(
+          'california',
+          VOTES_URL,
+          ds,
+          repIndex,
+        );
+        expect(res.outcome).toBe('extraction-unparseable');
+        expect(mockDb.billVote.createMany).not.toHaveBeenCalled();
+        fetchSpy.mockRestore();
+      });
+
+      it('defaults votes-extraction maxTokens to 8000 (#894)', async () => {
+        setProviders(JSON.stringify({ votes: [] }));
+        mockDb.bill.findUnique.mockResolvedValue({ id: 'bill-uuid' } as never);
+        const fetchSpy = stubFetch();
+
+        await internals().extractVotesOnlyPage(
+          'california',
+          VOTES_URL,
+          ds,
+          repIndex,
+        );
+        const generate = (internals().llm as { generate: jest.Mock }).generate;
+        expect(generate).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ maxTokens: 8000 }),
+        );
+        fetchSpy.mockRestore();
+      });
+
+      it('lets a per-source llmMaxTokens override the default (#894)', async () => {
+        setProviders(JSON.stringify({ votes: [] }));
+        mockDb.bill.findUnique.mockResolvedValue({ id: 'bill-uuid' } as never);
+        const fetchSpy = stubFetch();
+
+        await internals().extractVotesOnlyPage(
+          'california',
+          VOTES_URL,
+          { llmMaxTokens: 12000 },
+          repIndex,
+        );
+        const generate = (internals().llm as { generate: jest.Mock }).generate;
+        expect(generate).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({ maxTokens: 12000 }),
+        );
+        fetchSpy.mockRestore();
+      });
     });
 
     describe('runVotesPhase — throughput (#892)', () => {

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
@@ -770,6 +770,97 @@ describe('RegionSyncService', () => {
         fetchSpy.mockRestore();
       });
     });
+
+    describe('runVotesPhase — throughput (#892)', () => {
+      type RunVotesFn = (
+        regionId: string,
+        allVotesUrls: Array<{ url: string; ds: Record<string, unknown> }>,
+        repIndex: Map<string, { id: string; chamber: string }>,
+      ) => Promise<{ updated: number }>;
+
+      const repIndex = new Map<string, { id: string; chamber: string }>();
+
+      const callRunVotes = (urls: string[]): Promise<{ updated: number }> =>
+        (
+          service as unknown as { runVotesPhase: RunVotesFn }
+        ).runVotesPhase.bind(service)(
+          'california',
+          urls.map((url) => ({ url, ds: {} })),
+          repIndex,
+        );
+
+      const setConcurrency = (n: number) => {
+        (
+          service as unknown as { billVotesConcurrency: number }
+        ).billVotesConcurrency = n;
+      };
+
+      const mkUrls = (n: number) =>
+        Array.from(
+          { length: n },
+          (_, i) =>
+            `https://leginfo.legislature.ca.gov/faces/billVotesClient.xhtml?bill_id=2025202600AB${i}`,
+        );
+
+      /** Spy extractVotesOnlyPage, tracking max concurrent in-flight calls. */
+      const spyExtract = (outcomes?: string[]) => {
+        let inFlight = 0;
+        let maxInFlight = 0;
+        let call = 0;
+        jest
+          .spyOn(
+            service as unknown as {
+              extractVotesOnlyPage: (...a: unknown[]) => Promise<unknown>;
+            },
+            'extractVotesOnlyPage',
+          )
+          .mockImplementation(async () => {
+            inFlight++;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            await new Promise((r) => setTimeout(r, 5));
+            inFlight--;
+            const outcome = outcomes ? outcomes[call++] : 'votes-upserted';
+            return { outcome, count: outcome === 'votes-upserted' ? 3 : 0 };
+          });
+        return { getMax: () => maxInFlight };
+      };
+
+      it('runs bills in parallel batches when concurrency > 1 (max in-flight == concurrency)', async () => {
+        setConcurrency(3);
+        const { getMax } = spyExtract();
+
+        const result = await callRunVotes(mkUrls(7));
+
+        expect(getMax()).toBe(3);
+        expect(result.updated).toBe(7);
+      });
+
+      it('stays serial by default (max in-flight == 1)', async () => {
+        // No setConcurrency → constructor default of 1.
+        const { getMax } = spyExtract();
+
+        const result = await callRunVotes(mkUrls(4));
+
+        expect(getMax()).toBe(1);
+        expect(result.updated).toBe(4);
+      });
+
+      it('keeps the updated tally identical regardless of concurrency', async () => {
+        setConcurrency(3);
+        // 3 upserted, the rest non-success → only upserts count toward updated.
+        spyExtract([
+          'votes-upserted',
+          'shell-missing',
+          'votes-upserted',
+          'extraction-failed',
+          'votes-upserted',
+        ]);
+
+        const result = await callRunVotes(mkUrls(5));
+
+        expect(result.updated).toBe(3);
+      });
+    });
   });
 
   describe('syncAll', () => {

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -132,6 +132,11 @@ type VotesOutcome =
   | 'providers-unavailable'
   | 'fetch-failed'
   | 'no-votes-on-page'
+  // Split out from a blanket 'extraction-failed' (#894) so the phase summary
+  // distinguishes truncation (empty/unparseable — raise BILL_VOTES_MAX_TOKENS)
+  // from genuine post-parse errors.
+  | 'extraction-empty'
+  | 'extraction-unparseable'
   | 'extraction-failed';
 
 interface VotesExtractionResult {
@@ -157,6 +162,8 @@ const VOTES_OUTCOME_TRACKING: Record<
   'no-votes-on-page': { counter: 'skipped' },
   'providers-unavailable': { counter: 'error' },
   'fetch-failed': { counter: 'error' },
+  'extraction-empty': { counter: 'error' },
+  'extraction-unparseable': { counter: 'error' },
   'extraction-failed': { counter: 'error' },
 };
 
@@ -416,6 +423,11 @@ export class RegionSyncService implements OnModuleDestroy {
       'BILL_VOTES_CONCURRENCY',
       1,
     );
+    this.billVotesMaxTokens = readPositiveInt(
+      this.config,
+      'BILL_VOTES_MAX_TOKENS',
+      8000,
+    );
   }
 
   // Bill-enrichment throughput knobs (#889 follow-up). Defaults reproduce
@@ -434,6 +446,13 @@ export class RegionSyncService implements OnModuleDestroy {
   // also accepts parallel requests (OLLAMA_NUM_PARALLEL ≥ this); otherwise
   // calls queue server-side. Default 1 reproduces the prior serial loop.
   private readonly billVotesConcurrency: number;
+  // Max output tokens for votes extraction (#894). A large roll-call
+  // (an 80-member chamber × multiple motions) serializes to a votes JSON
+  // that overran the prior 4000-token cap → truncated mid-object →
+  // unparseable → ~33% of bills silently lost their votes. Default 8000
+  // clears typical CA roll-calls; a per-source DataSourceConfig.llmMaxTokens
+  // still overrides when set.
+  private readonly billVotesMaxTokens: number;
 
   async onModuleDestroy(): Promise<void> {
     await this.cacheService.destroy();
@@ -2376,19 +2395,34 @@ export class RegionSyncService implements OnModuleDestroy {
         });
 
       const llmResult = await this.llm.generate(promptText, {
-        maxTokens: ds.llmMaxTokens ?? 4000,
+        maxTokens: ds.llmMaxTokens ?? this.billVotesMaxTokens,
         temperature: 0.1,
         requestTimeoutMs: ds.llmRequestTimeoutMs,
       });
 
+      // A large roll-call whose votes JSON exceeds maxTokens is truncated
+      // mid-object, so no complete `{...}` slice is found (#894). Surface it
+      // as its own outcome — the fix is to raise BILL_VOTES_MAX_TOKENS, not
+      // to debug the parser.
       const candidate = extractJsonObjectSlice(llmResult.text);
-      if (!candidate) return { outcome: 'extraction-failed', count: 0 };
+      if (!candidate) {
+        this.logger.warn(
+          `Bills: votes extraction produced no JSON object for ${sourceUrl} ` +
+            `(${llmResult.text.length} chars; likely maxTokens truncation)`,
+        );
+        return { outcome: 'extraction-empty', count: 0 };
+      }
 
       let raw: RollCallExtraction;
       try {
         raw = JSON.parse(candidate) as RollCallExtraction;
-      } catch {
-        return { outcome: 'extraction-failed', count: 0 };
+      } catch (e) {
+        this.logger.warn(
+          `Bills: votes JSON parse failed for ${sourceUrl}: ` +
+            `${(e as Error).message} (candidate ${candidate.length} chars; ` +
+            `likely maxTokens truncation)`,
+        );
+        return { outcome: 'extraction-unparseable', count: 0 };
       }
 
       // The votes template emits chamber-level roll-call records; flatten to

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -411,6 +411,11 @@ export class RegionSyncService implements OnModuleDestroy {
       'BILL_ENRICHMENT_REQUEST_TIMEOUT_MS',
       120_000,
     );
+    this.billVotesConcurrency = readPositiveInt(
+      this.config,
+      'BILL_VOTES_CONCURRENCY',
+      1,
+    );
   }
 
   // Bill-enrichment throughput knobs (#889 follow-up). Defaults reproduce
@@ -423,6 +428,12 @@ export class RegionSyncService implements OnModuleDestroy {
   //    bills (~4.4% aborted); a generous cap converts those to successes.
   private readonly billEnrichmentConcurrency: number;
   private readonly billEnrichmentTimeoutMs: number;
+  // Votes-phase (Phase 3, votes_only) throughput knob (#892). Mirrors
+  // BILL_ENRICHMENT_CONCURRENCY: bills whose votes pages are fetched +
+  // LLM-extracted in parallel per batch. Only helps if the Ollama server
+  // also accepts parallel requests (OLLAMA_NUM_PARALLEL ≥ this); otherwise
+  // calls queue server-side. Default 1 reproduces the prior serial loop.
+  private readonly billVotesConcurrency: number;
 
   async onModuleDestroy(): Promise<void> {
     await this.cacheService.destroy();
@@ -1025,36 +1036,12 @@ export class RegionSyncService implements OnModuleDestroy {
     skippedTotal += extractCounts.skipped;
 
     // ─── Phase 3/6 — votes_only ─────────────────────────────────────
-    const votesTracker = billSyncTracker(
-      this.logger,
-      'votes_only',
-      allVotesUrls.length,
-      { region: regionId },
+    const votesResult = await this.runVotesPhase(
+      regionId,
+      allVotesUrls,
+      repIndex,
     );
-    for (const { url, ds } of allVotesUrls) {
-      const externalId = this.safeBillIdFromUrl(url) ?? null;
-      const billNumber = billNumberFromExternalId(externalId ?? undefined);
-      const { outcome, count } = await this.extractVotesOnlyPage(
-        regionId,
-        url,
-        ds,
-        repIndex,
-      );
-      // Report the TRUE per-bill outcome (#889). The extraCounter bucket
-      // (== the outcome string) makes the phase-complete summary show the
-      // distribution, e.g. "... 4998 shell-missing, 20 extraction-failed".
-      const mapped = VOTES_OUTCOME_TRACKING[outcome];
-      votesTracker.item({
-        name: billNumber,
-        externalId,
-        outcomeLabel:
-          outcome === 'votes-upserted' ? `votes upserted (${count})` : outcome,
-        outcome: mapped.counter,
-        extraCounters: [outcome],
-      });
-      if (outcome === 'votes-upserted') updated++;
-    }
-    votesTracker.complete();
+    updated += votesResult.updated;
 
     // ─── Phase 4/6 — stage_backfill ────────────────────────────────
     if (stagePatterns.length > 0) {
@@ -1564,6 +1551,79 @@ export class RegionSyncService implements OnModuleDestroy {
       outcomeLabel,
       outcome,
     });
+  }
+
+  /**
+   * Phase 3 (votes_only): fetch + LLM-extract each bill's votes page and
+   * upsert per-member rows. Runs in bounded-concurrency batches (#892) —
+   * extractVotesOnlyPage is self-contained (findUnique → fetch → LLM →
+   * linkBillVotes, all per-bill with no shared mutable state), so votes
+   * pages are safe to run in parallel. Batch results are applied in slice
+   * order, so tracker lines and the `updated` tally stay deterministic —
+   * identical to the prior serial loop. concurrency=1 == that serial loop,
+   * and only helps if the Ollama server accepts parallel requests
+   * (OLLAMA_NUM_PARALLEL ≥ concurrency); otherwise calls queue server-side.
+   */
+  private async runVotesPhase(
+    regionId: string,
+    allVotesUrls: Array<{ url: string; ds: DataSourceConfig }>,
+    repIndex: Map<string, { id: string; chamber: string }>,
+  ): Promise<{ updated: number }> {
+    const votesTracker = billSyncTracker(
+      this.logger,
+      'votes_only',
+      allVotesUrls.length,
+      { region: regionId },
+    );
+    const concurrency = this.billVotesConcurrency;
+    if (concurrency > 1) {
+      votesTracker.note(`extracting votes with concurrency=${concurrency}`);
+    }
+    const updatedRef = { total: 0 };
+    for (let i = 0; i < allVotesUrls.length; i += concurrency) {
+      const batch = allVotesUrls.slice(i, i + concurrency);
+      const results = await Promise.all(
+        batch.map(({ url, ds }) =>
+          this.extractVotesOnlyPage(regionId, url, ds, repIndex),
+        ),
+      );
+      results.forEach((result, j) => {
+        this.applyVotesResult(result, batch[j].url, updatedRef, votesTracker);
+      });
+    }
+    votesTracker.complete();
+    return { updated: updatedRef.total };
+  }
+
+  /**
+   * Fold one votes_only extraction into the phase tracker and the boxed
+   * `updated` tally. Extracted from the Phase 3 batch loop (#892) so
+   * runVotesPhase stays under the SonarCloud cognitive-complexity gate.
+   * Derives externalId/billNumber from the URL here (not in the parallel
+   * map) so the tracker line is emitted in deterministic slice order.
+   */
+  private applyVotesResult(
+    result: VotesExtractionResult,
+    url: string,
+    updatedRef: { total: number },
+    tracker: SyncPhaseTracker<BillSyncPhase>,
+  ): void {
+    const externalId = this.safeBillIdFromUrl(url) ?? null;
+    const billNumber = billNumberFromExternalId(externalId ?? undefined);
+    const { outcome, count } = result;
+    // Report the TRUE per-bill outcome (#889). The extraCounter bucket
+    // (== the outcome string) makes the phase-complete summary show the
+    // distribution, e.g. "... 4998 shell-missing, 20 extraction-failed".
+    const mapped = VOTES_OUTCOME_TRACKING[outcome];
+    tracker.item({
+      name: billNumber,
+      externalId,
+      outcomeLabel:
+        outcome === 'votes-upserted' ? `votes upserted (${count})` : outcome,
+      outcome: mapped.counter,
+      extraCounters: [outcome],
+    });
+    if (outcome === 'votes-upserted') updatedRef.total += 1;
   }
 
   private async enrichSingleBill(


### PR DESCRIPTION
## Description

BillSync Phase 3 (`votes_only`) was both **slow** and **incomplete**. This branch fixes both so the post-#889 full-corpus votes backfill can be re-run fast and complete. Two focused commits:

**perf(#892) — parallelize the votes phase.** The phase was strictly serial (one page fetch + LLM extract per bill, ~18s each), so a full-corpus backfill (~5,019 CA bills) ran ~25h. Extracted into `runVotesPhase`, processing `allVotesUrls` in bounded-concurrency `Promise.all` batches gated by a new `BILL_VOTES_CONCURRENCY` env (default `1` = prior serial behavior), mirroring the `BILL_ENRICHMENT_CONCURRENCY` treatment of Phase 6. Batch results are applied in slice order, so tracker lines and the `updated` tally stay deterministic. Real speedup requires `OLLAMA_NUM_PARALLEL >= concurrency`.

**fix(#894) — stop maxTokens truncation silently dropping ~33% of bills.** The votes LLM call capped output at 4000 tokens; a large roll-call (an 80-member chamber × multiple motions) overran it → truncated JSON → parse failure → `extraction-failed`. On the backfill this silently lost votes for ~1 in 3 bills (a ~52s LLM run that *then* failed to parse — not a timeout). Fix:
- Add `BILL_VOTES_MAX_TOKENS` (default 8000, up from 4000); a per-source `DataSourceConfig.llmMaxTokens` still overrides.
- Split the blanket `extraction-failed` into `extraction-empty` (no balanced object — the dominant truncation shape) and `extraction-unparseable` (balanced but invalid JSON), each logging the real reason so the phase summary distinguishes truncation from genuine post-parse errors.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Infrastructure/DevOps change

<!-- Also a perf improvement; both knobs default to prior behavior so no runtime change unless configured. -->

## Related Issues

Fixes #892
Fixes #894

## Checklist

### Code Quality
- [x] My code follows the project's coding standards
- [x] I have run `pnpm lint` and fixed any issues
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for new functionality (if applicable)

### Documentation
- [x] I have updated relevant documentation (if applicable)
- [x] I have added JSDoc comments for new public APIs (if applicable)

### Accessibility
- [ ] UI changes meet WCAG 2.2 Level AA requirements (if applicable)
- [ ] I have tested with keyboard navigation (if applicable)

### Architecture Reminder

- [x] I confirm this PR contains platform code, not region-specific configuration

## Additional Notes

- Both new env knobs default to prior behavior (`BILL_VOTES_CONCURRENCY=1`, and the effective maxTokens rises 4000→8000 which only *reduces* failures) — no behavior change unless tuned.
- Not folded in: **#893** (Ollama single-GPU concurrency ceiling — a hardware/tuning + `create-op-node` follow-up, not codeable here), and #894's optional truncation-resilient/repair-parse + roll-call-size correlation bullets, left as follow-ups.
- 107 unit tests pass; `/op-review` and `/security-review` run clean on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)