### PR TITLE
fix(region): self-heal stale committee→rep links on each sync (#953)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.spec.ts
@@ -16,12 +16,28 @@ interface Cmte {
   candidateName: string | null;
   candidateOffice: string | null;
 }
+/** An already-linked committee, as the reconcile pass reads it. */
+interface LinkedCmte {
+  id: string;
+  name: string;
+  candidateName: string | null;
+}
 
-function build(reps: Rep[], committees: Cmte[]) {
+function build(reps: Rep[], committees: Cmte[], linked: LinkedCmte[] = []) {
   const update = jest.fn((args: unknown) => ({ __op: args }));
   const $transaction = jest.fn().mockResolvedValue([]);
   const repFindMany = jest.fn().mockResolvedValue(reps);
-  const cmteFindMany = jest.fn().mockResolvedValue(committees);
+  // linkAll queries committee.findMany twice: the reconcile pass filters
+  // `representativeId: { not: null }`, the link pass filters `representativeId: null`.
+  const cmteFindMany = jest.fn(
+    (args: { where?: { representativeId?: unknown } }) => {
+      const rid = args?.where?.representativeId;
+      if (rid && typeof rid === 'object' && 'not' in rid) {
+        return Promise.resolve(linked); // reconcile pass
+      }
+      return Promise.resolve(committees); // link pass
+    },
+  );
   const db = {
     representative: { findMany: repFindMany },
     committee: { findMany: cmteFindMany, update },
@@ -274,8 +290,13 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
       ],
     );
     await svc.linkAll();
-    // idempotent: never re-scans already-linked committees; state-scoped
-    expect(cmteFindMany.mock.calls[0][0].where).toMatchObject({
+    // The link pass (representativeId: null) is state-scoped to unlinked
+    // cal_access candidate committees. (calls[0] is now the reconcile pass.)
+    const linkCall = cmteFindMany.mock.calls.find(
+      (c: [{ where?: { representativeId?: unknown } }]) =>
+        c[0]?.where?.representativeId === null,
+    );
+    expect(linkCall?.[0].where).toMatchObject({
       type: 'candidate',
       representativeId: null,
       sourceSystem: 'cal_access',
@@ -286,6 +307,43 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
     });
   });
 
+  it('self-heals: unlinks an already-linked committee that fails the controlled gate (#953)', async () => {
+    const { svc, update } = build(
+      [
+        {
+          id: 'rep-1',
+          lastName: 'Gonzalez',
+          name: 'Lena Gonzalez',
+          chamber: 'Senate',
+        },
+      ],
+      [], // nothing new to link this run
+      [
+        {
+          id: 'c-badpac',
+          name: 'Los Angeles County Federation of Labor AFL-CIO Council on Political Education',
+          candidateName: 'Gonzalez',
+        },
+        {
+          id: 'c-good',
+          name: 'Gonzalez for Senate 2024',
+          candidateName: 'Gonzalez',
+        },
+      ],
+    );
+    const res = await svc.linkAll();
+    expect(res.reconciledUnlinked).toBe(1);
+    // The union PAC is unlinked; the genuine controlled committee is left alone.
+    expect(update).toHaveBeenCalledWith({
+      where: { id: 'c-badpac' },
+      data: { representativeId: null },
+    });
+    expect(update).not.toHaveBeenCalledWith({
+      where: { id: 'c-good' },
+      data: { representativeId: null },
+    });
+  });
+
   it('is a no-op with no db wired', async () => {
     const svc = new CandidateCommitteeLinkerService();
     const res = await svc.linkAll();
@@ -293,6 +351,7 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
       linked: 0,
       skippedAmbiguous: 0,
       skippedNonControlled: 0,
+      reconciledUnlinked: 0,
       unmatched: 0,
       candidateCommittees: 0,
     });

--- a/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.ts
@@ -13,6 +13,10 @@ export interface CandidateCommitteeLinkResult {
    * controlled committee (a support/oppose, ballot-measure, sponsored, or PAC
    * committee that merely references the candidate). Never attributed (#953). */
   skippedNonControlled: number;
+  /** Previously-linked committees that no longer pass the controlled-committee
+   * gate and were unlinked this run — self-heals stale links from before #953
+   * without manual SQL. */
+  reconciledUnlinked: number;
   unmatched: number;
   candidateCommittees: number;
 }
@@ -103,13 +107,21 @@ export class CandidateCommitteeLinkerService {
       linked: 0,
       skippedAmbiguous: 0,
       skippedNonControlled: 0,
+      reconciledUnlinked: 0,
       unmatched: 0,
       candidateCommittees: 0,
     };
     if (!this.db) return empty;
 
     const repIndex = await this.buildRepIndex();
+    // Guard: an empty rep index means reps aren't loaded (transient/degenerate)
+    // — do NOT reconcile then, or a bad load would nuke every existing link.
     if (repIndex.size === 0) return empty;
+
+    // Self-heal first: unlink any currently-linked committee that no longer
+    // passes the controlled-committee gate (e.g. links made before #953). This
+    // removes the need to manually clear representative_id before a re-sync.
+    const reconciledUnlinked = await this.reconcileExistingLinks();
 
     const committees = await this.db.committee.findMany({
       where: {
@@ -172,6 +184,7 @@ export class CandidateCommitteeLinkerService {
       linked: updates.length,
       skippedAmbiguous,
       skippedNonControlled,
+      reconciledUnlinked,
       unmatched,
       candidateCommittees: committees.length,
     };
@@ -179,10 +192,47 @@ export class CandidateCommitteeLinkerService {
       `Candidate-committee linker: linked=${result.linked}, ` +
         `ambiguous=${result.skippedAmbiguous}, ` +
         `nonControlled=${result.skippedNonControlled}, ` +
+        `reconciledUnlinked=${result.reconciledUnlinked}, ` +
         `unmatched=${result.unmatched} ` +
         `(of ${result.candidateCommittees} candidate committees)`,
     );
     return result;
+  }
+
+  /**
+   * Re-validate already-linked candidate committees against the controlled-
+   * committee gate and unlink any that no longer qualify. This self-heals stale
+   * attributions — e.g. the IE / ballot-measure / union-PAC links made before
+   * the #953 gate existed — so operators never have to null `representative_id`
+   * by hand before a re-sync. Only touches CAL-ACCESS candidate committees that
+   * are currently linked; correctly-linked controlled committees are untouched.
+   */
+  private async reconcileExistingLinks(): Promise<number> {
+    const linked = await this.db!.committee.findMany({
+      where: {
+        representativeId: { not: null },
+        type: 'candidate',
+        sourceSystem: 'cal_access',
+        deletedAt: null,
+      },
+      select: { id: true, name: true, candidateName: true },
+    });
+    const stale = linked.filter(
+      (c) =>
+        !isCandidateOwnCommittee(c.name, (c.candidateName ?? '').split(',')[0]),
+    );
+    if (stale.length > 0) {
+      await batchTransaction(
+        this.db!,
+        stale.map((c) =>
+          this.db!.committee.update({
+            where: { id: c.id },
+            data: { representativeId: null },
+          }),
+        ),
+      );
+    }
+    return stale.length;
   }
 
   /** Build `normalize(lastName)|chamber` → repId, marking collisions AMBIGUOUS. */


### PR DESCRIPTION
Follow-up to #957. Removes the manual-SQL step from the #953 deploy.

## Why

#957's gate stops **new** mislinks, but the linker only sets `representativeId` on *unlinked* committees — so the IE / ballot-measure / union-PAC links made before the gate (e.g. the $1.5M union PAC on Sen. Gonzalez) **persist** until someone runs `UPDATE committees SET representative_id = NULL …` by hand. This automates that cleanup.

## Change

Add a **reconcile pass** at the start of `linkAll()`: re-validate every currently-linked CAL-ACCESS candidate committee against `isCandidateOwnCommittee` and unlink any that no longer qualify. The money trail self-corrects on the next finance sync — no manual SQL.

- **Guarded**: runs only when the rep index is non-empty, so a transient/degenerate empty rep load can never null every link.
- Only touches CAL-ACCESS candidate committees that are currently linked; correctly-linked controlled committees are untouched.
- New `reconciledUnlinked` counter in the linker result + log.

## Tests

`candidate-committee-linker.service.spec.ts` (17): a linked union PAC is unlinked while the genuine `Gonzalez for Senate` committee is left alone; existing scoping/linking tests updated for the two-pass `findMany`. Full backend suite green.

## Rollout

Takes effect on the next `syncRegionData(dataTypes:[CAMPAIGN_FINANCE])` after this ships (a release **after** v1.1.2). Until then, v1.1.2's deploy still needs the one-time SQL cleanup. No schema migration.

Relates to #953 (its deploy-hygiene half). Reviewed: op-review (no blockers), pre-push AI code + security review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)