### PR TITLE
docs: SDLC tooling section in CLAUDE.md (#967)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,10 +136,14 @@ How it works:
 - WCAG 2.2 AA required for all UI — run `pnpm test:a11y` before marking UI work done
 - Deployed to Cloudflare Pages via `@opennextjs/cloudflare`
 
+## SDLC tooling (Claude Code plugin)
+
+The `op-*` workflow commands — `/op-review`, `/op-issue-plan`, `/op-release`, `/op-verify`, `/op-phi-scan`, `/op-trace`, `/op-change-record`, `/op-validate`, and the rest — ship as the shared **[opuspopuli-sdlc](https://github.com/OpusPopuli/opuspopuli-sdlc)** Claude Code plugin. It's auto-enabled in every session (local or remote) via the committed `.claude/settings.json`; the only per-developer step is trusting the repo folder once. Repo-specific commands (`/op-migration`) live in `.claude/skills/`. The plugin's `docs/compliance-model.md` maps the lifecycle to HIPAA / SOC 2 / 21 CFR Part 11 controls.
+
 ## Pre-push workflow (mandatory)
 
 Before running any `git push`, always:
-1. Run `/op-review` — fix any blocking findings before proceeding
+1. Run `/op-review` (from the opuspopuli-sdlc plugin) — fix any blocking findings before proceeding
 2. Run `/security-review` — fix any security issues before proceeding
 3. Only push after both pass cleanly
 


### PR DESCRIPTION
Adds an SDLC-tooling section and points the pre-push workflow at the shared [opuspopuli-sdlc](https://github.com/OpusPopuli/opuspopuli-sdlc) plugin (auto-enabled via committed `.claude/settings.json`; `op-migration` stays repo-local in `.claude/skills/`). Closes the docs task on #967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)