### PR TITLE
fix(finance): un-orphan campaign-finance hub + fix CVR2 Form-410 routing (#936)

### DIFF
--- a/apps/frontend/__tests__/pages/region/page.test.tsx
+++ b/apps/frontend/__tests__/pages/region/page.test.tsx
@@ -239,5 +239,27 @@ describe("RegionPage", () => {
         screen.queryByText("Legislative Committees"),
       ).not.toBeInTheDocument();
     });
+
+    it("gates Legislative Committees on MEETINGS without hiding Campaign Finance (#936)", () => {
+      // MEETINGS absent → no committees card; CAMPAIGN_FINANCE still renders
+      // its own finance card (the two are decoupled).
+      mockQueryResult = {
+        data: {
+          regionInfo: {
+            ...mockRegionInfo,
+            supportedDataTypes: ["PROPOSITIONS", "CAMPAIGN_FINANCE"],
+          },
+        },
+        loading: false,
+        error: null,
+      };
+
+      render(<RegionPage />);
+
+      expect(screen.getByText("Campaign Finance")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Legislative Committees"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/frontend/__tests__/pages/region/page.test.tsx
+++ b/apps/frontend/__tests__/pages/region/page.test.tsx
@@ -109,11 +109,12 @@ describe("RegionPage", () => {
       // forward-looking calendar entries are lower civic-action value.
       expect(screen.queryByText("Meetings")).not.toBeInTheDocument();
       expect(screen.getByText("Representatives")).toBeInTheDocument();
-      // The CAMPAIGN_FINANCE data-type slot now displays as the
-      // Legislative Committees card on the home page; the campaign-finance
-      // hub stays reachable via direct URL and from proposition pages.
+      // Campaign Finance has its own front door again (#936) — no longer
+      // hijacked to render legislative-committees.
+      expect(screen.getByText("Campaign Finance")).toBeInTheDocument();
+      // Legislative Committees renders as its own card, gated on MEETINGS
+      // support (derived from minutes ingestion, not a backend DataType).
       expect(screen.getByText("Legislative Committees")).toBeInTheDocument();
-      expect(screen.queryByText("Campaign Finance")).not.toBeInTheDocument();
     });
 
     it("should render data type descriptions", () => {
@@ -162,6 +163,15 @@ describe("RegionPage", () => {
       expect(legislativeCommitteesLink).toHaveAttribute(
         "href",
         "/region/legislative-committees",
+      );
+
+      // Campaign Finance now links to its own hub (#936).
+      const campaignFinanceLink = screen.getByRole("link", {
+        name: /Campaign Finance/i,
+      });
+      expect(campaignFinanceLink).toHaveAttribute(
+        "href",
+        "/region/campaign-finance",
       );
     });
 

--- a/apps/frontend/app/region/page.tsx
+++ b/apps/frontend/app/region/page.tsx
@@ -35,18 +35,16 @@ const DATA_TYPE_CARDS: Partial<
     href: "/region/representatives",
     icon: "users",
   },
-  // Repurposed — the underlying DataType key (CAMPAIGN_FINANCE) is what
-  // the backend advertises in `supportedDataTypes`, but the home-page card
-  // now points at the new legislative-committees hub. The campaign-finance
-  // hub at /region/campaign-finance stays reachable via direct URL and
-  // from each proposition's funding section; only the home front door
-  // changes — voters get more value from "what shapes a bill before it
-  // hits the floor" than from disconnected donor lists.
+  // Campaign finance gets its own front door again (#936). It was briefly
+  // repurposed to point at legislative-committees, which orphaned finance
+  // (no inbound link for signed-in users) and conflated two unrelated
+  // "committee" concepts — FPPC campaign filers vs. Assembly/Senate policy
+  // committees. Legislative Committees now renders as its own card below.
   CAMPAIGN_FINANCE: {
-    title: "Legislative Committees",
-    description: "Where bills get debated and shaped before the floor vote",
-    href: "/region/legislative-committees",
-    icon: "committee",
+    title: "Campaign Finance",
+    description: "Follow the money — donors, committees, and spending",
+    href: "/region/campaign-finance",
+    icon: "finance",
   },
   BILLS: {
     title: "Bills",
@@ -162,6 +160,36 @@ function DataTypeIcon({ type }: { readonly type: string }) {
   }
 }
 
+/** A single region-hub navigation card. Shared by the data-type-driven
+ *  cards and the derived Legislative Committees card so the markup lives
+ *  in one place (#936). */
+function RegionCard({
+  href,
+  icon,
+  title,
+  description,
+}: {
+  readonly href: string;
+  readonly icon: string;
+  readonly title: string;
+  readonly description: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="group bg-surface rounded-lg p-6 transition-all duration-200"
+    >
+      <div className="text-content-dim group-hover:text-content transition-colors mb-4">
+        <DataTypeIcon type={icon} />
+      </div>
+      <h2 className="text-lg font-semibold text-content group-hover:text-blue-600 transition-colors">
+        {title}
+      </h2>
+      <p className="mt-1 text-sm text-content-dim">{description}</p>
+    </Link>
+  );
+}
+
 export default function RegionPage() {
   const { data, loading, error } = useQuery<RegionInfoData>(GET_REGION_INFO);
 
@@ -219,25 +247,20 @@ export default function RegionPage() {
         {regionInfo?.supportedDataTypes.map((dataType) => {
           const card = DATA_TYPE_CARDS[dataType];
           if (!card) return null;
-
-          return (
-            <Link
-              key={dataType}
-              href={card.href}
-              className="group bg-surface rounded-lg p-6 transition-all duration-200"
-            >
-              <div className="text-content-dim group-hover:text-content transition-colors mb-4">
-                <DataTypeIcon type={card.icon} />
-              </div>
-              <h2 className="text-lg font-semibold text-content group-hover:text-blue-600 transition-colors">
-                {card.title}
-              </h2>
-              <p className="mt-1 text-sm text-content-dim">
-                {card.description}
-              </p>
-            </Link>
-          );
+          return <RegionCard key={dataType} {...card} />;
         })}
+        {/* Legislative Committees isn't a backend DataType — it's derived
+            from minutes/meetings ingestion — so it renders as its own card
+            (no longer hijacking the CAMPAIGN_FINANCE key), gated on MEETINGS
+            support. #936. */}
+        {regionInfo?.supportedDataTypes.includes("MEETINGS") && (
+          <RegionCard
+            href="/region/legislative-committees"
+            icon="committee"
+            title="Legislative Committees"
+            description="Where bills get debated and shaped before the floor vote"
+          />
+        )}
       </div>
 
       {/* Civics Hub */}

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1127,5 +1127,58 @@ describe("DomainMapperService", () => {
         supportOrOppose: "oppose",
       });
     });
+
+    it("routes 'Committee Positions' (CVR2/Form 410) to measure filings, not committees (#936)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "CVR2-1",
+              filingId: "F123",
+              ballotName: "Clean Water Act",
+              ballotNumber: "Prop 5",
+              ballotJurisdiction: "STATEWIDE",
+              supportOrOppose: "S",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          // Category contains "committee" — must NOT misroute to mapCommittee.
+          category: "CAL-ACCESS Committee Positions",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.items[0]).toMatchObject({
+        externalId: "CVR2-1",
+        filingId: "F123",
+        ballotName: "Clean Water Act",
+        ballotNumber: "Prop 5",
+        supportOrOppose: "support",
+      });
+    });
+
+    it("drops a 'Committee Positions' row missing filingId rather than treating it as a committee (#936)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "x",
+              name: "Some PAC",
+              type: "OTHER",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Committee Positions",
+        }),
+      );
+
+      expect(result.items).toHaveLength(0);
+    });
   });
 });

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1160,6 +1160,50 @@ describe("DomainMapperService", () => {
       });
     });
 
