### PR TITLE
fix(infra): stop uat API_KEYS default baking in literal quotes (#915)

### DIFF
--- a/docker-compose-uat.yml
+++ b/docker-compose-uat.yml
@@ -71,7 +71,11 @@ x-backend-env: &backend-env
   # via shell env or .env when running UAT; the dev-grade defaults below
   # preserve the existing UAT workflow until #811 lands.
   GATEWAY_HMAC_SECRET: ${GATEWAY_HMAC_SECRET:-integration-test-hmac-secret}
-  API_KEYS: ${API_KEYS:-'{"api-gateway":"integration-test-hmac-secret"}'}
+  # Wrap the whole value in YAML single-quotes (stripped by the YAML parser)
+  # so the `:-` default is clean JSON. Quoting the default *inside* the `${…}`
+  # instead would leave literal quotes in the value — Compose interpolation
+  # doesn't strip them — breaking JSON.parse in the subgraphs (401s). See #915.
+  API_KEYS: '${API_KEYS:-{"api-gateway":"integration-test-hmac-secret"}}'
   JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required — run create-op-node bootstrap}
   # AUTH_JWT_SECRET historically equals JWT_SECRET in dev/UAT — falls back
   # to JWT_SECRET when not set independently.


### PR DESCRIPTION
## Description

A fresh `pnpm uat:up` crash-looped `opuspopuli-uat-api`: the Apollo gateway couldn't compose the supergraph because every subgraph returned **401** on schema introspection.

## Root cause

`docker-compose-uat.yml`:
```yaml
API_KEYS: ${API_KEYS:-'{"api-gateway":"integration-test-hmac-secret"}'}
```
The single quotes sat *inside* the `${…}` default. Compose interpolation doesn't strip them, so subgraphs received `'{"api-gateway":"…"}'` with literal quotes → `JSON.parse` failed → no valid `api-gateway` key → the gateway's HMAC-signed introspection was rejected 401 → container restart loop.

(`docker-compose-integration.yml` was unaffected — it uses a plain YAML single-quoted scalar, which the YAML parser strips.)

## Fix

Wrap the whole value in YAML single-quotes so the default resolves to clean JSON, matching the integration compose file. The `${API_KEYS:-…}` env-override path is preserved.

```yaml
API_KEYS: '${API_KEYS:-{"api-gateway":"integration-test-hmac-secret"}}'
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Infrastructure/DevOps change

## Related Issues

Fixes #915

## Testing

- `docker compose -f docker-compose-uat.yml config` renders `API_KEYS` as clean JSON on the default; an explicit `API_KEYS=…` override is still respected; file validates.
- Force-recreated `users` + `api` on the compose default alone (no `.env` override): subgraph env shows clean JSON, api reaches `healthy`, no 401s in gateway logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)