### PR TITLE
fix(region): canonicalize donor names on the rep money-trail (#954)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/representative-funding.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/representative-funding.service.spec.ts
@@ -1,5 +1,8 @@
 import { DbService } from '@opuspopuli/relationaldb-provider';
-import { RepresentativeFundingService } from './representative-funding.service';
+import {
+  RepresentativeFundingService,
+  canonicalizeDonorName,
+} from './representative-funding.service';
 
 /** Minimal Prisma.Decimal stand-in — the service only calls `.toNumber()`. */
 const dec = (n: number) => ({ toNumber: () => n });
@@ -8,21 +11,23 @@ interface GroupByArgs {
   by: string[];
 }
 
+type DonorRow = {
+  donorName: string;
+  _sum: { amount: unknown };
+  _count: { _all: number };
+};
+type EmployerRow = {
+  donorEmployer: string | null;
+  _sum: { amount: unknown };
+  _count: { _all: number };
+};
+
 function build(opts: {
   committees?: { id: string; name: string }[];
   contributionSum?: number;
   expenditureSum?: number;
-  donorAgg?: {
-    donorName: string;
-    _sum: { amount: unknown };
-    _count: { _all: number };
-  }[];
-  employerAgg?: {
-    donorEmployer: string | null;
-    _sum: { amount: unknown };
-    _count: { _all: number };
-  }[];
-  donorCount?: number;
+  donorAgg?: DonorRow[];
+  employerAgg?: EmployerRow[];
   perCommittee?: { committeeId: string; _sum: { amount: unknown } }[];
 }) {
   const groupBy = jest.fn((args: GroupByArgs) => {
@@ -48,11 +53,62 @@ function build(opts: {
         .fn()
         .mockResolvedValue({ _sum: { amount: dec(opts.expenditureSum ?? 0) } }),
     },
-    // $queryRaw is a tagged-template fn — return the DB-side distinct count.
-    $queryRaw: jest.fn().mockResolvedValue([{ count: opts.donorCount ?? 0 }]),
   } as unknown as DbService;
   return new RepresentativeFundingService(db);
 }
+
+/** Build a donor group row for the mocked groupBy. */
+const donor = (name: string, amount: number, count = 1): DonorRow => ({
+  donorName: name,
+  _sum: { amount: dec(amount) },
+  _count: { _all: count },
+});
+
+describe('canonicalizeDonorName (#954)', () => {
+  it('collapses case, punctuation, and whitespace variants', () => {
+    expect(canonicalizeDonorName('ACME Widgets')).toBe(
+      canonicalizeDonorName('acme,  widgets.'),
+    );
+  });
+
+  it('is word-order independent', () => {
+    expect(canonicalizeDonorName('Jones Smith')).toBe(
+      canonicalizeDonorName('Smith Jones'),
+    );
+  });
+
+  it('expands "&" to "and" so both spellings match', () => {
+    expect(canonicalizeDonorName('Smith & Jones')).toBe(
+      canonicalizeDonorName('Smith and Jones'),
+    );
+  });
+
+  it('drops boilerplate tokens (PAC / Inc / Committee / trailing suffix)', () => {
+    expect(canonicalizeDonorName('Realtors PAC')).toBe(
+      canonicalizeDonorName('Realtors'),
+    );
+    expect(canonicalizeDonorName('Widgets Inc')).toBe(
+      canonicalizeDonorName('Widgets'),
+    );
+  });
+
+  it('returns "" for a boilerplate-only name (callers must not merge these)', () => {
+    expect(canonicalizeDonorName('PAC')).toBe('');
+    expect(canonicalizeDonorName('The Committee')).toBe('');
+  });
+
+  it('keeps substantive words that distinguish donors — no over-merge', () => {
+    // "Council on Political Education" carries substantive tokens; two counties
+    // must stay distinct.
+    expect(
+      canonicalizeDonorName(
+        'Los Angeles County Council on Political Education',
+      ),
+    ).not.toBe(
+      canonicalizeDonorName('San Diego County Council on Political Education'),
+    );
+  });
+});
 
 describe('RepresentativeFundingService (#943)', () => {
   it('returns an empty-shaped result when the rep has no linked committees', async () => {
@@ -75,13 +131,7 @@ describe('RepresentativeFundingService (#943)', () => {
       committees: [{ id: 'c1', name: 'Friends of Doe' }],
       contributionSum: 1000,
       expenditureSum: 250,
-      donorAgg: [
-        {
-          donorName: 'ACME PAC',
-          _sum: { amount: dec(600) },
-          _count: { _all: 3 },
-        },
-      ],
+      donorAgg: [donor('ACME PAC', 600, 3)],
       employerAgg: [
         {
           donorEmployer: 'Big Oil Co',
@@ -89,14 +139,15 @@ describe('RepresentativeFundingService (#943)', () => {
           _count: { _all: 2 },
         },
       ],
-      donorCount: 2,
       perCommittee: [{ committeeId: 'c1', _sum: { amount: dec(1000) } }],
     });
 
     const f = await svc.getFunding('rep-1');
     expect(f.totalRaised).toBe(1000);
     expect(f.totalSpent).toBe(250);
-    expect(f.donorCount).toBe(2);
+    // donorCount is now the distinct-canonical bucket count, not a raw
+    // COUNT(DISTINCT donor_name): one donor → 1.
+    expect(f.donorCount).toBe(1);
     expect(f.committeeCount).toBe(1);
     expect(f.topDonors).toEqual([
       { donorName: 'ACME PAC', totalAmount: 600, contributionCount: 3 },
@@ -109,7 +160,37 @@ describe('RepresentativeFundingService (#943)', () => {
     ]);
   });
 
-  it('drops employer buckets with a null employer', async () => {
+  it('merges donor-name spelling variants into one donor and sums the money (#954)', async () => {
+    // The prod case: one contributor split across spellings. Each fragment can
+    // rank below the others, but merged it is the dominant donor.
+    const svc = build({
+      committees: [{ id: 'c1', name: 'Doe for Senate' }],
+      donorAgg: [
+        donor('ACME Widgets PAC', 5000, 4),
+        donor('Widgets, ACME', 3000, 2), // punctuation + order variant
+        donor('acme widgets', 2000, 6), // case variant
+        donor('Different Donor LLC', 4000, 1),
+      ],
+    });
+
+    const f = await svc.getFunding('rep-1');
+    // 4 raw names → 2 canonical donors.
+    expect(f.donorCount).toBe(2);
+    // The three ACME variants merge to $10,000 / 12 gifts and rank first; the
+    // displayed name is the highest-dollar raw variant.
+    expect(f.topDonors[0]).toEqual({
+      donorName: 'ACME Widgets PAC',
+      totalAmount: 10000,
+      contributionCount: 12,
+    });
+    expect(f.topDonors[1]).toEqual({
+      donorName: 'Different Donor LLC',
+      totalAmount: 4000,
+      contributionCount: 1,
+    });
+  });
+
+  it('merges employer variants and drops null employers', async () => {
     const svc = build({
       committees: [{ id: 'c1', name: 'C1' }],
       employerAgg: [
@@ -119,16 +200,32 @@ describe('RepresentativeFundingService (#943)', () => {
           _count: { _all: 9 },
         },
         {
-          donorEmployer: 'Real Employer',
-          _sum: { amount: dec(100) },
-          _count: { _all: 1 },
+          donorEmployer: 'Big Oil Co.',
+          _sum: { amount: dec(600) },
+          _count: { _all: 3 },
+        },
+        {
+          donorEmployer: 'BIG OIL CO',
+          _sum: { amount: dec(400) },
+          _count: { _all: 2 },
         },
       ],
     });
     const f = await svc.getFunding('rep-1');
     expect(f.topEmployers).toEqual([
-      { employer: 'Real Employer', totalAmount: 100, contributionCount: 1 },
+      { employer: 'Big Oil Co.', totalAmount: 1000, contributionCount: 5 },
     ]);
+  });
+
+  it('does not merge distinct boilerplate-only names together', async () => {
+    // Two different all-boilerplate names must stay separate (canonical key ''
+    // falls back to the raw name).
+    const svc = build({
+      committees: [{ id: 'c1', name: 'C1' }],
+      donorAgg: [donor('PAC', 100, 1), donor('The Committee', 50, 1)],
+    });
+    const f = await svc.getFunding('rep-1');
+    expect(f.donorCount).toBe(2);
   });
 
   it('is empty-shaped with no db wired', async () => {

--- a/apps/backend/src/apps/region/src/domains/representative-funding.service.ts
+++ b/apps/backend/src/apps/region/src/domains/representative-funding.service.ts
@@ -36,6 +36,102 @@ export interface RepresentativeFunding {
 const TOP_DONORS_LIMIT = 8;
 const TOP_EMPLOYERS_LIMIT = 8;
 
+// Canonicalization merges donor-name variants AFTER the DB returns rows, so we
+// must scan more than the final 8: a donor fragmented across many spellings can
+// have each fragment ranked well below the top 8 yet dominate once merged (in
+// prod one labor federation was split 8 ways across a rep's contributions).
+// Bounded so the @Public endpoint never does a fully unbounded scan; a rep with
+// >1000 distinct raw donor strings would under-report the long tail only.
+const DONOR_SCAN_LIMIT = 1000;
+
+// Boilerplate tokens dropped before building a donor's canonical key. Kept
+// deliberately conservative — only legal-form / committee-type noise, never
+// substantive words — so distinct donors are not merged. Semantic variants
+// (e.g. "LA" vs "Los Angeles", added/dropped significant words) still fragment;
+// abbreviation and fuzzy/alias resolution are the follow-up (#954).
+const DONOR_NOISE_TOKENS = new Set([
+  'pac',
+  'inc',
+  'llc',
+  'corp',
+  'co',
+  'ltd',
+  'committee',
+  'the',
+  'a',
+  'of',
+  'on',
+  'and',
+  'for',
+]);
+
+interface RawDonorGroup {
+  name: string;
+  amount: number;
+  count: number;
+}
+
+interface DonorBucket {
+  name: string;
+  totalAmount: number;
+  contributionCount: number;
+}
+
+/**
+ * Reduce a donor/employer name to a canonical key so spelling variants of the
+ * same contributor aggregate together. Lowercases, expands `&`, strips
+ * punctuation, drops boilerplate tokens (see DONOR_NOISE_TOKENS), and sorts the
+ * remaining tokens so word-order variants collapse. Returns '' when a name is
+ * only boilerplate — callers fall back to the raw name so those never merge.
+ */
+export function canonicalizeDonorName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t && !DONOR_NOISE_TOKENS.has(t))
+    .sort((a, b) => a.localeCompare(b))
+    .join(' ');
+}
+
+/**
+ * Merge DB-grouped donor/employer rows by their canonical key, summing amounts
+ * and counts, and return buckets sorted by total desc. The displayed `name` is
+ * the highest-dollar raw variant in each bucket (the most representative
+ * spelling). A name that canonicalizes to '' keeps its raw form as its key so
+ * boilerplate-only names are never collapsed together.
+ */
+function bucketByCanonicalName(groups: RawDonorGroup[]): DonorBucket[] {
+  const buckets = new Map<string, DonorBucket & { nameAmount: number }>();
+  for (const g of groups) {
+    const key = canonicalizeDonorName(g.name) || g.name.toLowerCase().trim();
+    const existing = buckets.get(key);
+    if (!existing) {
+      buckets.set(key, {
+        name: g.name,
+        nameAmount: g.amount,
+        totalAmount: g.amount,
+        contributionCount: g.count,
+      });
+    } else {
+      existing.totalAmount += g.amount;
+      existing.contributionCount += g.count;
+      if (g.amount > existing.nameAmount) {
+        existing.name = g.name;
+        existing.nameAmount = g.amount;
+      }
+    }
+  }
+  return [...buckets.values()]
+    .map(({ name, totalAmount, contributionCount }) => ({
+      name,
+      totalAmount,
+      contributionCount,
+    }))
+    .sort((a, b) => b.totalAmount - a.totalAmount);
+}
+
 /**
  * Aggregate campaign finance for a representative (#943, epic #936) across the
  * committees the candidate-committee linker (#941) attributed to them. Powers
@@ -90,18 +186,21 @@ export class RepresentativeFundingService {
       expenditureAgg,
       donorAgg,
       employerAgg,
-      donorCountRows,
       perCommittee,
     ] = await Promise.all([
       this.db.contribution.aggregate({ where, _sum: { amount: true } }),
       this.db.expenditure.aggregate({ where, _sum: { amount: true } }),
+      // Scan the top DONOR_SCAN_LIMIT raw names by amount, then canonicalize +
+      // merge in-memory (a fragmented donor's pieces can each rank low yet
+      // dominate once summed). donorCount comes from the merged buckets, so a
+      // separate COUNT(DISTINCT donor_name) would overcount the fragments.
       this.db.contribution.groupBy({
         by: ['donorName'],
         where,
         _sum: { amount: true },
         _count: { _all: true },
         orderBy: { _sum: { amount: 'desc' } },
-        take: TOP_DONORS_LIMIT,
+        take: DONOR_SCAN_LIMIT,
       }),
       this.db.contribution.groupBy({
         by: ['donorEmployer'],
@@ -109,17 +208,8 @@ export class RepresentativeFundingService {
         _sum: { amount: true },
         _count: { _all: true },
         orderBy: { _sum: { amount: 'desc' } },
-        take: TOP_EMPLOYERS_LIMIT,
+        take: DONOR_SCAN_LIMIT,
       }),
-      // DB-side distinct count — returns a single row instead of materializing
-      // every distinct donor name just to `.length` it (the @Public endpoint
-      // could otherwise force a large unbounded scan). committeeIds are bound
-      // via Prisma.join, so this is parameterized.
-      this.db.$queryRaw<{ count: number }[]>`
-        SELECT COUNT(DISTINCT donor_name)::int AS count
-        FROM contributions
-        WHERE committee_id IN (${Prisma.join(committeeIds)})
-      `,
       this.db.contribution.groupBy({
         by: ['committeeId'],
         where,
@@ -131,25 +221,40 @@ export class RepresentativeFundingService {
       perCommittee.map((p) => [p.committeeId, toNumber(p._sum.amount)]),
     );
 
+    const donorBuckets = bucketByCanonicalName(
+      donorAgg.map((d) => ({
+        name: d.donorName,
+        amount: toNumber(d._sum.amount),
+        count: d._count._all,
+      })),
+    );
+    const employerBuckets = bucketByCanonicalName(
+      employerAgg
+        .filter((e) => e.donorEmployer)
+        .map((e) => ({
+          name: e.donorEmployer as string,
+          amount: toNumber(e._sum.amount),
+          count: e._count._all,
+        })),
+    );
+
     return {
       representativeId,
       asOf: new Date(),
       totalRaised: toNumber(contributionAgg._sum.amount),
       totalSpent: toNumber(expenditureAgg._sum.amount),
-      donorCount: donorCountRows[0]?.count ?? 0,
+      donorCount: donorBuckets.length,
       committeeCount: committees.length,
-      topDonors: donorAgg.map((d) => ({
-        donorName: d.donorName,
-        totalAmount: toNumber(d._sum.amount),
-        contributionCount: d._count._all,
+      topDonors: donorBuckets.slice(0, TOP_DONORS_LIMIT).map((b) => ({
+        donorName: b.name,
+        totalAmount: b.totalAmount,
+        contributionCount: b.contributionCount,
       })),
-      topEmployers: employerAgg
-        .filter((e) => e.donorEmployer)
-        .map((e) => ({
-          employer: e.donorEmployer as string,
-          totalAmount: toNumber(e._sum.amount),
-          contributionCount: e._count._all,
-        })),
+      topEmployers: employerBuckets.slice(0, TOP_EMPLOYERS_LIMIT).map((b) => ({
+        employer: b.name,
+        totalAmount: b.totalAmount,
+        contributionCount: b.contributionCount,
+      })),
       // Ordered by money so the "flows through" list is meaningful + stable.
       committees: committees
         .map((c) => ({


### PR DESCRIPTION
Fixes #954. Part of epic #936 ("follow the money").

## Problem

The rep money-trail "top donors" grouped by **exact `donorName`**, so a single contributor filing under spelling variants fragmented into many rows — inflating the list, breaking `donorCount`, and hiding how concentrated the money is. Prod example (Lena Gonzalez, D33): one labor federation appeared **8 times** (~$1.39M ≈ 92% of receipts from effectively one entity) shown as 8 separate donors.

## Change

Aggregate on a **canonical key** instead of the raw name:
- Scan the top `DONOR_SCAN_LIMIT` (1000) raw donor/employer names by amount, then merge in-memory via `canonicalizeDonorName` (lowercase, `&`→`and`, strip punctuation, drop legal-form/committee boilerplate tokens, sort remaining tokens).
- `donorCount` is now the distinct-canonical bucket count (the old `COUNT(DISTINCT donor_name)` overcounted fragments); the `$queryRaw` is removed.
- Each bucket displays its **highest-dollar raw variant** as the name.
- Applies to `topDonors`, `topEmployers`, and `donorCount`.

## Deliberately conservative (safety)

Only boilerplate tokens are dropped — never substantive words — so **distinct donors are never merged**. A unit test guards `LA County Council on Political Education` ≠ `San Diego County Council on Political Education`.

## Scope / honest limits (follow-up)

v1 fixes fragmentation from **case / punctuation / whitespace / word-order / `&` / trailing PAC·Inc·LLC** — the common CAL-ACCESS pattern. It does **not** merge **semantic** variants ("LA" vs "Los Angeles", added/dropped significant words) — those have genuinely different token sets and need an abbreviation dictionary and/or fuzzy/alias resolution, which carry real over-merge risk and are intentionally deferred (documented on #954). This PR establishes the canonicalization seam they'll build on.

## Tests

`representative-funding.service.spec.ts` (14 tests): `canonicalizeDonorName` behavior (case/punct/word-order/`&`/boilerplate/over-merge guard), donor+employer bucket merging with summed totals and highest-dollar display name, `donorCount` = bucket count, boilerplate-only names kept separate. Full backend suite green.

## Rollout

Read-time aggregation only — **no schema migration, no sync required**. Ships with the next backend deploy; the money-trail panels reflect merged donors immediately.

## Reviews
- op-review (self): no blockers — removes a `$queryRaw` (now pure parameterized Prisma), linear regex, bounded scan.
- Pre-push gate: AI code + security review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)