### PR TITLE
fix(region): attribute only a candidate's own controlled committee to a rep (#953)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.spec.ts
@@ -1,5 +1,8 @@
 import { DbService } from '@opuspopuli/relationaldb-provider';
-import { CandidateCommitteeLinkerService } from './candidate-committee-linker.service';
+import {
+  CandidateCommitteeLinkerService,
+  isCandidateOwnCommittee,
+} from './candidate-committee-linker.service';
 
 interface Rep {
   id: string;
@@ -9,6 +12,7 @@ interface Rep {
 }
 interface Cmte {
   id: string;
+  name: string;
   candidateName: string | null;
   candidateOffice: string | null;
 }
@@ -27,11 +31,81 @@ function build(reps: Rep[], committees: Cmte[]) {
   return { svc, update, repFindMany, cmteFindMany };
 }
 
+describe('isCandidateOwnCommittee (#953)', () => {
+  it('accepts a committee named after the candidate with no IE/ballot marker', () => {
+    expect(isCandidateOwnCommittee('NGUYEN FOR ASSEMBLY 2020', 'Nguyen')).toBe(
+      true,
+    );
+    expect(
+      isCandidateOwnCommittee('Friends of Jane Doe for Senate', 'Doe'),
+    ).toBe(true);
+  });
+
+  it('tolerates CAL-ACCESS punctuation variance on the surname', () => {
+    // Committee keeps the apostrophe, candidateName drops it (or vice-versa).
+    expect(isCandidateOwnCommittee("O'Brien for Senate 2024", 'OBRIEN')).toBe(
+      true,
+    );
+    expect(
+      isCandidateOwnCommittee('Alvarado Gil for Senate', 'Alvarado-Gil'),
+    ).toBe(true);
+  });
+
+  it('rejects an independent-expenditure "in support of" committee', () => {
+    expect(
+      isCandidateOwnCommittee(
+        'Legislative Action PAC in support of Marie Alvarado-Gil for Senate 2026',
+        'Alvarado-Gil',
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a ballot-measure committee even though it names the candidate', () => {
+    expect(
+      isCandidateOwnCommittee(
+        'Safe Communities, Strong Futures: A Nick Schultz Ballot Measure Committee',
+        'Schultz',
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a sponsored PAC', () => {
+    expect(
+      isCandidateOwnCommittee(
+        'Nurses and Working Families for Better Healthcare, sponsored by SEIU',
+        'Umberg',
+      ),
+    ).toBe(false);
+  });
+
+  it('rejects a committee that does not name the candidate at all (union/issue PAC)', () => {
+    expect(
+      isCandidateOwnCommittee(
+        'Los Angeles County Federation of Labor AFL-CIO Council on Political Education',
+        'Gonzalez',
+      ),
+    ).toBe(false);
+  });
+
+  it('does not gate on surnames too short to match safely', () => {
+    // "Vo" (2 chars) would substring-match "vote"/"advocacy"; fall back to
+    // office/name matching for these rather than false-reject.
+    expect(isCandidateOwnCommittee('Committee to Elect Vo', 'Vo')).toBe(true);
+  });
+});
+
 describe('CandidateCommitteeLinkerService (#941)', () => {
-  it('links a candidate committee to a rep by last name + office→chamber', async () => {
+  it('links a candidate’s own controlled committee by last name + office→chamber', async () => {
     const { svc, update } = build(
       [{ id: 'rep-1', lastName: 'Doe', name: 'Jane Doe', chamber: 'Assembly' }],
-      [{ id: 'c-1', candidateName: 'Doe', candidateOffice: 'ASM' }],
+      [
+        {
+          id: 'c-1',
+          name: 'Doe for Assembly 2024',
+          candidateName: 'Doe',
+          candidateOffice: 'ASM',
+        },
+      ],
     );
     const res = await svc.linkAll();
     expect(res.linked).toBe(1);
@@ -39,6 +113,31 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
       where: { id: 'c-1' },
       data: { representativeId: 'rep-1' },
     });
+  });
+
+  it('skips a committee that matches a rep but is not the candidate’s own (#953)', async () => {
+    const { svc, update } = build(
+      [
+        {
+          id: 'rep-1',
+          lastName: 'Alvarado-Gil',
+          name: 'Marie Alvarado-Gil',
+          chamber: 'Senate',
+        },
+      ],
+      [
+        {
+          id: 'c-ie',
+          name: 'Legislative Action PAC in support of Marie Alvarado-Gil for Senate 2026',
+          candidateName: 'Alvarado-Gil',
+          candidateOffice: 'SEN',
+        },
+      ],
+    );
+    const res = await svc.linkAll();
+    expect(res.linked).toBe(0);
+    expect(res.skippedNonControlled).toBe(1);
+    expect(update).not.toHaveBeenCalled();
   });
 
   it('skips an ambiguous last name shared by two reps in the same chamber', async () => {
@@ -57,7 +156,14 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
           chamber: 'Assembly',
         },
       ],
-      [{ id: 'c-1', candidateName: 'Garcia', candidateOffice: 'ASM' }],
+      [
+        {
+          id: 'c-1',
+          name: 'Garcia for Assembly',
+          candidateName: 'Garcia',
+          candidateOffice: 'ASM',
+        },
+      ],
     );
     const res = await svc.linkAll();
     expect(res.linked).toBe(0);
@@ -71,7 +177,14 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
         { id: 'rep-asm', lastName: 'Lee', name: 'A Lee', chamber: 'Assembly' },
         { id: 'rep-sen', lastName: 'Lee', name: 'B Lee', chamber: 'Senate' },
       ],
-      [{ id: 'c-1', candidateName: 'Lee', candidateOffice: 'SEN' }],
+      [
+        {
+          id: 'c-1',
+          name: 'Lee for Senate 2024',
+          candidateName: 'Lee',
+          candidateOffice: 'SEN',
+        },
+      ],
     );
     const res = await svc.linkAll();
     expect(res.linked).toBe(1);
@@ -81,7 +194,7 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
     });
   });
 
