### PR TITLE
fix(pipeline): self-heal stale manifest in-run instead of silent zero (#911)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/meetings-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/meetings-sync.service.ts
@@ -62,6 +62,14 @@ export class MeetingsSyncService {
     discoverTracker.complete();
 
     if (meetings.length === 0) {
+      // A zero result can be legitimate (recess) OR a degraded extraction. A
+      // silent skip previously masked stale-manifest zero-yield (#911), so make
+      // it visible. The pipeline now self-heals a stale manifest in-run, so a
+      // persistent zero here points at the source itself, not a stale cache.
+      this.logger.warn(
+        `No meetings extracted for ${regionId} — if this source normally lists ` +
+          `meetings, check source/extraction health (see #911). Proceeding to minutes.`,
+      );
       // Skip the empty extract+minutes_link phases for clarity.
       return this.syncMinutes(provider);
     }

--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -42,6 +42,8 @@ export interface StructuralManifest {
   successCount: number;
   /** Number of failed extractions using this manifest */
   failureCount: number;
+  /** Item count from the last successful extraction — baseline for count-drift self-heal (#911) */
+  lastItemCount?: number;
   /** Whether this is the active manifest for this (regionId, sourceUrl, dataType) */
   isActive: boolean;
   /** LLM provider used for analysis */

--- a/packages/relationaldb-provider/prisma/migrations/20260719000000_manifest_last_item_count/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260719000000_manifest_last_item_count/migration.sql
@@ -1,0 +1,7 @@
+-- #911: persist the item count from the last successful extraction so the
+-- self-healing validator can detect a *drop* (e.g. 13 → 1) rather than only a
+-- total zero. Without a stored baseline `previousItemCount` was always
+-- undefined and the count-drift check was dead code. Additive, nullable column
+-- — no rewrite, prod-safe. Backfills as NULL (drift check no-ops until the
+-- first successful extraction records a baseline).
+ALTER TABLE "structural_manifests" ADD COLUMN "last_item_count" INTEGER;

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -1833,6 +1833,7 @@ model StructuralManifest {
   confidence      Float     @default(0)
   successCount    Int       @default(0) @map("success_count")
   failureCount    Int       @default(0) @map("failure_count")
+  lastItemCount   Int?      @map("last_item_count") /// Items from last successful extraction — baseline for count-drift self-heal (#911)
   isActive        Boolean   @default(true) @map("is_active") /// Only one active per (regionId, sourceUrl, dataType)
   llmProvider     String?   @map("llm_provider") @db.VarChar(50)
   llmModel        String?   @map("llm_model") @db.VarChar(100)

--- a/packages/scraping-pipeline/__tests__/manifest-store.spec.ts
+++ b/packages/scraping-pipeline/__tests__/manifest-store.spec.ts
@@ -57,6 +57,7 @@ function createRecord(overrides: Partial<ManifestRecord> = {}): ManifestRecord {
     confidence: 0.8,
     successCount: 5,
     failureCount: 1,
+    lastItemCount: null,
     isActive: true,
     llmProvider: "ollama",
     llmModel: "llama3",
@@ -195,6 +196,28 @@ describe("ManifestStoreService", () => {
       await store.incrementSuccess("nonexistent");
 
       expect(repo.update).not.toHaveBeenCalled();
+    });
+
+    it("persists lastItemCount as the drift baseline when given a count (#911)", async () => {
+      repo.findFirst.mockResolvedValue(createRecord({ successCount: 5 }));
+      repo.update.mockResolvedValue(createRecord());
+
+      await store.incrementSuccess("manifest-1", 13);
+
+      expect(repo.update).toHaveBeenCalledWith({
+        where: { id: "manifest-1" },
+        data: expect.objectContaining({ successCount: 6, lastItemCount: 13 }),
+      });
+    });
+
+    it("leaves lastItemCount untouched when no count is supplied", async () => {
+      repo.findFirst.mockResolvedValue(createRecord({ successCount: 5 }));
+      repo.update.mockResolvedValue(createRecord());
+
+      await store.incrementSuccess("manifest-1");
+
+      const data = repo.update.mock.calls[0][0].data;
+      expect(data).not.toHaveProperty("lastItemCount");
     });
   });
 

--- a/packages/scraping-pipeline/__tests__/pipeline.spec.ts
+++ b/packages/scraping-pipeline/__tests__/pipeline.spec.ts
@@ -148,7 +148,8 @@ describe("ScrapingPipelineService", () => {
       expect(result.success).toBe(true);
       expect(result.items).toHaveLength(1);
       expect(mockAnalyzer.analyze).not.toHaveBeenCalled();
-      expect(mockStore.incrementSuccess).toHaveBeenCalledWith("manifest-1");
+      // Records success with the extracted item count as the drift baseline (#911)
+      expect(mockStore.incrementSuccess).toHaveBeenCalledWith("manifest-1", 1);
       expect(mockStore.markChecked).toHaveBeenCalledWith("manifest-1");
     });
 
@@ -230,8 +231,8 @@ describe("ScrapingPipelineService", () => {
       expect(mockStore.save).toHaveBeenCalled();
       // Should re-extract with new manifest
       expect(mockExtractor.extract).toHaveBeenCalledTimes(2);
-      // Should record success on new manifest
-      expect(mockStore.incrementSuccess).toHaveBeenCalledWith("manifest-2");
+      // Should record success on new manifest with its item count baseline
+      expect(mockStore.incrementSuccess).toHaveBeenCalledWith("manifest-2", 1);
     });
 
     it("should record failure when healing also fails", async () => {
@@ -260,6 +261,83 @@ describe("ScrapingPipelineService", () => {
 
       expect(mockStore.incrementFailure).toHaveBeenCalledWith(
         "manifest-healed",
+      );
+    });
+
+    it("re-analyzes in-run even in async/worker mode on zero-yield (#911)", async () => {
+      // Regression: previously the async path (onManifestMissing wired) only
+      // enqueued a background refresh and returned the degraded 0-item result,
+      // so a stale cached manifest silently zeroed out meetings until a later
+      // sync converged. The pipeline must now heal in the same run.
+      const onManifestMissing = jest.fn().mockResolvedValue(undefined);
+      pipeline = new ScrapingPipelineService(
+        { generate: jest.fn() } as any,
+        mockExtraction,
+        mockAnalyzer,
+        mockStore,
+        mockExtractor,
+        mockMapper,
+        mockHealing,
+        {} as unknown as BulkDownloadHandler,
+        {} as unknown as ApiIngestHandler,
+        {} as any,
+        {} as any,
+        { enrichItems: jest.fn().mockImplementation((r: any) => r) } as any,
+        onManifestMissing,
+      );
+
+      // Cache hit (hashes match) whose stale selectors yield 0 items, then a
+      // healthy re-extraction after re-analysis.
+      mockHealing.evaluate
+        .mockReturnValueOnce({
+          shouldHeal: true,
+          reason: "Zero items extracted",
+          validation: {
+            valid: false,
+            issues: [{ severity: "error", message: "Zero items extracted" }],
+          },
+        })
+        .mockReturnValueOnce({
+          shouldHeal: false,
+          reason: "Extraction passed validation",
+          validation: { valid: true, issues: [] },
+        });
+      mockExtractor.extract
+        .mockReturnValueOnce({
+          items: [],
+          success: false,
+          warnings: [],
+          errors: [],
+        })
+        .mockReturnValueOnce({
+          items: [{ name: "Recovered" }],
+          success: true,
+          warnings: [],
+          errors: [],
+        });
+      mockAnalyzer.analyze.mockResolvedValue(
+        createManifest({ id: "manifest-2", version: 2 }),
+      );
+
+      await pipeline.execute(createSource(), "california");
+
+      // Healed in-run: re-analyzed and re-extracted rather than deferring.
+      expect(mockAnalyzer.analyze).toHaveBeenCalledTimes(1);
+      expect(mockExtractor.extract).toHaveBeenCalledTimes(2);
+      expect(mockStore.incrementSuccess).toHaveBeenCalledWith("manifest-2", 1);
+    });
+
+    it("passes the stored lastItemCount as the drift baseline (#911)", async () => {
+      mockStore.findLatest.mockResolvedValue(
+        createManifest({ lastItemCount: 13 }),
+      );
+
+      await pipeline.execute(createSource(), "california");
+
+      expect(mockHealing.evaluate).toHaveBeenCalledWith(
+        expect.any(Object),
+        expect.any(Object),
+        13,
       );
     });
   });

--- a/packages/scraping-pipeline/src/manifest/manifest-store.service.ts
+++ b/packages/scraping-pipeline/src/manifest/manifest-store.service.ts
@@ -51,6 +51,7 @@ export interface ManifestRecord {
   confidence: number;
   successCount: number;
   failureCount: number;
+  lastItemCount: number | null;
   isActive: boolean;
   llmProvider: string | null;
   llmModel: string | null;
@@ -149,6 +150,7 @@ export class ManifestStoreService {
         confidence: manifest.confidence,
         successCount: 0,
         failureCount: 0,
+        lastItemCount: null,
         isActive: true,
         llmProvider: manifest.llmProvider ?? null,
         llmModel: manifest.llmModel ?? null,
@@ -168,9 +170,14 @@ export class ManifestStoreService {
   }
 
   /**
-   * Record a successful extraction using this manifest.
+   * Record a successful extraction using this manifest. When `itemCount` is
+   * supplied it is persisted as the drift baseline (`lastItemCount`) that the
+   * self-healing validator compares future extractions against (#911).
    */
-  async incrementSuccess(manifestId: string): Promise<void> {
+  async incrementSuccess(
+    manifestId: string,
+    itemCount?: number,
+  ): Promise<void> {
     const record = await this.repository.findFirst({
       where: { id: manifestId },
     });
@@ -180,6 +187,7 @@ export class ManifestStoreService {
         data: {
           successCount: record.successCount + 1,
           lastUsedAt: new Date(),
+          ...(itemCount === undefined ? {} : { lastItemCount: itemCount }),
         },
       });
     }
@@ -275,6 +283,7 @@ export class ManifestStoreService {
       confidence: record.confidence,
       successCount: record.successCount,
       failureCount: record.failureCount,
+      lastItemCount: record.lastItemCount ?? undefined,
       isActive: record.isActive,
       llmProvider: record.llmProvider ?? undefined,
       llmModel: record.llmModel ?? undefined,

--- a/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
+++ b/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
@@ -15,7 +15,9 @@ import type {
   DataSourceConfig,
   ExtractionResult,
   ILLMProvider,
+  RawExtractionResult,
   StructuralAnalysisResult,
+  StructuralManifest,
   DataType,
 } from "@opuspopuli/common";
 import { ExtractionProvider } from "@opuspopuli/extraction-provider";
@@ -254,55 +256,35 @@ export class ScrapingPipelineService {
 
     // Stage 3: Extract content using manifest
     let rawResult = this.extractor.extract(html, manifest, source.url);
+    let effectiveVersion = manifest.version;
 
-    // Self-healing: check if extraction results are acceptable
-    const healingDecision = this.healing.evaluate(rawResult, manifest);
+    // Self-healing: check if extraction results are acceptable. Passing the
+    // stored lastItemCount lets the validator flag a sharp *drop* (e.g. 13 → 1),
+    // not just a total zero (#911).
+    const healingDecision = this.healing.evaluate(
+      rawResult,
+      manifest,
+      manifest.lastItemCount,
+    );
 
     if (healingDecision.shouldHeal) {
+      // Stale cached rules produced degraded output. Re-derive and re-extract
+      // in THIS run — even in async/worker mode — so the sync self-heals
+      // immediately instead of silently returning the degraded set and
+      // deferring to a background refresh that may not converge (#911).
       this.logger.warn(
         `Self-healing: re-analyzing ${source.url} — ${healingDecision.reason}`,
       );
-
-      if (this.onManifestMissing) {
-        // Async path: enqueue refresh, continue with degraded extraction.
-        await this.onManifestMissing({
-          regionId,
-          sourceUrl: source.url,
-          dataType: source.dataType,
-          contentGoal: source.contentGoal,
-          category: source.category,
-          hints: source.hints,
-          requestedBy: "cache_stale",
-        });
-        await this.manifestStore.incrementFailure(manifest.id);
-      } else {
-        // Inline path: re-analyze immediately.
-        const newManifest = await this.analyzer.analyze(html, source);
-        newManifest.regionId = regionId;
-        newManifest.version = await this.manifestStore.getNextVersion(
-          regionId,
-          source.url,
-          source.dataType,
-        );
-        await this.manifestStore.save(newManifest);
-
-        rawResult = this.extractor.extract(html, newManifest, source.url);
-
-        const secondCheck = this.healing.evaluate(
-          rawResult,
-          newManifest,
-          undefined,
-          true,
-        );
-        if (secondCheck.shouldHeal) {
-          await this.manifestStore.incrementFailure(newManifest.id);
-        } else {
-          await this.manifestStore.incrementSuccess(newManifest.id);
-        }
-      }
+      const healed = await this.healManifest(source, regionId, html, manifest);
+      rawResult = healed.rawResult;
+      effectiveVersion = healed.version;
     } else {
-      // Original manifest worked — record success and update timestamps
-      await this.manifestStore.incrementSuccess(manifest.id);
+      // Original manifest worked — record success (updating the drift baseline)
+      // and refresh the checked timestamp.
+      await this.manifestStore.incrementSuccess(
+        manifest.id,
+        rawResult.items.length,
+      );
       await this.manifestStore.markChecked(manifest.id);
     }
 
@@ -325,7 +307,7 @@ export class ScrapingPipelineService {
 
     // Stage 4: Map to domain types
     const result = this.mapper.map<T>(rawResult, source);
-    result.manifestVersion = manifest.version;
+    result.manifestVersion = effectiveVersion;
 
     const totalMs = Date.now() - pipelineStart;
     this.logger.log(
@@ -334,6 +316,55 @@ export class ScrapingPipelineService {
     );
 
     return result;
+  }
+
+  /**
+   * Re-derive a manifest for a source whose cached rules produced degraded
+   * output, then re-extract with the fresh manifest. Bounded to a single
+   * re-analysis per run (healAttempted=true) so a genuinely-empty or
+   * genuinely-shrunken source can't loop. Records the new drift baseline on
+   * success. Returns the re-extracted result and the new manifest version.
+   * See #911.
+   */
+  private async healManifest(
+    source: DataSourceConfig,
+    regionId: string,
+    html: string,
+    staleManifest: StructuralManifest,
+  ): Promise<{ rawResult: RawExtractionResult; version: number }> {
+    await this.manifestStore.incrementFailure(staleManifest.id);
+
+    const newManifest = await this.analyzer.analyze(html, source);
+    newManifest.regionId = regionId;
+    newManifest.version = await this.manifestStore.getNextVersion(
+      regionId,
+      source.url,
+      source.dataType,
+    );
+    newManifest.structureHash = computeStructureHash(html);
+    const saved = await this.manifestStore.save(newManifest);
+
+    const rawResult = this.extractor.extract(html, saved, source.url);
+    const secondCheck = this.healing.evaluate(
+      rawResult,
+      saved,
+      undefined,
+      true,
+    );
+    if (secondCheck.shouldHeal) {
+      await this.manifestStore.incrementFailure(saved.id);
+      this.logger.warn(
+        `Self-heal re-extraction still degraded for ${source.url}: ` +
+          `${rawResult.items.length} item(s)`,
+      );
+    } else {
+      await this.manifestStore.incrementSuccess(
+        saved.id,
+        rawResult.items.length,
+      );
+    }
+
+    return { rawResult, version: saved.version };
   }
 
   /**


### PR DESCRIPTION
## Description

A cached `html_scrape` manifest whose selectors go stale extracted **0 items**, but in production (async/worker) mode the pipeline only *enqueued* a background re-analysis and returned the degraded 0-item result for the current run. It depended on a worker + follow-up-sync cycle to converge — which on the Studio did not, so **meetings silently sat at zero for days** (#911).

## Root cause

`executeHtmlScrape` had two heal branches: the local/inline branch re-analyzed + re-extracted in the same run (correct), but the async branch (the production wiring) only enqueued and returned the degraded set. A stale cache that still hash-matched (`canReuse`) therefore yielded 0 items with no in-run recovery.

## Fix

- **Unify the heal path** into `healManifest`: whenever self-healing triggers, re-derive and re-extract with a fresh manifest **in this run**, regardless of async mode. Bounded to one attempt (`healAttempted=true`). Deploying this + running one meetings sync **auto-heals a stale manifest on the Studio — no manual invalidation needed**. Also sets `structureHash` on the healed manifest (the old inline branch didn't, which could cause repeat re-analysis).
- **Drift detection** (was dead code): persist `last_item_count` (additive nullable column + migration) and feed it as `previousItemCount`, so a sharp *drop* (e.g. 13 → 1) triggers heal, not only a total zero.
- **Visibility**: `meetings-sync` now WARNs on a zero result instead of silently skipping the upsert.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #911

## Migration

`20260719000000_manifest_last_item_count` — `ALTER TABLE structural_manifests ADD COLUMN last_item_count INTEGER` (additive, nullable, no rewrite, backfills NULL). Prod-safe.

## Testing

- New pipeline specs: async/worker-mode zero-yield now heals in-run (the #911 regression); `lastItemCount` passed as the drift baseline.
- New manifest-store specs: `incrementSuccess` persists `lastItemCount` when given a count, leaves it untouched otherwise.
- Existing self-heal + cached-manifest specs updated for the new success-baseline arg.
- Full monorepo suite green via pre-commit hook. `/security-review` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)