### PR TITLE
feat(scraping-pipeline): structured selector-failure diagnostics + mapping-aware self-heal (#966 W1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,7 @@ Use `git push --no-verify` only for explicit WIP/draft pushes to your own branch
 
 ## MVP target
 
-**July 4, 2026** is the public MVP launch deadline. Prioritize citizen-facing flows over internal tooling or polish. Flag anything that risks this date.
+**September 1, 2026** is the public MVP launch deadline. Prioritize citizen-facing flows over internal tooling or polish. Flag anything that risks this date.
 
 ## CI
 

--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -770,6 +770,40 @@ export interface ExtractionResult<T> {
    * the next run will find the freshly-derived manifest in cache.
    */
   pendingManifestAnalysis?: boolean;
+  /** Structured selector/schema failure diagnostics (#966 W1) */
+  selectorFailures?: SelectorFailure[];
+}
+
+/**
+ * Structured diagnostic for a selector or schema failure during extraction.
+ *
+ * This is the "which selector failed" record (#966 W1): unlike the flat
+ * `warnings`/`errors` strings, it survives with enough structure for the
+ * self-heal evaluation — and later the selector-repair agent — to act on
+ * without re-parsing English.
+ */
+export interface SelectorFailure {
+  /** Failure class */
+  kind:
+    | "container_miss"
+    | "item_miss"
+    | "field_miss"
+    | "detail_field_error"
+    | "schema_reject";
+  /** The selector that failed to match, when one is implicated */
+  selector?: string;
+  /** Enclosing scope selector (item/field misses) */
+  containerSelector?: string;
+  /** Field name, for field-level and schema failures */
+  field?: string;
+  /** Whether the field was marked required (field_miss only) */
+  required?: boolean;
+  /** Fraction of extracted items affected (field_miss / schema_reject) */
+  missRatio?: number;
+  /** Deduplicated Zod issue summaries (schema_reject only) */
+  schemaIssues?: string[];
+  /** Human-readable summary */
+  message: string;
 }
 
 /**
@@ -784,6 +818,8 @@ export interface RawExtractionResult {
   warnings: string[];
   /** Fatal errors */
   errors: string[];
+  /** Structured selector-level failure diagnostics (#966 W1) */
+  selectorFailures?: SelectorFailure[];
 }
 
 /**

--- a/packages/scraping-pipeline/__tests__/detail-crawler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/detail-crawler.spec.ts
@@ -566,3 +566,64 @@ describe("DetailCrawlerService", () => {
     });
   });
 });
+
+describe("detail field failure diagnostics (#966 W1)", () => {
+  it("records a detail_field_error instead of silently swallowing an invalid selector", async () => {
+    const mockExtraction = createMockExtraction();
+    const mockLlm = createMockLlm();
+    const crawler = new DetailCrawlerService(
+      mockExtraction as unknown as never,
+    );
+
+    const raw = createRawResult([
+      { title: "Measure A", detailUrl: "https://example.com/detail/a" },
+      { title: "Measure B", detailUrl: "https://example.com/detail/b" },
+    ]);
+    const source = createSource({
+      detailFields: {
+        // Unclosed pseudo-class — Cheerio throws on parse
+        fullText: "div:nth-child(",
+        summary: "main p",
+      },
+    });
+
+    const result = await crawler.enrichItems(raw, source, mockLlm);
+
+    const failure = (result.selectorFailures ?? []).find(
+      (f) => f.kind === "detail_field_error",
+    );
+    expect(failure).toBeDefined();
+    expect(failure!.field).toBe("fullText");
+    expect(failure!.selector).toBe("div:nth-child(");
+    expect(
+      result.warnings.some((w) => w.includes('"fullText"')),
+    ).toBe(true);
+    // The valid selector still extracted
+    expect(result.items[0].summary).toBeDefined();
+  });
+
+  it("records a broken selector once, not once per enriched item", async () => {
+    const mockExtraction = createMockExtraction();
+    const mockLlm = createMockLlm();
+    const crawler = new DetailCrawlerService(
+      mockExtraction as unknown as never,
+    );
+
+    const raw = createRawResult([
+      { title: "A", detailUrl: "https://example.com/a" },
+      { title: "B", detailUrl: "https://example.com/b" },
+      { title: "C", detailUrl: "https://example.com/c" },
+    ]);
+    const source = createSource({
+      detailFields: { fullText: "div:nth-child(" },
+    });
+
+    const result = await crawler.enrichItems(raw, source, mockLlm);
+
+    expect(
+      (result.selectorFailures ?? []).filter(
+        (f) => f.kind === "detail_field_error",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1313,3 +1313,70 @@ describe("DomainMapperService", () => {
     });
   });
 });
+
+describe("schema rejection diagnostics (#966 W1)", () => {
+  let mapper: DomainMapperService;
+
+  beforeEach(() => {
+    mapper = new DomainMapperService();
+  });
+
+  it("records a schema_reject failure with Zod issues when items fail validation", () => {
+    const raw = createRawResult({
+      items: [{ junk: "a" }, { junk: "b" }],
+    });
+
+    const result = mapper.map(raw, createSource());
+
+    expect(result.items).toHaveLength(0);
+    const reject = (result.selectorFailures ?? []).find(
+      (f) => f.kind === "schema_reject",
+    );
+    expect(reject).toBeDefined();
+    expect(reject!.missRatio).toBe(1);
+    expect(
+      reject!.schemaIssues!.some((i) => i.startsWith("Proposition.")),
+    ).toBe(true);
+    expect(
+      result.warnings.some((w) => w.includes("rejected by the")),
+    ).toBe(true);
+  });
+
+  it("passes extractor selectorFailures through to the mapped result", () => {
+    const raw = createRawResult({
+      items: [],
+      success: false,
+      selectorFailures: [
+        {
+          kind: "container_miss",
+          selector: ".gone",
+          message: 'Container not found: ".gone"',
+        },
+      ],
+    });
+
+    const result = mapper.map(raw, createSource());
+
+    expect(result.selectorFailures).toEqual([
+      expect.objectContaining({ kind: "container_miss", selector: ".gone" }),
+    ]);
+  });
+
+  it("does not count intentional drops as schema rejects", () => {
+    // A meeting with neither externalId nor title is dropped by design
+    // (identity gate), not by the Zod schema — it must not feed the heal loop.
+    const raw = createRawResult({
+      items: [{ location: "Room 101" }],
+    });
+
+    const result = mapper.map(
+      raw,
+      createSource({ dataType: DataType.MEETINGS }),
+    );
+
+    expect(result.items).toHaveLength(0);
+    expect(
+      (result.selectorFailures ?? []).find((f) => f.kind === "schema_reject"),
+    ).toBeUndefined();
+  });
+});

--- a/packages/scraping-pipeline/__tests__/extraction-validator.spec.ts
+++ b/packages/scraping-pipeline/__tests__/extraction-validator.spec.ts
@@ -208,3 +208,59 @@ describe("ExtractionValidator", () => {
     expect(result.valid).toBe(true);
   });
 });
+
+describe("field selector failures (#966 W1)", () => {
+  let validator: ExtractionValidator;
+
+  beforeEach(() => {
+    validator = new ExtractionValidator();
+  });
+
+  it("surfaces non-required field misses as warnings without failing validation", () => {
+    const result = validator.validate(
+      createResult({
+        selectorFailures: [
+          {
+            kind: "field_miss",
+            field: "party",
+            selector: ".party-renamed",
+            required: false,
+            missRatio: 1,
+            message: 'Field "party" selector matched nothing in 100% of items',
+          },
+        ],
+      }),
+      createManifest(),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        severity: "warning",
+        message: expect.stringContaining('"party"'),
+      }),
+    ]);
+  });
+
+  it("does not duplicate required-field misses (covered by coverage check)", () => {
+    const result = validator.validate(
+      createResult({
+        selectorFailures: [
+          {
+            kind: "field_miss",
+            field: "name",
+            selector: ".name",
+            required: true,
+            missRatio: 1,
+            message: 'Field "name" selector matched nothing',
+          },
+        ],
+      }),
+      createManifest(),
+    );
+
+    expect(
+      result.issues.filter((i) => i.message.includes("matched nothing")),
+    ).toHaveLength(0);
+  });
+});

--- a/packages/scraping-pipeline/__tests__/manifest-extractor.spec.ts
+++ b/packages/scraping-pipeline/__tests__/manifest-extractor.spec.ts
@@ -929,3 +929,168 @@ describe("ManifestExtractorService", () => {
     });
   });
 });
+
+describe("selector failure diagnostics (#966 W1)", () => {
+  let extractor: ManifestExtractorService;
+
+  beforeEach(() => {
+    extractor = new ManifestExtractorService();
+  });
+
+  it("records a container_miss failure when the container selector matches nothing", () => {
+    const manifest = createTestManifest({
+      extractionRules: {
+        containerSelector: ".vanished",
+        itemSelector: ".item",
+        fieldMappings: [],
+      },
+    });
+
+    const result = extractor.extract('<div class="other"></div>', manifest);
+
+    expect(result.success).toBe(false);
+    expect(result.selectorFailures).toEqual([
+      expect.objectContaining({
+        kind: "container_miss",
+        selector: ".vanished",
+      }),
+    ]);
+  });
+
+  it("records an item_miss failure when the item selector matches nothing in a found container", () => {
+    const manifest = createTestManifest({
+      extractionRules: {
+        containerSelector: ".container",
+        itemSelector: ".row",
+        fieldMappings: [],
+      },
+    });
+
+    const result = extractor.extract(
+      '<div class="container"><p>no rows here</p></div>',
+      manifest,
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.selectorFailures).toEqual([
+      expect.objectContaining({
+        kind: "item_miss",
+        selector: ".row",
+        containerSelector: ".container",
+      }),
+    ]);
+  });
+
+  it("records a field_miss for a non-required field whose selector matches nothing", () => {
+    const manifest = createTestManifest({
+      extractionRules: {
+        containerSelector: ".container",
+        itemSelector: ".card",
+        fieldMappings: [
+          {
+            fieldName: "name",
+            selector: ".name",
+            extractionMethod: "text",
+            required: true,
+          },
+          {
+            fieldName: "party",
+            selector: ".party-renamed",
+            extractionMethod: "text",
+            required: false,
+          },
+        ],
+      },
+    });
+
+    const html =
+      '<div class="container">' +
+      '<div class="card"><span class="name">A</span></div>' +
+      '<div class="card"><span class="name">B</span></div>' +
+      "</div>";
+    const result = extractor.extract(html, manifest);
+
+    expect(result.items).toHaveLength(2);
+    expect(result.selectorFailures).toEqual([
+      expect.objectContaining({
+        kind: "field_miss",
+        field: "party",
+        selector: ".party-renamed",
+        required: false,
+        missRatio: 1,
+      }),
+    ]);
+    expect(
+      result.warnings.some((w) => w.includes('"party"')),
+    ).toBe(true);
+  });
+
+  it("counts a selector miss even when a defaultValue masks it", () => {
+    const manifest = createTestManifest({
+      extractionRules: {
+        containerSelector: ".container",
+        itemSelector: ".card",
+        fieldMappings: [
+          {
+            fieldName: "name",
+            selector: ".name",
+            extractionMethod: "text",
+            required: true,
+          },
+          {
+            fieldName: "status",
+            selector: ".status-gone",
+            extractionMethod: "text",
+            required: false,
+            defaultValue: "active",
+          },
+        ],
+      },
+    });
+
+    const html =
+      '<div class="container">' +
+      '<div class="card"><span class="name">A</span></div>' +
+      "</div>";
+    const result = extractor.extract(html, manifest);
+
+    // Default fills the value…
+    expect(result.items[0].status).toBe("active");
+    // …but the drifted selector is still reported.
+    expect(result.selectorFailures).toEqual([
+      expect.objectContaining({ kind: "field_miss", field: "status" }),
+    ]);
+  });
+
+  it("does not record field_miss for constant fields or working selectors", () => {
+    const manifest = createTestManifest({
+      extractionRules: {
+        containerSelector: ".container",
+        itemSelector: ".card",
+        fieldMappings: [
+          {
+            fieldName: "name",
+            selector: ".name",
+            extractionMethod: "text",
+            required: true,
+          },
+          {
+            fieldName: "source",
+            selector: "",
+            extractionMethod: "constant",
+            required: false,
+            defaultValue: "ca-sos",
+          },
+        ],
+      },
+    });
+
+    const html =
+      '<div class="container">' +
+      '<div class="card"><span class="name">A</span></div>' +
+      "</div>";
+    const result = extractor.extract(html, manifest);
+
+    expect(result.selectorFailures).toBeUndefined();
+  });
+});

--- a/packages/scraping-pipeline/__tests__/pipeline.spec.ts
+++ b/packages/scraping-pipeline/__tests__/pipeline.spec.ts
@@ -122,6 +122,11 @@ describe("ScrapingPipelineService", () => {
         reason: "Extraction passed validation",
         validation: { valid: true, issues: [] },
       }),
+      evaluateMapping: jest.fn().mockReturnValue({
+        shouldHeal: false,
+        reason: "Mapping losses within tolerance",
+        validation: { valid: true, issues: [] },
+      }),
     } as unknown as jest.Mocked<SelfHealingService>;
 
     pipeline = new ScrapingPipelineService(
@@ -493,6 +498,103 @@ describe("ScrapingPipelineService", () => {
         ]),
       );
       expect(mockApiIngest.execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mapping-aware self-healing (#966 W1)", () => {
+    it("re-analyzes once when domain mapping rejects a majority of items", async () => {
+      // Extraction looks healthy both times…
+      mockHealing.evaluate.mockReturnValue({
+        shouldHeal: false,
+        reason: "Extraction passed validation",
+        validation: { valid: true, issues: [] },
+      });
+      // …but mapping rejects everything on the first pass.
+      (mockHealing.evaluateMapping as jest.Mock)
+        .mockReturnValueOnce({
+          shouldHeal: true,
+          reason: "Domain mapping rejected 100% of extracted items",
+          validation: {
+            valid: false,
+            issues: [{ severity: "error", message: "mapping loss" }],
+          },
+        })
+        .mockReturnValue({
+          shouldHeal: false,
+          reason: "Mapping losses within tolerance",
+          validation: { valid: true, issues: [] },
+        });
+      (mockMapper.map as jest.Mock)
+        .mockReturnValueOnce({
+          items: [],
+          manifestVersion: 0,
+          success: false,
+          warnings: [],
+          errors: [],
+          extractionTimeMs: 1,
+          selectorFailures: [
+            { kind: "schema_reject", missRatio: 1, message: "rejected" },
+          ],
+        })
+        .mockReturnValueOnce({
+          items: [{ id: "fixed" }],
+          manifestVersion: 0,
+          success: true,
+          warnings: [],
+          errors: [],
+          extractionTimeMs: 1,
+        });
+
+      const newManifest = createManifest({ id: "manifest-2", version: 2 });
+      mockAnalyzer.analyze.mockResolvedValue(newManifest);
+
+      const result = await pipeline.execute(createSource(), "california");
+
+      // Healed via re-analysis and kept the better (remapped) outcome
+      expect(mockAnalyzer.analyze).toHaveBeenCalled();
+      expect(mockExtractor.extract).toHaveBeenCalledTimes(2);
+      expect(result.items).toEqual([{ id: "fixed" }]);
+    });
+
+    it("keeps the original result when the mapping-heal remap is not better", async () => {
+      mockHealing.evaluate.mockReturnValue({
+        shouldHeal: false,
+        reason: "Extraction passed validation",
+        validation: { valid: true, issues: [] },
+      });
+      (mockHealing.evaluateMapping as jest.Mock).mockReturnValueOnce({
+        shouldHeal: true,
+        reason: "Domain mapping rejected 100% of extracted items",
+        validation: {
+          valid: false,
+          issues: [{ severity: "error", message: "mapping loss" }],
+        },
+      });
+      const emptyMapped = {
+        items: [],
+        manifestVersion: 0,
+        success: false,
+        warnings: [],
+        errors: [],
+        extractionTimeMs: 1,
+      };
+      (mockMapper.map as jest.Mock)
+        .mockReturnValueOnce({
+          ...emptyMapped,
+          selectorFailures: [
+            { kind: "schema_reject", missRatio: 1, message: "rejected" },
+          ],
+        })
+        .mockReturnValueOnce(emptyMapped);
+
+      const newManifest = createManifest({ id: "manifest-2", version: 2 });
+      mockAnalyzer.analyze.mockResolvedValue(newManifest);
+
+      const result = await pipeline.execute(createSource(), "california");
+
+      expect(result.items).toEqual([]);
+      // Original manifest version retained — the failed heal didn't win
+      expect(result.manifestVersion).toBe(1);
     });
   });
 });

--- a/packages/scraping-pipeline/__tests__/self-healing.spec.ts
+++ b/packages/scraping-pipeline/__tests__/self-healing.spec.ts
@@ -127,3 +127,78 @@ describe("SelfHealingService", () => {
     expect(decision.validation.issues.length).toBeGreaterThan(0);
   });
 });
+
+describe("evaluateMapping (#966 W1)", () => {
+  let healing: SelfHealingService;
+
+  function createMapped(
+    missRatio: number | undefined,
+    items: unknown[] = [],
+  ) {
+    return {
+      items,
+      manifestVersion: 0,
+      success: items.length > 0,
+      warnings: [],
+      errors: [],
+      extractionTimeMs: 1,
+      ...(missRatio !== undefined && {
+        selectorFailures: [
+          {
+            kind: "schema_reject" as const,
+            missRatio,
+            schemaIssues: ["Proposition.externalId: Required"],
+            message: "rejected",
+          },
+        ],
+      }),
+    };
+  }
+
+  beforeEach(() => {
+    healing = new SelfHealingService();
+  });
+
+  it("heals when the schema rejected a majority of extracted items", () => {
+    const decision = healing.evaluateMapping(
+      createResult(),
+      createMapped(0.9),
+      createManifest(),
+    );
+
+    expect(decision.shouldHeal).toBe(true);
+    expect(decision.reason).toContain("90%");
+    expect(decision.reason).toContain("Proposition.externalId");
+  });
+
+  it("does not heal when healing was already attempted this run", () => {
+    const decision = healing.evaluateMapping(
+      createResult(),
+      createMapped(1),
+      createManifest(),
+      true,
+    );
+
+    expect(decision.shouldHeal).toBe(false);
+  });
+
+  it("does not heal without a schema_reject failure", () => {
+    const decision = healing.evaluateMapping(
+      createResult(),
+      createMapped(undefined, [{ ok: true }]),
+      createManifest(),
+    );
+
+    expect(decision.shouldHeal).toBe(false);
+  });
+
+  it("does not heal at or below the 50% rejection threshold", () => {
+    const decision = healing.evaluateMapping(
+      createResult(),
+      createMapped(0.5),
+      createManifest(),
+    );
+
+    expect(decision.shouldHeal).toBe(false);
+  });
+});

--- a/packages/scraping-pipeline/src/crawling/detail-crawler.service.ts
+++ b/packages/scraping-pipeline/src/crawling/detail-crawler.service.ts
@@ -22,6 +22,7 @@ import type {
   DataSourceConfig,
   RawExtractionResult,
   ILLMProvider,
+  SelectorFailure,
   StructuredFieldConfig,
 } from "@opuspopuli/common";
 import { ExtractionProvider } from "@opuspopuli/extraction-provider";
@@ -76,6 +77,7 @@ export class DetailCrawlerService {
     // Derive extraction plan from the first detail page, reuse for the rest
     let extractionPlan: Record<string, string | StructuredFieldConfig> | null =
       null;
+    const detailFailures = new Map<string, SelectorFailure>();
 
     for (let i = 0; i < toFetch.length; i++) {
       extractionPlan = await this.enrichSingleItem(
@@ -84,12 +86,22 @@ export class DetailCrawlerService {
         source,
         llm,
         rawResult.warnings,
+        detailFailures,
       );
 
       // Rate limit between fetches
       if (i < toFetch.length - 1) {
         await this.delay(DETAIL_FETCH_DELAY_MS);
       }
+    }
+
+    if (detailFailures.size > 0) {
+      const failures = [...detailFailures.values()];
+      rawResult.selectorFailures = [
+        ...(rawResult.selectorFailures ?? []),
+        ...failures,
+      ];
+      rawResult.warnings.push(...failures.map((f) => f.message));
     }
 
     return rawResult;
@@ -105,6 +117,7 @@ export class DetailCrawlerService {
     source: DataSourceConfig,
     llm: ILLMProvider,
     warnings: string[],
+    failures?: Map<string, SelectorFailure>,
   ): Promise<Record<string, string | StructuredFieldConfig> | null> {
     const rawUrl = item.detailUrl as string;
     const detailUrl = DetailCrawlerService.resolveUrl(rawUrl, source.url);
@@ -133,6 +146,7 @@ export class DetailCrawlerService {
         isHtml,
         extractionPlan,
         source.dataType,
+        failures,
       );
       this.mergeContent(item, content);
     } catch (error) {
@@ -181,9 +195,10 @@ export class DetailCrawlerService {
     isHtml: boolean,
     plan: Record<string, string | StructuredFieldConfig>,
     dataType: string,
+    failures?: Map<string, SelectorFailure>,
   ): Record<string, unknown> {
     if (Object.keys(plan).length > 0 && isHtml) {
-      const content = this.extractContent(pageContent, plan);
+      const content = this.extractContent(pageContent, plan, failures);
       if (Object.keys(content).length > 0) {
         this.logger.debug(
           `Extracted fields: ${Object.keys(content).join(", ")}`,
@@ -401,6 +416,7 @@ Respond with ONLY valid JSON, no explanation. Example:
   private extractContent(
     html: string,
     plan: Record<string, string | StructuredFieldConfig>,
+    failures?: Map<string, SelectorFailure>,
   ): Record<string, unknown> {
     const $ = cheerio.load(html);
     $("script, style, noscript, svg, iframe").remove();
@@ -416,8 +432,25 @@ Respond with ONLY valid JSON, no explanation. Example:
           const value = this.extractSimpleField($, field, config);
           if (value) result[field] = value;
         }
-      } catch {
-        // Skip fields with invalid selectors
+      } catch (error) {
+        // Invalid selector (e.g. Cheerio parse failure). Previously a bare
+        // catch {} — detailFields drift produced no diagnostic at all
+        // (#966 W1). Keyed by field so the same broken selector isn't
+        // recorded once per enriched item.
+        const selector =
+          typeof config === "string" ? config : (config.selector ?? "");
+        failures?.set(field, {
+          kind: "detail_field_error",
+          field,
+          selector,
+          message:
+            'Detail field "' +
+            field +
+            '" selector failed: "' +
+            selector +
+            '" — ' +
+            (error as Error).message,
+        });
       }
     }
 

--- a/packages/scraping-pipeline/src/extraction/extraction-validator.ts
+++ b/packages/scraping-pipeline/src/extraction/extraction-validator.ts
@@ -40,6 +40,7 @@ export class ExtractionValidator {
     this.checkRequiredFieldCoverage(result, manifest, issues);
     this.checkItemCountDrift(result, previousItemCount, issues);
     this.checkWarningCount(result, issues);
+    this.checkFieldSelectorFailures(result, issues);
 
     const hasErrors = issues.some((i) => i.severity === "error");
     if (hasErrors) {
@@ -169,6 +170,24 @@ export class ExtractionValidator {
           pct +
           "%)",
       });
+    }
+  }
+
+  /**
+   * Surface non-required field selector misses from the extractor's
+   * structured diagnostics (#966 W1). Warning severity on purpose: an
+   * optional field that is legitimately absent from a page shape must not
+   * trigger an LLM re-analysis on every run — required-field breakage
+   * already escalates via checkRequiredFieldCoverage.
+   */
+  private checkFieldSelectorFailures(
+    result: RawExtractionResult,
+    issues: ValidationIssue[],
+  ): void {
+    for (const failure of result.selectorFailures ?? []) {
+      if (failure.kind === "field_miss" && failure.required !== true) {
+        issues.push({ severity: "warning", message: failure.message });
+      }
     }
   }
 

