### PR TITLE
chore(postman): add Regenerate Minutes Summaries (Admin) request

### DIFF
--- a/postman/OpusPopuli.postman_collection.json
+++ b/postman/OpusPopuli.postman_collection.json
@@ -742,6 +742,26 @@
           }
         },
         {
+          "name": "Regenerate Minutes Summaries (Admin)",
+          "description": "Enqueue AI-synopsis (re)generation for existing minutes rows (#813). Optionally filter by chamber via `body` (\"Assembly\" | \"Senate\") and cap with `limit`. Returns the number of jobs enqueued; the minutes-summary worker fans out and MinutesSummaryService writes minutes.summary + summary_claims. Use to backfill synopses over the historical corpus or re-run after a prompt tweak (force is applied). Requires an admin session.",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation RegenerateMinutesSummaries($body: String, $limit: Int) {\n  regenerateMinutesSummaries(body: $body, limit: $limit)\n}",
+                "variables": "{\n  \"limit\": 50\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
           "name": "Sync — County Reps, All Counties (Admin)",
           "description": "Sync Board of Supervisors for all 58 enabled CA county sub-regions. Saves sync_job_id.",
           "event": [


### PR DESCRIPTION
## Description

Adds a **"Regenerate Minutes Summaries (Admin)"** request to the *Pipeline Jobs (Region Worker)* folder for the `regenerateMinutesSummaries` mutation (#813):

```graphql
mutation RegenerateMinutesSummaries($body: String, $limit: Int) {
  regenerateMinutesSummaries(body: $body, limit: $limit)
}
```

Default `{ "limit": 50 }`. Returns the number of jobs enqueued; the minutes-summary worker fans out and writes `minutes.summary` / `summary_claims`. One-click backfill of synopses over the ingested journals (and re-run after a prompt tweak). Verified in prod — returns the eligible count and the worker populates summaries.

## Type of Change
- [x] Chore / tooling

## Related
Follows #926 (MinutesSummaryService), #929 (enqueue fix), #925 (meetings backfill request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)