### PR TITLE
fix(region): normalize committee names so bill→committee linking works (#908)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
@@ -1,7 +1,10 @@
 import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { RegionSyncService } from './region-sync.service';
+import {
+  RegionSyncService,
+  normalizeCommitteeName,
+} from './region-sync.service';
 import { PropositionsSyncService } from './propositions-sync.service';
 import { MeetingsSyncService } from './meetings-sync.service';
 import { RepresentativesSyncService } from './representatives-sync.service';
@@ -3194,5 +3197,40 @@ describe('RegionSyncService — proposition finance wiring', () => {
       expect(cf?.errors).toEqual([]);
       expect(linker.linkAll).toHaveBeenCalled();
     });
+  });
+});
+
+describe('normalizeCommitteeName (#908)', () => {
+  it('strips chamber + "committee on" boilerplate to the core policy area', () => {
+    expect(normalizeCommitteeName('Assembly Committee on Appropriations')).toBe(
+      'appropriations',
+    );
+    expect(normalizeCommitteeName('Committee on Public Safety')).toBe(
+      'public safety',
+    );
+    expect(normalizeCommitteeName('Senate Judiciary')).toBe('judiciary');
+    expect(
+      normalizeCommitteeName('Select Committee on Youth Mental Health'),
+    ).toBe('youth mental health');
+  });
+
+  it('is symmetric — verbose extracted name and short canonical name normalize equal', () => {
+    expect(normalizeCommitteeName('Assembly Committee on Appropriations')).toBe(
+      normalizeCommitteeName('Appropriations'),
+    );
+    expect(
+      normalizeCommitteeName('Committee on Governmental Organization'),
+    ).toBe(normalizeCommitteeName('Governmental Organization'));
+  });
+
+  it('leaves boilerplate-free names essentially unchanged (lowercased)', () => {
+    expect(
+      normalizeCommitteeName('Environmental Safety and Toxic Materials'),
+    ).toBe('environmental safety and toxic materials');
+  });
+
+  it('returns empty string for boilerplate-only input (never aliased)', () => {
+    expect(normalizeCommitteeName('Committee')).toBe('');
+    expect(normalizeCommitteeName('Assembly Committee')).toBe('');
   });
 });

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -211,6 +211,27 @@ function normalizeVotePosition(
 }
 
 /**
+ * Reduce a committee name to its core policy area for fuzzy matching. The LLM
+ * extracts verbose page strings ("Assembly Committee on Appropriations",
+ * "Committee on Public Safety") while legislative_committees stores short
+ * canonical names ("Appropriations", "Public Safety"), so an exact match linked
+ * almost nothing (#908). Strips chamber/qualifier words + the "committee (on)"
+ * boilerplate and collapses whitespace. Applied to BOTH sides so the comparison
+ * is symmetric; returns '' when a name is only boilerplate (never aliased).
+ */
+export function normalizeCommitteeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(
+      /\b(assembly|senate|joint|select|standing|legislative|subcommittee|committee|on)\b/g,
+      ' ',
+    )
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
  * Map the enrich-single-bill result onto a phase tracker outcome shape.
  * Lifted to a named helper so the call site avoids two nested ternaries
  * (one for label, one for counter bucket) — sonarjs/no-nested-conditional
@@ -1965,8 +1986,25 @@ export class RegionSyncService implements OnModuleDestroy {
       select: { id: true, name: true },
     });
     const index = new Map<string, string>();
+    // Exact canonical keys first — the original behavior, never regressed.
     for (const c of committees) {
       index.set(c.name.toLowerCase().trim(), c.id);
+    }
+    // Normalized-core aliases so verbose extracted names ("Assembly Committee on
+    // Appropriations") resolve to short canonical committees ("Appropriations").
+    // Collect ids per normalized key, then add only unambiguous ones (a core
+    // shared by ≥2 committees is skipped — never mis-link) that aren't already
+    // an exact key (#908).
+    const byNorm = new Map<string, string[]>();
+    for (const c of committees) {
+      const norm = normalizeCommitteeName(c.name);
+      if (!norm) continue;
+      const ids = byNorm.get(norm) ?? [];
+      ids.push(c.id);
+      byNorm.set(norm, ids);
+    }
+    for (const [norm, ids] of byNorm) {
+      if (ids.length === 1 && !index.has(norm)) index.set(norm, ids[0]);
     }
     return index;
   }
@@ -2586,7 +2624,11 @@ export class RegionSyncService implements OnModuleDestroy {
     await this.db.billCommitteeAssignment.deleteMany({ where: { billId } });
     const rows = names
       .map((name) => {
-        const committeeId = committeeIndex.get(name.toLowerCase().trim());
+        // Exact match first; fall back to the normalized-core alias so verbose
+        // extracted names link to short canonical committees (#908).
+        const committeeId =
+          committeeIndex.get(name.toLowerCase().trim()) ??
+          committeeIndex.get(normalizeCommitteeName(name));
         return committeeId
           ? { billId, legislativeCommitteeId: committeeId }
           : null;


### PR DESCRIPTION
Fixes #908.

## Problem

`bill_committee_assignments` held **3 rows across 5,019 bills**. The data was extracted fine — it just failed to *link*. `linkBillCommittees` matched extracted names against the index with an **exact lowercase `.get()`**, but the two sides use different formats:

- **Extraction** pulls verbose page strings: *"Assembly Committee on Appropriations"*, *"Committee on Public Safety"*.
- **`legislative_committees`** stores short canonical names: `Appropriations`, `Public Safety`.

`"assembly committee on appropriations"` ≠ `"appropriations"` → dropped. Reps don't have this problem because `resolveRepByName` has a fallback; committee linking had **none**.

## Fix (linking logic only — no migration)

- **`normalizeCommitteeName()`** — strip chamber/qualifier words (`assembly`/`senate`/`joint`/`select`/…) + the `committee`/`on` boilerplate, collapse whitespace, so both `"Assembly Committee on Appropriations"` and `"Appropriations"` reduce to `appropriations`. Returns `''` for boilerplate-only input.
- **`buildCommitteeNameIndex`** — keep exact canonical keys (no regression), then add **collision-safe normalized-core aliases**: a core shared by >1 committee is skipped (never mis-link), and a normalized key never overrides an exact key.
- **`linkBillCommittees`** — exact match first, then fall back to the normalized alias.

Applied symmetrically to both sides. Exact matching is unchanged.

## Verification
- Unit tests for `normalizeCommitteeName` (chamber/boilerplate stripping, symmetry between verbose↔canonical, boilerplate-only → `''`). Full backend spec green (113 tests).
- Sanity-checked against the real us-ca committee names — all 5 sampled (`Appropriations`, `Public Safety`, `Governmental Organization`, `Environmental Safety and Toxic Materials`, `Joint Legislative Committee on Emergency Management`) now match their verbose extracted forms.

## Backfill
`bill_committee_assignments` recomputes per bill on sync (`deleteMany` + `createMany`), so a `bills` re-run after deploy backfills the ~5,000 bills that carry a referral — no migration, no data change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)