### PR TITLE
feat(infra): SDLC hardening — HIPAA pre-push gate + sdlc plugin install (#967)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "opuspopuli-sdlc": {
+      "source": {
+        "source": "github",
+        "repo": "OpusPopuli/opuspopuli-sdlc"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "opuspopuli-sdlc@opuspopuli-sdlc": true
+  }
+}

--- a/.claude/skills/op-migration/SKILL.md
+++ b/.claude/skills/op-migration/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: op-migration
+description: Create an additive-safe Supabase migration (up + rollback), checking indexes, RLS, FKs, and data classification. Use when a change needs a schema migration in the opuspopuli monorepo.
+argument-hint: <what the migration should do>
+---
+
+Create a Supabase migration for: $ARGUMENTS
+
+1. Draft the up migration SQL
+2. Draft the down/rollback migration SQL
+3. Check for: index requirements (especially pgvector indexes), RLS policy impacts, foreign key safety
+4. Verify the migration is additive — no destructive column drops or renames without a deprecation path
+   (additive-only on existing tables in production; deprecate first, remove in a follow-up after deploy)
+5. Check that any new columns have appropriate defaults for existing rows
+6. **Data classification (HIPAA):** if a new column or table holds PHI/PII, say so, confirm an RLS policy
+   restricts access, and confirm it will be masked in audit logs. Regulated columns must not be world-readable.
+7. Name the migration file with timestamp + descriptive slug, under `supabase/migrations/`
+8. Show me the full SQL for review before writing any files
+
+Flag if this migration requires a coordinated deploy with application code changes.
+
+> Repo-specific skill: this encodes the opuspopuli monorepo's Supabase migration layout and additive-only
+> rules, so it lives here rather than in the shared `opuspopuli-sdlc` plugin.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -137,6 +137,9 @@ Check for:
 5. Hardcoded credentials, API keys, or tokens committed in code
 6. Path traversal in file operations
 7. Insecure deserialization (eval, Function constructor with user input)
+8. PHI/PII exposure (HIPAA) — real personal/health data (names, DOB, SSN, medical/insurance IDs,
+   addresses) written to logs, error messages, OpenTelemetry attributes, test fixtures, or seed data
+   without masking, or interpolated into a model prompt. Synthetic/faker data is fine; real data is not.
 
 Respond with EXACTLY one of:
   PASS


### PR DESCRIPTION
Adds the HIPAA PHI/PII lens to the enforced `pre-push` security-review gate, and installs the shared `opuspopuli-sdlc` Claude Code plugin via `.claude/settings.json` (force-added; `.claude/` is gitignored).

The org-wide SDLC workflow skills now live in https://github.com/OpusPopuli/opuspopuli-sdlc — this wires the monorepo to consume them. Part of #967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)