### PR TITLE
feat(region): API-payload controls for meetings historical backfill (maxDocuments + resetWatermark)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/meetings-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/meetings-sync.service.ts
@@ -1,6 +1,10 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { DbService } from '@opuspopuli/relationaldb-provider';
-import type { Meeting, MinutesWithActions } from '@opuspopuli/common';
+import type {
+  ArchiveIngestOptions,
+  Meeting,
+  MinutesWithActions,
+} from '@opuspopuli/common';
 import { LegislativeActionLinkerService } from './legislative-action-linker.service';
 import { meetingSyncTracker, minutesSyncTracker } from './sync-phase-logger';
 import type { UpsertByExternalId } from './propositions-sync.service';
@@ -14,7 +18,9 @@ import type { UpsertByExternalId } from './propositions-sync.service';
 export interface MeetingsProvider {
   getName?(): string;
   fetchMeetings(pipelineJobId?: string): Promise<Meeting[]>;
-  fetchMeetingMinutes?(): Promise<MinutesWithActions[]>;
+  fetchMeetingMinutes?(
+    options?: ArchiveIngestOptions,
+  ): Promise<MinutesWithActions[]>;
 }
 
 /**
@@ -45,6 +51,7 @@ export class MeetingsSyncService {
     provider: MeetingsProvider,
     pipelineJobId: string | undefined,
     upsertByExternalId: UpsertByExternalId,
+    options?: ArchiveIngestOptions,
   ): Promise<{ processed: number; created: number; updated: number }> {
     const regionId = provider.getName?.() ?? 'unknown';
 
@@ -71,7 +78,7 @@ export class MeetingsSyncService {
           `meetings, check source/extraction health (see #911). Proceeding to minutes.`,
       );
       // Skip the empty extract+minutes_link phases for clarity.
-      return this.syncMinutes(provider);
+      return this.syncMinutes(provider, options);
     }
 
     // ─── Phase 2/3 — extract_and_upsert ────────────────────────────
@@ -147,7 +154,7 @@ export class MeetingsSyncService {
     });
     linkTracker.complete();
 
-    const minutesResult = await this.syncMinutes(provider);
+    const minutesResult = await this.syncMinutes(provider, options);
     return {
       processed: result.processed + minutesResult.processed,
       created: result.created + minutesResult.created,
@@ -165,6 +172,7 @@ export class MeetingsSyncService {
    */
   private async syncMinutes(
     provider: MeetingsProvider,
+    options?: ArchiveIngestOptions,
   ): Promise<{ processed: number; created: number; updated: number }> {
     if (!provider.fetchMeetingMinutes) {
       // Emit phase markers even on the early-return path so the
@@ -184,7 +192,7 @@ export class MeetingsSyncService {
 
     // ─── Phase 1/3 — discover ──────────────────────────────────────
     const discoverTracker = minutesSyncTracker(this.logger, 'discover', 1);
-    const bundles = await provider.fetchMeetingMinutes();
+    const bundles = await provider.fetchMeetingMinutes(options);
     discoverTracker.item({
       name: 'minutes provider',
       externalId: null,

--- a/apps/backend/src/apps/region/src/domains/pipeline-job.service.ts
+++ b/apps/backend/src/apps/region/src/domains/pipeline-job.service.ts
@@ -18,6 +18,8 @@ export interface CreatePipelineJobInput {
   depth?: string;
   maxReps?: number;
   maxBills?: number;
+  maxDocuments?: number;
+  resetWatermark?: boolean;
 }
 
 @Injectable()
@@ -36,6 +38,8 @@ export class PipelineJobService {
         depth: input.depth ?? null,
         maxReps: input.maxReps ?? null,
         maxBills: input.maxBills ?? null,
+        maxDocuments: input.maxDocuments ?? null,
+        resetWatermark: input.resetWatermark ?? null,
         status: JOB_STATUS.QUEUED,
       },
       select: { id: true },

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.ts
@@ -18,6 +18,7 @@ import {
 import {
   batchTransaction,
   extractJsonObjectSlice,
+  type ArchiveIngestOptions,
   type Proposition,
   type Meeting,
   type Representative,
@@ -593,6 +594,7 @@ export class RegionSyncService implements OnModuleDestroy {
     scopedRegionId?: string,
     pipelineJobId?: string,
     forceStatusRecheck?: boolean,
+    archiveOptions?: ArchiveIngestOptions,
   ): Promise<SyncResult[]> {
     // Re-read enabled plugins from the DB before every sync. The hot-swap
     // on `setRegionPluginEnabled` only fires in the *region service* process;
@@ -633,6 +635,7 @@ export class RegionSyncService implements OnModuleDestroy {
           maxBills,
           pipelineJobId,
           forceStatusRecheck,
+          archiveOptions,
         )),
       );
     }
@@ -646,6 +649,7 @@ export class RegionSyncService implements OnModuleDestroy {
           scopedRegionId,
           pipelineJobId,
           forceStatusRecheck,
+          archiveOptions,
         )),
       );
     }
@@ -662,6 +666,7 @@ export class RegionSyncService implements OnModuleDestroy {
     maxBills?: number,
     pipelineJobId?: string,
     forceStatusRecheck?: boolean,
+    archiveOptions?: ArchiveIngestOptions,
   ): Promise<SyncResult[]> {
     const supported = instance.getSupportedDataTypes();
     const filtered = dataTypes
@@ -679,6 +684,7 @@ export class RegionSyncService implements OnModuleDestroy {
           name,
           pipelineJobId,
           forceStatusRecheck,
+          archiveOptions,
         );
         results.push(result);
       } catch (error) {
@@ -705,6 +711,7 @@ export class RegionSyncService implements OnModuleDestroy {
     scopedRegionId?: string,
     pipelineJobId?: string,
     forceStatusRecheck?: boolean,
+    archiveOptions?: ArchiveIngestOptions,
   ): Promise<SyncResult[]> {
     const where = scopedRegionId
       ? { name: scopedRegionId, parentRegionId: { not: null }, enabled: true }
@@ -745,6 +752,7 @@ export class RegionSyncService implements OnModuleDestroy {
             maxBills,
             pipelineJobId,
             forceStatusRecheck,
+            archiveOptions,
           )),
         );
       } catch (error) {
@@ -784,6 +792,7 @@ export class RegionSyncService implements OnModuleDestroy {
     regionId?: string,
     pipelineJobId?: string,
     forceStatusRecheck?: boolean,
+    archiveOptions?: ArchiveIngestOptions,
   ): Promise<SyncResult> {
     this.logger.log(`Syncing ${dataType} from ${pluginName}`);
     const startTime = Date.now();
@@ -801,7 +810,8 @@ export class RegionSyncService implements OnModuleDestroy {
     > = {
       [DataType.PROPOSITIONS]: () =>
         this.syncPropositions(provider, pipelineJobId),
-      [DataType.MEETINGS]: () => this.syncMeetings(provider, pipelineJobId),
+      [DataType.MEETINGS]: () =>
+        this.syncMeetings(provider, pipelineJobId, archiveOptions),
       [DataType.REPRESENTATIVES]: () =>
         this.syncRepresentatives(provider, maxReps, regionId),
       [DataType.CAMPAIGN_FINANCE]: () =>
@@ -909,6 +919,7 @@ export class RegionSyncService implements OnModuleDestroy {
   private async syncMeetings(
     provider: DataFetcher = this.regionService,
     pipelineJobId?: string,
+    archiveOptions?: ArchiveIngestOptions,
   ): Promise<{ processed: number; created: number; updated: number }> {
     if (!this.meetingsSyncService) {
       return { processed: 0, created: 0, updated: 0 };
@@ -917,6 +928,7 @@ export class RegionSyncService implements OnModuleDestroy {
       provider,
       pipelineJobId,
       this.upsertByExternalId.bind(this),
+      archiveOptions,
     );
   }
 

--- a/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.spec.ts
@@ -808,6 +808,29 @@ describe('RegionResolver', () => {
       expect(createCall.bullmqJobId).toBe(createCall.id);
       expect(createCall.triggerSource).toBe('manual');
     });
+
+    it('threads maxDocuments + resetWatermark into the job (backfill controls)', async () => {
+      // syncRegionData(dataTypes, depth, regionId, maxReps, maxBills,
+      //                maxDocuments, resetWatermark, ctx)
+      await resolver.syncRegionData(
+        [DataTypeGQL.MEETINGS],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        25,
+        true,
+      );
+
+      expect(queueService.enqueue).toHaveBeenCalledWith(
+        'region-sync',
+        expect.objectContaining({ maxDocuments: 25, resetWatermark: true }),
+        expect.anything(),
+      );
+      const createCall = pipelineJobService.create.mock.calls[0][0];
+      expect(createCall.maxDocuments).toBe(25);
+      expect(createCall.resetWatermark).toBe(true);
+    });
   });
 
   // ==========================================

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -986,6 +986,10 @@ export class RegionResolver {
     maxReps?: number,
     @Args('maxBills', { type: () => Int, nullable: true })
     maxBills?: number,
+    @Args('maxDocuments', { type: () => Int, nullable: true })
+    maxDocuments?: number,
+    @Args('resetWatermark', { type: () => Boolean, nullable: true })
+    resetWatermark?: boolean,
     @Context() ctx?: { req: { user?: { id?: string } } },
   ): Promise<RegionSyncJobModel> {
     const userId = ctx?.req?.user?.id;
@@ -996,6 +1000,8 @@ export class RegionResolver {
         depth: depth as string,
         maxReps,
         maxBills,
+        maxDocuments,
+        resetWatermark,
       },
       userId,
     );
@@ -1034,6 +1040,8 @@ export class RegionResolver {
       depth?: string;
       maxReps?: number;
       maxBills?: number;
+      maxDocuments?: number;
+      resetWatermark?: boolean;
     },
     userId?: string,
   ): Promise<RegionSyncJobModel> {

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -13,7 +13,10 @@
  */
 import { Injectable } from '@nestjs/common';
 import { DataType, SyncResult } from '@opuspopuli/region-provider';
-import type { DataSourceConfig } from '@opuspopuli/common';
+import type {
+  ArchiveIngestOptions,
+  DataSourceConfig,
+} from '@opuspopuli/common';
 import { Prisma } from '@opuspopuli/relationaldb-provider';
 import { CivicsBlockModel } from './models/region-info.model';
 import { RegionInfoModel } from './models/region-info.model';
@@ -271,6 +274,7 @@ export class RegionDomainService {
     scopedRegionId?: string,
     pipelineJobId?: string,
     forceStatusRecheck?: boolean,
+    archiveOptions?: ArchiveIngestOptions,
   ): Promise<SyncResult[]> {
     return this.syncService.syncAll(
       dataTypes,
@@ -280,6 +284,7 @@ export class RegionDomainService {
       scopedRegionId,
       pipelineJobId,
       forceStatusRecheck,
+      archiveOptions,
     );
   }
 

--- a/apps/backend/src/apps/workers/region-worker/src/region-sync.processor.ts
+++ b/apps/backend/src/apps/workers/region-worker/src/region-sync.processor.ts
@@ -101,7 +101,17 @@ export class RegionSyncProcessor
       maxReps,
       maxBills,
       forceStatusRecheck,
+      maxDocuments,
+      resetWatermark,
     } = job.data;
+
+    // Build the archive-ingest override only when the operator supplied one,
+    // so a normal sync is unaffected (undefined → source-config maxNew, no
+    // watermark reset).
+    const archiveOptions =
+      maxDocuments != null || resetWatermark != null
+        ? { maxDocuments, resetWatermark }
+        : undefined;
 
     this.logger.log(
       {
@@ -137,6 +147,7 @@ export class RegionSyncProcessor
         regionId,
         effectiveJobId,
         forceStatusRecheck,
+        archiveOptions,
       );
 
       const gqlResults = results.map((r) => ({

--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -12,6 +12,33 @@
 import type { DataType } from "../region/types.js";
 
 // ============================================
+// ARCHIVE INGEST OPTIONS
+// ============================================
+
+/**
+ * Per-run overrides for `pdf_archive` ingestion (daily-journals /
+ * weekly-histories). Threaded from the `syncRegionData` mutation down to
+ * {@link MinutesIngestHandler} so an operator can trigger a historical
+ * backfill from the API instead of editing region config or hand-deleting
+ * watermark rows. See region-worker backfill controls.
+ */
+export interface ArchiveIngestOptions {
+  /**
+   * Overrides `pdfArchive.maxNew` for this run — how many archive documents
+   * (PDFs) to ingest. Each document is dense (~140 legislative actions), so a
+   * larger value means a heavier, longer sync. Falls back to the source
+   * config's `maxNew` (default 10) when unset.
+   */
+  maxDocuments?: number;
+  /**
+   * When true, the archive walk ignores the stored ingestion watermark for
+   * this run and re-processes from the top (bounded by `maxDocuments`). Item
+   * upserts are idempotent; the watermark still advances normally afterward.
+   */
+  resetWatermark?: boolean;
+}
+
+// ============================================
 // STRUCTURAL MANIFEST
 // ============================================
 

--- a/packages/queue-provider/src/queue.types.ts
+++ b/packages/queue-provider/src/queue.types.ts
@@ -16,6 +16,19 @@ export interface RegionSyncJobData {
    * changes the journal linker can't see. See #689.
    */
   forceStatusRecheck?: boolean;
+  /**
+   * Per-run override for the meetings `pdf_archive` walk (daily-journals /
+   * weekly-histories): number of archive documents to ingest this run,
+   * overriding the region config's `pdfArchive.maxNew`. Operator-facing
+   * backfill control from the `syncRegionData` mutation.
+   */
+  maxDocuments?: number;
+  /**
+   * When true, the meetings `pdf_archive` walk ignores the stored ingestion
+   * watermark for this run and re-processes from the top (bounded by
+   * `maxDocuments`), enabling an on-demand historical backfill.
+   */
+  resetWatermark?: boolean;
 }
 
 export interface RegionSyncJobResult {

--- a/packages/region-provider/__tests__/declarative-region-plugin.spec.ts
+++ b/packages/region-provider/__tests__/declarative-region-plugin.spec.ts
@@ -157,6 +157,7 @@ describe("DeclarativeRegionPlugin", () => {
         "california",
         undefined,
         undefined,
+        undefined,
       );
       expect(result).toEqual(mockProps);
     });

--- a/packages/region-provider/src/declarative/declarative-region-plugin.ts
+++ b/packages/region-provider/src/declarative/declarative-region-plugin.ts
@@ -12,6 +12,7 @@
 import { Logger } from "@nestjs/common";
 import { BaseRegionPlugin } from "../base/base-plugin.js";
 import type {
+  ArchiveIngestOptions,
   DataType,
   RegionInfo,
   Proposition,
@@ -36,6 +37,7 @@ export interface IPipelineService {
     regionId: string,
     onBatch?: (items: T[]) => Promise<void>,
     pipelineJobId?: string,
+    options?: ArchiveIngestOptions,
   ): Promise<ExtractionResult<T>>;
   invalidateManifest(regionId: string, sourceUrl: string): Promise<number>;
 }
@@ -192,11 +194,15 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
    * LegislativeActionLinkerService mines the stored rawText
    * post-sync to produce action records. Issue #665.
    */
-  async fetchMeetingMinutes(): Promise<MinutesWithActions[]> {
+  async fetchMeetingMinutes(
+    options?: ArchiveIngestOptions,
+  ): Promise<MinutesWithActions[]> {
     return this.fetchByDataType<MinutesWithActions>(
       "meetings",
       undefined,
       (s) => s.sourceType === "pdf_archive",
+      undefined,
+      options,
     );
   }
 
@@ -293,6 +299,7 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
     onBatch?: (items: T[]) => Promise<void>,
     sourceFilter?: (source: DataSourceConfig) => boolean,
     pipelineJobId?: string,
+    options?: ArchiveIngestOptions,
   ): Promise<T[]> {
     const sources = this.regionConfig.dataSources.filter(
       (ds) =>
@@ -323,6 +330,7 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
           dataType,
           onBatch,
           pipelineJobId,
+          options,
         );
         allItems.push(...items);
         batchedItemCount += batched;
@@ -353,6 +361,7 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
     dataType: string,
     onBatch?: (items: T[]) => Promise<void>,
     pipelineJobId?: string,
+    options?: ArchiveIngestOptions,
   ): Promise<{ items: T[]; batched: number }> {
     try {
       const category = source.category ? " (" + source.category + ")" : "";
@@ -366,6 +375,7 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
         this.regionConfig.regionId,
         useBatch ? onBatch : undefined,
         pipelineJobId,
+        options,
       );
 
       this.logResultDiagnostics(source.url, result);

--- a/packages/relationaldb-provider/prisma/migrations/20260722000000_pipeline_job_backfill_controls/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260722000000_pipeline_job_backfill_controls/migration.sql
@@ -1,0 +1,7 @@
+-- Operator-facing meetings historical-backfill controls on the region-sync job.
+-- `syncRegionData` now accepts `maxDocuments` (override pdf_archive maxNew) and
+-- `resetWatermark` (ignore the ingestion watermark for one run) — persisted here
+-- for observability, mirroring max_reps / max_bills. Additive, nullable columns
+-- — no rewrite, prod-safe.
+ALTER TABLE "pipeline_jobs" ADD COLUMN "max_documents" INTEGER;
+ALTER TABLE "pipeline_jobs" ADD COLUMN "reset_watermark" BOOLEAN;

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -1912,6 +1912,8 @@ model PipelineJob {
   depth         String?
   maxReps       Int?      @map("max_reps")
   maxBills      Int?      @map("max_bills")
+  maxDocuments  Int?      @map("max_documents") /// Meetings pdf_archive maxNew override (API backfill)
+  resetWatermark Boolean? @map("reset_watermark") /// Ignore ingestion watermark for this run (API backfill)
   status        String
   attempts      Int       @default(0)
   enqueuedBy    String?   @map("enqueued_by")

--- a/packages/scraping-pipeline/__tests__/minutes-ingest.handler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/minutes-ingest.handler.spec.ts
@@ -206,6 +206,42 @@ describe("MinutesIngestHandler", () => {
     expect(ids).toEqual(["ca-meetings-2026-04-27", "ca-meetings-2026-04-28"]);
   });
 
+  it("maxDocuments override wins over the source config's maxNew (API backfill)", async () => {
+    const fake = setupExtraction();
+    const handler = new MinutesIngestHandler(fake as never);
+    // Source config says maxNew:10 — the per-run override caps ingestion at 2.
+    const result = await handler.execute(SOURCE, "ca", { maxDocuments: 2 });
+    expect(result.items).toHaveLength(2);
+  });
+
+  it("resetWatermark ignores the stored watermark and re-walks from the top", async () => {
+    const fake = setupExtraction();
+    const repo = new InMemoryWatermarkRepo();
+    const watermarks = new IngestionWatermarkService(repo);
+    // Apr 27 already ingested — a normal run would stop after Apr 28 only.
+    await watermarks.advance(
+      "ca",
+      SOURCE.url,
+      SOURCE.dataType,
+      "ca-meetings-2026-04-27",
+      0,
+    );
+
+    const handler = new MinutesIngestHandler(fake as never, watermarks);
+    const result = await handler.execute(SOURCE, "ca", {
+      resetWatermark: true,
+    });
+
+    // Watermark ignored → the walk re-processes the already-seen documents.
+    const ids = result.items.map((b) => b.minutes.externalId);
+    expect(ids.length).toBeGreaterThan(1);
+    expect(ids).toContain("ca-meetings-2026-04-27");
+
+    // Watermark still advances normally afterward.
+    const wm = await watermarks.read("ca", SOURCE.url, SOURCE.dataType);
+    expect(wm?.lastExternalId).toBe("ca-meetings-2026-04-28");
+  });
+
   it("captures revisionSeq from filenames matching revisionPattern", async () => {
     const fake = setupExtraction();
     const handler = new MinutesIngestHandler(fake as never);

--- a/packages/scraping-pipeline/src/handlers/minutes-ingest.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/minutes-ingest.handler.ts
@@ -21,6 +21,7 @@
 import { Inject, Injectable, Logger, Optional } from "@nestjs/common";
 import * as cheerio from "cheerio";
 import {
+  type ArchiveIngestOptions,
   type DataSourceConfig,
   type ExtractionResult,
   type Minutes,
@@ -52,6 +53,7 @@ export class MinutesIngestHandler {
   async execute(
     source: DataSourceConfig,
     regionId: string,
+    options?: ArchiveIngestOptions,
   ): Promise<ExtractionResult<MinutesWithActions>> {
     const start = Date.now();
     const warnings: string[] = [];
@@ -64,14 +66,20 @@ export class MinutesIngestHandler {
 
     const cfg = source.pdfArchive;
     const maxPages = cfg.maxPages ?? 10;
-    const maxNew = cfg.maxNew ?? 10;
+    // Per-run maxDocuments override (API backfill) wins over the source
+    // config's maxNew.
+    const maxNew = options?.maxDocuments ?? cfg.maxNew ?? 10;
 
     this.logger.log(
-      `Pipeline started [pdf_archive]: ${regionId}/${source.dataType} from ${source.url} (maxNew=${maxNew})`,
+      `Pipeline started [pdf_archive]: ${regionId}/${source.dataType} from ${source.url} ` +
+        `(maxNew=${maxNew}${options?.resetWatermark ? ", watermark reset" : ""})`,
     );
 
+    // resetWatermark: ignore the stored watermark for this run so the walk
+    // re-processes from the top (bounded by maxNew). The watermark still
+    // advances normally afterward, so later runs resume incrementally.
     let watermarkLastId: string | undefined;
-    if (this.watermarks) {
+    if (this.watermarks && !options?.resetWatermark) {
       const watermark = await this.watermarks.read(
         regionId,
         source.url,

--- a/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
+++ b/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
@@ -12,6 +12,7 @@
 
 import { Inject, Injectable, Logger, Optional } from "@nestjs/common";
 import type {
+  ArchiveIngestOptions,
   DataSourceConfig,
   ExtractionResult,
   ILLMProvider,
@@ -119,6 +120,7 @@ export class ScrapingPipelineService {
     regionId: string,
     onBatch?: (items: T[]) => Promise<void>,
     pipelineJobId?: string,
+    options?: ArchiveIngestOptions,
   ): Promise<ExtractionResult<T>> {
     const sourceType = source.sourceType ?? "html_scrape";
 
@@ -135,7 +137,7 @@ export class ScrapingPipelineService {
       case "pdf":
         return this.executePdfExtract<T>(source, regionId);
       case "pdf_archive":
-        return this.executePdfArchive<T>(source, regionId);
+        return this.executePdfArchive<T>(source, regionId, options);
       case "html_scrape":
       default:
         return this.executeHtmlScrape<T>(source, regionId);
@@ -151,10 +153,13 @@ export class ScrapingPipelineService {
   private async executePdfArchive<T>(
     source: DataSourceConfig,
     regionId: string,
+    options?: ArchiveIngestOptions,
   ): Promise<ExtractionResult<T>> {
-    return this.minutesIngest.execute(source, regionId) as unknown as Promise<
-      ExtractionResult<T>
-    >;
+    return this.minutesIngest.execute(
+      source,
+      regionId,
+      options,
+    ) as unknown as Promise<ExtractionResult<T>>;
   }
 
   /**


### PR DESCRIPTION
## Description

Adds operator-facing controls to the `syncRegionData` mutation so a **historical archive backfill** can be triggered from the API — no region-config edits, no manual `ingestion_watermarks` deletes (which is what we had to do by hand on prod to restore the us-ca legislative-actions corpus).

The meetings `pdf_archive` sources (`daily-journals`, `weekly-histories`) are where the historical civic record comes from — legislative actions, presence rolls (attendance), committee hearings. Their depth was fixed at the region config's `pdfArchive.maxNew` (10), and the ingestion watermark blocked re-processing already-seen documents. This exposes both as per-request knobs, parallel to the existing `maxReps`/`maxBills`.

## New mutation args

```graphql
syncRegionData(dataTypes: [MEETINGS], maxDocuments: 25, resetWatermark: true)
```

- **`maxDocuments: Int`** — overrides `pdfArchive.maxNew` for this run (how many archive PDFs to ingest). Each journal is dense (~140 actions).
- **`resetWatermark: Boolean`** — the archive walk ignores the stored watermark for this run and re-processes from the top (bounded by `maxDocuments`); item upserts are idempotent and the watermark still advances afterward.

Both are `@Roles(Role.Admin)` behind `AuthGuard`, same as `maxReps`/`maxBills`.

## Design

Threaded as a small `ArchiveIngestOptions` object (`@opuspopuli/common`) along the meetings→archive path only, to avoid churning the `maxReps`/`maxBills` plumbing:

`mutation → job (pipeline_jobs columns + BullMQ data) → region-worker → RegionSyncService → MeetingsProvider.fetchMeetingMinutes → pipeline.execute → MinutesIngestHandler` (`maxNew`/watermark override).

Touches `@opuspopuli/common`, `queue-provider`, `region-provider`, `scraping-pipeline`, `relationaldb-provider`, and the backend region service + worker + resolver.

## Type of Change

- [x] New feature (non-breaking)

## Migration

`20260722000000_pipeline_job_backfill_controls` — additive nullable `max_documents` / `reset_watermark` columns on `pipeline_jobs` (mirrors `max_reps`/`max_bills`, for observability). No rewrite, prod-safe.

## Testing

- `minutes-ingest.handler.spec`: `maxDocuments` overrides `cfg.maxNew`; `resetWatermark` re-walks with the watermark ignored and still advances it (8/8).
- `region.resolver.spec`: `maxDocuments`/`resetWatermark` thread into the enqueued job + DB create.
- `declarative-region-plugin.spec`: updated `pipeline.execute` arg-count assertion.
- Full monorepo suite + pre-push CVE/Trivy/AI reviews green.

## Rollout

Inert until `@opuspopuli/region-provider` + `@opuspopuli/scraping-pipeline` ship in the `region`/`region-worker` images (next release → Studio pull). Then a single admin `syncRegionData(dataTypes:[MEETINGS], maxDocuments: N, resetWatermark: true)` backfills the historical corpus.

## Related

Follows the us-ca meetings restoration (#911/#914/#920). Complements #919 (Senate PDF), #921 (mapped-yield heal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)