--- a/packages/scraping-pipeline/src/extraction/manifest-extractor.service.ts
+++ b/packages/scraping-pipeline/src/extraction/manifest-extractor.service.ts
@@ -15,6 +15,7 @@ import type {
   FieldMapping,
   PreprocessingStep,
   RawExtractionResult,
+  SelectorFailure,
 } from "@opuspopuli/common";
 import { FieldTransformer } from "./field-transformer.js";
 import { safeRegex } from "./safe-regex.js";
@@ -61,6 +62,13 @@ export class ManifestExtractorService {
         success: false,
         warnings: [],
         errors: ["Container not found: " + rules.containerSelector],
+        selectorFailures: [
+          {
+            kind: "container_miss",
+            selector: rules.containerSelector,
+            message: "Container not found: " + rules.containerSelector,
+          },
+        ],
       };
     }
 
@@ -106,17 +114,32 @@ export class ManifestExtractorService {
             " within " +
             rules.containerSelector,
         ],
+        selectorFailures: [
+          {
+            kind: "item_miss",
+            selector: rules.itemSelector,
+            containerSelector: rules.containerSelector,
+            message:
+              "No items found: " +
+              rules.itemSelector +
+              " within " +
+              rules.containerSelector,
+          },
+        ],
       };
     }
 
