### PR TITLE
feat(frontend): campaign-finance disclaimers — official-source provenance + not-an-allegation (#962)

### DIFF
--- a/apps/frontend/__tests__/components/Footer.test.tsx
+++ b/apps/frontend/__tests__/components/Footer.test.tsx
@@ -29,4 +29,11 @@ describe("Footer", () => {
     const link = screen.getByRole("link", { name: "Transparency" });
     expect(link).toHaveAttribute("href", "/transparency");
   });
+
+  it("renders the illustrative-purpose / not-an-allegation notice (#962)", () => {
+    expect(screen.getByText(/illustrative purposes/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/not\s+an allegation of wrongdoing/i),
+    ).toBeInTheDocument();
+  });
 });

--- a/apps/frontend/__tests__/components/region/FinanceDisclaimer.test.tsx
+++ b/apps/frontend/__tests__/components/region/FinanceDisclaimer.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { FinanceDisclaimer } from "@/components/region/FinanceDisclaimer";
+
+describe("FinanceDisclaimer (#962)", () => {
+  it("names the official public records as the data source", () => {
+    render(<FinanceDisclaimer />);
+    expect(screen.getByText(/official public records/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/CAL-ACCESS.*Federal Election Commission/i),
+    ).toBeInTheDocument();
+  });
+
+  it("states attributions are automated and NOT an allegation, and to verify", () => {
+    render(<FinanceDisclaimer />);
+    expect(
+      screen.getByText(/not an allegation of wrongdoing/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/verify against the official filings/i),
+    ).toBeInTheDocument();
+  });
+
+  it("exposes an accessible note label (not a nested landmark)", () => {
+    render(<FinanceDisclaimer />);
+    expect(
+      screen.getByRole("note", {
+        name: /campaign-finance data disclaimer/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/app/region/campaign-finance/page.tsx
+++ b/apps/frontend/app/region/campaign-finance/page.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 
+import { FinanceDisclaimer } from "@/components/region/FinanceDisclaimer";
+
 const CAMPAIGN_FINANCE_CARDS = [
   {
     title: "Committees",
@@ -63,6 +65,8 @@ export default function CampaignFinancePage() {
           </Link>
         ))}
       </div>
+
+      <FinanceDisclaimer className="mt-8" />
     </div>
   );
 }

--- a/apps/frontend/components/Footer.tsx
+++ b/apps/frontend/components/Footer.tsx
@@ -3,6 +3,24 @@ import Link from "next/link";
 export function Footer() {
   return (
     <footer className="border-t border-line bg-surface">
+      {/* Illustrative-purpose notice (#962): the platform is a civic-education
+          tool built on public sources; summaries and data matches are
+          automated and may be inaccurate. Site-wide safety net against
+          misreading derived views (esp. campaign-finance attributions) as
+          authoritative or as allegations. */}
+      <div className="max-w-6xl mx-auto px-8 pt-6">
+        <p className="text-xs leading-relaxed text-content-dim">
+          Opus Populi is a civic-education tool for illustrative purposes. Its
+          data comes from official public records (such as the California
+          Secretary of State&apos;s CAL-ACCESS database and the U.S. Federal
+          Election Commission), always with attribution. Those records are
+          authoritative; the summaries this site generates are AI-produced, and
+          the links it draws (including campaign-finance attributions) are
+          automated best-effort and may be incomplete or inaccurate — not an
+          allegation of wrongdoing. Verify against the official sources before
+          relying on or republishing anything here.
+        </p>
+      </div>
       <div className="max-w-6xl mx-auto px-8 py-6 flex flex-col sm:flex-row items-center justify-between gap-4">
         <p className="text-sm text-content-dim">
           &copy; {new Date().getFullYear()} Opus Populi. All rights reserved.

--- a/apps/frontend/components/region/FinanceDisclaimer.tsx
+++ b/apps/frontend/components/region/FinanceDisclaimer.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+/**
+ * Shared legal/provenance disclaimer for every campaign-finance surface (#962).
+ *
+ * States the public-source provenance (CAL-ACCESS / FEC) AND — critically —
+ * that committee→representative links and donor groupings are automated
+ * best-effort matches that may be inaccurate and are **not an allegation** of
+ * wrongdoing. This is the safety net against false-attribution liability while
+ * attribution accuracy keeps improving (#953). Render it on any surface that
+ * shows finance data attributed to a named person or measure.
+ */
+export function FinanceDisclaimer({
+  className = "",
+}: {
+  readonly className?: string;
+}) {
+  const { t } = useTranslation("civics");
+  // role="note" (not <aside>): a disclaimer is an annotation, not a landmark —
+  // an <aside> complementary landmark nested inside the panel's section landmark
+  // fails WCAG "landmark-complementary-is-top-level".
+  return (
+    <div
+      role="note"
+      aria-label={t("finance.disclaimerLabel")}
+      className={`border-t border-line pt-2 text-[11px] leading-relaxed text-content-dim ${className}`}
+    >
+      <p>{t("finance.sources")}</p>
+      <p className="mt-1">{t("finance.bestEffort")}</p>
+    </div>
+  );
+}

--- a/apps/frontend/components/region/PropositionFundingSection.tsx
+++ b/apps/frontend/components/region/PropositionFundingSection.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/graphql/region";
 import { formatCurrency, formatDate } from "@/lib/format";
 import { SectionTitle } from "@/components/region/SectionTitle";
+import { FinanceDisclaimer } from "@/components/region/FinanceDisclaimer";
 
 /**
  * "Who's Funding This" section for the proposition detail page (Layer 2).
@@ -83,6 +84,7 @@ export function PropositionFundingSection({
       <p className="mt-3 text-xs text-slate-500">
         Reflects CalAccess records as of {formatDate(funding.asOf)}.
       </p>
+      <FinanceDisclaimer className="mt-2" />
     </section>
   );
 }

--- a/apps/frontend/components/region/RepresentativeFundingPanel.tsx
+++ b/apps/frontend/components/region/RepresentativeFundingPanel.tsx
@@ -9,6 +9,7 @@ import {
   type RepresentativeFundingData,
   type IdVars,
 } from "@/lib/graphql/region";
+import { FinanceDisclaimer } from "@/components/region/FinanceDisclaimer";
 
 type Formatter = (n: number) => string;
 
@@ -117,9 +118,7 @@ export function RepresentativeFundingPanel({
         />
       )}
 
-      <p className="text-[11px] text-content-dim italic">
-        {t("repFinance.provenance")}
-      </p>
+      <FinanceDisclaimer className="mt-1" />
     </section>
   );
 }

--- a/apps/frontend/locales/en/civics.json
+++ b/apps/frontend/locales/en/civics.json
@@ -88,7 +88,11 @@
     "topEmployers": "Top employers behind the money",
     "throughCommittees": "Money flows through these committees",
     "contributions_one": "{{count}} gift",
-    "contributions_other": "{{count}} gifts",
-    "provenance": "Source: public CAL-ACCESS / FEC campaign-finance filings."
+    "contributions_other": "{{count}} gifts"
+  },
+  "finance": {
+    "disclaimerLabel": "Campaign-finance data disclaimer",
+    "sources": "This data comes directly from official public records — the California Secretary of State's CAL-ACCESS database and the U.S. Federal Election Commission (FEC).",
+    "bestEffort": "Those filings are authoritative; the links this site draws between committees and representatives, and its grouping of donors, are generated automatically and may be incomplete or inaccurate — they are not an allegation of wrongdoing by anyone named. Verify against the official filings before relying on or republishing this information."
   }
 }

--- a/apps/frontend/locales/es/civics.json
+++ b/apps/frontend/locales/es/civics.json
@@ -88,7 +88,11 @@
     "topEmployers": "Principales empleadores detrás del dinero",
     "throughCommittees": "El dinero fluye a través de estos comités",
     "contributions_one": "{{count}} aporte",
-    "contributions_other": "{{count}} aportes",
-    "provenance": "Fuente: informes públicos de financiamiento de campaña de CAL-ACCESS / FEC."
+    "contributions_other": "{{count}} aportes"
+  },
+  "finance": {
+    "disclaimerLabel": "Aviso sobre los datos de financiamiento de campaña",
+    "sources": "Estos datos provienen directamente de registros públicos oficiales: la base de datos CAL-ACCESS de la Secretaría de Estado de California y la Comisión Federal Electoral (FEC) de EE. UU.",
+    "bestEffort": "Esos informes son la fuente autorizada; los vínculos que este sitio establece entre comités y representantes, y su agrupación de donantes, se generan automáticamente y pueden estar incompletos o ser inexactos; no constituyen una acusación de conducta indebida contra ninguna persona mencionada. Verifique los informes oficiales antes de utilizar o republicar esta información."
   }
 }


### PR DESCRIPTION
Addresses the **core (P0) of #962**: the false-attribution liability on the money-trail surfaces, now that they're live (v1.2.0).

## Approach — one shared disclaimer, shown in-context + a site-wide footer

Not four bespoke per-page disclaimers, and not a footer-only blanket (legally weak). A **single reusable `<FinanceDisclaimer>` component** (i18n EN/ES — copy lives in one place) rendered **adjacent to the data** on every finance surface, plus a **site-wide illustrative-purpose notice in the footer**. Adjacency matters: a disclaimer next to "$X is this rep's money" qualifies that specific claim far better than a page-bottom footnote.

## What the copy says

Two deliberate halves:
- **The data is real and authoritative** — sourced directly from **official public records**: the California Secretary of State's **CAL-ACCESS** database and the **U.S. Federal Election Commission (FEC)**, always with attribution.
- **The derived views are best-effort** — committee→representative links and donor groupings are generated automatically, may be incomplete or inaccurate, and are **not an allegation of wrongdoing** by anyone named; verify against the official filings.

## Surfaces covered

- `RepresentativeFundingPanel` (rep money trail) — replaces the weak one-line provenance.
- `PropositionFundingSection` ("Who's Funding This").
- Campaign-finance hub page.
- Global `Footer` — site-wide illustrative-purpose + official-source notice.

## a11y

`role="note"` (not `<aside>`) so the disclaimer isn't a complementary landmark nested inside the panel's `section` landmark — fixes a WCAG `landmark-complementary-is-top-level` violation caught by the existing axe test.

## Tests

New `FinanceDisclaimer.test.tsx` (official-source naming, not-an-allegation + verify, `note` role/label); extended `Footer.test.tsx`; existing rep-funding a11y + proposition + campaign-finance suites green (28 tests across 6 suites).

## Scope / remaining #962 (follow-ups)

This is the legal-risk core. Still open in #962: a first-visit / About "how to read this site" notice; auditing the AI-synopsis "AI-generated" labels for consistency; the campaign-finance **subpages** (committees/contributions/expenditures/IE data tables); and full footer i18n (the footer is currently English-only, pre-existing). I'd suggest these as a fast follow-up PR.

**Legal wording** should get a quick counsel review before launch — this lands clear placeholder-but-defensible copy now, swappable via i18n.

Reviewed: op-review (self) no blockers; pre-push AI code + security review PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)