-  it('matches case/punctuation-insensitively', async () => {
+  it('matches case/punctuation-insensitively on the surname', async () => {
     const { svc } = build(
       [
         {
@@ -91,7 +204,14 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
           chamber: 'Senate',
         },
       ],
-      [{ id: 'c-1', candidateName: 'OBRIEN', candidateOffice: 'senate' }],
+      [
+        {
+          id: 'c-1',
+          name: "O'Brien for Senate 2024",
+          candidateName: 'OBRIEN',
+          candidateOffice: 'senate',
+        },
+      ],
     );
     const res = await svc.linkAll();
     expect(res.linked).toBe(1);
@@ -101,8 +221,18 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
     const { svc, update } = build(
       [{ id: 'rep-1', lastName: 'Doe', name: 'Jane Doe', chamber: 'Assembly' }],
       [
-        { id: 'c-unknown', candidateName: 'Nobody', candidateOffice: 'ASM' },
-        { id: 'c-gov', candidateName: 'Doe', candidateOffice: 'GOV' },
+        {
+          id: 'c-unknown',
+          name: 'Nobody for Assembly',
+          candidateName: 'Nobody',
+          candidateOffice: 'ASM',
+        },
+        {
+          id: 'c-gov',
+          name: 'Doe for Governor',
+          candidateName: 'Doe',
+          candidateOffice: 'GOV',
+        },
       ],
     );
     const res = await svc.linkAll();
@@ -114,7 +244,14 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
   it('derives the last name from full name when lastName is empty', async () => {
     const { svc, update } = build(
       [{ id: 'rep-1', lastName: '', name: 'Jane Doe', chamber: 'Assembly' }],
-      [{ id: 'c-1', candidateName: 'Doe', candidateOffice: 'ASM' }],
+      [
+        {
+          id: 'c-1',
+          name: 'Doe for Assembly',
+          candidateName: 'Doe',
+          candidateOffice: 'ASM',
+        },
+      ],
     );
     const res = await svc.linkAll();
     expect(res.linked).toBe(1);
@@ -127,7 +264,14 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
   it('scopes queries: only unlinked cal_access committees, and excludes federal reps', async () => {
     const { svc, repFindMany, cmteFindMany } = build(
       [{ id: 'rep-1', lastName: 'Doe', name: 'Jane Doe', chamber: 'Assembly' }],
-      [{ id: 'c-1', candidateName: 'Doe', candidateOffice: 'ASM' }],
+      [
+        {
+          id: 'c-1',
+          name: 'Doe for Assembly',
+          candidateName: 'Doe',
+          candidateOffice: 'ASM',
+        },
+      ],
     );
     await svc.linkAll();
     // idempotent: never re-scans already-linked committees; state-scoped
@@ -148,6 +292,7 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
     expect(res).toEqual({
       linked: 0,
       skippedAmbiguous: 0,
+      skippedNonControlled: 0,
       unmatched: 0,
       candidateCommittees: 0,
     });

--- a/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.ts
@@ -9,8 +9,75 @@ type RepSlot = string | typeof AMBIGUOUS;
 export interface CandidateCommitteeLinkResult {
   linked: number;
   skippedAmbiguous: number;
+  /** Name/office matched a rep, but the committee is not the candidate's OWN
+   * controlled committee (a support/oppose, ballot-measure, sponsored, or PAC
+   * committee that merely references the candidate). Never attributed (#953). */
+  skippedNonControlled: number;
   unmatched: number;
   candidateCommittees: number;
+}
+
+/**
+ * Markers in a committee NAME that identify it as a support/oppose, ballot-
+ * measure, sponsored, or general-purpose committee rather than the candidate's
+ * OWN controlled committee. CAL-ACCESS populates CAND_NAML/OFFICE_CD on the
+ * cover page of ANY committee that references a candidate, so those fields alone
+ * mislinked union PACs, IE committees, and ballot-measure committees to
+ * legislators (#953). The committee name is the reliable signal.
+ */
+const NON_CONTROLLED_MARKERS = [
+  'in support of',
+  'in opposition to',
+  'opposed to',
+  'opposing',
+  'supporting',
+  'sponsored by',
+  'ballot measure',
+  'independent expenditure',
+  'recall',
+];
+
+/** Lowercase and collapse every run of non-alphanumerics to a single space —
+ * used for phrase-marker matching (keeps word boundaries). */
+function soften(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+/** Lowercase and drop everything but [a-z0-9]. Matches the surname key the
+ * linker builds, so "O'Brien" / "OBRIEN" / "Alvarado-Gil" reduce to one token
+ * regardless of how CAL-ACCESS punctuates the committee name. */
+function alnumKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+/** Below this many alnum chars a surname can't be substring-gated without false
+ * matches (e.g. "Vo" inside "vote"); such reps fall back to office/name + marker
+ * matching only. */
+const SURNAME_MIN_GATE_LEN = 3;
+
+/**
+ * True only when a committee looks like the candidate's OWN controlled
+ * committee: (1) the committee name carries no support/oppose/ballot/sponsored
+ * marker (those name the candidate but spend independently), and (2) the name
+ * actually contains the candidate surname — a real controlled committee is
+ * titled after them ("{Surname} for Assembly", "Friends of {Surname}"), while a
+ * union/issue PAC is not. Surname matching uses the alnum key so it tolerates
+ * CAL-ACCESS punctuation ("O'Brien" vs "OBRIEN") and hyphenated names (#953).
+ */
+export function isCandidateOwnCommittee(
+  committeeName: string,
+  surname: string,
+): boolean {
+  const softened = soften(committeeName);
+  if (NON_CONTROLLED_MARKERS.some((marker) => softened.includes(marker))) {
+    return false;
+  }
+  const surnameKey = alnumKey(surname);
+  if (surnameKey.length < SURNAME_MIN_GATE_LEN) return true;
+  return alnumKey(committeeName).includes(surnameKey);
 }
 
 /**
@@ -35,6 +102,7 @@ export class CandidateCommitteeLinkerService {
     const empty: CandidateCommitteeLinkResult = {
       linked: 0,
       skippedAmbiguous: 0,
+      skippedNonControlled: 0,
       unmatched: 0,
       candidateCommittees: 0,
     };
@@ -53,11 +121,17 @@ export class CandidateCommitteeLinkerService {
         sourceSystem: 'cal_access',
         deletedAt: null,
       },
-      select: { id: true, candidateName: true, candidateOffice: true },
+      select: {
+        id: true,
+        name: true,
+        candidateName: true,
+        candidateOffice: true,
+      },
     });
 
     const updates: Array<{ id: string; representativeId: string }> = [];
     let skippedAmbiguous = 0;
+    let skippedNonControlled = 0;
     let unmatched = 0;
 
     for (const c of committees) {
@@ -69,10 +143,16 @@ export class CandidateCommitteeLinkerService {
       const hit = key ? repIndex.get(key) : undefined;
       if (hit === AMBIGUOUS) {
         skippedAmbiguous++;
-      } else if (hit) {
-        updates.push({ id: c.id, representativeId: hit });
-      } else {
+      } else if (!hit) {
         unmatched++;
+      } else if (!isCandidateOwnCommittee(c.name, last)) {
+        // Name/office matched a rep, but the committee only references the
+        // candidate (IE/ballot-measure/sponsored/PAC) — not their controlled
+        // committee. Never attribute it, or the money trail shows money that is
+        // not the representative's (#953).
+        skippedNonControlled++;
+      } else {
+        updates.push({ id: c.id, representativeId: hit });
       }
     }
 
@@ -91,12 +171,15 @@ export class CandidateCommitteeLinkerService {
     const result: CandidateCommitteeLinkResult = {
       linked: updates.length,
       skippedAmbiguous,
+      skippedNonControlled,
       unmatched,
       candidateCommittees: committees.length,
     };
     this.logger.log(
       `Candidate-committee linker: linked=${result.linked}, ` +
-        `ambiguous=${result.skippedAmbiguous}, unmatched=${result.unmatched} ` +
+        `ambiguous=${result.skippedAmbiguous}, ` +
+        `nonControlled=${result.skippedNonControlled}, ` +
+        `unmatched=${result.unmatched} ` +
         `(of ${result.candidateCommittees} candidate committees)`,
     );
     return result;


### PR DESCRIPTION
Addresses the **accuracy (false-positive) half of #953**. Part of epic #936.

## Problem (confirmed in prod)

CAL-ACCESS populates `CAND_NAML` + `OFFICE_CD` on the cover page of **any** committee that references a candidate — independent-expenditure, ballot-measure, sponsored, and general-purpose/union PACs included. The linker matched reps on `candidateName` + office alone, so it mislinked those. The first prod sync's 5 links:

| rep | committee | actually | verdict |
|---|---|---|---|
| Nguyen | `NGUYEN FOR ASSEMBLY 2020…` | controlled committee | ✅ keep |
| Schultz | `…Nick Schultz Ballot Measure Committee` | ballot-measure | ❌ drop |
| Alvarado-Gil | `Legislative Action PAC in support of Marie Alvarado-Gil…` | IE committee | ❌ drop |
| Gonzalez | `Los Angeles County Federation of Labor AFL-CIO…` | union PAC ($1.5M **not hers**) | ❌ drop |
| Umberg | `Nurses and Working Families…, sponsored by…` | sponsored PAC | ❌ drop |

4 of 5 were wrong, and Gonzalez rendered confidently-wrong money on a public surface.

## Fix

Gate attribution on the committee **name** — the reliable signal — via `isCandidateOwnCommittee(name, surname)`. Link only when the name:
1. carries **no** support/oppose/ballot/sponsored marker (`in support of`, `in opposition to`, `sponsored by`, `ballot measure`, `independent expenditure`, `recall`, …), **and**
2. actually **contains the candidate surname** (a controlled committee is titled after the candidate; a union/issue PAC is not).

Surname matching uses the alnum key (`O'Brien`↔`OBRIEN`, hyphenated names) with the linker's existing normalization; surnames < 3 chars fall back to office/name matching to avoid substring false hits. A new `skippedNonControlled` counter surfaces the drops in the linker log.

On the prod set this keeps **Nguyen** and drops the other **4** — correctness over coverage: **showing nothing is safer than showing money that isn't the representative's.**

## Scope — what this does NOT do (remaining half of #953)

It does **not** raise real coverage. Reps whose genuine controlled committee never got `candidateName` populated (so it's not in the linker's candidate-committee query) still won't link — e.g. Gonzalez's actual "Friends of…" committee. That **yield** half needs broadening the committee selection (match controlled committees by name pattern, not just the `candidateName` field) and is intentionally deferred; #953 stays open for it.

## Tests

`candidate-committee-linker.service.spec.ts` (16): `isCandidateOwnCommittee` accepts controlled names (incl. `O'Brien`/`Alvarado-Gil` punctuation), rejects each of the 4 real false-positive shapes, short-surname fallback; linker links a controlled committee and records `skippedNonControlled` for a matched-but-non-controlled one. Full backend suite green.

## Rollout

Linker runs at the end of each finance sync — takes effect on the next `syncRegionData(dataTypes:[CAMPAIGN_FINANCE])` after deploy. No schema migration. The linker only *sets* `representativeId`; existing wrong links from the prior sync should be cleared (one-time `UPDATE committees SET representative_id = NULL WHERE representative_id IS NOT NULL` before the re-sync, or I can add a reconciliation step — flagging for a deploy note).

## Reviews
- op-review (self): no blockers — pure additive gate, linear string ops, no new query cost.
- Pre-push gate: AI code + security review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)