### PR TITLE
Release: campaign-finance roster — give committees their identity (#936)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -87,7 +87,7 @@
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/queue-provider": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.71",
+    "@opuspopuli/regions": "^1.0.72",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
@@ -1,0 +1,121 @@
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import type { CampaignFinanceResult } from '@opuspopuli/common';
+import { CampaignFinanceSyncService } from './campaign-finance-sync.service';
+
+type RosterCommittee = CampaignFinanceResult['committees'][number];
+
+function build() {
+  const upsert = jest.fn((args: unknown) => ({ __op: args }));
+  const $transaction = jest.fn().mockResolvedValue([]);
+  const db = { committee: { upsert }, $transaction } as unknown as DbService;
+  const svc = new CampaignFinanceSyncService(db);
+  return { svc, upsert, $transaction };
+}
+
+function committee(over: Partial<RosterCommittee> = {}): RosterCommittee {
+  return {
+    externalId: 'C001',
+    name: 'Friends of Jane Doe',
+    type: 'candidate',
+    candidateName: 'Doe',
+    candidateOffice: 'ASM',
+    party: 'DEM',
+    status: 'active',
+    sourceSystem: 'cal_access',
+    ...over,
+  } as RosterCommittee;
+}
+
+function result(committees: RosterCommittee[]): CampaignFinanceResult {
+  return {
+    committees,
+    contributions: [],
+    expenditures: [],
+    independentExpenditures: [],
+    committeeMeasureFilings: [],
+  };
+}
+
+const enrich = (svc: CampaignFinanceSyncService, data: CampaignFinanceResult) =>
+  (
+    svc as unknown as {
+      enrichCommittees: (d: CampaignFinanceResult) => Promise<void>;
+    }
+  ).enrichCommittees(data);
+
+describe('CampaignFinanceSyncService.enrichCommittees (#939)', () => {
+  it('upserts each roster committee by externalId with its real identity', async () => {
+    const { svc, upsert, $transaction } = build();
+    await enrich(svc, result([committee()]));
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const args = upsert.mock.calls[0][0] as {
+      where: unknown;
+      create: Record<string, unknown>;
+      update: Record<string, unknown>;
+    };
+    // keyed by externalId → enriches the existing row in place (no id churn)
+    expect(args.where).toEqual({ externalId: 'C001' });
+    expect(args.create).toMatchObject({
+      externalId: 'C001',
+      name: 'Friends of Jane Doe',
+      type: 'candidate',
+      candidateName: 'Doe',
+      candidateOffice: 'ASM',
+    });
+    expect(args.update).toMatchObject({
+      name: 'Friends of Jane Doe',
+      type: 'candidate',
+      candidateName: 'Doe',
+    });
+    expect($transaction).toHaveBeenCalled();
+  });
+
+  it('dedups repeated cover-page rows by externalId (last wins)', async () => {
+    const { svc, upsert } = build();
+    await enrich(
+      svc,
+      result([
+        committee({ name: 'Stale Name' }),
+        committee({ name: 'Current Name' }),
+      ]),
+    );
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    const create = (
+      upsert.mock.calls[0][0] as { create: Record<string, unknown> }
+    ).create;
+    expect(create.name).toBe('Current Name');
+  });
+
+  it('never blanks an existing candidate/party field when a filing lacks it', async () => {
+    const { svc, upsert } = build();
+    await enrich(
+      svc,
+      result([
+        committee({
+          candidateName: undefined,
+          candidateOffice: undefined,
+          party: undefined,
+        }),
+      ]),
+    );
+
+    const update = (
+      upsert.mock.calls[0][0] as { update: Record<string, unknown> }
+    ).update;
+    expect(update).not.toHaveProperty('candidateName');
+    expect(update).not.toHaveProperty('candidateOffice');
+    expect(update).not.toHaveProperty('party');
+    // name + type always refresh (roster is authoritative for those)
+    expect(update.name).toBeDefined();
+    expect(update.type).toBeDefined();
+  });
+
+  it('is a no-op when there are no roster committees', async () => {
+    const { svc, upsert, $transaction } = build();
+    await enrich(svc, result([]));
+    expect(upsert).not.toHaveBeenCalled();
+    expect($transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
@@ -12,7 +12,9 @@ function build() {
   return { svc, upsert, $transaction };
 }
 
-function committee(over: Partial<RosterCommittee> = {}): RosterCommittee {
+function committee(
+  over: Partial<Omit<RosterCommittee, 'type'>> & { type?: string } = {},
+): RosterCommittee {
   return {
     externalId: 'C001',
     name: 'Friends of Jane Doe',
@@ -110,6 +112,34 @@ describe('CampaignFinanceSyncService.enrichCommittees (#939)', () => {
     // name + type always refresh (roster is authoritative for those)
     expect(update.name).toBeDefined();
     expect(update.type).toBeDefined();
+  });
+
+  it('does not overwrite an enriched type with a later blank (other) filing', async () => {
+    const { svc, upsert } = build();
+    await enrich(svc, result([committee({ type: 'other' })]));
+
+    const update = (
+      upsert.mock.calls[0][0] as { update: Record<string, unknown> }
+    ).update;
+    // 'other' must not downgrade a committee already typed candidate/pac/etc.
+    expect(update).not.toHaveProperty('type');
+    // a recognized type still refreshes
+    upsert.mockClear();
+    await enrich(svc, result([committee({ type: 'candidate' })]));
+    const update2 = (
+      upsert.mock.calls[0][0] as { update: Record<string, unknown> }
+    ).update;
+    expect(update2.type).toBe('candidate');
+  });
+
+  it('skips roster records with no externalId', async () => {
+    const { svc, upsert, $transaction } = build();
+    await enrich(
+      svc,
+      result([committee({ externalId: '' as unknown as string })]),
+    );
+    expect(upsert).not.toHaveBeenCalled();
+    expect($transaction).not.toHaveBeenCalled();
   });
 
   it('is a no-op when there are no roster committees', async () => {

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -118,6 +118,7 @@ export class CampaignFinanceSyncService {
     const onBatch = async (items: Record<string, unknown>[]) => {
       const tracker = ensureExtractTracker();
       const batchData = this.sortItems(items);
+      await this.enrichCommittees(batchData);
       await this.ensureCommitteeStubs(batchData);
       const result = await this.upsertBatch(batchData);
       totalProcessed += result.processed;
@@ -132,12 +133,14 @@ export class CampaignFinanceSyncService {
     const data = await provider.fetchCampaignFinance(onBatch, pipelineJobId);
 
     if (
+      data.committees.length > 0 ||
       data.contributions.length > 0 ||
       data.expenditures.length > 0 ||
       data.independentExpenditures.length > 0 ||
       data.committeeMeasureFilings.length > 0
     ) {
       const tracker = ensureExtractTracker();
+      await this.enrichCommittees(data);
       await this.ensureCommitteeStubs(data);
       const result = await this.upsertBatch(data);
       totalProcessed += result.processed;
@@ -265,6 +268,62 @@ export class CampaignFinanceSyncService {
     for (const ie of data.independentExpenditures) {
       ie.committeeId = idMap.get(ie.committeeId) ?? ie.committeeId;
     }
+  }
+
+  /**
+   * Enrich committee rows from roster records (FEC cm.txt / CAL-ACCESS CVR
+   * cover pages). Upserts by externalId so a stub created from a transaction
+   * (name = externalId, type = OTHER) is updated IN PLACE with its real
+   * identity — same DB id, so every Contribution/Expenditure/IE FK is
+   * preserved (#939). Never deletes or recreates a committee, and never
+   * blanks out an existing candidate/party field from a filing that lacked
+   * it (cover pages repeat per filing and some carry less data).
+   */
+  private async enrichCommittees(data: CampaignFinanceResult): Promise<void> {
+    if (data.committees.length === 0) return;
+    // Cover pages repeat per filing — dedup within the batch (last wins).
+    const byExternalId = new Map<
+      string,
+      CampaignFinanceResult['committees'][number]
+    >();
+    for (const c of data.committees) {
+      if (c.externalId) byExternalId.set(c.externalId, c);
+    }
+    if (byExternalId.size === 0) return;
+
+    await batchTransaction(
+      this.db,
+      [...byExternalId.values()].map((c) =>
+        this.db.committee.upsert({
+          where: { externalId: c.externalId },
+          create: {
+            externalId: c.externalId,
+            name: c.name,
+            type: c.type,
+            candidateName: c.candidateName ?? null,
+            candidateOffice: c.candidateOffice ?? null,
+            party: c.party ?? null,
+            status: c.status ?? 'active',
+            sourceSystem: c.sourceSystem,
+            sourceUrl: c.sourceUrl ?? null,
+          },
+          update: {
+            name: c.name,
+            type: c.type,
+            sourceSystem: c.sourceSystem,
+            ...(c.candidateName ? { candidateName: c.candidateName } : {}),
+            ...(c.candidateOffice
+              ? { candidateOffice: c.candidateOffice }
+              : {}),
+            ...(c.party ? { party: c.party } : {}),
+            ...(c.sourceUrl ? { sourceUrl: c.sourceUrl } : {}),
+          },
+        }),
+      ),
+    );
+    this.logger.log(
+      `Enriched ${byExternalId.size} committee(s) from roster records`,
+    );
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -242,7 +242,7 @@ export class CampaignFinanceSyncService {
             data: {
               externalId,
               name: externalId,
-              type: 'OTHER',
+              type: 'other',
               status: 'active',
               sourceSystem: sourceSystemByExternalId.get(externalId) ?? 'fec',
             },
@@ -302,20 +302,25 @@ export class CampaignFinanceSyncService {
             type: c.type,
             candidateName: c.candidateName ?? null,
             candidateOffice: c.candidateOffice ?? null,
-            party: c.party ?? null,
+            // party is a VarChar(50) — cap so a malformed oversized value
+            // skips this field rather than failing the whole 500-row chunk.
+            party: c.party ? c.party.slice(0, 50) : null,
             status: c.status ?? 'active',
             sourceSystem: c.sourceSystem,
             sourceUrl: c.sourceUrl ?? null,
           },
           update: {
             name: c.name,
-            type: c.type,
             sourceSystem: c.sourceSystem,
+            // Only overwrite `type` with a recognized value — a later filing
+            // whose CMTTE_TYPE was blank/unknown maps to 'other', which must
+            // not downgrade a committee already enriched to candidate/pac/etc.
+            ...(c.type && c.type !== 'other' ? { type: c.type } : {}),
             ...(c.candidateName ? { candidateName: c.candidateName } : {}),
             ...(c.candidateOffice
               ? { candidateOffice: c.candidateOffice }
               : {}),
-            ...(c.party ? { party: c.party } : {}),
+            ...(c.party ? { party: c.party.slice(0, 50) } : {}),
             ...(c.sourceUrl ? { sourceUrl: c.sourceUrl } : {}),
           },
         }),

--- a/apps/frontend/__tests__/pages/region/page.test.tsx
+++ b/apps/frontend/__tests__/pages/region/page.test.tsx
@@ -239,5 +239,27 @@ describe("RegionPage", () => {
         screen.queryByText("Legislative Committees"),
       ).not.toBeInTheDocument();
     });
+
+    it("gates Legislative Committees on MEETINGS without hiding Campaign Finance (#936)", () => {
+      // MEETINGS absent → no committees card; CAMPAIGN_FINANCE still renders
+      // its own finance card (the two are decoupled).
+      mockQueryResult = {
+        data: {
+          regionInfo: {
+            ...mockRegionInfo,
+            supportedDataTypes: ["PROPOSITIONS", "CAMPAIGN_FINANCE"],
+          },
+        },
+        loading: false,
+        error: null,
+      };
+
+      render(<RegionPage />);
+
+      expect(screen.getByText("Campaign Finance")).toBeInTheDocument();
+      expect(
+        screen.queryByText("Legislative Committees"),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/frontend/__tests__/pages/region/page.test.tsx
+++ b/apps/frontend/__tests__/pages/region/page.test.tsx
@@ -109,11 +109,12 @@ describe("RegionPage", () => {
       // forward-looking calendar entries are lower civic-action value.
       expect(screen.queryByText("Meetings")).not.toBeInTheDocument();
       expect(screen.getByText("Representatives")).toBeInTheDocument();
-      // The CAMPAIGN_FINANCE data-type slot now displays as the
-      // Legislative Committees card on the home page; the campaign-finance
-      // hub stays reachable via direct URL and from proposition pages.
+      // Campaign Finance has its own front door again (#936) — no longer
+      // hijacked to render legislative-committees.
+      expect(screen.getByText("Campaign Finance")).toBeInTheDocument();
+      // Legislative Committees renders as its own card, gated on MEETINGS
+      // support (derived from minutes ingestion, not a backend DataType).
       expect(screen.getByText("Legislative Committees")).toBeInTheDocument();
-      expect(screen.queryByText("Campaign Finance")).not.toBeInTheDocument();
     });
 
     it("should render data type descriptions", () => {
@@ -162,6 +163,15 @@ describe("RegionPage", () => {
       expect(legislativeCommitteesLink).toHaveAttribute(
         "href",
         "/region/legislative-committees",
+      );
+
+      // Campaign Finance now links to its own hub (#936).
+      const campaignFinanceLink = screen.getByRole("link", {
+        name: /Campaign Finance/i,
+      });
+      expect(campaignFinanceLink).toHaveAttribute(
+        "href",
+        "/region/campaign-finance",
       );
     });
 

--- a/apps/frontend/app/region/page.tsx
+++ b/apps/frontend/app/region/page.tsx
@@ -35,18 +35,16 @@ const DATA_TYPE_CARDS: Partial<
     href: "/region/representatives",
     icon: "users",
   },
-  // Repurposed — the underlying DataType key (CAMPAIGN_FINANCE) is what
-  // the backend advertises in `supportedDataTypes`, but the home-page card
-  // now points at the new legislative-committees hub. The campaign-finance
-  // hub at /region/campaign-finance stays reachable via direct URL and
-  // from each proposition's funding section; only the home front door
-  // changes — voters get more value from "what shapes a bill before it
-  // hits the floor" than from disconnected donor lists.
+  // Campaign finance gets its own front door again (#936). It was briefly
+  // repurposed to point at legislative-committees, which orphaned finance
+  // (no inbound link for signed-in users) and conflated two unrelated
+  // "committee" concepts — FPPC campaign filers vs. Assembly/Senate policy
+  // committees. Legislative Committees now renders as its own card below.
   CAMPAIGN_FINANCE: {
-    title: "Legislative Committees",
-    description: "Where bills get debated and shaped before the floor vote",
-    href: "/region/legislative-committees",
-    icon: "committee",
+    title: "Campaign Finance",
+    description: "Follow the money — donors, committees, and spending",
+    href: "/region/campaign-finance",
+    icon: "finance",
   },
   BILLS: {
     title: "Bills",
@@ -162,6 +160,36 @@ function DataTypeIcon({ type }: { readonly type: string }) {
   }
 }
 
+/** A single region-hub navigation card. Shared by the data-type-driven
+ *  cards and the derived Legislative Committees card so the markup lives
+ *  in one place (#936). */
+function RegionCard({
+  href,
+  icon,
+  title,
+  description,
+}: {
+  readonly href: string;
+  readonly icon: string;
+  readonly title: string;
+  readonly description: string;
+}) {
+  return (
+    <Link
+      href={href}
+      className="group bg-surface rounded-lg p-6 transition-all duration-200"
+    >
+      <div className="text-content-dim group-hover:text-content transition-colors mb-4">
+        <DataTypeIcon type={icon} />
+      </div>
+      <h2 className="text-lg font-semibold text-content group-hover:text-blue-600 transition-colors">
+        {title}
+      </h2>
+      <p className="mt-1 text-sm text-content-dim">{description}</p>
+    </Link>
+  );
+}
+
 export default function RegionPage() {
   const { data, loading, error } = useQuery<RegionInfoData>(GET_REGION_INFO);
 
@@ -219,25 +247,20 @@ export default function RegionPage() {
         {regionInfo?.supportedDataTypes.map((dataType) => {
           const card = DATA_TYPE_CARDS[dataType];
           if (!card) return null;
-
-          return (
-            <Link
-              key={dataType}
-              href={card.href}
-              className="group bg-surface rounded-lg p-6 transition-all duration-200"
-            >
-              <div className="text-content-dim group-hover:text-content transition-colors mb-4">
-                <DataTypeIcon type={card.icon} />
-              </div>
-              <h2 className="text-lg font-semibold text-content group-hover:text-blue-600 transition-colors">
-                {card.title}
-              </h2>
-              <p className="mt-1 text-sm text-content-dim">
-                {card.description}
-              </p>
-            </Link>
-          );
+          return <RegionCard key={dataType} {...card} />;
         })}
+        {/* Legislative Committees isn't a backend DataType — it's derived
+            from minutes/meetings ingestion — so it renders as its own card
+            (no longer hijacking the CAMPAIGN_FINANCE key), gated on MEETINGS
+            support. #936. */}
+        {regionInfo?.supportedDataTypes.includes("MEETINGS") && (
+          <RegionCard
+            href="/region/legislative-committees"
+            icon="committee"
+            title="Legislative Committees"
+            description="Where bills get debated and shaped before the floor vote"
+          />
+        )}
       </div>
 
       {/* Civics Hub */}

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.71"
+    "@opuspopuli/regions": "^1.0.72"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1127,5 +1127,58 @@ describe("DomainMapperService", () => {
         supportOrOppose: "oppose",
       });
     });
+
+    it("routes 'Committee Positions' (CVR2/Form 410) to measure filings, not committees (#936)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "CVR2-1",
+              filingId: "F123",
+              ballotName: "Clean Water Act",
+              ballotNumber: "Prop 5",
+              ballotJurisdiction: "STATEWIDE",
+              supportOrOppose: "S",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          // Category contains "committee" — must NOT misroute to mapCommittee.
+          category: "CAL-ACCESS Committee Positions",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.items[0]).toMatchObject({
+        externalId: "CVR2-1",
+        filingId: "F123",
+        ballotName: "Clean Water Act",
+        ballotNumber: "Prop 5",
+        supportOrOppose: "support",
+      });
+    });
+
+    it("drops a 'Committee Positions' row missing filingId rather than treating it as a committee (#936)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "x",
+              name: "Some PAC",
+              type: "OTHER",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Committee Positions",
+        }),
+      );
+
+      expect(result.items).toHaveLength(0);
+    });
   });
 });

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -795,6 +795,74 @@ describe("DomainMapperService", () => {
         sourceSystem: "fec",
       });
     });
+
+    it.each([
+      ["S", "candidate"], // FEC senate campaign
+      ["N", "pac"], // FEC non-qualified PAC
+      ["O", "super_pac"], // FEC IE-only super PAC
+      ["Y", "party"], // FEC qualified party
+      ["CTL", "candidate"], // CAL-ACCESS controlled committee
+      ["BMC", "ballot_measure"], // CAL-ACCESS ballot-measure committee
+      ["RCP", "pac"], // CAL-ACCESS recipient committee
+      ["candidate", "candidate"], // already-canonical passes through
+      ["ZZ", "other"], // unknown code → other
+    ])(
+      "maps roster committee-type code %s → %s (#940)",
+      (rawType, expected) => {
+        const result = mapper.map(
+          createRawResult({
+            items: [
+              {
+                externalId: "C-TYPE",
+                name: "Some Committee",
+                type: rawType,
+                sourceSystem: "cal_access",
+              },
+            ],
+          }),
+          createSource({
+            dataType: DataType.CAMPAIGN_FINANCE,
+            category: "CAL-ACCESS Committees",
+          }),
+        );
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0]).toMatchObject({ type: expected });
+      },
+    );
+
+    it("does not drop a roster committee whose type is a raw code (#940)", () => {
+      // Regression: z.nativeEnum rejected raw codes, failing the whole
+      // CommitteeSchema so the committee was dropped — everything defaulted
+      // to OTHER because only stub rows survived.
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "C-KEEP",
+              name: "Friends of Jane Doe",
+              type: "CTL",
+              candidateName: "Doe",
+              candidateOffice: "ASM",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Committees",
+        }),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        externalId: "C-KEEP",
+        name: "Friends of Jane Doe",
+        type: "candidate",
+        candidateName: "Doe",
+        candidateOffice: "ASM",
+      });
+    });
   });
 
   describe("campaign finance — contributions", () => {

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -804,8 +804,10 @@ describe("DomainMapperService", () => {
       ["CTL", "candidate"], // CAL-ACCESS controlled committee
       ["BMC", "ballot_measure"], // CAL-ACCESS ballot-measure committee
       ["RCP", "pac"], // CAL-ACCESS recipient committee
+      ["GPC", "pac"], // CAL-ACCESS general-purpose committee
       ["candidate", "candidate"], // already-canonical passes through
       ["ZZ", "other"], // unknown code → other
+      ["", "other"], // empty code → other (previously dropped by nativeEnum)
     ])(
       "maps roster committee-type code %s → %s (#940)",
       (rawType, expected) => {
@@ -862,6 +864,23 @@ describe("DomainMapperService", () => {
         candidateName: "Doe",
         candidateOffice: "ASM",
       });
+    });
+
+    it("defaults an absent type to other (preserves the old .default behavior) (#940)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            { externalId: "C-NOTYPE", name: "No Type Co", sourceSystem: "fec" },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "FEC Committees",
+        }),
+      );
+
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({ type: "other" });
     });
   });
 

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1160,6 +1160,50 @@ describe("DomainMapperService", () => {
       });
     });
 