-    // Extract each item
+    // Extract each item, counting per-field selector misses across all
+    // attempted items (dropped items included — their misses are the signal).
     const items: Record<string, unknown>[] = [];
+    const fieldMissCounts = new Map<string, number>();
     itemElements.each((_i, el) => {
       const result = this.extractItem(
         $,
         $(el as Element),
         firstContainer,
         rules.fieldMappings,
+        fieldMissCounts,
         baseUrl,
       );
 
@@ -125,6 +148,13 @@ export class ManifestExtractorService {
         warnings.push(...result.warnings);
       }
     });
+
+    const selectorFailures = this.collectFieldMissFailures(
+      rules.fieldMappings,
+      fieldMissCounts,
+      itemElements.length,
+      warnings,
+    );
 
     const duration = Date.now() - startTime;
     this.logger.debug(
@@ -142,7 +172,64 @@ export class ManifestExtractorService {
       success: items.length > 0,
       warnings,
       errors,
+      ...(selectorFailures.length > 0 && { selectorFailures }),
     };
+  }
+
+  /**
+   * Turn per-field selector-miss counts into structured failures.
+   *
+   * A field whose selector missed in ≥50% of attempted items has almost
+   * certainly drifted — that includes non-required fields, which produced no
+   * signal at all before #966 W1 (defaults and optionality masked them).
+   */
+  private collectFieldMissFailures(
+    mappings: FieldMapping[],
+    missCounts: Map<string, number>,
+    attemptedItems: number,
+    warnings: string[],
+  ): SelectorFailure[] {
+    const failures: SelectorFailure[] = [];
+    if (attemptedItems === 0) {
+      return failures;
+    }
+
+    for (const mapping of mappings) {
+      const misses = missCounts.get(mapping.fieldName) ?? 0;
+      const missRatio = misses / attemptedItems;
+      if (missRatio < 0.5) {
+        continue;
+      }
+
+      const pct = Math.round(missRatio * 100);
+      const message =
+        'Field "' +
+        mapping.fieldName +
+        '" selector matched nothing in ' +
+        pct +
+        "% of items (" +
+        misses +
+        "/" +
+        attemptedItems +
+        '): "' +
+        (mapping.selector ?? "") +
+        '"';
+      failures.push({
+        kind: "field_miss",
+        field: mapping.fieldName,
+        selector: mapping.selector,
+        required: mapping.required === true,
+        missRatio,
+        message,
+      });
+      // Required-field misses already warn per item; surface the aggregate
+      // for non-required fields, which were previously invisible.
+      if (mapping.required !== true) {
+        warnings.push(message);
+      }
+    }
+
+    return failures;
   }
 
   /**
@@ -153,6 +240,7 @@ export class ManifestExtractorService {
     element: Cheerio<Element>,
     container: Cheerio<Element>,
     mappings: FieldMapping[],
+    fieldMissCounts: Map<string, number>,
     baseUrl?: string,
   ): { data: Record<string, unknown>; warnings: string[] } | null {
     const data: Record<string, unknown> = {};
@@ -166,7 +254,21 @@ export class ManifestExtractorService {
       }
 
       const scope = mapping.scope === "container" ? container : element;
-      const value = this.resolveFieldValue($, scope, mapping, baseUrl);
+      const { value, selectorMiss } = this.resolveFieldValue(
+        $,
+        scope,
+        mapping,
+        baseUrl,
+      );
+
+      // Selector-level miss, counted before defaults/transforms so a
+      // defaultValue can't mask a drifted selector (#966 W1).
+      if (selectorMiss) {
+        fieldMissCounts.set(
+          mapping.fieldName,
+          (fieldMissCounts.get(mapping.fieldName) ?? 0) + 1,
+        );
+      }
 
       const isEmpty =
         value === undefined ||
@@ -194,30 +296,50 @@ export class ManifestExtractorService {
 
   /**
    * Extract, transform, and apply defaults for a single field.
-   * Returns a string for scalar methods, an array of objects for 'structured'.
+   * Returns a string for scalar methods, an array of objects for 'structured',
+   * plus whether the field's selector matched nothing (measured before
+   * transforms and defaults are applied, so they can't mask drift).
    */
   private resolveFieldValue(
     $: CheerioAPI,
     element: Cheerio<Element>,
     mapping: FieldMapping,
     baseUrl?: string,
-  ): unknown {
-    // Structured extraction produces an array — transforms/defaults don't apply
-    if (mapping.extractionMethod === "structured") {
-      return this.extractStructuredArray($, element, mapping, baseUrl);
+  ): { value: unknown; selectorMiss: boolean } {
+    // "constant" has no selector to break
+    if (mapping.extractionMethod === "constant") {
+      return {
+        value: mapping.defaultValue || undefined,
+        selectorMiss: false,
+      };
     }
 
-    let value = this.extractFieldValue($, element, mapping);
+    // Structured extraction produces an array — transforms/defaults don't apply
+    if (mapping.extractionMethod === "structured") {
+      const value = this.extractStructuredArray($, element, mapping, baseUrl);
+      return {
+        value,
+        selectorMiss: Boolean(mapping.selector) && value.length === 0,
+      };
+    }
 
+    const raw = this.extractFieldValue($, element, mapping);
+    const selectorMiss = Boolean(mapping.selector) && raw === undefined;
+
+    let value: unknown = raw;
     if (value && mapping.transform) {
-      value = FieldTransformer.apply(value, mapping.transform, baseUrl);
+      value = FieldTransformer.apply(
+        value as string,
+        mapping.transform,
+        baseUrl,
+      );
     }
 
     if (!value && mapping.defaultValue !== undefined) {
       value = mapping.defaultValue;
     }
 
-    return value;
+    return { value, selectorMiss };
   }
 
   /**
@@ -278,12 +400,7 @@ export class ManifestExtractorService {
     element: Cheerio<Element>,
     mapping: FieldMapping,
   ): string | undefined {
-    // "constant" extraction method returns the defaultValue directly (no selector needed)
-    if (mapping.extractionMethod === "constant") {
-      return mapping.defaultValue || undefined;
-    }
-
-    // Skip if no selector provided
+    // "constant" is short-circuited in resolveFieldValue; skip if no selector
     if (!mapping.selector) {
       return undefined;
     }

--- a/packages/scraping-pipeline/src/healing/self-healing.service.ts
+++ b/packages/scraping-pipeline/src/healing/self-healing.service.ts
@@ -7,6 +7,7 @@
 
 import { Injectable, Logger } from "@nestjs/common";
 import type {
+  ExtractionResult,
   RawExtractionResult,
   StructuralManifest,
 } from "@opuspopuli/common";
@@ -83,6 +84,62 @@ export class SelfHealingService {
       shouldHeal: true,
       reason: `Extraction validation failed: ${errorMessages.join("; ")}`,
       validation,
+    };
+  }
+
+  /**
+   * Post-mapping evaluation (#966 W1).
+   *
+   * The pre-mapping `evaluate()` can't see the failure mode where a drifted
+   * selector matches the *wrong* elements: extraction "succeeds" with
+   * plausible-looking items that the domain Zod schema then rejects. Those
+   * rejections used to be swallowed as debug logs — a selector could drop
+   * every item while the heal gate stayed green.
+   *
+   * Triggers healing when the schema rejected a majority of extracted items.
+   * Intentional drops (identity-less meetings, non-ballot CVR2 rows) are not
+   * counted as rejects by the mapper, so filtering-heavy sources don't loop.
+   */
+  evaluateMapping(
+    raw: RawExtractionResult,
+    mapped: ExtractionResult<unknown>,
+    manifest: StructuralManifest,
+    healAttempted: boolean = false,
+  ): HealingDecision {
+    if (healAttempted) {
+      return {
+        shouldHeal: false,
+        reason: "Healing already attempted this run — avoiding infinite loop",
+        validation: { valid: true, issues: [] },
+      };
+    }
+
+    const reject = (mapped.selectorFailures ?? []).find(
+      (f) => f.kind === "schema_reject",
+    );
+    if (!reject || raw.items.length === 0 || (reject.missRatio ?? 0) <= 0.5) {
+      return {
+        shouldHeal: false,
+        reason: "Mapping losses within tolerance",
+        validation: { valid: true, issues: [] },
+      };
+    }
+
+    const detail = reject.schemaIssues?.[0]
+      ? ` (${reject.schemaIssues[0]})`
+      : "";
+    const reason = `Domain mapping rejected ${Math.round((reject.missRatio ?? 0) * 100)}% of extracted items${detail}`;
+    this.logger.warn(
+      `Self-healing triggered for ${manifest.sourceUrl}: ${reason}`,
+    );
+
+    return {
+      shouldHeal: true,
+      reason,
+      validation: {
+        valid: false,
+        issues: [{ severity: "error", message: reason }],
+      },
     };
   }
 }

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -23,7 +23,20 @@ import {
   type RawExtractionResult,
   type ExtractionResult,
   type DataSourceConfig,
+  type SelectorFailure,
 } from "@opuspopuli/common";
