### PR TITLE
Release: surface minutes AI synopsis + flagged concerns in the frontend (#932)

### DIFF
--- a/apps/frontend/__tests__/accessibility/minutes-synopsis.a11y.test.tsx
+++ b/apps/frontend/__tests__/accessibility/minutes-synopsis.a11y.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * WCAG 2.2 AA accessibility tests for the minutes synopsis + claims surface
+ * (#932). Covers the presentational pieces (synopsis panel, claim list,
+ * concerns badge) that render inside an ActionCard disclosure. The disclosure
+ * toggle's expand/collapse semantics are exercised in
+ * MinutesDisclosure.test.tsx; this file targets the rendered content for axe.
+ */
+
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+
+import { axe } from "@/__tests__/utils/a11y-utils";
+import { MinutesSynopsis } from "@/components/region/MinutesSynopsis";
+import { MinutesClaims } from "@/components/region/MinutesClaims";
+import { ConcernsBadge } from "@/components/region/ConcernsBadge";
+import type { MinutesSummaryClaim } from "@/lib/graphql/region";
+
+const claims: MinutesSummaryClaim[] = [
+  {
+    kind: "DECISION",
+    title: "Voted 5-2 to advance AB 1234",
+    detail: "The committee moved the housing bill to appropriations.",
+    citation: { quote: "the motion carried 5 to 2", pageHint: "p. 8" },
+    billRefs: ["AB 1234"],
+  },
+  {
+    kind: "CONTROVERSY",
+    title: "Dispute over fiscal note",
+    detail: "Members disagreed on the cost estimate.",
+    citation: { quote: "the fiscal note is disputed" },
+    billRefs: ["SB 99"],
+    severity: "HIGH",
+  },
+];
+
+describe("Minutes synopsis surface — WCAG 2.2 AA", () => {
+  it("synopsis panel has no axe violations", async () => {
+    const { container } = render(
+      <MinutesSynopsis summary="The committee advanced two bills and heard public comment on housing." />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("claim list has no axe violations", async () => {
+    const { container } = render(<MinutesClaims claims={claims} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("concerns badge has no axe violations", async () => {
+    const { container } = render(<ConcernsBadge claims={claims} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("claim list empty state has no axe violations", async () => {
+    const { container } = render(<MinutesClaims claims={[]} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/frontend/__tests__/components/region/ConcernsBadge.test.tsx
+++ b/apps/frontend/__tests__/components/region/ConcernsBadge.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { ConcernsBadge } from "@/components/region/ConcernsBadge";
+import type { MinutesSummaryClaim } from "@/lib/graphql/region";
+
+function claim(over: Partial<MinutesSummaryClaim>): MinutesSummaryClaim {
+  return {
+    kind: "DECISION",
+    title: "t",
+    detail: "d",
+    citation: {},
+    billRefs: [],
+    ...over,
+  };
+}
+
+function renderBadge(claims?: MinutesSummaryClaim[]) {
+  return render(<ConcernsBadge claims={claims} />);
+}
+
+describe("ConcernsBadge (#932)", () => {
+  it("renders nothing when there are no concern/controversy claims", () => {
+    const { container } = renderBadge([claim({ kind: "DECISION" })]);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for undefined claims", () => {
+    const { container } = renderBadge(undefined);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("counts only concern + controversy claims", () => {
+    renderBadge([
+      claim({ kind: "DECISION" }),
+      claim({ kind: "CONCERN", severity: "LOW" }),
+      claim({ kind: "CONTROVERSY", severity: "MEDIUM" }),
+      claim({ kind: "PUBLIC_COMMENT" }),
+    ]);
+    expect(screen.getByText("2 concerns")).toBeInTheDocument();
+  });
+
+  it("uses the singular label for a single concern", () => {
+    renderBadge([claim({ kind: "CONCERN", severity: "LOW" })]);
+    expect(screen.getByText("1 concern")).toBeInTheDocument();
+  });
+
+  it("colours to the highest severity present (HIGH → red)", () => {
+    renderBadge([
+      claim({ kind: "CONCERN", severity: "LOW" }),
+      claim({ kind: "CONTROVERSY", severity: "HIGH" }),
+    ]);
+    const badge = screen.getByText("2 concerns");
+    expect(badge).toHaveClass("bg-red-100", "text-red-800");
+  });
+
+  it("defaults a missing severity to LOW when picking the colour", () => {
+    renderBadge([claim({ kind: "CONCERN" })]);
+    const badge = screen.getByText("1 concern");
+    expect(badge).toHaveClass("bg-green-100", "text-green-800");
+  });
+});

--- a/apps/frontend/__tests__/components/region/MinutesClaims.test.tsx
+++ b/apps/frontend/__tests__/components/region/MinutesClaims.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { MinutesClaims } from "@/components/region/MinutesClaims";
+import type { MinutesSummaryClaim } from "@/lib/graphql/region";
+
+function renderClaims(claims?: MinutesSummaryClaim[]) {
+  return render(<MinutesClaims claims={claims} />);
+}
+
+describe("MinutesClaims (#932)", () => {
+  it("shows the empty state for no claims", () => {
+    renderClaims([]);
+    expect(
+      screen.getByText(
+        "No structured decisions or concerns were extracted for this session.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders kind label, severity, title, detail, quote and bill chips", () => {
+    renderClaims([
+      {
+        kind: "CONCERN",
+        title: "Raised a fiscal objection",
+        detail: "A member flagged unfunded costs.",
+        citation: { quote: "the appropriation is unfunded", pageHint: "p. 12" },
+        billRefs: ["AB 1234", "SB 9"],
+        severity: "HIGH",
+      },
+    ]);
+    expect(screen.getByText("Concern")).toBeInTheDocument();
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByText("Raised a fiscal objection")).toBeInTheDocument();
+    expect(
+      screen.getByText("A member flagged unfunded costs."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/the appropriation is unfunded/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/p\. 12/)).toBeInTheDocument();
+    expect(screen.getByText("AB 1234")).toBeInTheDocument();
+    expect(screen.getByText("SB 9")).toBeInTheDocument();
+  });
+
+  it("omits the severity tag when severity is absent", () => {
+    renderClaims([
+      {
+        kind: "DECISION",
+        title: "Advanced the bill",
+        detail: "",
+        citation: {},
+        billRefs: [],
+      },
+    ]);
+    expect(screen.getByText("Decision")).toBeInTheDocument();
+    expect(screen.queryByText("Low")).not.toBeInTheDocument();
+    expect(screen.queryByText("Medium")).not.toBeInTheDocument();
+    expect(screen.queryByText("High")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/__tests__/components/region/MinutesDisclosure.test.tsx
+++ b/apps/frontend/__tests__/components/region/MinutesDisclosure.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { MinutesDisclosure } from "@/components/region/MinutesDisclosure";
+import type { Minutes } from "@/lib/graphql/region";
+
+const mockLoad = jest.fn();
+let lazyState: {
+  data?: { minutes: Minutes | null };
+  loading: boolean;
+  error?: Error;
+  called: boolean;
+};
+
+jest.mock("@apollo/client/react", () => ({
+  useLazyQuery: () => [mockLoad, lazyState],
+}));
+
+function renderDisclosure(minutesId = "min-1") {
+  return render(<MinutesDisclosure minutesId={minutesId} />);
+}
+
+function minutes(over: Partial<Minutes> = {}): Minutes {
+  return {
+    id: "min-1",
+    externalId: "assembly-2026-07-03",
+    body: "Assembly",
+    date: "2026-07-03",
+    summary: "The committee advanced two bills and heard public comment.",
+    claims: [],
+    sourceUrl: "https://example.gov/j.pdf",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mockLoad.mockClear();
+  lazyState = {
+    data: undefined,
+    loading: false,
+    error: undefined,
+    called: false,
+  };
+});
+
+describe("MinutesDisclosure (#932)", () => {
+  it("is collapsed by default and does not fire the query until expanded", () => {
+    renderDisclosure();
+    const button = screen.getByRole("button", {
+      name: /session synopsis & concerns/i,
+    });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(mockLoad).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText(/the committee advanced/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("lazy-loads minutes(id) on expand", async () => {
+    const user = userEvent.setup();
+    renderDisclosure("min-42");
+    await user.click(screen.getByRole("button"));
+    expect(mockLoad).toHaveBeenCalledWith({ variables: { id: "min-42" } });
+    expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");
+  });
+
+  it("renders the synopsis, concern badge and claims once loaded", async () => {
+    const user = userEvent.setup();
+    lazyState.data = {
+      minutes: minutes({
+        claims: [
+          {
+            kind: "CONCERN",
+            title: "Objection raised",
+            detail: "A member flagged costs.",
+            citation: { quote: "unfunded" },
+            billRefs: ["AB 1"],
+            severity: "HIGH",
+          },
+        ],
+      }),
+    };
+    renderDisclosure();
+    await user.click(screen.getByRole("button"));
+    expect(screen.getByText(/the committee advanced/i)).toBeInTheDocument();
+    expect(screen.getByText("1 concern")).toBeInTheDocument();
+    expect(screen.getByText("Objection raised")).toBeInTheDocument();
+    expect(screen.getByText("AB 1")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when nothing was generated", async () => {
+    const user = userEvent.setup();
+    lazyState.data = { minutes: minutes({ summary: undefined, claims: [] }) };
+    renderDisclosure();
+    await user.click(screen.getByRole("button"));
+    expect(
+      screen.getByText(/no ai synopsis has been generated/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a loading message while the query is in flight", async () => {
+    const user = userEvent.setup();
+    lazyState.loading = true;
+    renderDisclosure();
+    await user.click(screen.getByRole("button"));
+    expect(screen.getByText(/loading synopsis/i)).toBeInTheDocument();
+  });
+
+  it("shows an error message when the query fails", async () => {
+    const user = userEvent.setup();
+    lazyState.error = new Error("boom");
+    renderDisclosure();
+    await user.click(screen.getByRole("button"));
+    expect(
+      screen.getByText(/couldn't load the session synopsis/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/region/ActionCard.tsx
+++ b/apps/frontend/components/region/ActionCard.tsx
@@ -7,6 +7,7 @@ import {
   formatActionTypeLabel,
   actionTypeAccentClass,
 } from "@/lib/format-action";
+import { MinutesDisclosure } from "./MinutesDisclosure";
 
 /**
  * One activity-feed row. Renders a type-coded badge, the date,
@@ -73,6 +74,11 @@ export function ActionCard({
           </button>
         )}
       </div>
+      {/* Session synopsis + flagged concerns for the source journal (#932).
+          Full cards only — compact bill-batch chips stay dense. */}
+      {!compact && action.minutesId && (
+        <MinutesDisclosure minutesId={action.minutesId} />
+      )}
     </article>
   );
 }

--- a/apps/frontend/components/region/ClaimBadges.tsx
+++ b/apps/frontend/components/region/ClaimBadges.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 
 import type { ClaimSeverity, MinutesClaimKind } from "@/lib/graphql/region";
 
+import { SEVERITY_STYLES } from "./claim-severity";
+
 /**
  * Badges for a minutes summary claim (#932). `ClaimKindBadge` colour-codes the
  * claim category (decision / concern / controversy / public comment /
@@ -42,12 +44,6 @@ export function ClaimKindBadge({ kind }: { readonly kind: MinutesClaimKind }) {
     </span>
   );
 }
-
-const SEVERITY_STYLES: Record<ClaimSeverity, string> = {
-  LOW: "bg-green-100 text-green-800",
-  MEDIUM: "bg-amber-100 text-amber-800",
-  HIGH: "bg-red-100 text-red-800",
-};
 
 const SEVERITY_I18N_KEY: Record<ClaimSeverity, string> = {
   LOW: "low",

--- a/apps/frontend/components/region/ClaimBadges.tsx
+++ b/apps/frontend/components/region/ClaimBadges.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+import type { ClaimSeverity, MinutesClaimKind } from "@/lib/graphql/region";
+
+/**
+ * Badges for a minutes summary claim (#932). `ClaimKindBadge` colour-codes the
+ * claim category (decision / concern / controversy / public comment /
+ * disclosure); `ClaimSeverityTag` renders the green→amber→red severity ramp
+ * for flagged concerns. Styling mirrors the shared region badges
+ * (PropositionStatusBadge) and the fiscal-level severity ramp on the bill page.
+ * Labels are localised via the `civics` namespace.
+ */
+
+const KIND_STYLES: Record<MinutesClaimKind, { bg: string; text: string }> = {
+  DECISION: { bg: "bg-blue-100", text: "text-blue-800" },
+  CONCERN: { bg: "bg-amber-100", text: "text-amber-800" },
+  CONTROVERSY: { bg: "bg-red-100", text: "text-red-800" },
+  PUBLIC_COMMENT: { bg: "bg-slate-100", text: "text-slate-700" },
+  DISCLOSURE: { bg: "bg-violet-100", text: "text-violet-800" },
+};
+
+/** Wire enum value → civics i18n leaf key. */
+const KIND_I18N_KEY: Record<MinutesClaimKind, string> = {
+  DECISION: "decision",
+  CONCERN: "concern",
+  CONTROVERSY: "controversy",
+  PUBLIC_COMMENT: "publicComment",
+  DISCLOSURE: "disclosure",
+};
+
+export function ClaimKindBadge({ kind }: { readonly kind: MinutesClaimKind }) {
+  const { t } = useTranslation("civics");
+  const style = KIND_STYLES[kind] ?? KIND_STYLES.PUBLIC_COMMENT;
+  const key = KIND_I18N_KEY[kind] ?? "publicComment";
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${style.bg} ${style.text}`}
+    >
+      {t(`minutes.claimKind.${key}`)}
+    </span>
+  );
+}
+
+const SEVERITY_STYLES: Record<ClaimSeverity, string> = {
+  LOW: "bg-green-100 text-green-800",
+  MEDIUM: "bg-amber-100 text-amber-800",
+  HIGH: "bg-red-100 text-red-800",
+};
+
+const SEVERITY_I18N_KEY: Record<ClaimSeverity, string> = {
+  LOW: "low",
+  MEDIUM: "medium",
+  HIGH: "high",
+};
+
+export function ClaimSeverityTag({
+  severity,
+}: {
+  readonly severity: ClaimSeverity;
+}) {
+  const { t } = useTranslation("civics");
+  const style = SEVERITY_STYLES[severity] ?? SEVERITY_STYLES.LOW;
+  const key = SEVERITY_I18N_KEY[severity] ?? "low";
+  return (
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[11px] font-medium ${style}`}
+    >
+      {t(`minutes.severity.${key}`)}
+    </span>
+  );
+}

--- a/apps/frontend/components/region/ConcernsBadge.tsx
+++ b/apps/frontend/components/region/ConcernsBadge.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+import type { ClaimSeverity, MinutesSummaryClaim } from "@/lib/graphql/region";
+
+/**
+ * At-a-glance badge aggregating a session's `concern` + `controversy` claims
+ * (#932): a count plus a colour keyed to the highest severity present, so a
+ * citizen can tell whether anything contested happened without expanding the
+ * full claim list. Renders nothing when there are no flagged items.
+ */
+
+const SEVERITY_RANK: Record<ClaimSeverity, number> = {
+  LOW: 1,
+  MEDIUM: 2,
+  HIGH: 3,
+};
+
+const BADGE_STYLE: Record<ClaimSeverity, string> = {
+  LOW: "bg-green-100 text-green-800",
+  MEDIUM: "bg-amber-100 text-amber-800",
+  HIGH: "bg-red-100 text-red-800",
+};
+
+function highestSeverity(
+  claims: readonly MinutesSummaryClaim[],
+): ClaimSeverity {
+  return claims.reduce<ClaimSeverity>((max, c) => {
+    const s = c.severity ?? "LOW";
+    return SEVERITY_RANK[s] > SEVERITY_RANK[max] ? s : max;
+  }, "LOW");
+}
+
+export function ConcernsBadge({
+  claims,
+}: {
+  readonly claims?: readonly MinutesSummaryClaim[];
+}) {
+  const { t } = useTranslation("civics");
+  const flagged = (claims ?? []).filter(
+    (c) => c.kind === "CONCERN" || c.kind === "CONTROVERSY",
+  );
+  if (flagged.length === 0) return null;
+
+  const style = BADGE_STYLE[highestSeverity(flagged)];
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${style}`}
+    >
+      <svg
+        className="w-3 h-3"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M12 9v2m0 4h.01M5.07 19h13.86a2 2 0 001.74-3l-6.93-12a2 2 0 00-3.48 0l-6.93 12a2 2 0 001.74 3z"
+        />
+      </svg>
+      {t("minutes.concerns.badge", { count: flagged.length })}
+    </span>
+  );
+}

--- a/apps/frontend/components/region/ConcernsBadge.tsx
+++ b/apps/frontend/components/region/ConcernsBadge.tsx
@@ -4,6 +4,8 @@ import { useTranslation } from "react-i18next";
 
 import type { ClaimSeverity, MinutesSummaryClaim } from "@/lib/graphql/region";
 
+import { SEVERITY_STYLES } from "./claim-severity";
+
 /**
  * At-a-glance badge aggregating a session's `concern` + `controversy` claims
  * (#932): a count plus a colour keyed to the highest severity present, so a
@@ -15,12 +17,6 @@ const SEVERITY_RANK: Record<ClaimSeverity, number> = {
   LOW: 1,
   MEDIUM: 2,
   HIGH: 3,
-};
-
-const BADGE_STYLE: Record<ClaimSeverity, string> = {
-  LOW: "bg-green-100 text-green-800",
-  MEDIUM: "bg-amber-100 text-amber-800",
-  HIGH: "bg-red-100 text-red-800",
 };
 
 function highestSeverity(
@@ -43,7 +39,7 @@ export function ConcernsBadge({
   );
   if (flagged.length === 0) return null;
 
-  const style = BADGE_STYLE[highestSeverity(flagged)];
+  const style = SEVERITY_STYLES[highestSeverity(flagged)];
   return (
     <span
       className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${style}`}

--- a/apps/frontend/components/region/MinutesClaims.tsx
+++ b/apps/frontend/components/region/MinutesClaims.tsx
@@ -45,7 +45,7 @@ function ClaimRow({
       )}
       {claim.billRefs.length > 0 && (
         <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
-          <span className="text-[11px] uppercase tracking-wide text-slate-500">
+          <span className="text-[11px] uppercase tracking-wide text-slate-600">
             {billsLabel}
           </span>
           {claim.billRefs.map((ref) => (

--- a/apps/frontend/components/region/MinutesClaims.tsx
+++ b/apps/frontend/components/region/MinutesClaims.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+import type { MinutesSummaryClaim } from "@/lib/graphql/region";
+
+import { ClaimKindBadge, ClaimSeverityTag } from "./ClaimBadges";
+
+/**
+ * Per-claim attribution list for a minutes synopsis (#932). Mirrors the
+ * `BioClaims` treatment on the rep page: each row shows a kind badge, an
+ * optional severity tag, the plain-language title + detail, the verbatim
+ * citation quote, and any referenced bills. `billRefs` are external bill
+ * identifiers (e.g. "AB 1234") rendered as chips — clickable links await a
+ * resolve-by-externalId path (fast-follow).
+ */
+
+function ClaimRow({
+  claim,
+  billsLabel,
+}: {
+  readonly claim: MinutesSummaryClaim;
+  readonly billsLabel: string;
+}) {
+  return (
+    <li className="text-sm border-l-2 border-line pl-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <ClaimKindBadge kind={claim.kind} />
+        {claim.severity && <ClaimSeverityTag severity={claim.severity} />}
+        <span className="font-medium text-content">{claim.title}</span>
+      </div>
+      {claim.detail && (
+        <p className="mt-1 text-content-dim leading-relaxed">{claim.detail}</p>
+      )}
+      {claim.citation?.quote && (
+        <blockquote className="mt-1.5 border-l-2 border-amber-200 pl-2 text-[13px] italic text-slate-600">
+          &ldquo;{claim.citation.quote}&rdquo;
+          {claim.citation.pageHint && (
+            <span className="not-italic text-slate-500">
+              {" "}
+              — {claim.citation.pageHint}
+            </span>
+          )}
+        </blockquote>
+      )}
+      {claim.billRefs.length > 0 && (
+        <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+          <span className="text-[11px] uppercase tracking-wide text-slate-500">
+            {billsLabel}
+          </span>
+          {claim.billRefs.map((ref) => (
+            <span
+              key={ref}
+              className="inline-flex items-center rounded bg-slate-100 px-1.5 py-0.5 font-mono text-[11px] text-slate-700"
+            >
+              {ref}
+            </span>
+          ))}
+        </div>
+      )}
+    </li>
+  );
+}
+
+export function MinutesClaims({
+  claims,
+}: {
+  readonly claims?: readonly MinutesSummaryClaim[];
+}) {
+  const { t } = useTranslation("civics");
+  if (!claims || claims.length === 0) {
+    return (
+      <p className="text-sm text-slate-600 italic">
+        {t("minutes.claims.empty")}
+      </p>
+    );
+  }
+  const billsLabel = t("minutes.claims.billRefsLabel");
+  return (
+    <ol className="space-y-3">
+      {claims.map((claim, idx) => (
+        <ClaimRow
+          key={`${claim.kind}-${idx}-${claim.title}`}
+          claim={claim}
+          billsLabel={billsLabel}
+        />
+      ))}
+    </ol>
+  );
+}

--- a/apps/frontend/components/region/MinutesDisclosure.tsx
+++ b/apps/frontend/components/region/MinutesDisclosure.tsx
@@ -60,12 +60,14 @@ export function MinutesDisclosure({
   const toggle = () => {
     const next = !open;
     setOpen(next);
-    if (next && !called) void load({ variables: { id: minutesId } });
+    // Fetch on first expand; also re-fire after a failed load so the "Try
+    // again" copy is actionable (a prior error leaves `called` true).
+    if (next && (!called || error)) {
+      void load({ variables: { id: minutesId } });
+    }
   };
 
-  // Apollo types lazy `data` as possibly-partial; the query selects every
-  // field the panel renders, so a full-shape narrowing is safe.
-  const minutes = data?.minutes as Minutes | null | undefined;
+  const minutes = data?.minutes;
   return (
     <div className="mt-3 border-t border-slate-100 pt-3">
       <button
@@ -78,23 +80,23 @@ export function MinutesDisclosure({
         <span aria-hidden="true">{open ? "▾" : "▸"}</span>
         {open ? t("minutes.disclosure.hide") : t("minutes.disclosure.show")}
       </button>
-      {open && (
-        <div id={panelId} className="mt-3 space-y-3">
-          {loading && (
-            <p className="text-sm text-content-dim italic">
-              {t("minutes.disclosure.loading")}
-            </p>
-          )}
-          {error && (
-            <p className="text-sm text-red-700">
-              {t("minutes.disclosure.error")}
-            </p>
-          )}
-          {!loading && !error && minutes && (
-            <MinutesPanelBody minutes={minutes} />
-          )}
-        </div>
-      )}
+      {/* Panel always present (with a stable id) so `aria-controls` resolves
+          even while collapsed; `hidden` toggles visibility for AT + sighted. */}
+      <div id={panelId} hidden={!open} className="mt-3 space-y-3">
+        {open && loading && (
+          <p className="text-sm text-content-dim italic">
+            {t("minutes.disclosure.loading")}
+          </p>
+        )}
+        {open && error && (
+          <p className="text-sm text-red-700">
+            {t("minutes.disclosure.error")}
+          </p>
+        )}
+        {open && !loading && !error && minutes && (
+          <MinutesPanelBody minutes={minutes} />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/frontend/components/region/MinutesDisclosure.tsx
+++ b/apps/frontend/components/region/MinutesDisclosure.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useId, useState } from "react";
+import { useLazyQuery } from "@apollo/client/react";
+import { useTranslation } from "react-i18next";
+
+import {
+  GET_MINUTES,
+  type IdVars,
+  type Minutes,
+  type MinutesData,
+} from "@/lib/graphql/region";
+
+import { ConcernsBadge } from "./ConcernsBadge";
+import { MinutesClaims } from "./MinutesClaims";
+import { MinutesSynopsis } from "./MinutesSynopsis";
+
+/**
+ * On-demand disclosure surfacing a session's AI synopsis + flagged concerns
+ * (#932). Rendered from an `ActionCard` when the action carries a `minutesId`,
+ * so it lands on both the committee "Recent activity" feed and the rep
+ * activity view via the shared card. The `minutes(id)` query is lazy — it
+ * fires only when the citizen expands — so a feed with dozens of actions
+ * costs nothing until a row is opened (no N+1).
+ */
+
+function MinutesPanelBody({ minutes }: { readonly minutes: Minutes }) {
+  const { t } = useTranslation("civics");
+  const hasContent =
+    Boolean(minutes.summary) || (minutes.claims?.length ?? 0) > 0;
+  if (!hasContent) {
+    return (
+      <p className="text-sm text-slate-600 italic">
+        {t("minutes.disclosure.empty")}
+      </p>
+    );
+  }
+  return (
+    <>
+      <ConcernsBadge claims={minutes.claims} />
+      <MinutesSynopsis summary={minutes.summary} />
+      <MinutesClaims claims={minutes.claims} />
+    </>
+  );
+}
+
+export function MinutesDisclosure({
+  minutesId,
+}: {
+  readonly minutesId: string;
+}) {
+  const { t } = useTranslation("civics");
+  const panelId = useId();
+  const [open, setOpen] = useState(false);
+  const [load, { data, loading, error, called }] = useLazyQuery<
+    MinutesData,
+    IdVars
+  >(GET_MINUTES);
+
+  const toggle = () => {
+    const next = !open;
+    setOpen(next);
+    if (next && !called) void load({ variables: { id: minutesId } });
+  };
+
+  // Apollo types lazy `data` as possibly-partial; the query selects every
+  // field the panel renders, so a full-shape narrowing is safe.
+  const minutes = data?.minutes as Minutes | null | undefined;
+  return (
+    <div className="mt-3 border-t border-slate-100 pt-3">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={open}
+        aria-controls={panelId}
+        className="inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline"
+      >
+        <span aria-hidden="true">{open ? "▾" : "▸"}</span>
+        {open ? t("minutes.disclosure.hide") : t("minutes.disclosure.show")}
+      </button>
+      {open && (
+        <div id={panelId} className="mt-3 space-y-3">
+          {loading && (
+            <p className="text-sm text-content-dim italic">
+              {t("minutes.disclosure.loading")}
+            </p>
+          )}
+          {error && (
+            <p className="text-sm text-red-700">
+              {t("minutes.disclosure.error")}
+            </p>
+          )}
+          {!loading && !error && minutes && (
+            <MinutesPanelBody minutes={minutes} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/components/region/MinutesSynopsis.tsx
+++ b/apps/frontend/components/region/MinutesSynopsis.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+/**
+ * AI-generated plain-English synopsis of a minutes / journal session (#932,
+ * data from #813). Mirrors the shared `ActivitySummary` affordance — amber
+ * card, "AI-generated" pill, provenance disclaimer — so users always know
+ * which content is machine-summarised. Renders nothing until a synopsis
+ * exists (`summary` is null until MinutesSummaryService runs).
+ */
+export function MinutesSynopsis({
+  summary,
+}: {
+  readonly summary?: string | null;
+}) {
+  const { t } = useTranslation("civics");
+  if (!summary || summary.trim().length === 0) return null;
+
+  return (
+    <section
+      aria-label={t("minutes.aiPanel.heading")}
+      className="bg-amber-50/40 border border-amber-200 rounded-lg p-4"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-50 text-amber-800 border border-amber-200">
+          <svg
+            className="w-3 h-3"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M13 10V3L4 14h7v7l9-11h-7z"
+            />
+          </svg>
+          {t("minutes.aiPanel.badge")}
+        </span>
+        <span className="text-[11px] uppercase tracking-wider font-bold text-content-dim">
+          {t("minutes.aiPanel.heading")}
+        </span>
+      </div>
+      <p className="text-content-dim leading-relaxed whitespace-pre-line">
+        {summary}
+      </p>
+      <p className="mt-3 text-[11px] text-content-dim italic">
+        {t("minutes.aiPanel.disclaimer")}
+      </p>
+    </section>
+  );
+}

--- a/apps/frontend/components/region/claim-severity.ts
+++ b/apps/frontend/components/region/claim-severity.ts
@@ -1,0 +1,12 @@
+import type { ClaimSeverity } from "@/lib/graphql/region";
+
+/**
+ * Shared severity → Tailwind colour ramp for minutes claim badges (#932),
+ * mirroring the fiscal-level ramp on the bill page (green → amber → red).
+ * Single source of truth for both `ClaimSeverityTag` and `ConcernsBadge`.
+ */
+export const SEVERITY_STYLES: Record<ClaimSeverity, string> = {
+  LOW: "bg-green-100 text-green-800",
+  MEDIUM: "bg-amber-100 text-amber-800",
+  HIGH: "bg-red-100 text-red-800",
+};

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -343,6 +343,72 @@ export interface PaginatedLegislativeActions {
   hasMore: boolean;
 }
 
+// ============================================
+// MINUTES AI SYNOPSIS + CLAIMS (issue #932 — data from #813 / #926)
+// ============================================
+
+/**
+ * Category of a minutes summary claim. GraphQL `MinutesClaimKind` enum —
+ * the wire value is the SCREAMING_SNAKE key (backend maps to lowercase).
+ */
+export type MinutesClaimKind =
+  | "DECISION"
+  | "CONCERN"
+  | "CONTROVERSY"
+  | "PUBLIC_COMMENT"
+  | "DISCLOSURE";
+
+/** Severity of a flagged minutes concern. GraphQL `ClaimSeverity` enum. */
+export type ClaimSeverity = "LOW" | "MEDIUM" | "HIGH";
+
+/** Citation anchoring a claim back into the minutes source text. */
+export interface MinutesSummaryCitation {
+  /** Optional page/section hint from the PDF, e.g. "p. 12". */
+  pageHint?: string;
+  /** Verbatim supporting quote from the minutes text. */
+  quote?: string;
+}
+
+/**
+ * A structured decision or flagged concern extracted from a minutes
+ * document by MinutesSummaryService (#813). Rendered as a per-claim row
+ * (kind badge + severity + citation + bill links) mirroring BioClaims.
+ */
+export interface MinutesSummaryClaim {
+  kind: MinutesClaimKind;
+  /** Short headline, e.g. "Voted 5-2 to advance AB 1234". */
+  title: string;
+  /** 1-2 sentence plain-language context. */
+  detail: string;
+  citation: MinutesSummaryCitation;
+  /** External IDs of bills referenced — link to bill pages. */
+  billRefs: string[];
+  severity?: ClaimSeverity;
+}
+
+/**
+ * A meeting-minutes / journal document with its AI synopsis + claims (#813).
+ * `summary` is null and `claims` empty until MinutesSummaryService runs.
+ */
+export interface Minutes {
+  id: string;
+  externalId: string;
+  /** "Assembly" | "Senate". */
+  body: string;
+  date: string;
+  /** Plain-English synopsis — null until generated. */
+  summary?: string;
+  claims: MinutesSummaryClaim[];
+  sourceUrl: string;
+  pageCount?: number;
+  parsedAt?: string;
+}
+
+/** Result shape for GET_MINUTES (nullable — id may not resolve). */
+export interface MinutesData {
+  minutes: Minutes | null;
+}
+
 /**
  * At-a-glance counters for the rep detail page Layer 3
  * ("What They've Done"). Drives the top-of-L3 stats grid.
@@ -1398,6 +1464,35 @@ export const GET_MINUTES_PASSAGE = gql`
       passageEnd
       passageText
       sectionContext
+    }
+  }
+`;
+
+/**
+ * A single minutes / journal document with its AI synopsis + structured
+ * claims (#813). Lazy-loaded on demand from an ActionCard when the action
+ * carries a `minutesId`. Reuses the shared `IdVars` variables type.
+ */
+export const GET_MINUTES = gql`
+  query GetMinutes($id: ID!) {
+    minutes(id: $id) {
+      id
+      externalId
+      body
+      date
+      summary
+      sourceUrl
+      claims {
+        kind
+        title
+        detail
+        severity
+        billRefs
+        citation {
+          pageHint
+          quote
+        }
+      }
     }
   }
 `;

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -397,7 +397,7 @@ export interface Minutes {
   body: string;
   date: string;
   /** Plain-English synopsis — null until generated. */
-  summary?: string;
+  summary?: string | null;
   claims: MinutesSummaryClaim[];
   sourceUrl: string;
   pageCount?: number;
@@ -1477,11 +1477,7 @@ export const GET_MINUTES = gql`
   query GetMinutes($id: ID!) {
     minutes(id: $id) {
       id
-      externalId
-      body
-      date
       summary
-      sourceUrl
       claims {
         kind
         title

--- a/apps/frontend/locales/en/civics.json
+++ b/apps/frontend/locales/en/civics.json
@@ -41,5 +41,40 @@
     "title": "How Your Government Works",
     "subtitle": "A plain-language guide to {{regionName}}'s legislative process",
     "noData": "Civics data is still being indexed. Check back soon."
+  },
+  "minutes": {
+    "disclosure": {
+      "show": "Session synopsis & concerns",
+      "hide": "Hide session synopsis",
+      "loading": "Loading synopsis…",
+      "error": "Couldn't load the session synopsis. Try again.",
+      "empty": "No AI synopsis has been generated for this session yet."
+    },
+    "aiPanel": {
+      "badge": "AI-generated",
+      "heading": "Session synopsis",
+      "disclaimer": "May contain inaccuracies — verify against the source journal before citing."
+    },
+    "claims": {
+      "heading": "Decisions & flagged items",
+      "empty": "No structured decisions or concerns were extracted for this session.",
+      "billRefsLabel": "Bills"
+    },
+    "claimKind": {
+      "decision": "Decision",
+      "concern": "Concern",
+      "controversy": "Controversy",
+      "publicComment": "Public comment",
+      "disclosure": "Disclosure"
+    },
+    "severity": {
+      "low": "Low",
+      "medium": "Medium",
+      "high": "High"
+    },
+    "concerns": {
+      "badge_one": "{{count}} concern",
+      "badge_other": "{{count}} concerns"
+    }
   }
 }

--- a/apps/frontend/locales/en/civics.json
+++ b/apps/frontend/locales/en/civics.json
@@ -56,7 +56,6 @@
       "disclaimer": "May contain inaccuracies — verify against the source journal before citing."
     },
     "claims": {
-      "heading": "Decisions & flagged items",
       "empty": "No structured decisions or concerns were extracted for this session.",
       "billRefsLabel": "Bills"
     },

--- a/apps/frontend/locales/es/civics.json
+++ b/apps/frontend/locales/es/civics.json
@@ -41,5 +41,40 @@
     "title": "Cómo funciona su gobierno",
     "subtitle": "Una guía en lenguaje sencillo del proceso legislativo de {{regionName}}",
     "noData": "Los datos cívicos aún se están indexando. Vuelva pronto."
+  },
+  "minutes": {
+    "disclosure": {
+      "show": "Síntesis de la sesión e inquietudes",
+      "hide": "Ocultar la síntesis de la sesión",
+      "loading": "Cargando síntesis…",
+      "error": "No se pudo cargar la síntesis de la sesión. Inténtelo de nuevo.",
+      "empty": "Aún no se ha generado una síntesis con IA para esta sesión."
+    },
+    "aiPanel": {
+      "badge": "Generado por IA",
+      "heading": "Síntesis de la sesión",
+      "disclaimer": "Puede contener imprecisiones — verifique con el acta original antes de citar."
+    },
+    "claims": {
+      "heading": "Decisiones y asuntos señalados",
+      "empty": "No se extrajeron decisiones ni inquietudes estructuradas de esta sesión.",
+      "billRefsLabel": "Proyectos"
+    },
+    "claimKind": {
+      "decision": "Decisión",
+      "concern": "Inquietud",
+      "controversy": "Controversia",
+      "publicComment": "Comentario público",
+      "disclosure": "Divulgación"
+    },
+    "severity": {
+      "low": "Baja",
+      "medium": "Media",
+      "high": "Alta"
+    },
+    "concerns": {
+      "badge_one": "{{count}} inquietud",
+      "badge_other": "{{count}} inquietudes"
+    }
   }
 }

--- a/apps/frontend/locales/es/civics.json
+++ b/apps/frontend/locales/es/civics.json
@@ -56,7 +56,6 @@
       "disclaimer": "Puede contener imprecisiones — verifique con el acta original antes de citar."
     },
     "claims": {
-      "heading": "Decisiones y asuntos señalados",
       "empty": "No se extrajeron decisiones ni inquietudes estructuradas de esta sesión.",
       "billRefsLabel": "Proyectos"
     },

--- a/postman/OpusPopuli.postman_collection.json
+++ b/postman/OpusPopuli.postman_collection.json
@@ -742,6 +742,26 @@
           }
         },
         {
+          "name": "Regenerate Minutes Summaries (Admin)",
+          "description": "Enqueue AI-synopsis (re)generation for existing minutes rows (#813). Optionally filter by chamber via `body` (\"Assembly\" | \"Senate\") and cap with `limit`. Returns the number of jobs enqueued; the minutes-summary worker fans out and MinutesSummaryService writes minutes.summary + summary_claims. Use to backfill synopses over the historical corpus or re-run after a prompt tweak (force is applied). Requires an admin session.",
+          "request": {
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "graphql",
+              "graphql": {
+                "query": "mutation RegenerateMinutesSummaries($body: String, $limit: Int) {\n  regenerateMinutesSummaries(body: $body, limit: $limit)\n}",
+                "variables": "{\n  \"limit\": 50\n}"
+              }
+            },
+            "url": {
+              "raw": "{{gateway_url}}/api",
+              "host": ["{{gateway_url}}"],
+              "path": ["api"]
+            }
+          }
+        },
+        {
           "name": "Sync — County Reps, All Counties (Admin)",
           "description": "Sync Board of Supervisors for all 58 enabled CA county sub-regions. Saves sync_job_id.",
           "event": [


### PR DESCRIPTION
## Release: minutes AI synopsis in the frontend

Promotes `develop` → `main`. Contains **2 PRs** since the last release (#930).

Suggested version: **1.1.0** (minor — one new non-breaking user-facing feature; no fixes, no breaking changes).

### ✨ Features
- **Surface minutes AI synopsis + flagged concerns** (#933, closes #932)
  The #813/#926 minutes synopsis (`minutes.summary`) and structured claims (decisions / concerns / controversies / public comment / disclosures) are now surfaced in the UI via an on-demand disclosure on the shared legislative-action card — landing on both the **Legislative Committee "Recent activity"** feed and the **Representative activity** view (no top-level meetings browser). Each entry shows a kind badge, severity, the verbatim citation quote, referenced-bill chips, and an at-a-glance concerns badge. The `minutes(id)` query is lazy (fires only on expand — no N+1); localized EN/ES; passes WCAG 2.2 AA (jest-axe).

### 🧰 Chores
- Postman: add **Regenerate Minutes Summaries (Admin)** request (#931)

### Verification
- Frontend-only — no backend, schema, federation, or migration changes. Consumes the already-federated `minutes(id)` query shipped in #926.
- Reviewed via `/op-review` (no blockers) and `/security-review` (clean — no critical/high/medium).
- CI green on #933; full workspace test suite passed in pre-commit.

### Issue closure
- #932 — closed ✅ (on #933's merge to develop)
- #931 — chore, no linked issue (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