+    it("maps an 'O' support/oppose code on a measure filing to oppose (#936)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "CVR2-2",
+              filingId: "F200",
+              ballotNumber: "Prop 9",
+              supportOrOppose: "O",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Committee Positions",
+        }),
+      );
+
+      expect(result.items[0]).toMatchObject({ supportOrOppose: "oppose" });
+    });
+
+    it("drops a CVR2 row that carries no ballotName/ballotNumber (non-ballot declaration) (#936)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "CVR2-3",
+              filingId: "F300",
+              // no ballotName, no ballotNumber — entity declaration, not a measure
+              supportOrOppose: "S",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Committee Positions",
+        }),
+      );
+
+      expect(result.items).toHaveLength(0);
+    });
+
     it("drops a 'Committee Positions' row missing filingId rather than treating it as a committee (#936)", () => {
       const result = mapper.map(
         createRawResult({

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -761,6 +761,7 @@ const committeeTypeTransform = (val: string | undefined): CommitteeType => {
     case "BMC": // ballot-measure committee
       return CommitteeType.BALLOT_MEASURE;
     case "RCP": // recipient committee
+    case "GPC": // general-purpose committee
       return CommitteeType.PAC;
     case "PTY": // political party
       return CommitteeType.PARTY;

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -116,7 +116,7 @@ export class DomainMapperService {
     // otherwise misroute to mapCommittee and be rejected for having no `name`
     // — the reason cvr2_filings sat at 0 and no committee→measure link ever
     // formed (#936).
-    if (cat.includes("position") || cat.includes("cvr2")) {
+    if (cat.includes("committee position") || cat.includes("cvr2")) {
       return this.mapCommitteeMeasureFiling(record);
     } else if (cat.includes("independent") || cat.includes("s496")) {
       return this.mapIndependentExpenditure(record);
@@ -236,7 +236,15 @@ export class DomainMapperService {
       );
       return null;
     }
-    return result.data;
+    const filing = result.data;
+    // Most CVR2 rows are non-ballot entity declarations. Only ballot-measure
+    // declarations (a ballotName or ballotNumber) are useful — the
+    // proposition-finance-linker resolves by those — so drop the rest here
+    // rather than persisting noise the linker would skip anyway. #936.
+    if (!filing.ballotName && !filing.ballotNumber) {
+      return null;
+    }
+    return filing;
   }
 
   private mapContribution(
@@ -866,9 +874,10 @@ const IndependentExpenditureSchema = z.object({
 });
 
 // CVR2 / Form 410 ballot-measure declaration (#936). externalId + filingId are
-// required; ballot fields are optional because most CVR2 rows are non-ballot
-// entity declarations — the proposition-finance-linker filters those out at
-// resolve time by requiring a non-empty ballotName/ballotNumber.
+// required; ballot fields are optional at the schema level, but
+// mapCommitteeMeasureFiling drops any row carrying neither a ballotName nor a
+// ballotNumber — only ballot-measure declarations are useful for the
+// proposition-finance-linker, which resolves by ballotName/ballotNumber.
 const CommitteeMeasureFilingSchema = z.object({
   externalId: z.string().min(1),
   filingId: z.string().min(1),

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -19,6 +19,7 @@ import {
   type Contribution,
   type Expenditure,
   type IndependentExpenditure,
+  type CommitteeMeasureFiling,
   type RawExtractionResult,
   type ExtractionResult,
   type DataSourceConfig,
@@ -78,6 +79,7 @@ export class DomainMapperService {
     | Contribution
     | Expenditure
     | IndependentExpenditure
+    | CommitteeMeasureFiling
     | null {
     switch (source.dataType) {
       case DataType.PROPOSITIONS:
@@ -99,13 +101,27 @@ export class DomainMapperService {
   private mapCampaignFinanceItem(
     record: Record<string, unknown>,
     category?: string,
-  ): Committee | Contribution | Expenditure | IndependentExpenditure | null {
+  ):
+    | Committee
+    | Contribution
+    | Expenditure
+    | IndependentExpenditure
+    | CommitteeMeasureFiling
+    | null {
     const cat = (category ?? "").toLowerCase();
 
-    if (cat.includes("committee")) {
-      return this.mapCommittee(record);
+    // CVR2 / Form 410 ballot-measure declarations MUST be checked before the
+    // generic "committee" branch: the CA source category is "CAL-ACCESS
+    // Committee Positions", which also contains "committee" and would
+    // otherwise misroute to mapCommittee and be rejected for having no `name`
+    // — the reason cvr2_filings sat at 0 and no committee→measure link ever
+    // formed (#936).
+    if (cat.includes("position") || cat.includes("cvr2")) {
+      return this.mapCommitteeMeasureFiling(record);
     } else if (cat.includes("independent") || cat.includes("s496")) {
       return this.mapIndependentExpenditure(record);
+    } else if (cat.includes("committee")) {
+      return this.mapCommittee(record);
     } else if (cat.includes("expenditure")) {
       return this.mapExpenditure(record);
     } else if (cat.includes("contribution")) {
@@ -205,6 +221,19 @@ export class DomainMapperService {
     const result = CommitteeSchema.safeParse(record);
     if (!result.success) {
       this.logger.debug(`Committee validation failed: ${result.error.message}`);
+      return null;
+    }
+    return result.data;
+  }
+
+  private mapCommitteeMeasureFiling(
+    record: Record<string, unknown>,
+  ): CommitteeMeasureFiling | null {
+    const result = CommitteeMeasureFilingSchema.safeParse(record);
+    if (!result.success) {
+      this.logger.debug(
+        `Committee measure filing validation failed: ${result.error.message}`,
+      );
       return null;
     }
     return result.data;
@@ -833,5 +862,35 @@ const IndependentExpenditureSchema = z.object({
     .nullable()
     .transform((v) => v ?? undefined)
     .optional(),
+  sourceSystem: z.enum(["cal_access", "fec"]),
+});
+
+// CVR2 / Form 410 ballot-measure declaration (#936). externalId + filingId are
+// required; ballot fields are optional because most CVR2 rows are non-ballot
+// entity declarations — the proposition-finance-linker filters those out at
+// resolve time by requiring a non-empty ballotName/ballotNumber.
+const CommitteeMeasureFilingSchema = z.object({
+  externalId: z.string().min(1),
+  filingId: z.string().min(1),
+  ballotName: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined)
+    .optional(),
+  ballotNumber: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined)
+    .optional(),
+  ballotJurisdiction: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined)
+    .optional(),
+  supportOrOppose: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((val) => (val ? supportOpposeTransform(val) : undefined)),
   sourceSystem: z.enum(["cal_access", "fec"]),
 });

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -726,10 +726,56 @@ const donorTypeTransform = (val: string | undefined) => {
   return "other" as const;
 };
 
+// FEC (CMTE_TP) + CAL-ACCESS (CMTTE_TYPE) committee-type codes → CommitteeType
+// (#940). Without this, roster records carry raw codes that z.nativeEnum would
+// reject — dropping the whole committee — so everything defaulted to OTHER.
+// An already-canonical value (e.g. "candidate") passes through unchanged.
+const committeeTypeTransform = (val: string | undefined): CommitteeType => {
+  if (!val) return CommitteeType.OTHER;
+  const lower = val.toLowerCase().trim();
+  if ((Object.values(CommitteeType) as string[]).includes(lower)) {
+    return lower as CommitteeType;
+  }
+  switch (val.toUpperCase().trim()) {
+    // FEC CMTE_TP
+    case "P": // presidential
+    case "H": // house
+    case "S": // senate
+      return CommitteeType.CANDIDATE;
+    case "N": // non-qualified PAC
+    case "Q": // qualified PAC
+    case "V": // hybrid PAC (non-qualified)
+    case "W": // hybrid PAC (qualified)
+      return CommitteeType.PAC;
+    case "O": // super PAC (independent-expenditure-only)
+    case "U": // single-candidate super PAC
+      return CommitteeType.SUPER_PAC;
+    case "X": // party (non-qualified)
+    case "Y": // party (qualified)
+    case "Z": // national party organization
+      return CommitteeType.PARTY;
+    // CAL-ACCESS CMTTE_TYPE
+    case "CTL": // controlled (candidate-controlled)
+    case "CAO": // candidate/officeholder
+      return CommitteeType.CANDIDATE;
+    case "BMC": // ballot-measure committee
+      return CommitteeType.BALLOT_MEASURE;
+    case "RCP": // recipient committee
+      return CommitteeType.PAC;
+    case "PTY": // political party
+      return CommitteeType.PARTY;
+    default:
+      return CommitteeType.OTHER;
+  }
+};
+
 const CommitteeSchema = z.object({
   externalId: z.string().min(1),
   name: z.string().min(1),
-  type: z.nativeEnum(CommitteeType).default(CommitteeType.OTHER),
+  type: z
+    .string()
+    .optional()
+    .transform((v) => committeeTypeTransform(v)),
   candidateName: z.string().optional(),
   candidateOffice: z.string().optional(),
   propositionId: z.string().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,8 +189,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.71
-        version: 1.0.71
+        specifier: ^1.0.72
+        version: 1.0.72
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -1008,8 +1008,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.71
-        version: 1.0.71
+        specifier: ^1.0.72
+        version: 1.0.72
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4912,8 +4912,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.71':
-    resolution: {integrity: sha512-LdTEIOoliUg1tWgiGvAxHFB+R4Q38IyeAH4T1cMMglGBA5esQjhc0uy1VfN4w8CqMpYlfopowG7QE9ROo8h/mA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.71/505d649ceb4c36ddfd78692a2fc6d203bdfcdd03}
+  '@opuspopuli/regions@1.0.72':
+    resolution: {integrity: sha512-zur6I0JM0dReOk1wklbB36llvAbalZdzmSsLpiy2yYmI5eZHGeXvMk1JyV5NBIZIv+eh8+z57ZVxthpIYAw1PQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.72/bb277b2ecc3ed9af58d3c91bb7bb34549feb240d}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -16587,7 +16587,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.71':
+  '@opuspopuli/regions@1.0.72':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
@@ -20891,7 +20891,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.1)
+      retry-axios: 2.6.0(axios@1.18.1(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -23600,7 +23600,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.18.1):
+  retry-axios@2.6.0(axios@1.18.1(debug@4.4.3)):
     dependencies:
       axios: 1.18.1(debug@4.4.3)
 


### PR DESCRIPTION
## Release: campaign-finance roster — give committees their identity

Promotes `develop` → `main`. Ships the foundation of the finance-linkage epic (#936): committees stop being opaque IDs so the 3.8M contributions can be attributed.

### 🐛 Fixes
- **fix(finance): un-orphan the campaign-finance hub + fix CVR2 Form-410 routing** (#937)
  - The region hub linked to finance again (was orphaned for signed-in users) and stopped conflating campaign committees with legislative committees.
  - CVR2 (Form 410 ballot-measure declarations) were misrouted to the committee mapper by their "Committee Positions" category and dropped — so `cvr2_filings` sat at 0 and no committee ever linked to a proposition. Now routed correctly.

### ✨ Features
- **feat(region): enrich committees from the filer roster + map committee types** (#944)
  - `enrichCommittees` upserts roster records **by `externalId`**, so a stub (`name = committee id`, `type = OTHER`) is updated **in place** with its real name/type/candidate/office — same DB id, **all 3.8M contribution FKs preserved**.
  - `committeeTypeTransform` maps FEC/CAL-ACCESS type codes → `CommitteeType` (this was load-bearing: raw codes were being rejected and dropping the whole committee).
- **chore(deps): bump `@opuspopuli/regions` to 1.0.72** (#945) — pulls the committee/filer **roster sources** (FEC `cm.txt` + CAL-ACCESS `CVR`) into the `region` image. Minimal lockfile diff (regions only).

### 🚀 Post-deploy (operator)
After deploy, run **one** finance-roster sync — `syncRegionData(dataTypes:[CAMPAIGN_FINANCE])` — to enrich all 42,954 committees **in place**. **Finance-scoped: does not touch bills.** Then verify names/types populate. Next milestone (no further scrape): the candidate→rep linker (#941) → the money trail on rep pages.

### Verification
All three PRs reviewed (`/op-review` no blockers, `/security-review` clean) and green on CI. Data-preserving by construction; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