+
+/**
+ * Per-map() collection of Zod schema rejections (#966 W1).
+ *
+ * Only genuine schema failures count here — intentional drops (meetings
+ * without any identity, CVR2 rows without a ballot link) are filtering,
+ * not drift, and must not feed the heal loop.
+ */
+interface MappingDiagnostics {
+  schemaRejects: number;
+  issues: string[];
+}
 
 @Injectable()
 export class DomainMapperService {
@@ -44,10 +57,11 @@ export class DomainMapperService {
     const warnings = [...raw.warnings];
     const errors = [...raw.errors];
     const items: T[] = [];
+    const diagnostics: MappingDiagnostics = { schemaRejects: 0, issues: [] };
 
     for (let i = 0; i < raw.items.length; i++) {
       try {
-        const mapped = this.mapItem(raw.items[i], source);
+        const mapped = this.mapItem(raw.items[i], source, diagnostics);
         if (mapped) {
           items.push(mapped as T);
         }
@@ -58,6 +72,13 @@ export class DomainMapperService {
       }
     }
 
+    const selectorFailures = this.buildSelectorFailures(
+      raw,
+      source,
+      diagnostics,
+      warnings,
+    );
+
     return {
       items,
       manifestVersion: 0, // Set by pipeline orchestrator
@@ -65,12 +86,75 @@ export class DomainMapperService {
       warnings,
       errors,
       extractionTimeMs: Date.now() - startTime,
+      ...(selectorFailures.length > 0 && { selectorFailures }),
     };
+  }
+
+  /**
+   * Carry the extractor's selector diagnostics through mapping and append a
+   * schema_reject entry when Zod turned items away. Before #966 W1 these
+   * rejections were logger.debug'd and discarded — a selector matching the
+   * wrong element could drop every item without any surviving signal.
+   */
+  private buildSelectorFailures(
+    raw: RawExtractionResult,
+    source: DataSourceConfig,
+    diagnostics: MappingDiagnostics,
+    warnings: string[],
+  ): SelectorFailure[] {
+    const failures: SelectorFailure[] = [...(raw.selectorFailures ?? [])];
+
+    if (diagnostics.schemaRejects > 0 && raw.items.length > 0) {
+      const schemaIssues = [...new Set(diagnostics.issues)].slice(0, 10);
+      const message =
+        diagnostics.schemaRejects +
+        "/" +
+        raw.items.length +
+        " extracted items rejected by the " +
+        source.dataType +
+        " schema";
+      failures.push({
+        kind: "schema_reject",
+        missRatio: diagnostics.schemaRejects / raw.items.length,
+        schemaIssues,
+        message,
+      });
+      warnings.push(
+        message + (schemaIssues.length > 0 ? " — " + schemaIssues[0] : ""),
+      );
+    }
+
+    return failures;
+  }
+
+  /**
+   * Validate a record against a schema, collecting Zod issues on failure.
+   * The collected issues are the expected-schema-vs-actual-shape diff the
+   * selector-repair agent consumes (#966).
+   */
+  private parseOrCollect<S extends z.ZodType>(
+    schema: S,
+    record: unknown,
+    label: string,
+    diag: MappingDiagnostics,
+  ): z.infer<S> | null {
+    const result = schema.safeParse(record);
+    if (result.success) {
+      return result.data;
+    }
+    this.logger.debug(label + " validation failed: " + result.error.message);
+    diag.schemaRejects++;
+    for (const issue of result.error.issues) {
+      const path = issue.path.length > 0 ? issue.path.join(".") : "(root)";
+      diag.issues.push(label + "." + path + ": " + issue.message);
+    }
+    return null;
   }
 
   private mapItem(
     record: Record<string, unknown>,
     source: DataSourceConfig,
+    diag: MappingDiagnostics,
   ):
     | Proposition
     | Meeting
@@ -83,13 +167,13 @@ export class DomainMapperService {
     | null {
     switch (source.dataType) {
       case DataType.PROPOSITIONS:
-        return this.mapProposition(record);
+        return this.mapProposition(record, diag);
       case DataType.MEETINGS:
-        return this.mapMeeting(record, source.category);
+        return this.mapMeeting(record, diag, source.category);
       case DataType.REPRESENTATIVES:
-        return this.mapRepresentative(record, source.category);
+        return this.mapRepresentative(record, diag, source.category);
       case DataType.CAMPAIGN_FINANCE:
-        return this.mapCampaignFinanceItem(record, source.category);
+        return this.mapCampaignFinanceItem(record, diag, source.category);
       default:
         return null;
     }
@@ -100,6 +184,7 @@ export class DomainMapperService {
    */
   private mapCampaignFinanceItem(
     record: Record<string, unknown>,
+    diag: MappingDiagnostics,
     category?: string,
   ):
     | Committee
@@ -117,22 +202,25 @@ export class DomainMapperService {
     // — the reason cvr2_filings sat at 0 and no committee→measure link ever
     // formed (#936).
     if (cat.includes("committee position") || cat.includes("cvr2")) {
-      return this.mapCommitteeMeasureFiling(record);
+      return this.mapCommitteeMeasureFiling(record, diag);
     } else if (cat.includes("independent") || cat.includes("s496")) {
-      return this.mapIndependentExpenditure(record);
+      return this.mapIndependentExpenditure(record, diag);
     } else if (cat.includes("committee")) {
-      return this.mapCommittee(record);
+      return this.mapCommittee(record, diag);
     } else if (cat.includes("expenditure")) {
-      return this.mapExpenditure(record);
+      return this.mapExpenditure(record, diag);
     } else if (cat.includes("contribution")) {
-      return this.mapContribution(record);
+      return this.mapContribution(record, diag);
     }
 
     // Default: try contribution (most common campaign finance record type)
-    return this.mapContribution(record);
+    return this.mapContribution(record, diag);
   }
 
-  private mapProposition(record: Record<string, unknown>): Proposition | null {
+  private mapProposition(
+    record: Record<string, unknown>,
+    diag: MappingDiagnostics,
+  ): Proposition | null {
     // The CA SOS qualified-ballot-measures page emits each measure as an
     // anchor whose href points to the bill PDF. The regions config
     // extracts that href as `detailUrl`, but the proposition domain
@@ -141,18 +229,12 @@ export class DomainMapperService {
       ...record,
       sourceUrl: record.sourceUrl ?? record.detailUrl,
     };
-    const result = PropositionSchema.safeParse(enriched);
-    if (!result.success) {
-      this.logger.debug(
-        `Proposition validation failed: ${result.error.message}`,
-      );
-      return null;
-    }
-    return result.data;
+    return this.parseOrCollect(PropositionSchema, enriched, "Proposition", diag);
   }
 
   private mapMeeting(
     record: Record<string, unknown>,
+    diag: MappingDiagnostics,
     category?: string,
   ): Meeting | null {
     const title = typeof record.title === "string" ? record.title : undefined;
@@ -189,16 +271,17 @@ export class DomainMapperService {
       return null;
     }
 
-    const result = MeetingSchema.safeParse({ ...record, body, externalId });
-    if (!result.success) {
-      this.logger.debug(`Meeting validation failed: ${result.error.message}`);
-      return null;
-    }
-    return result.data;
+    return this.parseOrCollect(
+      MeetingSchema,
+      { ...record, body, externalId },
+      "Meeting",
+      diag,
+    );
   }
 
   private mapRepresentative(
     record: Record<string, unknown>,
+    diag: MappingDiagnostics,
     category?: string,
   ): Representative | null {
     // Inject chamber from category if not in record
@@ -207,36 +290,34 @@ export class DomainMapperService {
       chamber: record.chamber ?? category ?? "Unknown",
     };
 
-    const result = RepresentativeSchema.safeParse(enriched);
-    if (!result.success) {
-      this.logger.debug(
-        `Representative validation failed: ${result.error.message}`,
-      );
-      return null;
-    }
-    return result.data;
+    return this.parseOrCollect(
+      RepresentativeSchema,
+      enriched,
+      "Representative",
+      diag,
+    );
   }
 
-  private mapCommittee(record: Record<string, unknown>): Committee | null {
-    const result = CommitteeSchema.safeParse(record);
-    if (!result.success) {
-      this.logger.debug(`Committee validation failed: ${result.error.message}`);
-      return null;
-    }
-    return result.data;
+  private mapCommittee(
+    record: Record<string, unknown>,
+    diag: MappingDiagnostics,
+  ): Committee | null {
+    return this.parseOrCollect(CommitteeSchema, record, "Committee", diag);
   }
 
   private mapCommitteeMeasureFiling(
     record: Record<string, unknown>,
+    diag: MappingDiagnostics,
   ): CommitteeMeasureFiling | null {
-    const result = CommitteeMeasureFilingSchema.safeParse(record);
-    if (!result.success) {
-      this.logger.debug(
-        `Committee measure filing validation failed: ${result.error.message}`,
-      );
+    const filing = this.parseOrCollect(
+      CommitteeMeasureFilingSchema,
+      record,
+      "CommitteeMeasureFiling",
+      diag,
+    );
+    if (!filing) {
       return null;
     }
-    const filing = result.data;
     // Most CVR2 rows are non-ballot entity declarations. Only ballot-measure
     // declarations (a ballotName or ballotNumber) are useful — the
     // proposition-finance-linker resolves by those — so drop the rest here
@@ -249,6 +330,7 @@ export class DomainMapperService {
 
   private mapContribution(
     record: Record<string, unknown>,
+    diag: MappingDiagnostics,
   ): Contribution | null {
     // Combine first/last name fields if donorName not already set
     const enriched = { ...record };
@@ -261,38 +343,31 @@ export class DomainMapperService {
       enriched.donorName = first ? `${last}, ${first}`.trim() : last;
     }
 
-    const result = ContributionSchema.safeParse(enriched);
-    if (!result.success) {
-      this.logger.debug(
-        `Contribution validation failed: ${result.error.message}`,
-      );
-      return null;
-    }
-    return result.data;
+    return this.parseOrCollect(
+      ContributionSchema,
+      enriched,
+      "Contribution",
+      diag,
+    );
   }
 
-  private mapExpenditure(record: Record<string, unknown>): Expenditure | null {
-    const result = ExpenditureSchema.safeParse(record);
-    if (!result.success) {
-      this.logger.debug(
-        `Expenditure validation failed: ${result.error.message}`,
-      );
-      return null;
-    }
-    return result.data;
+  private mapExpenditure(
+    record: Record<string, unknown>,
+    diag: MappingDiagnostics,
+  ): Expenditure | null {
+    return this.parseOrCollect(ExpenditureSchema, record, "Expenditure", diag);
   }
 
   private mapIndependentExpenditure(
     record: Record<string, unknown>,
+    diag: MappingDiagnostics,
   ): IndependentExpenditure | null {
-    const result = IndependentExpenditureSchema.safeParse(record);
-    if (!result.success) {
-      this.logger.debug(
-        `IndependentExpenditure validation failed: ${result.error.message}`,
-      );
-      return null;
-    }
-    return result.data;
+    return this.parseOrCollect(
+      IndependentExpenditureSchema,
+      record,
+      "IndependentExpenditure",
+      diag,
+    );
   }
 }
 

--- a/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
+++ b/packages/scraping-pipeline/src/pipeline/pipeline.service.ts
@@ -272,6 +272,7 @@ export class ScrapingPipelineService {
       manifest.lastItemCount,
     );
 
+    let healAttempted = false;
     if (healingDecision.shouldHeal) {
       // Stale cached rules produced degraded output. Re-derive and re-extract
       // in THIS run — even in async/worker mode — so the sync self-heals
@@ -283,6 +284,7 @@ export class ScrapingPipelineService {
       const healed = await this.healManifest(source, regionId, html, manifest);
       rawResult = healed.rawResult;
       effectiveVersion = healed.version;
+      healAttempted = true;
     } else {
       // Original manifest worked — record success (updating the drift baseline)
       // and refresh the checked timestamp.
@@ -294,7 +296,57 @@ export class ScrapingPipelineService {
     }
 
     // Stage 3.5: Enrich items with detail page content (if detailUrl extracted)
-    // Also check contactInfo.website — AI sometimes maps homepage links there instead of detailUrl
+    rawResult = await this.enrichWithDetails(rawResult, source);
+
+    // Stage 4: Map to domain types
+    let result = this.mapper.map<T>(rawResult, source);
+
+    // Stage 4.5: Mapping-aware heal (#966 W1). A drifted selector that
+    // matches the wrong elements passes the pre-mapping gate — extraction
+    // "succeeds" — while the domain schema rejects everything. Re-derive
+    // once when mapping losses reveal that, bounded by the same
+    // one-heal-per-run rule as the pre-mapping path.
+    const mappingDecision = this.healing.evaluateMapping(
+      rawResult,
+      result,
+      manifest,
+      healAttempted,
+    );
+    if (mappingDecision.shouldHeal) {
+      this.logger.warn(
+        `Self-healing: re-analyzing ${source.url} — ${mappingDecision.reason}`,
+      );
+      const healed = await this.healManifest(source, regionId, html, manifest);
+      healAttempted = true;
+      const healedRaw = await this.enrichWithDetails(healed.rawResult, source);
+      const remapped = this.mapper.map<T>(healedRaw, source);
+      // Keep whichever outcome mapped more items — a failed heal must not
+      // discard the (partial) original result.
+      if (remapped.items.length > result.items.length) {
+        result = remapped;
+        effectiveVersion = healed.version;
+      }
+    }
+    result.manifestVersion = effectiveVersion;
+
+    const totalMs = Date.now() - pipelineStart;
+    this.logger.log(
+      `Pipeline complete: ${result.items.length} items extracted in ${totalMs}ms ` +
+        `(cache: ${analysisResult.fromCache}, heal: ${healAttempted})`,
+    );
+
+    return result;
+  }
+
+  /**
+   * Stage 3.5: enrich items that carry a detailUrl with detail-page content.
+   * Also checks contactInfo.website — AI sometimes maps homepage links there
+   * instead of detailUrl. Shared by the main path and the mapping-aware heal.
+   */
+  private async enrichWithDetails(
+    rawResult: RawExtractionResult,
+    source: DataSourceConfig,
+  ): Promise<RawExtractionResult> {
     for (const item of rawResult.items) {
       if (!item.detailUrl) {
         item.detailUrl =
@@ -303,24 +355,9 @@ export class ScrapingPipelineService {
       }
     }
     if (rawResult.items.some((item) => item.detailUrl)) {
-      rawResult = await this.detailCrawler.enrichItems(
-        rawResult,
-        source,
-        this.llm,
-      );
+      return this.detailCrawler.enrichItems(rawResult, source, this.llm);
     }
-
-    // Stage 4: Map to domain types
-    const result = this.mapper.map<T>(rawResult, source);
-    result.manifestVersion = effectiveVersion;
-
-    const totalMs = Date.now() - pipelineStart;
-    this.logger.log(
-      `Pipeline complete: ${result.items.length} items extracted in ${totalMs}ms ` +
-        `(cache: ${analysisResult.fromCache}, heal: ${healingDecision.shouldHeal})`,
-    );
-
-    return result;
+    return rawResult;
   }
 
   /**


### PR DESCRIPTION
## Description

W1 (failure signal enrichment) from #966's groomed plan — the pipeline now records **which selector broke** as structured data instead of flattening failures into log strings, and the heal loop can see schema-level breakage for the first time:

- **New `SelectorFailure` diagnostic type** on `RawExtractionResult`/`ExtractionResult` (`container_miss`, `item_miss`, `field_miss`, `detail_field_error`, `schema_reject`) — the input contract for the future selector-repair agent.
- **`ManifestExtractorService`**: structured failures for container/item misses; per-field selector-miss tracking measured *before* transforms/defaults, so a `defaultValue` can't mask drift. Non-required field breakage was previously invisible.
- **`DomainMapperService`**: Zod rejections collected via a central `parseOrCollect` (deduped issue paths) instead of being swallowed as `logger.debug`. Intentional drops (identity-less meetings, non-ballot CVR2 rows) deliberately do **not** count as rejects, so filtering-heavy sources can't trigger heal loops.
- **`SelfHealingService.evaluateMapping` + pipeline stage 4.5**: a drifted selector matching the *wrong* elements — extraction "succeeds", schema rejects everything — now triggers one bounded re-analysis. Previously it passed the heal gate while dropping every item. A failed heal keeps the better of the two outcomes.
- **`DetailCrawlerService`**: the bare `catch {}` on invalid detail selectors now records a `detail_field_error`, keyed per field (not per enriched item).
- **`ExtractionValidator`**: non-required field misses surface as warnings only — an optional-but-absent field must not cause an LLM re-analysis every run.

Also included: CLAUDE.md MVP deadline refresh to September 1, 2026 (resolves the stale-date note in #966).

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issues

Relates to #966 (W1 of the groomed plan; W2–W7 follow separately)

## Checklist

### Code Quality
- [x] My code follows the project's coding standards
- [x] I have run `pnpm lint` and fixed any issues (changed packages define no lint script; root jscpd gate: 0 clones)
- [x] I have run `pnpm test` and all tests pass (scraping-pipeline: 394/394 including 18 new; full monorepo suite runs in CI — this environment cannot fetch the private `@opuspopuli/regions` package)
- [x] I have added tests for new functionality (if applicable)

### Documentation
- [x] I have updated relevant documentation (if applicable)
- [x] I have added JSDoc comments for new public APIs (if applicable)

### Accessibility
- [ ] UI changes meet WCAG 2.2 Level AA requirements (n/a — no UI changes)
- [ ] I have tested with keyboard navigation (n/a)

- [x] I confirm this PR contains platform code, not region-specific configuration

## Additional Notes

- All changes to shared types are additive optional fields — no consumer contract breaks.
- Security review ran clean. One forward-looking hardening note for W4: Zod v3 enum-failure messages embed the received (scraped) value, so `schemaIssues` strings must be truncated/sanitized before the repair agent consumes them as LLM prompt input.
- The heal-economics decisions (non-required misses warn but never heal; intentional mapper drops don't count as rejects; one heal per run) are documented in code comments at the decision sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019F2eNnFjgkucM2Fi4NefUU

---
_Generated by [Claude Code](https://claude.ai/code/session_019F2eNnFjgkucM2Fi4NefUU)_