### PR TITLE
chore(postman): add meetings historical-backfill sync request

### DIFF
--- a/postman/OpusPopuli.postman_collection.json
+++ b/postman/OpusPopuli.postman_collection.json
@@ -704,6 +704,44 @@
           }
         },
         {
+          "name": "Sync — Meetings Historical Backfill (Admin)",
+          "description": "Backfill the meetings pdf_archive sources (Assembly daily-journals + weekly-histories) with per-run overrides.\n\n- maxDocuments overrides pdfArchive.maxNew for this run — how many archive PDFs to ingest. Each journal is dense (~140 legislative actions) and is an LLM extraction, so a large value makes a long, heavy sync.\n- resetWatermark re-walks the archive from the top, ignoring the stored ingestion watermark (idempotent upserts; the watermark still advances afterward).\n\nUse this to backfill historical legislative actions, presence rolls (attendance), and committee hearings. Saves sync_job_id.",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const res = pm.response.json();",
+                  "const job = res.data && res.data.syncRegionData;",
+                  "if (job && job.jobId) {",
+                  "    pm.environment.set('sync_job_id', job.jobId);",
+                  "    console.log('sync_job_id saved:', job.jobId, '— status:', job.status);",
+                  "} else {",
+                  "    console.log('No jobId in response:', JSON.stringify(res));",
+                  "}"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation SyncRegionData($dataTypes: [DataType!], $regionId: String, $maxDocuments: Int, $resetWatermark: Boolean) {\n  syncRegionData(dataTypes: $dataTypes, regionId: $regionId, maxDocuments: $maxDocuments, resetWatermark: $resetWatermark) {\n    jobId\n    status\n    triggerSource\n    regionId\n    dataTypes\n    enqueuedAt\n  }\n}",
+                "variables": "{\n  \"dataTypes\": [\"MEETINGS\"],\n  \"regionId\": \"california\",\n  \"maxDocuments\": 25,\n  \"resetWatermark\": true\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
           "name": "Sync — County Reps, All Counties (Admin)",
           "description": "Sync Board of Supervisors for all 58 enabled CA county sub-regions. Saves sync_job_id.",
           "event": [


### PR DESCRIPTION
## Description

Adds a **"Sync — Meetings Historical Backfill (Admin)"** request to the *Pipeline Jobs (Region Worker)* folder of the Postman collection, exercising the new `syncRegionData` args shipped in #923:

- `maxDocuments` — override `pdfArchive.maxNew` for this run
- `resetWatermark` — re-walk the archive ignoring the stored ingestion watermark

Default variables:
```json
{ "dataTypes": ["MEETINGS"], "regionId": "california", "maxDocuments": 25, "resetWatermark": true }
```

Saves `sync_job_id` like the sibling requests. The existing reps/bills sync requests didn't expose these args, so there was no ready payload for the archive backfill — which is exactly what tripped us up (an operator fired the old mutation and the overrides came through null).

## Type of Change

- [x] Chore / tooling

## Related

Follows #923 (backfill controls). Enables the operator historical-backfill workflow for legislative actions / attendance / committee hearings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)