### PR TITLE
fix(region): strip NUL bytes from extracted PDF text (#912)

### DIFF
--- a/packages/extraction-provider/__tests__/extraction.provider.spec.ts
+++ b/packages/extraction-provider/__tests__/extraction.provider.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ExtractionProvider } from "../src/extraction.provider";
+import { ExtractionProvider, stripNulBytes } from "../src/extraction.provider";
 import { FetchError } from "../src/types";
 
 // Mock fetch globally
@@ -285,6 +285,40 @@ describe("ExtractionProvider", () => {
       const text = await provider.extractPdfText(buffer);
 
       expect(text).toBe("Extracted PDF text");
+    });
+
+    // #912: scanned / mixed-encoding PDFs emit NUL bytes (0x00) that Postgres
+    // text columns reject ("invalid byte sequence for encoding UTF8"), crashing
+    // any downstream DB write (e.g. minutes.rawText). extractPdfText is the
+    // single choke point every PDF path flows through, so it must sanitize.
+    it("should strip NUL bytes emitted by the underlying PDF extractor", async () => {
+      const { PDFParse } = jest.requireMock("pdf-parse");
+      PDFParse.mockImplementationOnce(() => ({
+        getText: jest
+          .fn()
+          .mockResolvedValue({ text: "clean\u0000text\u0000here" }),
+        destroy: jest.fn().mockResolvedValue(undefined),
+      }));
+
+      const text = await provider.extractPdfText(Buffer.from("fake pdf"));
+
+      expect(text).toBe("cleantexthere");
+      expect(text).not.toContain("\u0000");
+    });
+  });
+
+  describe("stripNulBytes", () => {
+    it("removes every NUL byte (0x00) from the input", () => {
+      expect(stripNulBytes("a\u0000b\u0000c")).toBe("abc");
+    });
+
+    it("returns non-NUL text unchanged", () => {
+      expect(stripNulBytes("no nuls here")).toBe("no nuls here");
+    });
+
+    it("handles empty and all-NUL strings", () => {
+      expect(stripNulBytes("")).toBe("");
+      expect(stripNulBytes("\u0000\u0000\u0000")).toBe("");
     });
   });
 

--- a/packages/extraction-provider/src/extraction.provider.ts
+++ b/packages/extraction-provider/src/extraction.provider.ts
@@ -47,6 +47,16 @@ import {
 import { normalizeUrl } from "./utils/url-normalize.js";
 
 /**
+ * Remove NUL bytes (0x00) from extracted text. Postgres `text`/`utf8` columns
+ * reject 0x00 ("invalid byte sequence for encoding UTF8"), so any downstream DB
+ * write of PDF text would crash. Scanned / mixed-encoding PDFs emit these. See
+ * #912. Exported for unit testing.
+ */
+export function stripNulBytes(text: string): string {
+  return text.replace(/\u0000/g, "");
+}
+
+/**
  * Selected element from HTML parsing
  */
 export interface SelectedElement {
@@ -217,7 +227,13 @@ export class ExtractionProvider {
    */
   async extractPdfText(buffer: Buffer): Promise<string> {
     this.logger.debug("Extracting text from PDF");
-    return PdfExtractor.extract(buffer, this.ocrService);
+    const text = await PdfExtractor.extract(buffer, this.ocrService);
+    // Strip NUL bytes (0x00) that scanned / mixed-encoding PDFs can emit.
+    // Postgres text columns reject 0x00 ("invalid byte sequence for encoding
+    // UTF8"), which would crash any downstream DB write of the extracted text
+    // (minutes.rawText, bill/meeting fields). Single choke point for every PDF
+    // path — see #912.
+    return stripNulBytes(text);
   }
 
   /**


### PR DESCRIPTION
## Description

Scanned / mixed-encoding PDFs emit NUL bytes (`0x00`) in their extracted text. Postgres `text`/`utf8` columns reject `0x00` (`invalid byte sequence for encoding UTF8`), so any downstream DB write crashed — observed as the `minutes.rawText` upsert failing during meetings sync and dropping the whole minutes record.

## Fix

Sanitize at `extractPdfText`, the single PDF→text primitive every path flows through:
- scheduled meetings (`PdfExtractHandler`)
- minutes (`MinutesIngestHandler` → `fetchPdfText` → `extractPdfText`)
- bill PDFs

One choke point fixes all callers rather than patching each DB boundary. `stripNulBytes` is extracted as a module-level exported pure function (mirrors the `normalizeUrl` / `normalizeCommitteeName` pattern) and unit-tested.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #912

## Testing

- 4 new unit tests: `extractPdfText` strips NUL from the underlying extractor output; `stripNulBytes` removes NUL, passes non-NUL through unchanged, and handles empty / all-NUL input.
- Full package + monorepo suite green via pre-commit hook (2217 backend tests + packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)