### PR TITLE
feat(region): enrich committees from filer roster + map committee types (#939, #940)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
@@ -1,0 +1,121 @@
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import type { CampaignFinanceResult } from '@opuspopuli/common';
+import { CampaignFinanceSyncService } from './campaign-finance-sync.service';
+
+type RosterCommittee = CampaignFinanceResult['committees'][number];
+
+function build() {
+  const upsert = jest.fn((args: unknown) => ({ __op: args }));
+  const $transaction = jest.fn().mockResolvedValue([]);
+  const db = { committee: { upsert }, $transaction } as unknown as DbService;
+  const svc = new CampaignFinanceSyncService(db);
+  return { svc, upsert, $transaction };
+}
+
+function committee(over: Partial<RosterCommittee> = {}): RosterCommittee {
+  return {
+    externalId: 'C001',
+    name: 'Friends of Jane Doe',
+    type: 'candidate',
+    candidateName: 'Doe',
+    candidateOffice: 'ASM',
+    party: 'DEM',
+    status: 'active',
+    sourceSystem: 'cal_access',
+    ...over,
+  } as RosterCommittee;
+}
+
+function result(committees: RosterCommittee[]): CampaignFinanceResult {
+  return {
+    committees,
+    contributions: [],
+    expenditures: [],
+    independentExpenditures: [],
+    committeeMeasureFilings: [],
+  };
+}
+
+const enrich = (svc: CampaignFinanceSyncService, data: CampaignFinanceResult) =>
+  (
+    svc as unknown as {
+      enrichCommittees: (d: CampaignFinanceResult) => Promise<void>;
+    }
+  ).enrichCommittees(data);
+
+describe('CampaignFinanceSyncService.enrichCommittees (#939)', () => {
+  it('upserts each roster committee by externalId with its real identity', async () => {
+    const { svc, upsert, $transaction } = build();
+    await enrich(svc, result([committee()]));
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const args = upsert.mock.calls[0][0] as {
+      where: unknown;
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    };
+    // keyed by externalId → enriches the existing row in place (no id churn)
+    expect(args.where).toEqual({ externalId: 'C001' });
+    expect(args.create).toMatchObject({
+      externalId: 'C001',
+      name: 'Friends of Jane Doe',
+      type: 'candidate',
+      candidateName: 'Doe',
+      candidateOffice: 'ASM',
+    });
+    expect(args.update).toMatchObject({
+      name: 'Friends of Jane Doe',
+      type: 'candidate',
+      candidateName: 'Doe',
+    });
+    expect($transaction).toHaveBeenCalled();
+  });
+
+  it('dedups repeated cover-page rows by externalId (last wins)', async () => {
+    const { svc, upsert } = build();
+    await enrich(
+      svc,
+      result([
+        committee({ name: 'Stale Name' }),
+        committee({ name: 'Current Name' }),
+      ]),
+    );
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const create = (
+      upsert.mock.calls[0][0] as { create: Record<string, unknown> }
+    ).create;
+    expect(create.name).toBe('Current Name');
+  });
+
+  it('never blanks an existing candidate/party field when a filing lacks it', async () => {
+    const { svc, upsert } = build();
+    await enrich(
+      svc,
+      result([
+        committee({
+          candidateName: undefined,
+          candidateOffice: undefined,
+          party: undefined,
+        }),
+      ]),
+    );
+
+    const update = (
+      upsert.mock.calls[0][0] as { update: Record<string, unknown> }
+    ).update;
+    expect(update).not.toHaveProperty('candidateName');
+    expect(update).not.toHaveProperty('candidateOffice');
+    expect(update).not.toHaveProperty('party');
+    // name + type always refresh (roster is authoritative for those)
+    expect(update.name).toBeDefined();
+    expect(update.type).toBeDefined();
+  });
+
+  it('is a no-op when there are no roster committees', async () => {
+    const { svc, upsert, $transaction } = build();
+    await enrich(svc, result([]));
+    expect(upsert).not.toHaveBeenCalled();
+    expect($transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
@@ -12,7 +12,9 @@ function build() {
   return { svc, upsert, $transaction };
 }
 
-function committee(over: Partial<RosterCommittee> = {}): RosterCommittee {
+function committee(
+  over: Partial<Omit<RosterCommittee, 'type'>> & { type?: string } = {},
+): RosterCommittee {
   return {
     externalId: 'C001',
     name: 'Friends of Jane Doe',
@@ -110,6 +112,34 @@ describe('CampaignFinanceSyncService.enrichCommittees (#939)', () => {
     // name + type always refresh (roster is authoritative for those)
     expect(update.name).toBeDefined();
     expect(update.type).toBeDefined();
+  });
+
+  it('does not overwrite an enriched type with a later blank (other) filing', async () => {
+    const { svc, upsert } = build();
+    await enrich(svc, result([committee({ type: 'other' })]));
+
+    const update = (
+      upsert.mock.calls[0][0] as { update: Record<string, unknown> }
+    ).update;
+    // 'other' must not downgrade a committee already typed candidate/pac/etc.
+    expect(update).not.toHaveProperty('type');
+    // a recognized type still refreshes
+    upsert.mockClear();
+    await enrich(svc, result([committee({ type: 'candidate' })]));
+    const update2 = (
+      upsert.mock.calls[0][0] as { update: Record<string, unknown> }
+    ).update;
+    expect(update2.type).toBe('candidate');
+  });
+
+  it('skips roster records with no externalId', async () => {
+    const { svc, upsert, $transaction } = build();
+    await enrich(
+      svc,
+      result([committee({ externalId: '' as unknown as string })]),
+    );
+    expect(upsert).not.toHaveBeenCalled();
+    expect($transaction).not.toHaveBeenCalled();
   });
 
   it('is a no-op when there are no roster committees', async () => {

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -118,6 +118,7 @@ export class CampaignFinanceSyncService {
     const onBatch = async (items: Record<string, unknown>[]) => {
       const tracker = ensureExtractTracker();
       const batchData = this.sortItems(items);
+      await this.enrichCommittees(batchData);
       await this.ensureCommitteeStubs(batchData);
       const result = await this.upsertBatch(batchData);
       totalProcessed += result.processed;
@@ -132,12 +133,14 @@ export class CampaignFinanceSyncService {
     const data = await provider.fetchCampaignFinance(onBatch, pipelineJobId);
 
     if (
+      data.committees.length > 0 ||
       data.contributions.length > 0 ||
       data.expenditures.length > 0 ||
       data.independentExpenditures.length > 0 ||
       data.committeeMeasureFilings.length > 0
     ) {
       const tracker = ensureExtractTracker();
+      await this.enrichCommittees(data);
       await this.ensureCommitteeStubs(data);
       const result = await this.upsertBatch(data);
       totalProcessed += result.processed;
@@ -265,6 +268,62 @@ export class CampaignFinanceSyncService {
     for (const ie of data.independentExpenditures) {
       ie.committeeId = idMap.get(ie.committeeId) ?? ie.committeeId;
     }
+  }
+
+  /**
+   * Enrich committee rows from roster records (FEC cm.txt / CAL-ACCESS CVR
+   * cover pages). Upserts by externalId so a stub created from a transaction
+   * (name = externalId, type = OTHER) is updated IN PLACE with its real
+   * identity — same DB id, so every Contribution/Expenditure/IE FK is
+   * preserved (#939). Never deletes or recreates a committee, and never
+   * blanks out an existing candidate/party field from a filing that lacked
+   * it (cover pages repeat per filing and some carry less data).
+   */
+  private async enrichCommittees(data: CampaignFinanceResult): Promise<void> {
+    if (data.committees.length === 0) return;
+    // Cover pages repeat per filing — dedup within the batch (last wins).
+    const byExternalId = new Map<
+      string,
+      CampaignFinanceResult['committees'][number]
+    >();
+    for (const c of data.committees) {
+      if (c.externalId) byExternalId.set(c.externalId, c);
+    }
+    if (byExternalId.size === 0) return;
+
+    await batchTransaction(
+      this.db,
+      [...byExternalId.values()].map((c) =>
+        this.db.committee.upsert({
+          where: { externalId: c.externalId },
+          create: {
+            externalId: c.externalId,
+            name: c.name,
+            type: c.type,
+            candidateName: c.candidateName ?? null,
+            candidateOffice: c.candidateOffice ?? null,
+            party: c.party ?? null,
+            status: c.status ?? 'active',
+            sourceSystem: c.sourceSystem,
+            sourceUrl: c.sourceUrl ?? null,
+          },
+          update: {
+            name: c.name,
+            type: c.type,
+            sourceSystem: c.sourceSystem,
+            ...(c.candidateName ? { candidateName: c.candidateName } : {}),
+            ...(c.candidateOffice
+              ? { candidateOffice: c.candidateOffice }
+              : {}),
+            ...(c.party ? { party: c.party } : {}),
+            ...(c.sourceUrl ? { sourceUrl: c.sourceUrl } : {}),
+          },
+        }),
+      ),
+    );
+    this.logger.log(
+      `Enriched ${byExternalId.size} committee(s) from roster records`,
+    );
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -242,7 +242,7 @@ export class CampaignFinanceSyncService {
             data: {
               externalId,
               name: externalId,
-              type: 'OTHER',
+              type: 'other',
               status: 'active',
               sourceSystem: sourceSystemByExternalId.get(externalId) ?? 'fec',
             },
@@ -302,20 +302,25 @@ export class CampaignFinanceSyncService {
             type: c.type,
             candidateName: c.candidateName ?? null,
             candidateOffice: c.candidateOffice ?? null,
-            party: c.party ?? null,
+            // party is a VarChar(50) — cap so a malformed oversized value
+            // skips this field rather than failing the whole 500-row chunk.
+            party: c.party ? c.party.slice(0, 50) : null,
             status: c.status ?? 'active',
             sourceSystem: c.sourceSystem,
             sourceUrl: c.sourceUrl ?? null,
           },
           update: {
             name: c.name,
-            type: c.type,
             sourceSystem: c.sourceSystem,
+            // Only overwrite `type` with a recognized value — a later filing
+            // whose CMTTE_TYPE was blank/unknown maps to 'other', which must
+            // not downgrade a committee already enriched to candidate/pac/etc.
+            ...(c.type && c.type !== 'other' ? { type: c.type } : {}),
             ...(c.candidateName ? { candidateName: c.candidateName } : {}),
             ...(c.candidateOffice
               ? { candidateOffice: c.candidateOffice }
               : {}),
-            ...(c.party ? { party: c.party } : {}),
+            ...(c.party ? { party: c.party.slice(0, 50) } : {}),
             ...(c.sourceUrl ? { sourceUrl: c.sourceUrl } : {}),
           },
         }),

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -795,6 +795,74 @@ describe("DomainMapperService", () => {
         sourceSystem: "fec",
       });
     });
+
+    it.each([
+      ["S", "candidate"], // FEC senate campaign
+      ["N", "pac"], // FEC non-qualified PAC
+      ["O", "super_pac"], // FEC IE-only super PAC
+      ["Y", "party"], // FEC qualified party
+      ["CTL", "candidate"], // CAL-ACCESS controlled committee
+      ["BMC", "ballot_measure"], // CAL-ACCESS ballot-measure committee
+      ["RCP", "pac"], // CAL-ACCESS recipient committee
+      ["candidate", "candidate"], // already-canonical passes through
+      ["ZZ", "other"], // unknown code → other
+    ])(
+      "maps roster committee-type code %s → %s (#940)",
+      (rawType, expected) => {
+        const result = mapper.map(
+          createRawResult({
+            items: [
+              {
+                externalId: "C-TYPE",
+                name: "Some Committee",
+                type: rawType,
+                sourceSystem: "cal_access",
+              },
+            ],
+          }),
+          createSource({
+            dataType: DataType.CAMPAIGN_FINANCE,
+            category: "CAL-ACCESS Committees",
+          }),
+        );
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0]).toMatchObject({ type: expected });
+      },
+    );
+
+    it("does not drop a roster committee whose type is a raw code (#940)", () => {
+      // Regression: z.nativeEnum rejected raw codes, failing the whole
+      // CommitteeSchema so the committee was dropped — everything defaulted
+      // to OTHER because only stub rows survived.
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "C-KEEP",
+              name: "Friends of Jane Doe",
+              type: "CTL",
+              candidateName: "Doe",
+              candidateOffice: "ASM",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Committees",
+        }),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        externalId: "C-KEEP",
+        name: "Friends of Jane Doe",
+        type: "candidate",
+        candidateName: "Doe",
+        candidateOffice: "ASM",
+      });
+    });
   });
 
   describe("campaign finance — contributions", () => {

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -804,8 +804,10 @@ describe("DomainMapperService", () => {
       ["CTL", "candidate"], // CAL-ACCESS controlled committee
       ["BMC", "ballot_measure"], // CAL-ACCESS ballot-measure committee
       ["RCP", "pac"], // CAL-ACCESS recipient committee
+      ["GPC", "pac"], // CAL-ACCESS general-purpose committee
       ["candidate", "candidate"], // already-canonical passes through
       ["ZZ", "other"], // unknown code → other
+      ["", "other"], // empty code → other (previously dropped by nativeEnum)
     ])(
       "maps roster committee-type code %s → %s (#940)",
       (rawType, expected) => {
@@ -862,6 +864,23 @@ describe("DomainMapperService", () => {
         candidateName: "Doe",
         candidateOffice: "ASM",
       });
+    });
+
+    it("defaults an absent type to other (preserves the old .default behavior) (#940)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            { externalId: "C-NOTYPE", name: "No Type Co", sourceSystem: "fec" },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "FEC Committees",
+        }),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({ type: "other" });
     });
   });
 

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -761,6 +761,7 @@ const committeeTypeTransform = (val: string | undefined): CommitteeType => {
     case "BMC": // ballot-measure committee
       return CommitteeType.BALLOT_MEASURE;
     case "RCP": // recipient committee
+    case "GPC": // general-purpose committee
       return CommitteeType.PAC;
     case "PTY": // political party
       return CommitteeType.PARTY;

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -726,10 +726,56 @@ const donorTypeTransform = (val: string | undefined) => {
   return "other" as const;
 };
 
+// FEC (CMTE_TP) + CAL-ACCESS (CMTTE_TYPE) committee-type codes → CommitteeType
+// (#940). Without this, roster records carry raw codes that z.nativeEnum would
+// reject — dropping the whole committee — so everything defaulted to OTHER.
+// An already-canonical value (e.g. "candidate") passes through unchanged.
+const committeeTypeTransform = (val: string | undefined): CommitteeType => {
+  if (!val) return CommitteeType.OTHER;
+  const lower = val.toLowerCase().trim();
+  if ((Object.values(CommitteeType) as string[]).includes(lower)) {
+    return lower as CommitteeType;
+  }
+  switch (val.toUpperCase().trim()) {
+    // FEC CMTE_TP
+    case "P": // presidential
+    case "H": // house
+    case "S": // senate
+      return CommitteeType.CANDIDATE;
+    case "N": // non-qualified PAC
+    case "Q": // qualified PAC
+    case "V": // hybrid PAC (non-qualified)
+    case "W": // hybrid PAC (qualified)
+      return CommitteeType.PAC;
+    case "O": // super PAC (independent-expenditure-only)
+    case "U": // single-candidate super PAC
+      return CommitteeType.SUPER_PAC;
+    case "X": // party (non-qualified)
+    case "Y": // party (qualified)
+    case "Z": // national party organization
+      return CommitteeType.PARTY;
+    // CAL-ACCESS CMTTE_TYPE
+    case "CTL": // controlled (candidate-controlled)
+    case "CAO": // candidate/officeholder
+      return CommitteeType.CANDIDATE;
+    case "BMC": // ballot-measure committee
+      return CommitteeType.BALLOT_MEASURE;
+    case "RCP": // recipient committee
+      return CommitteeType.PAC;
+    case "PTY": // political party
+      return CommitteeType.PARTY;
+    default:
+      return CommitteeType.OTHER;
+  }
+};
+
 const CommitteeSchema = z.object({
   externalId: z.string().min(1),
   name: z.string().min(1),
-  type: z.nativeEnum(CommitteeType).default(CommitteeType.OTHER),
+  type: z
+    .string()
+    .optional()
+    .transform((v) => committeeTypeTransform(v)),
   candidateName: z.string().optional(),
   candidateOffice: z.string().optional(),
   propositionId: z.string().optional(),


### PR DESCRIPTION
## S2 + S3 of epic #936 — make the committee roster persist identity

Pairs with the roster **sources** in [opuspopuli-regions#59](https://github.com/OpusPopuli/opuspopuli-regions/pull/59) (S1). Together they give every committee a real name/type/candidate so the 3.8M contributions can finally be attributed.

### S3 (#940) — committee-type transform
`committeeTypeTransform` maps FEC (`CMTE_TP`) + CAL-ACCESS (`CMTTE_TYPE`) codes → `CommitteeType`. **This was load-bearing, not cosmetic:** the raw codes were rejected by `z.nativeEnum`, failing `CommitteeSchema` and dropping the whole roster record — which is *why every committee was `OTHER`*. Canonical values pass through; unknown/blank/absent → `other`.

### S2 (#939) — enrich in place
`enrichCommittees` upserts roster records **by `externalId`**, so a stub created from a transaction (`name = C00401224`, `type = other`) is updated **in place** with its real identity — same DB `id`, so every Contribution/Expenditure/IE FK is preserved. Never deletes/recreates; guards `type`, `candidateName`, `candidateOffice`, `party` so a sparse cover page never downgrades or blanks an already-enriched committee. Wired into the batch loop + final flush.

### Review fixes applied
- `type` overwrite guarded symmetrically (blank filing can't downgrade an enriched committee).
- FK stub type normalized to lowercase `other` (matches the `@@index([type])` / `type='other'` filters).
- Added `GPC → pac`; `party` capped to VarChar(50).

### Constraints honored
- **Data-preserving** (upsert by externalId, no id churn). **Finance-scoped — no bills sync.**
- Inert until opuspopuli-regions#59 ships + one finance-roster sync runs.

Reviewed via `/op-review` (no blockers) + `/security-review` (clean). Tests: type-code mapping table (FEC + CAL-ACCESS incl. GPC/empty/absent), no-downgrade, enrich upsert-by-id / dedup / no-blank / missing-externalId / no-op. Full workspace suite passed in the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
