### PR TITLE
fix(region): widen bill_votes.motion_text to text so votes createMany stops dropping bills (#901)

### DIFF
--- a/apps/backend/__tests__/integration/region/bill-votes-extraction.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/bill-votes-extraction.integration.spec.ts
@@ -309,4 +309,41 @@ describe('votes_only extraction — integration (#889)', () => {
     const rows = await db.billVote.findMany({ where: { billId } });
     expect(rows.map((r) => r.representativeName)).toEqual(['Kept Member']);
   });
+
+  it('persists a verbose (>200 char) motion at full length — the whole vote set is not dropped (#901)', async () => {
+    // Pre-fix, motion_text was VARCHAR(200); a real CA reading motion exceeds
+    // that and, because createMany is atomic, dropped the bill's entire vote
+    // set → extraction-failed, 0 votes. This guards the widen to `text`.
+    const billId = await seedBillShell(db);
+    const longMotion =
+      'Assembly Third Reading. Do pass as amended and re-refer to the ' +
+      'Committee on Appropriations, and when so amended the bill shall be ' +
+      'ordered to a third reading and re-referred for further consideration ' +
+      'consistent with the standing rules of the Assembly and Senate.';
+    expect(longMotion.length).toBeGreaterThan(200);
+    mockLlm.generate.mockResolvedValue({
+      text: JSON.stringify({
+        billId: BILL_EXTERNAL_ID,
+        votes: [
+          {
+            chamber: 'Assembly',
+            date: '2025-05-01',
+            motionText: longMotion,
+            members: [
+              { name: 'Alice Smith', position: 'yes' },
+              { name: 'Bob Jones', position: 'no' },
+            ],
+          },
+        ],
+      }),
+    });
+
+    const result = await callExtract();
+
+    expect(result).toEqual({ outcome: 'votes-upserted', count: 2 });
+    const rows = await db.billVote.findMany({ where: { billId } });
+    expect(rows.length).toBe(2);
+    // Full motion round-trips — not truncated, not dropped.
+    expect(rows[0].motionText).toBe(longMotion);
+  });
 });

--- a/packages/relationaldb-provider/prisma/migrations/20260716000000_widen_bill_votes_motion_text/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260716000000_widen_bill_votes_motion_text/migration.sql
@@ -1,0 +1,10 @@
+-- #901: bill_votes column widths too short for full roll-call motions.
+-- createMany is atomic, so one over-long motion_text drops the bill's whole
+-- vote set (extraction-failed, 0 votes). This was masked before #894 —
+-- truncated JSON never parsed and never reached the insert. motion_text is
+-- free-form (no natural length) → text. Widen representative_name → text and
+-- position → varchar(50) defensively. varchar(n)→text and varchar(n)→varchar(m>n)
+-- are no-rewrite in Postgres — safe on prod, additive (no drops/renames).
+ALTER TABLE "bill_votes" ALTER COLUMN "motion_text" TYPE TEXT;
+ALTER TABLE "bill_votes" ALTER COLUMN "representative_name" TYPE TEXT;
+ALTER TABLE "bill_votes" ALTER COLUMN "position" TYPE VARCHAR(50);

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -1573,14 +1573,15 @@ model BillVote {
   /// Resolved FK — null when linker cannot match the name.
   representativeId   String?  @map("representative_id")
   /// Raw name from the roll-call table; preserved for linker re-runs.
-  representativeName String   @map("representative_name") @db.VarChar(200)
+  representativeName String   @map("representative_name")
   /// "Assembly" | "Senate"
   chamber            String   @db.VarChar(20)
   voteDate           DateTime @map("vote_date") @db.Date
   /// yes | no | abstain | absent | excused | no_vote
-  position           String   @db.VarChar(20)
-  /// The motion being voted on, e.g. "Do Pass" | "Do Pass as Amended".
-  motionText         String?  @map("motion_text") @db.VarChar(200)
+  position           String   @db.VarChar(50)
+  /// The motion being voted on. Free-form roll-call motion text (no natural
+  /// length); e.g. "Do Pass" or a verbose multi-clause CA reading motion (#901).
+  motionText         String?  @map("motion_text")
   sourceUrl          String   @map("source_url")
   createdAt          DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt          DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz


### PR DESCRIPTION
## Description

`bill_votes.motion_text` was `VARCHAR(200)`, but real CA roll-call motions are verbose multi-clause strings (e.g. *"Assembly Third Reading. Do pass as amended and re-refer to the Committee on Appropriations. (…)"*) that exceed 200 chars. Because `billVote.createMany()` is atomic, **one over-long motion drops the bill's entire vote set** → `extraction-failed`, 0 votes for that bill.

This was masked before #894 (truncated JSON never parsed and never reached the insert). Fixing the maxTokens truncation (#894) and the timeout (#897) let the full roll-call reach the DB, exposing the latent schema bug.

### Changes
- **Migration** `20260716000000_widen_bill_votes_motion_text` — widens `motion_text` → `text`, `representative_name` → `text`, `position` → `varchar(50)`. All three are no-rewrite widenings in Postgres (binary-coercible), so additive and prod-safe. `chamber` left at `varchar(20)` ("Assembly"/"Senate" fit).
- **Prisma model** `BillVote` — drop `@db.VarChar(200)` on `motionText`/`representativeName`, bump `position` to `@db.VarChar(50)`.
- **Integration test** — new regression case: a roll-call with a >200-char motion persists at full length (count > 0, `motionText` round-trips).

### Impact confirmed on prod (Studio node)
The 2026-07-16 250-bill CA sync (`pipeline_jobs` `ca5d6029…`, succeeded) lost **23 vote-bearing bills (~11%)** to this exact error — Phase 3 summary: `186 votes-upserted, 23 extraction-failed`, with 46 raw `value too long for the column's type` errors and **0** of the 23 attributable to fetch/timeout. The fix is not yet on prod (columns still `varchar(200)`, `_prisma_migrations` lacks the widen migration); this PR + release will apply it, after which a targeted `votes_only` re-run backfills the 23 bills.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #901

## Checklist

### Code Quality
- [x] My code follows the project's coding standards
- [x] I have run `pnpm lint` and fixed any issues
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for new functionality (integration regression for the >200-char motion)

### Documentation
- [x] I have updated relevant documentation (if applicable) — n/a, migration comment documents the rationale inline

### Accessibility
- [x] UI changes meet WCAG 2.2 Level AA requirements (if applicable) — n/a, no UI change

### Architecture Reminder

- [x] I confirm this PR contains platform code, not region-specific configuration

## Additional Notes

- **Migration safety**: widening only, no data loss, no full-table rewrite; satisfies the additive-only rule. No federation impact — GraphQL `motionText` is already an unbounded `String`.
- **Deploy note**: the widen migration must be applied on the Studio (worker `migrate deploy` on startup, or manually) before the backfill re-run.
- Follow-up filed separately for the leginfo `503` fetch failures (20 bills fetch-failed in the same run) — that's an independent coverage gap, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)