### PR TITLE
fix(region): widen bill_votes.chamber to text — next createMany overflow after #901 (#905)

### DIFF
--- a/apps/backend/__tests__/integration/region/bill-votes-extraction.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/bill-votes-extraction.integration.spec.ts
@@ -346,4 +346,34 @@ describe('votes_only extraction — integration (#889)', () => {
     // Full motion round-trips — not truncated, not dropped.
     expect(rows[0].motionText).toBe(longMotion);
   });
+
+  it('persists a >20 char chamber label — the whole vote set is not dropped (#905)', async () => {
+    // Pre-fix, chamber was VARCHAR(20); once #901 widened motion_text, a
+    // longer LLM-emitted chamber label became the next createMany overflow,
+    // atomically dropping the bill's votes. This guards the widen to `text`.
+    const billId = await seedBillShell(db);
+    const longChamber =
+      'Assembly Standing Committee on Appropriations Suspense File';
+    expect(longChamber.length).toBeGreaterThan(20);
+    mockLlm.generate.mockResolvedValue({
+      text: JSON.stringify({
+        billId: BILL_EXTERNAL_ID,
+        votes: [
+          {
+            chamber: longChamber,
+            date: '2025-05-01',
+            motionText: 'Do Pass',
+            members: [{ name: 'Alice Smith', position: 'yes' }],
+          },
+        ],
+      }),
+    });
+
+    const result = await callExtract();
+
+    expect(result).toEqual({ outcome: 'votes-upserted', count: 1 });
+    const rows = await db.billVote.findMany({ where: { billId } });
+    expect(rows.length).toBe(1);
+    expect(rows[0].chamber).toBe(longChamber);
+  });
 });

--- a/packages/relationaldb-provider/prisma/migrations/20260717000000_widen_bill_votes_chamber/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260717000000_widen_bill_votes_chamber/migration.sql
@@ -1,0 +1,8 @@
+-- #905: bill_votes.chamber VARCHAR(20) is the next createMany overflow after
+-- #901/#902 widened motion_text. The LLM votes-extraction sometimes emits a
+-- chamber string longer than 20 chars (a full committee/reading label rather
+-- than just "Assembly"/"Senate"); because createMany is atomic, one over-long
+-- value drops the bill's entire vote set. chamber has no natural length when
+-- LLM-extracted → text. varchar(n)→text is a no-rewrite widening in Postgres,
+-- additive and prod-safe. Matches the live ALTER already applied on the node.
+ALTER TABLE "bill_votes" ALTER COLUMN "chamber" TYPE TEXT;

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -1574,8 +1574,9 @@ model BillVote {
   representativeId   String?  @map("representative_id")
   /// Raw name from the roll-call table; preserved for linker re-runs.
   representativeName String   @map("representative_name")
-  /// "Assembly" | "Senate"
-  chamber            String   @db.VarChar(20)
+  /// Typically "Assembly" | "Senate", but LLM votes-extraction can emit a
+  /// longer roll-call label (e.g. a full committee name), so no length cap (#905).
+  chamber            String
   voteDate           DateTime @map("vote_date") @db.Date
   /// yes | no | abstain | absent | excused | no_vote
   position           String   @db.VarChar(50)


### PR DESCRIPTION
## Description

With `motion_text` widened to `text` (#901 / #902), the **next** bounded column in `bill_votes` — `chamber VARCHAR(20)` — became the overflow. The LLM votes-extraction sometimes emits a chamber string longer than 20 chars (a full committee/reading label rather than just `"Assembly"`/`"Senate"`). Because `billVote.createMany()` is atomic, one over-long value drops the bill's **entire** vote set → `extraction-failed`, 0 votes. Same failure signature as #901, different column.

### Changes
- **Prisma model** `BillVote.chamber` — drop `@db.VarChar(20)` (→ `text`).
- **Migration** `20260717000000_widen_bill_votes_chamber` — `ALTER TABLE "bill_votes" ALTER COLUMN "chamber" TYPE TEXT;` (no-rewrite widening).
- **Integration test** — new regression case: a >20-char chamber label persists at full length (count > 0, `chamber` round-trips).

### Confirmed live
The 2026-07-16 full-corpus CA sync (`32f11b2c`) began dropping bills on `chamber` overflow (starting `202520260AB1`) the moment `motion_text` stopped overflowing. A live `ALTER TABLE bill_votes ALTER COLUMN chamber TYPE text` was applied on the Studio node to stop the bleed mid-run (votes resumed immediately, zero further errors). **This PR codifies that ALTER** so the next deploy's schema sync doesn't try to revert `chamber` to `varchar(20)`.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues
Fixes #905

## Checklist
### Code Quality
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (2213 unit tests)
- [x] Added an integration regression test for the >20-char chamber case

### Architecture
- [x] Platform code, not region configuration

## Notes
- Widening only — no data loss, no full-table rewrite; additive per the migrations rule. No federation impact (`chamber` is an unbounded GraphQL `String`).
- Follows #901/#902 (motion_text); builds on #894 (maxTokens), #897 (votes timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)