### PR TITLE
chore(infra): add project MCP servers (Postgres read-only, Playwright)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@bytebase/dbhub",
+        "--transport",
+        "stdio",
+        "--dsn",
+        "${MCP_DATABASE_URL}"
+      ]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,7 @@ Rules:
 - **Additive only** on existing tables in production. Never drop columns or rename them in a single migration — deprecate, then remove in a follow-up after deploy.
 - Secrets go in Supabase Vault. Never store credentials in migration SQL or `.env` files committed to the repo.
 - `.env` files are local dev overrides only — never commit them.
+- `MCP_DATABASE_URL` (used by the Postgres MCP server in `.mcp.json`) must be a **read-only** DSN against a **local/non-prod** database — MCP query results flow to the hosted model, so never point it at production personal data.
 
 ## Testing conventions
 


### PR DESCRIPTION
Adds a project-scoped `.mcp.json` so the team inherits two MCP servers when they open the repo in Claude Code:

- **`postgres`** (`@bytebase/dbhub`, read-only) — schema/migration inspection, resolver-exposure checks. DSN comes from `${MCP_DATABASE_URL}` in local env (no secret committed).
- **`playwright`** (`@playwright/mcp`) — drive E2E / a11y flows during verification.

Plus a one-line note in `CLAUDE.md` documenting `MCP_DATABASE_URL`.

### ⚠️ Before relying on this — two things
1. **Verify the servers actually connect.** Run `claude mcp list` / `/mcp` after setting the env var. I'm confident on the config *shape*, but the exact package invocations (`@bytebase/dbhub`, `@playwright/mcp`) are worth a health-check before the team depends on them — swap the DB package if you prefer a different Postgres MCP.
2. **`MCP_DATABASE_URL` must be a read-only, local/non-prod DSN.** MCP query results flow to the hosted model, so pointing it at production personal data (PHI/CCPA) would violate our own data-residency control. This is documented in `CLAUDE.md`.

### Notes
- **Sentry MCP intentionally omitted** — our observability is OTEL → Prometheus/Grafana/Loki, not Sentry.
- Cloudflare MCP not included yet — worth adding once the exact remote-MCP endpoint is confirmed (didn't want to commit a guessed URL).
- Each teammate still gets a one-time trust/install prompt for the plugin/servers — that's a Claude Code security boundary, not something committed settings can bypass.

Passed the full pre-push gate (tests, duplication, lint, dep audit, trivy, gitleaks, AI review). Leaving for your review/merge rather than auto-merging, since the server connectivity needs verification in your environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)