### PR TITLE
feat(region): rep-page campaign-finance money trail (#943)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/models/representative-funding.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/representative-funding.model.ts
@@ -1,0 +1,74 @@
+import { Field, Float, ID, Int, ObjectType } from '@nestjs/graphql';
+
+/**
+ * Campaign-finance surface for a representative (#943, epic #936). Aggregates
+ * contributions/expenditures across the committees linked to this rep by the
+ * candidate-committee linker (#941). The "follow the money" view.
+ */
+
+@ObjectType()
+export class FinanceTopDonorModel {
+  @Field()
+  donorName!: string;
+
+  @Field(() => Float)
+  totalAmount!: number;
+
+  @Field(() => Int)
+  contributionCount!: number;
+}
+
+/** Aggregated giving by donor employer — the industry / conflict-of-interest lens. */
+@ObjectType()
+export class FinanceTopEmployerModel {
+  @Field()
+  employer!: string;
+
+  @Field(() => Float)
+  totalAmount!: number;
+
+  @Field(() => Int)
+  contributionCount!: number;
+}
+
+@ObjectType()
+export class RepFundingCommitteeModel {
+  @Field(() => ID)
+  id!: string;
+
+  @Field()
+  name!: string;
+
+  @Field(() => Float)
+  totalRaised!: number;
+}
+
+@ObjectType()
+export class RepresentativeFundingModel {
+  @Field(() => ID)
+  representativeId!: string;
+
+  @Field()
+  asOf!: Date;
+
+  @Field(() => Float)
+  totalRaised!: number;
+
+  @Field(() => Float)
+  totalSpent!: number;
+
+  @Field(() => Int)
+  donorCount!: number;
+
+  @Field(() => Int)
+  committeeCount!: number;
+
+  @Field(() => [FinanceTopDonorModel])
+  topDonors!: FinanceTopDonorModel[];
+
+  @Field(() => [FinanceTopEmployerModel])
+  topEmployers!: FinanceTopEmployerModel[];
+
+  @Field(() => [RepFundingCommitteeModel])
+  committees!: RepFundingCommitteeModel[];
+}

--- a/apps/backend/src/apps/region/src/domains/region-query.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.ts
@@ -6,6 +6,10 @@ import {
   PropositionFundingService,
   type PropositionFunding,
 } from './proposition-funding.service';
+import {
+  RepresentativeFundingService,
+  type RepresentativeFunding,
+} from './representative-funding.service';
 import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
 import {
   LegislativeCommitteeService,
@@ -269,6 +273,8 @@ export class RegionQueryService {
     private readonly legislativeCommittees?: LegislativeCommitteeService,
     @Optional()
     private readonly legislativeCommitteeLinker?: LegislativeCommitteeLinkerService,
+    @Optional()
+    private readonly representativeFunding?: RepresentativeFundingService,
   ) {}
 
   // ─── Civics data ──────────────────────────────────────────────────────────────
@@ -558,6 +564,13 @@ export class RegionQueryService {
   ): Promise<PropositionFunding | null> {
     if (!this.propositionFunding) return null;
     return this.propositionFunding.getFunding(propositionId);
+  }
+
+  async getRepresentativeFunding(
+    representativeId: string,
+  ): Promise<RepresentativeFunding | null> {
+    if (!this.representativeFunding) return null;
+    return this.representativeFunding.getFunding(representativeId);
   }
 
   // ─── Meetings ─────────────────────────────────────────────────────────────────

--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -52,6 +52,7 @@ import { MinutesSummaryService } from './minutes-summary.service';
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
 import { CandidateCommitteeLinkerService } from './candidate-committee-linker.service';
 import { PropositionFundingService } from './proposition-funding.service';
+import { RepresentativeFundingService } from './representative-funding.service';
 import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
 import { LegislativeActionLinkerService } from './legislative-action-linker.service';
 import { BoundaryLoaderService } from './boundary-loader.service';
@@ -218,6 +219,7 @@ const promptClientAsyncConfig = {
     PropositionFinanceLinkerService,
     CandidateCommitteeLinkerService,
     PropositionFundingService,
+    RepresentativeFundingService,
     LegislativeCommitteeLinkerService,
     LegislativeCommitteeService,
     LegislativeCommitteeDescriptionGeneratorService,

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -46,6 +46,7 @@ import {
   PaginatedPropositions,
 } from './models/proposition.model';
 import { PropositionFundingModel } from './models/proposition-funding.model';
+import { RepresentativeFundingModel } from './models/representative-funding.model';
 import { MeetingModel, PaginatedMeetings } from './models/meeting.model';
 import { MinutesModel, PaginatedMinutes } from './models/minutes.model';
 import {
@@ -185,6 +186,17 @@ export class RegionResolver {
       await this.regionService.getPropositionFunding(propositionId);
     if (!funding) return null;
     return funding as unknown as PropositionFundingModel;
+  }
+
+  @Public()
+  @Query(() => RepresentativeFundingModel, { nullable: true })
+  @Extensions({ complexity: 25 })
+  async representativeFunding(
+    @Args({ name: 'id', type: () => ID }) id: string,
+  ): Promise<RepresentativeFundingModel | null> {
+    const funding = await this.regionService.getRepresentativeFunding(id);
+    if (!funding) return null;
+    return funding as unknown as RepresentativeFundingModel;
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/region.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region.service.ts
@@ -42,6 +42,7 @@ import {
   BillLifecycle,
 } from './models/bill.model';
 import type { PropositionFunding } from './proposition-funding.service';
+import type { RepresentativeFunding } from './representative-funding.service';
 import type {
   LegislativeCommitteeDetail,
   PaginatedLegislativeCommittees as PaginatedLegislativeCommitteesShape,
@@ -362,6 +363,12 @@ export class RegionDomainService {
     propositionId: string,
   ): Promise<PropositionFunding | null> {
     return this.queryService.getPropositionFunding(propositionId);
+  }
+
+  getRepresentativeFunding(
+    representativeId: string,
+  ): Promise<RepresentativeFunding | null> {
+    return this.queryService.getRepresentativeFunding(representativeId);
   }
 
   getMeetings(skip?: number, take?: number): Promise<PaginatedMeetings> {

--- a/apps/backend/src/apps/region/src/domains/representative-funding.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/representative-funding.service.spec.ts
@@ -22,7 +22,7 @@ function build(opts: {
     _sum: { amount: unknown };
     _count: { _all: number };
   }[];
-  distinctDonors?: { donorName: string }[];
+  donorCount?: number;
   perCommittee?: { committeeId: string; _sum: { amount: unknown } }[];
 }) {
   const groupBy = jest.fn((args: GroupByArgs) => {
@@ -42,13 +42,14 @@ function build(opts: {
         _sum: { amount: dec(opts.contributionSum ?? 0) },
       }),
       groupBy,
-      findMany: jest.fn().mockResolvedValue(opts.distinctDonors ?? []),
     },
     expenditure: {
       aggregate: jest
         .fn()
         .mockResolvedValue({ _sum: { amount: dec(opts.expenditureSum ?? 0) } }),
     },
+    // $queryRaw is a tagged-template fn — return the DB-side distinct count.
+    $queryRaw: jest.fn().mockResolvedValue([{ count: opts.donorCount ?? 0 }]),
   } as unknown as DbService;
   return new RepresentativeFundingService(db);
 }
@@ -88,7 +89,7 @@ describe('RepresentativeFundingService (#943)', () => {
           _count: { _all: 2 },
         },
       ],
-      distinctDonors: [{ donorName: 'ACME PAC' }, { donorName: 'Jane' }],
+      donorCount: 2,
       perCommittee: [{ committeeId: 'c1', _sum: { amount: dec(1000) } }],
     });
 
@@ -135,5 +136,47 @@ describe('RepresentativeFundingService (#943)', () => {
     const f = await svc.getFunding('rep-1');
     expect(f.committeeCount).toBe(0);
     expect(f.topDonors).toEqual([]);
+  });
+
+  it('serves a cached result and revives the asOf Date without recomputing', async () => {
+    const cached = {
+      representativeId: 'rep-1',
+      asOf: '2026-07-24T00:00:00.000Z',
+      totalRaised: 500,
+      totalSpent: 100,
+      donorCount: 10,
+      committeeCount: 1,
+      topDonors: [],
+      topEmployers: [],
+      committees: [],
+    };
+    const committeeFindMany = jest.fn();
+    const cache = {
+      get: jest.fn().mockResolvedValue(JSON.stringify(cached)),
+      set: jest.fn(),
+    };
+    const db = {
+      committee: { findMany: committeeFindMany },
+    } as unknown as DbService;
+    const svc = new RepresentativeFundingService(db, cache as unknown as never);
+
+    const f = await svc.getFunding('rep-1');
+    expect(committeeFindMany).not.toHaveBeenCalled(); // cache hit → no compute
+    expect(f.asOf).toBeInstanceOf(Date);
+    expect(f.totalRaised).toBe(500);
+  });
+
+  it('does not cache an empty-shaped result (so a freshly-linked rep is not stuck empty)', async () => {
+    const cache = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn(),
+    };
+    const db = {
+      committee: { findMany: jest.fn().mockResolvedValue([]) },
+    } as unknown as DbService;
+    const svc = new RepresentativeFundingService(db, cache as unknown as never);
+
+    await svc.getFunding('rep-1');
+    expect(cache.set).not.toHaveBeenCalled();
   });
 });

--- a/apps/backend/src/apps/region/src/domains/representative-funding.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/representative-funding.service.spec.ts
@@ -1,0 +1,139 @@
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { RepresentativeFundingService } from './representative-funding.service';
+
+/** Minimal Prisma.Decimal stand-in — the service only calls `.toNumber()`. */
+const dec = (n: number) => ({ toNumber: () => n });
+
+interface GroupByArgs {
+  by: string[];
+}
+
+function build(opts: {
+  committees?: { id: string; name: string }[];
+  contributionSum?: number;
+  expenditureSum?: number;
+  donorAgg?: {
+    donorName: string;
+    _sum: { amount: unknown };
+    _count: { _all: number };
+  }[];
+  employerAgg?: {
+    donorEmployer: string | null;
+    _sum: { amount: unknown };
+    _count: { _all: number };
+  }[];
+  distinctDonors?: { donorName: string }[];
+  perCommittee?: { committeeId: string; _sum: { amount: unknown } }[];
+}) {
+  const groupBy = jest.fn((args: GroupByArgs) => {
+    if (args.by[0] === 'donorName') return Promise.resolve(opts.donorAgg ?? []);
+    if (args.by[0] === 'donorEmployer')
+      return Promise.resolve(opts.employerAgg ?? []);
+    if (args.by[0] === 'committeeId')
+      return Promise.resolve(opts.perCommittee ?? []);
+    return Promise.resolve([]);
+  });
+  const db = {
+    committee: {
+      findMany: jest.fn().mockResolvedValue(opts.committees ?? []),
+    },
+    contribution: {
+      aggregate: jest.fn().mockResolvedValue({
+        _sum: { amount: dec(opts.contributionSum ?? 0) },
+      }),
+      groupBy,
+      findMany: jest.fn().mockResolvedValue(opts.distinctDonors ?? []),
+    },
+    expenditure: {
+      aggregate: jest
+        .fn()
+        .mockResolvedValue({ _sum: { amount: dec(opts.expenditureSum ?? 0) } }),
+    },
+  } as unknown as DbService;
+  return new RepresentativeFundingService(db);
+}
+
+describe('RepresentativeFundingService (#943)', () => {
+  it('returns an empty-shaped result when the rep has no linked committees', async () => {
+    const svc = build({ committees: [] });
+    const funding = await svc.getFunding('rep-1');
+    expect(funding).toMatchObject({
+      representativeId: 'rep-1',
+      totalRaised: 0,
+      totalSpent: 0,
+      donorCount: 0,
+      committeeCount: 0,
+      topDonors: [],
+      topEmployers: [],
+      committees: [],
+    });
+  });
+
+  it('aggregates totals, top donors, top employers, and per-committee raised', async () => {
+    const svc = build({
+      committees: [{ id: 'c1', name: 'Friends of Doe' }],
+      contributionSum: 1000,
+      expenditureSum: 250,
+      donorAgg: [
+        {
+          donorName: 'ACME PAC',
+          _sum: { amount: dec(600) },
+          _count: { _all: 3 },
+        },
+      ],
+      employerAgg: [
+        {
+          donorEmployer: 'Big Oil Co',
+          _sum: { amount: dec(500) },
+          _count: { _all: 2 },
+        },
+      ],
+      distinctDonors: [{ donorName: 'ACME PAC' }, { donorName: 'Jane' }],
+      perCommittee: [{ committeeId: 'c1', _sum: { amount: dec(1000) } }],
+    });
+
+    const f = await svc.getFunding('rep-1');
+    expect(f.totalRaised).toBe(1000);
+    expect(f.totalSpent).toBe(250);
+    expect(f.donorCount).toBe(2);
+    expect(f.committeeCount).toBe(1);
+    expect(f.topDonors).toEqual([
+      { donorName: 'ACME PAC', totalAmount: 600, contributionCount: 3 },
+    ]);
+    expect(f.topEmployers).toEqual([
+      { employer: 'Big Oil Co', totalAmount: 500, contributionCount: 2 },
+    ]);
+    expect(f.committees).toEqual([
+      { id: 'c1', name: 'Friends of Doe', totalRaised: 1000 },
+    ]);
+  });
+
+  it('drops employer buckets with a null employer', async () => {
+    const svc = build({
+      committees: [{ id: 'c1', name: 'C1' }],
+      employerAgg: [
+        {
+          donorEmployer: null,
+          _sum: { amount: dec(999) },
+          _count: { _all: 9 },
+        },
+        {
+          donorEmployer: 'Real Employer',
+          _sum: { amount: dec(100) },
+          _count: { _all: 1 },
+        },
+      ],
+    });
+    const f = await svc.getFunding('rep-1');
+    expect(f.topEmployers).toEqual([
+      { employer: 'Real Employer', totalAmount: 100, contributionCount: 1 },
+    ]);
+  });
+
+  it('is empty-shaped with no db wired', async () => {
+    const svc = new RepresentativeFundingService();
+    const f = await svc.getFunding('rep-1');
+    expect(f.committeeCount).toBe(0);
+    expect(f.topDonors).toEqual([]);
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/representative-funding.service.ts
+++ b/apps/backend/src/apps/region/src/domains/representative-funding.service.ts
@@ -1,0 +1,169 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
+import type { ICache } from '@opuspopuli/common';
+import { REGION_CACHE } from './region.tokens';
+
+export interface RepFundingTopDonor {
+  donorName: string;
+  totalAmount: number;
+  contributionCount: number;
+}
+
+export interface RepFundingTopEmployer {
+  employer: string;
+  totalAmount: number;
+  contributionCount: number;
+}
+
+export interface RepFundingCommittee {
+  id: string;
+  name: string;
+  totalRaised: number;
+}
+
+export interface RepresentativeFunding {
+  representativeId: string;
+  asOf: Date;
+  totalRaised: number;
+  totalSpent: number;
+  donorCount: number;
+  committeeCount: number;
+  topDonors: RepFundingTopDonor[];
+  topEmployers: RepFundingTopEmployer[];
+  committees: RepFundingCommittee[];
+}
+
+const TOP_DONORS_LIMIT = 8;
+const TOP_EMPLOYERS_LIMIT = 8;
+
+/**
+ * Aggregate campaign finance for a representative (#943, epic #936) across the
+ * committees the candidate-committee linker (#941) attributed to them. Powers
+ * the rep-page "follow the money" surface: totals, top donors, and the top
+ * employers behind the money (the industry / conflict-of-interest lens).
+ *
+ * Cached in REGION_CACHE under `representativeFunding:{id}`; returns an
+ * empty-shaped result when the rep has no linked committees (or no DB).
+ */
+@Injectable()
+export class RepresentativeFundingService {
+  private readonly logger = new Logger(RepresentativeFundingService.name);
+
+  constructor(
+    @Optional() private readonly db?: DbService,
+    @Optional() @Inject(REGION_CACHE) private readonly cache?: ICache<string>,
+  ) {}
+
+  async getFunding(representativeId: string): Promise<RepresentativeFunding> {
+    const cacheKey = `representativeFunding:${representativeId}`;
+    const cached = await this.cache?.get(cacheKey);
+    if (cached) {
+      const parsed = JSON.parse(cached) as RepresentativeFunding;
+      parsed.asOf = new Date(parsed.asOf);
+      return parsed;
+    }
+    const fresh = await this.computeFunding(representativeId);
+    await this.cache?.set(cacheKey, JSON.stringify(fresh));
+    return fresh;
+  }
+
+  private async computeFunding(
+    representativeId: string,
+  ): Promise<RepresentativeFunding> {
+    if (!this.db) return this.empty(representativeId);
+
+    const committees = await this.db.committee.findMany({
+      where: { representativeId, deletedAt: null },
+      select: { id: true, name: true },
+    });
+    if (committees.length === 0) return this.empty(representativeId);
+    const committeeIds = committees.map((c) => c.id);
+    const where = { committeeId: { in: committeeIds } };
+
+    const [
+      contributionAgg,
+      expenditureAgg,
+      donorAgg,
+      employerAgg,
+      uniqueDonors,
+      perCommittee,
+    ] = await Promise.all([
+      this.db.contribution.aggregate({ where, _sum: { amount: true } }),
+      this.db.expenditure.aggregate({ where, _sum: { amount: true } }),
+      this.db.contribution.groupBy({
+        by: ['donorName'],
+        where,
+        _sum: { amount: true },
+        _count: { _all: true },
+        orderBy: { _sum: { amount: 'desc' } },
+        take: TOP_DONORS_LIMIT,
+      }),
+      this.db.contribution.groupBy({
+        by: ['donorEmployer'],
+        where: { ...where, donorEmployer: { not: null } },
+        _sum: { amount: true },
+        _count: { _all: true },
+        orderBy: { _sum: { amount: 'desc' } },
+        take: TOP_EMPLOYERS_LIMIT,
+      }),
+      this.db.contribution.findMany({
+        where,
+        distinct: ['donorName'],
+        select: { donorName: true },
+      }),
+      this.db.contribution.groupBy({
+        by: ['committeeId'],
+        where,
+        _sum: { amount: true },
+      }),
+    ]);
+
+    const raisedByCommittee = new Map(
+      perCommittee.map((p) => [p.committeeId, toNumber(p._sum.amount)]),
+    );
+
+    return {
+      representativeId,
+      asOf: new Date(),
+      totalRaised: toNumber(contributionAgg._sum.amount),
+      totalSpent: toNumber(expenditureAgg._sum.amount),
+      donorCount: uniqueDonors.length,
+      committeeCount: committees.length,
+      topDonors: donorAgg.map((d) => ({
+        donorName: d.donorName,
+        totalAmount: toNumber(d._sum.amount),
+        contributionCount: d._count._all,
+      })),
+      topEmployers: employerAgg
+        .filter((e) => e.donorEmployer)
+        .map((e) => ({
+          employer: e.donorEmployer as string,
+          totalAmount: toNumber(e._sum.amount),
+          contributionCount: e._count._all,
+        })),
+      committees: committees.map((c) => ({
+        id: c.id,
+        name: c.name,
+        totalRaised: raisedByCommittee.get(c.id) ?? 0,
+      })),
+    };
+  }
+
+  private empty(representativeId: string): RepresentativeFunding {
+    return {
+      representativeId,
+      asOf: new Date(),
+      totalRaised: 0,
+      totalSpent: 0,
+      donorCount: 0,
+      committeeCount: 0,
+      topDonors: [],
+      topEmployers: [],
+      committees: [],
+    };
+  }
+}
+
+function toNumber(value: Prisma.Decimal | null | undefined): number {
+  return value ? value.toNumber() : 0;
+}

--- a/apps/backend/src/apps/region/src/domains/representative-funding.service.ts
+++ b/apps/backend/src/apps/region/src/domains/representative-funding.service.ts
@@ -63,7 +63,12 @@ export class RepresentativeFundingService {
       return parsed;
     }
     const fresh = await this.computeFunding(representativeId);
-    await this.cache?.set(cacheKey, JSON.stringify(fresh));
+    // Don't cache the empty-shaped result: a rep freshly attributed committees
+    // by the linker (#941) + a finance sync would otherwise stay empty until
+    // the 4h TTL expires. Populated results are safe to cache.
+    if (fresh.committeeCount > 0) {
+      await this.cache?.set(cacheKey, JSON.stringify(fresh));
+    }
     return fresh;
   }
 
@@ -85,7 +90,7 @@ export class RepresentativeFundingService {
       expenditureAgg,
       donorAgg,
       employerAgg,
-      uniqueDonors,
+      donorCountRows,
       perCommittee,
     ] = await Promise.all([
       this.db.contribution.aggregate({ where, _sum: { amount: true } }),
@@ -106,11 +111,15 @@ export class RepresentativeFundingService {
         orderBy: { _sum: { amount: 'desc' } },
         take: TOP_EMPLOYERS_LIMIT,
       }),
-      this.db.contribution.findMany({
-        where,
-        distinct: ['donorName'],
-        select: { donorName: true },
-      }),
+      // DB-side distinct count — returns a single row instead of materializing
+      // every distinct donor name just to `.length` it (the @Public endpoint
+      // could otherwise force a large unbounded scan). committeeIds are bound
+      // via Prisma.join, so this is parameterized.
+      this.db.$queryRaw<{ count: number }[]>`
+        SELECT COUNT(DISTINCT donor_name)::int AS count
+        FROM contributions
+        WHERE committee_id IN (${Prisma.join(committeeIds)})
+      `,
       this.db.contribution.groupBy({
         by: ['committeeId'],
         where,
@@ -127,7 +136,7 @@ export class RepresentativeFundingService {
       asOf: new Date(),
       totalRaised: toNumber(contributionAgg._sum.amount),
       totalSpent: toNumber(expenditureAgg._sum.amount),
-      donorCount: uniqueDonors.length,
+      donorCount: donorCountRows[0]?.count ?? 0,
       committeeCount: committees.length,
       topDonors: donorAgg.map((d) => ({
         donorName: d.donorName,
@@ -141,11 +150,14 @@ export class RepresentativeFundingService {
           totalAmount: toNumber(e._sum.amount),
           contributionCount: e._count._all,
         })),
-      committees: committees.map((c) => ({
-        id: c.id,
-        name: c.name,
-        totalRaised: raisedByCommittee.get(c.id) ?? 0,
-      })),
+      // Ordered by money so the "flows through" list is meaningful + stable.
+      committees: committees
+        .map((c) => ({
+          id: c.id,
+          name: c.name,
+          totalRaised: raisedByCommittee.get(c.id) ?? 0,
+        }))
+        .sort((a, b) => b.totalRaised - a.totalRaised),
     };
   }
 

--- a/apps/frontend/__tests__/accessibility/rep-funding.a11y.test.tsx
+++ b/apps/frontend/__tests__/accessibility/rep-funding.a11y.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * WCAG 2.2 AA accessibility tests for the rep-page campaign-finance money-trail
+ * panel (#943, epic #936).
+ */
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+
+import { axe } from "@/__tests__/utils/a11y-utils";
+
+let mockResult: {
+  data: { representativeFunding: unknown } | undefined;
+  loading: boolean;
+};
+jest.mock("@apollo/client/react", () => ({
+  useQuery: () => mockResult,
+}));
+
+import { RepresentativeFundingPanel } from "@/components/region/RepresentativeFundingPanel";
+
+const funding = {
+  representativeId: "rep-1",
+  asOf: "2026-07-24",
+  totalRaised: 125000,
+  totalSpent: 40000,
+  donorCount: 320,
+  committeeCount: 2,
+  topDonors: [
+    { donorName: "ACME PAC", totalAmount: 25000, contributionCount: 12 },
+  ],
+  topEmployers: [
+    { employer: "Big Oil Co", totalAmount: 18000, contributionCount: 8 },
+  ],
+  committees: [{ id: "c1", name: "Re-Elect Jane Doe", totalRaised: 100000 }],
+};
+
+describe("RepresentativeFundingPanel — WCAG 2.2 AA", () => {
+  it("populated panel has no axe violations", async () => {
+    mockResult = { data: { representativeFunding: funding }, loading: false };
+    const { container } = render(
+      <RepresentativeFundingPanel representativeId="rep-1" />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("empty state has no axe violations", async () => {
+    mockResult = {
+      data: { representativeFunding: { ...funding, committeeCount: 0 } },
+      loading: false,
+    };
+    const { container } = render(
+      <RepresentativeFundingPanel representativeId="rep-1" />,
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/frontend/__tests__/components/region/RepresentativeFundingPanel.test.tsx
+++ b/apps/frontend/__tests__/components/region/RepresentativeFundingPanel.test.tsx
@@ -38,6 +38,9 @@ describe("RepresentativeFundingPanel (#943)", () => {
     expect(screen.getByText("$25,000")).toBeInTheDocument();
     expect(screen.getByText("Big Oil Co")).toBeInTheDocument(); // the industry lens
     expect(screen.getByText("$18,000")).toBeInTheDocument();
+    // money's path — the real (roster-identified) committee names
+    expect(screen.getByText("Re-Elect Jane Doe")).toBeInTheDocument();
+    expect(screen.getByText("$100,000")).toBeInTheDocument();
   });
 
   it("shows the empty state when the rep has no linked committees", () => {

--- a/apps/frontend/__tests__/components/region/RepresentativeFundingPanel.test.tsx
+++ b/apps/frontend/__tests__/components/region/RepresentativeFundingPanel.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+let mockResult: {
+  data: { representativeFunding: unknown } | undefined;
+  loading: boolean;
+};
+jest.mock("@apollo/client/react", () => ({
+  useQuery: () => mockResult,
+}));
+
+import { RepresentativeFundingPanel } from "@/components/region/RepresentativeFundingPanel";
+
+const base = {
+  representativeId: "rep-1",
+  asOf: "2026-07-24",
+  totalRaised: 125000,
+  totalSpent: 40000,
+  donorCount: 320,
+  committeeCount: 2,
+  topDonors: [
+    { donorName: "ACME PAC", totalAmount: 25000, contributionCount: 12 },
+  ],
+  topEmployers: [
+    { employer: "Big Oil Co", totalAmount: 18000, contributionCount: 8 },
+  ],
+  committees: [{ id: "c1", name: "Re-Elect Jane Doe", totalRaised: 100000 }],
+};
+
+describe("RepresentativeFundingPanel (#943)", () => {
+  it("renders totals, top donors and top employers as formatted currency", () => {
+    mockResult = { data: { representativeFunding: base }, loading: false };
+    render(<RepresentativeFundingPanel representativeId="rep-1" />);
+
+    expect(screen.getByText("$125,000")).toBeInTheDocument(); // total raised
+    expect(screen.getByText("$40,000")).toBeInTheDocument(); // total spent
+    expect(screen.getByText("ACME PAC")).toBeInTheDocument();
+    expect(screen.getByText("$25,000")).toBeInTheDocument();
+    expect(screen.getByText("Big Oil Co")).toBeInTheDocument(); // the industry lens
+    expect(screen.getByText("$18,000")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when the rep has no linked committees", () => {
+    mockResult = {
+      data: { representativeFunding: { ...base, committeeCount: 0 } },
+      loading: false,
+    };
+    render(<RepresentativeFundingPanel representativeId="rep-1" />);
+    expect(
+      screen.getByText(/no campaign-finance filings are linked/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the empty state when funding is null", () => {
+    mockResult = { data: { representativeFunding: null }, loading: false };
+    render(<RepresentativeFundingPanel representativeId="rep-1" />);
+    expect(
+      screen.getByText(/no campaign-finance filings are linked/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/app/region/representatives/[id]/page.tsx
+++ b/apps/frontend/app/region/representatives/[id]/page.tsx
@@ -24,6 +24,7 @@ import { LoadingSkeleton, ErrorState } from "@/components/region/ListStates";
 import { PartyBadge } from "@/components/region/PartyBadge";
 import { SectionTitle } from "@/components/region/SectionTitle";
 import { ComingSoon } from "@/components/region/ComingSoon";
+import { RepresentativeFundingPanel } from "@/components/region/RepresentativeFundingPanel";
 import { LayerButton } from "@/components/region/LayerButton";
 import { LayerNav } from "@/components/region/LayerNav";
 import { ActivityStats } from "@/components/region/ActivityStats";
@@ -659,10 +660,7 @@ function HowTheyAreSupported({
     <div className="animate-layer-enter">
       <div className="mb-8">
         <SectionTitle>Campaign Finance</SectionTitle>
-        <ComingSoon
-          title="Coming Soon"
-          description="Top contributors, total raised, expenditures, and independent spending supporting or opposing this representative. Tracked in #566."
-        />
+        <RepresentativeFundingPanel representativeId={rep.id} />
       </div>
 
       <div className="bg-surface-alt rounded-lg border-l-4 border-content p-6 mb-8">

--- a/apps/frontend/components/region/RepresentativeFundingPanel.tsx
+++ b/apps/frontend/components/region/RepresentativeFundingPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useQuery } from "@apollo/client/react";
 import { useTranslation } from "react-i18next";
 
@@ -9,11 +10,7 @@ import {
   type IdVars,
 } from "@/lib/graphql/region";
 
-const usd = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-});
+type Formatter = (n: number) => string;
 
 /**
  * The rep-page "money trail" (#943, epic #936). Aggregates the campaign finance
@@ -26,7 +23,18 @@ export function RepresentativeFundingPanel({
 }: {
   readonly representativeId: string;
 }) {
-  const { t } = useTranslation("civics");
+  const { t, i18n } = useTranslation("civics");
+  // Currency is USD (US campaign finance) but grouping follows the active
+  // locale so the ES surface reads naturally.
+  const usd = useMemo<Intl.NumberFormat>(
+    () =>
+      new Intl.NumberFormat(i18n.language || "en-US", {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 0,
+      }),
+    [i18n.language],
+  );
   const { data, loading } = useQuery<RepresentativeFundingData, IdVars>(
     GET_REPRESENTATIVE_FUNDING,
     { variables: { id: representativeId }, fetchPolicy: "cache-and-network" },
@@ -78,6 +86,7 @@ export function RepresentativeFundingPanel({
             amount: d.totalAmount,
             count: d.contributionCount,
           }))}
+          format={usd.format}
           countLabel={(n) => t("repFinance.contributions", { count: n })}
         />
       )}
@@ -91,6 +100,7 @@ export function RepresentativeFundingPanel({
             amount: e.totalAmount,
             count: e.contributionCount,
           }))}
+          format={usd.format}
           countLabel={(n) => t("repFinance.contributions", { count: n })}
         />
       )}
@@ -103,6 +113,7 @@ export function RepresentativeFundingPanel({
             name: c.name,
             amount: c.totalRaised,
           }))}
+          format={usd.format}
         />
       )}
 
@@ -135,6 +146,7 @@ function Stat({
 function MoneyList({
   heading,
   rows,
+  format,
   countLabel,
 }: {
   readonly heading: string;
@@ -144,6 +156,7 @@ function MoneyList({
     amount: number;
     count?: number;
   }[];
+  readonly format: Formatter;
   readonly countLabel?: (n: number) => string;
 }) {
   return (
@@ -160,7 +173,7 @@ function MoneyList({
             <span className="text-content truncate">{r.name}</span>
             <span className="flex-shrink-0 text-content-dim tabular-nums">
               <span className="font-semibold text-content">
-                {usd.format(r.amount)}
+                {format(r.amount)}
               </span>
               {countLabel && r.count != null && (
                 <span className="text-[11px] text-content-dim">

--- a/apps/frontend/components/region/RepresentativeFundingPanel.tsx
+++ b/apps/frontend/components/region/RepresentativeFundingPanel.tsx
@@ -95,6 +95,17 @@ export function RepresentativeFundingPanel({
         />
       )}
 
+      {funding.committees.length > 0 && (
+        <MoneyList
+          heading={t("repFinance.throughCommittees")}
+          rows={funding.committees.map((c) => ({
+            key: c.id,
+            name: c.name,
+            amount: c.totalRaised,
+          }))}
+        />
+      )}
+
       <p className="text-[11px] text-content-dim italic">
         {t("repFinance.provenance")}
       </p>
@@ -131,9 +142,9 @@ function MoneyList({
     key: string;
     name: string;
     amount: number;
-    count: number;
+    count?: number;
   }[];
-  readonly countLabel: (n: number) => string;
+  readonly countLabel?: (n: number) => string;
 }) {
   return (
     <div>
@@ -150,10 +161,13 @@ function MoneyList({
             <span className="flex-shrink-0 text-content-dim tabular-nums">
               <span className="font-semibold text-content">
                 {usd.format(r.amount)}
-              </span>{" "}
-              <span className="text-[11px] text-content-dim">
-                {countLabel(r.count)}
               </span>
+              {countLabel && r.count != null && (
+                <span className="text-[11px] text-content-dim">
+                  {" "}
+                  {countLabel(r.count)}
+                </span>
+              )}
             </span>
           </li>
         ))}

--- a/apps/frontend/components/region/RepresentativeFundingPanel.tsx
+++ b/apps/frontend/components/region/RepresentativeFundingPanel.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useQuery } from "@apollo/client/react";
+import { useTranslation } from "react-i18next";
+
+import {
+  GET_REPRESENTATIVE_FUNDING,
+  type RepresentativeFundingData,
+  type IdVars,
+} from "@/lib/graphql/region";
+
+const usd = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+});
+
+/**
+ * The rep-page "money trail" (#943, epic #936). Aggregates the campaign finance
+ * of the committees the linker (#941) attributed to this representative: totals,
+ * top donors, and the top employers behind the money (the conflict-of-interest
+ * lens). Empty-shaped until a rep has linked committees + a finance sync runs.
+ */
+export function RepresentativeFundingPanel({
+  representativeId,
+}: {
+  readonly representativeId: string;
+}) {
+  const { t } = useTranslation("civics");
+  const { data, loading } = useQuery<RepresentativeFundingData, IdVars>(
+    GET_REPRESENTATIVE_FUNDING,
+    { variables: { id: representativeId }, fetchPolicy: "cache-and-network" },
+  );
+
+  const funding = data?.representativeFunding;
+
+  if (loading && !funding) {
+    return (
+      <p className="text-sm text-content-dim italic">
+        {t("repFinance.loading")}
+      </p>
+    );
+  }
+
+  if (!funding || funding.committeeCount === 0) {
+    return (
+      <p className="text-sm text-slate-600 italic">{t("repFinance.empty")}</p>
+    );
+  }
+
+  return (
+    <section aria-label={t("repFinance.heading")} className="space-y-5">
+      <dl className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <Stat
+          label={t("repFinance.totalRaised")}
+          value={usd.format(funding.totalRaised)}
+        />
+        <Stat
+          label={t("repFinance.totalSpent")}
+          value={usd.format(funding.totalSpent)}
+        />
+        <Stat
+          label={t("repFinance.donors")}
+          value={funding.donorCount.toLocaleString()}
+        />
+        <Stat
+          label={t("repFinance.committees")}
+          value={funding.committeeCount.toLocaleString()}
+        />
+      </dl>
+
+      {funding.topDonors.length > 0 && (
+        <MoneyList
+          heading={t("repFinance.topDonors")}
+          rows={funding.topDonors.map((d) => ({
+            key: d.donorName,
+            name: d.donorName,
+            amount: d.totalAmount,
+            count: d.contributionCount,
+          }))}
+          countLabel={(n) => t("repFinance.contributions", { count: n })}
+        />
+      )}
+
+      {funding.topEmployers.length > 0 && (
+        <MoneyList
+          heading={t("repFinance.topEmployers")}
+          rows={funding.topEmployers.map((e) => ({
+            key: e.employer,
+            name: e.employer,
+            amount: e.totalAmount,
+            count: e.contributionCount,
+          }))}
+          countLabel={(n) => t("repFinance.contributions", { count: n })}
+        />
+      )}
+
+      <p className="text-[11px] text-content-dim italic">
+        {t("repFinance.provenance")}
+      </p>
+    </section>
+  );
+}
+
+function Stat({
+  label,
+  value,
+}: {
+  readonly label: string;
+  readonly value: string;
+}) {
+  return (
+    <div className="bg-surface-alt rounded-lg p-3">
+      <dt className="text-[11px] uppercase tracking-wide text-content-dim">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-lg font-bold text-content tabular-nums">
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function MoneyList({
+  heading,
+  rows,
+  countLabel,
+}: {
+  readonly heading: string;
+  readonly rows: {
+    key: string;
+    name: string;
+    amount: number;
+    count: number;
+  }[];
+  readonly countLabel: (n: number) => string;
+}) {
+  return (
+    <div>
+      <h4 className="text-[11px] uppercase tracking-wider font-bold text-content-dim mb-2">
+        {heading}
+      </h4>
+      <ol className="space-y-1.5">
+        {rows.map((r) => (
+          <li
+            key={r.key}
+            className="flex items-baseline justify-between gap-3 text-sm border-l-2 border-line pl-3"
+          >
+            <span className="text-content truncate">{r.name}</span>
+            <span className="flex-shrink-0 text-content-dim tabular-nums">
+              <span className="font-semibold text-content">
+                {usd.format(r.amount)}
+              </span>{" "}
+              <span className="text-[11px] text-content-dim">
+                {countLabel(r.count)}
+              </span>
+            </span>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -887,6 +887,66 @@ export const GET_PROPOSITION_FUNDING = gql`
   }
 `;
 
+// ============================================
+// REPRESENTATIVE FUNDING — the money trail (issue #943 / epic #936)
+// ============================================
+
+/** Aggregated giving by donor employer — the industry / conflict-of-interest lens. */
+export interface FinanceTopEmployer {
+  employer: string;
+  totalAmount: number;
+  contributionCount: number;
+}
+
+/**
+ * Campaign finance aggregated across the committees linked to a representative
+ * (by the candidate-committee linker, #941). Empty-shaped until a rep has
+ * linked committees + a finance sync has run.
+ */
+export interface RepresentativeFunding {
+  representativeId: string;
+  asOf: string;
+  totalRaised: number;
+  totalSpent: number;
+  donorCount: number;
+  committeeCount: number;
+  topDonors: TopDonor[];
+  topEmployers: FinanceTopEmployer[];
+  committees: CommitteeSummaryFunding[];
+}
+
+export interface RepresentativeFundingData {
+  representativeFunding: RepresentativeFunding | null;
+}
+
+export const GET_REPRESENTATIVE_FUNDING = gql`
+  query GetRepresentativeFunding($id: ID!) {
+    representativeFunding(id: $id) {
+      representativeId
+      asOf
+      totalRaised
+      totalSpent
+      donorCount
+      committeeCount
+      topDonors {
+        donorName
+        totalAmount
+        contributionCount
+      }
+      topEmployers {
+        employer
+        totalAmount
+        contributionCount
+      }
+      committees {
+        id
+        name
+        totalRaised
+      }
+    }
+  }
+`;
+
 export const REGENERATE_PROPOSITION_ANALYSIS = gql`
   mutation RegeneratePropositionAnalysis($id: ID!) {
     regeneratePropositionAnalysis(id: $id) {

--- a/apps/frontend/locales/en/civics.json
+++ b/apps/frontend/locales/en/civics.json
@@ -86,6 +86,7 @@
     "committees": "Committees",
     "topDonors": "Top donors",
     "topEmployers": "Top employers behind the money",
+    "throughCommittees": "Money flows through these committees",
     "contributions_one": "{{count}} gift",
     "contributions_other": "{{count}} gifts",
     "provenance": "Source: public CAL-ACCESS / FEC campaign-finance filings."

--- a/apps/frontend/locales/en/civics.json
+++ b/apps/frontend/locales/en/civics.json
@@ -75,5 +75,19 @@
       "badge_one": "{{count}} concern",
       "badge_other": "{{count}} concerns"
     }
+  },
+  "repFinance": {
+    "heading": "Campaign finance",
+    "loading": "Loading campaign finance…",
+    "empty": "No campaign-finance filings are linked to this representative yet.",
+    "totalRaised": "Total raised",
+    "totalSpent": "Total spent",
+    "donors": "Donors",
+    "committees": "Committees",
+    "topDonors": "Top donors",
+    "topEmployers": "Top employers behind the money",
+    "contributions_one": "{{count}} gift",
+    "contributions_other": "{{count}} gifts",
+    "provenance": "Source: public CAL-ACCESS / FEC campaign-finance filings."
   }
 }

--- a/apps/frontend/locales/es/civics.json
+++ b/apps/frontend/locales/es/civics.json
@@ -86,6 +86,7 @@
     "committees": "Comités",
     "topDonors": "Principales donantes",
     "topEmployers": "Principales empleadores detrás del dinero",
+    "throughCommittees": "El dinero fluye a través de estos comités",
     "contributions_one": "{{count}} aporte",
     "contributions_other": "{{count}} aportes",
     "provenance": "Fuente: informes públicos de financiamiento de campaña de CAL-ACCESS / FEC."

--- a/apps/frontend/locales/es/civics.json
+++ b/apps/frontend/locales/es/civics.json
@@ -75,5 +75,19 @@
       "badge_one": "{{count}} inquietud",
       "badge_other": "{{count}} inquietudes"
     }
+  },
+  "repFinance": {
+    "heading": "Financiamiento de campaña",
+    "loading": "Cargando financiamiento de campaña…",
+    "empty": "Aún no hay informes de financiamiento de campaña vinculados a este representante.",
+    "totalRaised": "Total recaudado",
+    "totalSpent": "Total gastado",
+    "donors": "Donantes",
+    "committees": "Comités",
+    "topDonors": "Principales donantes",
+    "topEmployers": "Principales empleadores detrás del dinero",
+    "contributions_one": "{{count}} aporte",
+    "contributions_other": "{{count}} aportes",
+    "provenance": "Fuente: informes públicos de financiamiento de campaña de CAL-ACCESS / FEC."
   }
 }


### PR DESCRIPTION
## S6 of epic #936 — the rep-page money trail (the visible payoff)

Replaces the #566 "Coming Soon" stub on the representative page (Layer 4) with the real **follow-the-money** surface — the head-turning conflict-of-interest view.

### Backend — `representativeFunding(id)` GraphQL surface
`RepresentativeFundingService` aggregates campaign finance across the committees the candidate-committee linker (#941) attributed to a rep:
- Totals (raised/spent), **donor count via DB-side `COUNT(DISTINCT)`**, top donors, **top employers behind the money** (the industry lens), and per-committee raised (ordered by amount).
- `@Public` + `complexity: 25`, cached in REGION_CACHE (empty results **not** cached, so a freshly-linked rep isn't stuck empty). Wired through RegionQueryService → RegionDomainService → resolver, mirroring `propositionFunding`. Federation via IntrospectAndCompose.

### Frontend — `RepresentativeFundingPanel`
Totals grid, top donors, **top employers behind the money**, and the committees the money flows through (real roster-identified names). Currency-formatted (locale-aware), empty/loading states, EN/ES i18n, WCAG 2.2 AA.

The complete chain on one page: **donor → industry → committee → legislator**, all sourced to public CAL-ACCESS/FEC filings.

### Reviews
`/op-review` (no blockers) + `/security-review` (one MEDIUM — the unbounded distinct scan — fixed via DB-side count). All suggestions applied.

### Depends on
The linker + schema from #941 (merged). Empty-shaped until a rep has linked committees + a finance-roster sync runs. Migration was in #941; no new migration here.

Completes epic #936. Tests: backend aggregation/cache (6), frontend panel + a11y (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