+    it("maps an 'O' support/oppose code on a measure filing to oppose (#936)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "CVR2-2",
+              filingId: "F200",
+              ballotNumber: "Prop 9",
+              supportOrOppose: "O",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Committee Positions",
+        }),
+      );
+
+      expect(result.items[0]).toMatchObject({ supportOrOppose: "oppose" });
+    });
+
+    it("drops a CVR2 row that carries no ballotName/ballotNumber (non-ballot declaration) (#936)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "CVR2-3",
+              filingId: "F300",
+              // no ballotName, no ballotNumber — entity declaration, not a measure
+              supportOrOppose: "S",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Committee Positions",
+        }),
+      );
+
+      expect(result.items).toHaveLength(0);
+    });
+
     it("drops a 'Committee Positions' row missing filingId rather than treating it as a committee (#936)", () => {
       const result = mapper.map(
         createRawResult({

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -116,7 +116,7 @@ export class DomainMapperService {
     // otherwise misroute to mapCommittee and be rejected for having no `name`
     // — the reason cvr2_filings sat at 0 and no committee→measure link ever
     // formed (#936).
-    if (cat.includes("position") || cat.includes("cvr2")) {
+    if (cat.includes("committee position") || cat.includes("cvr2")) {
       return this.mapCommitteeMeasureFiling(record);
     } else if (cat.includes("independent") || cat.includes("s496")) {
       return this.mapIndependentExpenditure(record);
@@ -236,7 +236,15 @@ export class DomainMapperService {
       );
       return null;
     }
-    return result.data;
+    const filing = result.data;
+    // Most CVR2 rows are non-ballot entity declarations. Only ballot-measure
+    // declarations (a ballotName or ballotNumber) are useful — the
+    // proposition-finance-linker resolves by those — so drop the rest here
+    // rather than persisting noise the linker would skip anyway. #936.
+    if (!filing.ballotName && !filing.ballotNumber) {
+      return null;
+    }
+    return filing;
   }
 
   private mapContribution(
@@ -866,9 +874,10 @@ const IndependentExpenditureSchema = z.object({
 });
 
 // CVR2 / Form 410 ballot-measure declaration (#936). externalId + filingId are
-// required; ballot fields are optional because most CVR2 rows are non-ballot
-// entity declarations — the proposition-finance-linker filters those out at
-// resolve time by requiring a non-empty ballotName/ballotNumber.
+// required; ballot fields are optional at the schema level, but
+// mapCommitteeMeasureFiling drops any row carrying neither a ballotName nor a
+// ballotNumber — only ballot-measure declarations are useful for the
+// proposition-finance-linker, which resolves by ballotName/ballotNumber.
 const CommitteeMeasureFilingSchema = z.object({
   externalId: z.string().min(1),
   filingId: z.string().min(1),

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -19,6 +19,7 @@ import {
   type Contribution,
   type Expenditure,
   type IndependentExpenditure,
+  type CommitteeMeasureFiling,
   type RawExtractionResult,
   type ExtractionResult,
   type DataSourceConfig,
@@ -78,6 +79,7 @@ export class DomainMapperService {
     | Contribution
     | Expenditure
     | IndependentExpenditure
+    | CommitteeMeasureFiling
     | null {
     switch (source.dataType) {
       case DataType.PROPOSITIONS:
@@ -99,13 +101,27 @@ export class DomainMapperService {
   private mapCampaignFinanceItem(
     record: Record<string, unknown>,
     category?: string,
-  ): Committee | Contribution | Expenditure | IndependentExpenditure | null {
+  ):
+    | Committee
+    | Contribution
+    | Expenditure
+    | IndependentExpenditure
+    | CommitteeMeasureFiling
+    | null {
     const cat = (category ?? "").toLowerCase();
 
-    if (cat.includes("committee")) {
-      return this.mapCommittee(record);
+    // CVR2 / Form 410 ballot-measure declarations MUST be checked before the
+    // generic "committee" branch: the CA source category is "CAL-ACCESS
+    // Committee Positions", which also contains "committee" and would
+    // otherwise misroute to mapCommittee and be rejected for having no `name`
+    // — the reason cvr2_filings sat at 0 and no committee→measure link ever
+    // formed (#936).
+    if (cat.includes("position") || cat.includes("cvr2")) {
+      return this.mapCommitteeMeasureFiling(record);
     } else if (cat.includes("independent") || cat.includes("s496")) {
       return this.mapIndependentExpenditure(record);
+    } else if (cat.includes("committee")) {
+      return this.mapCommittee(record);
     } else if (cat.includes("expenditure")) {
       return this.mapExpenditure(record);
     } else if (cat.includes("contribution")) {
@@ -205,6 +221,19 @@ export class DomainMapperService {
     const result = CommitteeSchema.safeParse(record);
     if (!result.success) {
       this.logger.debug(`Committee validation failed: ${result.error.message}`);
+      return null;
+    }
+    return result.data;
+  }
+
+  private mapCommitteeMeasureFiling(
+    record: Record<string, unknown>,
+  ): CommitteeMeasureFiling | null {
+    const result = CommitteeMeasureFilingSchema.safeParse(record);
+    if (!result.success) {
+      this.logger.debug(
+        `Committee measure filing validation failed: ${result.error.message}`,
+      );
       return null;
     }
     return result.data;
@@ -833,5 +862,35 @@ const IndependentExpenditureSchema = z.object({
     .nullable()
     .transform((v) => v ?? undefined)
     .optional(),
+  sourceSystem: z.enum(["cal_access", "fec"]),
+});
+
+// CVR2 / Form 410 ballot-measure declaration (#936). externalId + filingId are
+// required; ballot fields are optional because most CVR2 rows are non-ballot
+// entity declarations — the proposition-finance-linker filters those out at
+// resolve time by requiring a non-empty ballotName/ballotNumber.
+const CommitteeMeasureFilingSchema = z.object({
+  externalId: z.string().min(1),
+  filingId: z.string().min(1),
+  ballotName: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined)
+    .optional(),
+  ballotNumber: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined)
+    .optional(),
+  ballotJurisdiction: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined)
+    .optional(),
+  supportOrOppose: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((val) => (val ? supportOpposeTransform(val) : undefined)),
   sourceSystem: z.enum(["cal_access", "fec"]),
 });


### PR DESCRIPTION
## Description

Two related campaign-finance fixes (part of the #936 epic — weave finance into entity pages).

### 1. Un-orphan the finance pages + de-conflate the region hub (Path b)
The region hub had repurposed its `CAMPAIGN_FINANCE` card to point at `/region/legislative-committees`, leaving the finance hub with **no inbound link for signed-in users** and conflating two unrelated "committee" concepts (FPPC campaign filers vs. Assembly/Senate policy committees).
- Restore `CAMPAIGN_FINANCE` → `/region/campaign-finance` (finance icon).
- Render **Legislative Committees** as its own card, gated on `MEETINGS` support (it's derived from minutes ingestion, not a backend DataType).
- Extract a shared `RegionCard` (removes the duplicated markup).

The four finance pages already query with just `skip`/`take`, so they render the full scraped dataset (3.8M contributions, 43K committees, 5K expenditures) — this just makes them reachable again.

### 2. Fix CVR2 / Form 410 routing so committee↔measure links can form
Campaign-finance records route through the domain mapper by category substring. The CVR2 source's category is **"CAL-ACCESS Committee Positions"**, which matched `cat.includes("committee")` → `mapCommittee` → rejected (no `name`). The router had **no committee-measure-filing branch at all**, so `cvr2_filings` sat at 0 in prod and no committee ever linked to a proposition.
- Add a CVR2/positions routing branch (matched on `"committee position"`/`"cvr2"`, before the generic committee branch) + `mapCommitteeMeasureFiling` + `CommitteeMeasureFilingSchema`; widen the mapper return unions.
- Only ballot-measure declarations (a ballotName/ballotNumber) are kept — non-ballot CVR2 rows are dropped.

> Inert until a finance re-scrape runs on a deployed build. Diagnosed as part of #936; the deeper blocker (committees are opaque IDs — no filer roster ingested) is tracked in the epic and is the next work.

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactoring (no functional changes) — RegionCard extraction

## Related Issues
Relates to #936

## Checklist
### Code Quality
- [x] Follows coding standards
- [x] `pnpm lint` clean
- [x] `pnpm test` passes (full suite ran in pre-commit)
- [x] Added tests (CVR2 routing incl. ballot-less drop + O→oppose; frontend MEETINGS gate)

### Accessibility
- [x] Region hub cards unchanged in structure; a11y unaffected

- [x] Platform code, not region-specific configuration

## Additional Notes
Reviewed via `/op-review` (no blockers) and `/security-review` (clean — no critical/high/medium). All suggestions applied. No backend schema/federation/migration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
