### PR TITLE
release: develop → main — #955 independent-expenditure committee attribution

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -87,7 +87,7 @@
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/queue-provider": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.72",
+    "@opuspopuli/regions": "^1.0.76",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
@@ -35,6 +35,7 @@ function result(committees: RosterCommittee[]): CampaignFinanceResult {
     expenditures: [],
     independentExpenditures: [],
     committeeMeasureFilings: [],
+    cvrFilings: [],
   };
 }
 

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@opuspopuli/common';
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
 import { CandidateCommitteeLinkerService } from './candidate-committee-linker.service';
+import { IndependentExpenditureLinkerService } from './independent-expenditure-linker.service';
 import {
   campaignFinanceSyncTracker,
   type SyncPhaseTracker,
@@ -63,6 +64,8 @@ export class CampaignFinanceSyncService {
     private readonly propositionFinanceLinker?: PropositionFinanceLinkerService,
     @Optional()
     private readonly candidateCommitteeLinker?: CandidateCommitteeLinkerService,
+    @Optional()
+    private readonly independentExpenditureLinker?: IndependentExpenditureLinkerService,
   ) {}
 
   async sync(
@@ -140,7 +143,8 @@ export class CampaignFinanceSyncService {
       data.contributions.length > 0 ||
       data.expenditures.length > 0 ||
       data.independentExpenditures.length > 0 ||
-      data.committeeMeasureFilings.length > 0
+      data.committeeMeasureFilings.length > 0 ||
+      data.cvrFilings.length > 0
     ) {
       const tracker = ensureExtractTracker();
       await this.enrichCommittees(data);
@@ -169,6 +173,19 @@ export class CampaignFinanceSyncService {
         { note: 'no data from provider' },
       );
       emptyExtractTracker.complete();
+    }
+
+    // Attribute independent expenditures to their committee + target (#955) —
+    // runs BEFORE the proposition linker so the propositionTitle it stamps onto
+    // S496 IEs gets resolved to a propositionId in the same pass.
+    if (this.independentExpenditureLinker) {
+      try {
+        await this.independentExpenditureLinker.linkAll();
+      } catch (error) {
+        this.logger.warn(
+          `Independent-expenditure linker failed: ${(error as Error).message}`,
+        );
+      }
     }
 
     if (this.propositionFinanceLinker) {
@@ -281,7 +298,11 @@ export class CampaignFinanceSyncService {
       e.committeeId = idMap.get(e.committeeId) ?? e.committeeId;
     }
     for (const ie of data.independentExpenditures) {
-      ie.committeeId = idMap.get(ie.committeeId) ?? ie.committeeId;
+      // S496 IEs arrive with no committeeId (resolved later by the IE linker) —
+      // only rewrite the externalId -> UUID for IEs that reference one (#955).
+      if (ie.committeeId) {
+        ie.committeeId = idMap.get(ie.committeeId) ?? ie.committeeId;
+      }
     }
   }
 
@@ -360,6 +381,7 @@ export class CampaignFinanceSyncService {
       [];
     const committeeMeasureFilings: CampaignFinanceResult['committeeMeasureFilings'] =
       [];
+    const cvrFilings: CampaignFinanceResult['cvrFilings'] = [];
 
     for (const rec of items) {
       if ('donorName' in rec && 'amount' in rec) {
@@ -373,6 +395,12 @@ export class CampaignFinanceSyncService {
       } else if ('supportOrOppose' in rec && 'committeeName' in rec) {
         independentExpenditures.push(
           rec as unknown as CampaignFinanceResult['independentExpenditures'][0],
+        );
+      } else if ('filerId' in rec && 'filingId' in rec) {
+        // Form 496 cover page — filerId + filingId, no committeeName/ballot
+        // fields. Feeds the IE linker's FILING_ID -> committee join (#955).
+        cvrFilings.push(
+          rec as unknown as CampaignFinanceResult['cvrFilings'][0],
         );
       } else if (
         'filingId' in rec &&
@@ -394,6 +422,7 @@ export class CampaignFinanceSyncService {
       expenditures,
       independentExpenditures,
       committeeMeasureFilings,
+      cvrFilings,
     };
   }
 
@@ -446,6 +475,7 @@ export class CampaignFinanceSyncService {
         model: this.db.independentExpenditure,
         fields: [
           'committeeId',
+          'filingId',
           'committeeName',
           'candidateName',
           'propositionTitle',
@@ -465,6 +495,19 @@ export class CampaignFinanceSyncService {
           'ballotName',
           'ballotNumber',
           'ballotJurisdiction',
+          'supportOrOppose',
+          'sourceSystem',
+        ],
+      },
+      {
+        records: data.cvrFilings,
+        model: this.db.cvrFiling,
+        fields: [
+          'filingId',
+          'filerId',
+          'candidateName',
+          'candidateOffice',
+          'propositionTitle',
           'supportOrOppose',
           'sourceSystem',
         ],

--- a/apps/backend/src/apps/region/src/domains/independent-expenditure-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/independent-expenditure-linker.service.spec.ts
@@ -1,0 +1,161 @@
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { IndependentExpenditureLinkerService } from './independent-expenditure-linker.service';
+
+interface PendingIe {
+  id: string;
+  filingId: string | null;
+}
+interface Cover {
+  filingId: string;
+  filerId: string;
+  candidateName: string | null;
+  propositionTitle: string | null;
+  supportOrOppose: string | null;
+}
+interface Cmte {
+  externalId: string;
+  id: string;
+  name: string;
+}
+
+function build(opts: {
+  pending?: PendingIe[];
+  covers?: Cover[];
+  committees?: Cmte[];
+}) {
+  const update = jest.fn((args: unknown) => ({ __op: args }));
+  const $transaction = jest.fn().mockResolvedValue([]);
+  const ieFindMany = jest.fn().mockResolvedValue(opts.pending ?? []);
+  const cvrFindMany = jest.fn().mockResolvedValue(opts.covers ?? []);
+  const cmteFindMany = jest.fn().mockResolvedValue(opts.committees ?? []);
+  const db = {
+    independentExpenditure: { findMany: ieFindMany, update },
+    cvrFiling: { findMany: cvrFindMany },
+    committee: { findMany: cmteFindMany },
+    $transaction,
+  } as unknown as DbService;
+  const svc = new IndependentExpenditureLinkerService(db);
+  return { svc, update, ieFindMany, cvrFindMany, cmteFindMany };
+}
+
+describe('IndependentExpenditureLinkerService (#955)', () => {
+  it('links a committee-less IE via filing -> cover page -> committee', async () => {
+    const { svc, update } = build({
+      pending: [{ id: 'ie1', filingId: 'F1' }],
+      covers: [
+        {
+          filingId: 'F1',
+          filerId: 'C9',
+          candidateName: 'Jane Doe',
+          propositionTitle: null,
+          supportOrOppose: 'oppose',
+        },
+      ],
+      committees: [{ externalId: 'C9', id: 'cmte-uuid', name: 'Super PAC' }],
+    });
+
+    const res = await svc.linkAll();
+
+    expect(res).toMatchObject({
+      linked: 1,
+      skippedNoCoverPage: 0,
+      skippedNoCommittee: 0,
+      considered: 1,
+    });
+    expect(update).toHaveBeenCalledTimes(1);
+    const args = update.mock.calls[0][0] as {
+      where: unknown;
+      data: Record<string, unknown>;
+    };
+    expect(args.where).toEqual({ id: 'ie1' });
+    expect(args.data).toMatchObject({
+      committeeId: 'cmte-uuid',
+      committeeName: 'Super PAC',
+      candidateName: 'Jane Doe',
+      supportOrOppose: 'oppose',
+    });
+  });
+
+  it('only considers unresolved IEs — queries committeeId: null (idempotent)', async () => {
+    const { svc, ieFindMany } = build({ pending: [] });
+    const res = await svc.linkAll();
+    expect(res.linked).toBe(0);
+    expect(res.considered).toBe(0);
+    expect(ieFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { committeeId: null, filingId: { not: null } },
+      }),
+    );
+  });
+
+  it('skips an IE whose filing has no Form 496 cover page', async () => {
+    const { svc, update } = build({
+      pending: [{ id: 'ie1', filingId: 'F-MISSING' }],
+      covers: [
+        {
+          filingId: 'F1',
+          filerId: 'C9',
+          candidateName: null,
+          propositionTitle: null,
+          supportOrOppose: null,
+        },
+      ],
+      committees: [{ externalId: 'C9', id: 'cmte-uuid', name: 'Super PAC' }],
+    });
+
+    const res = await svc.linkAll();
+
+    expect(res).toMatchObject({ linked: 0, skippedNoCoverPage: 1 });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('skips an IE whose cover-page filer matches no committee', async () => {
+    const { svc, update } = build({
+      pending: [{ id: 'ie1', filingId: 'F1' }],
+      covers: [
+        {
+          filingId: 'F1',
+          filerId: 'C-UNKNOWN',
+          candidateName: null,
+          propositionTitle: null,
+          supportOrOppose: null,
+        },
+      ],
+      committees: [],
+    });
+
+    const res = await svc.linkAll();
+
+    expect(res).toMatchObject({ linked: 0, skippedNoCommittee: 1 });
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('counts every pending IE as noCoverPage when no cover pages exist yet', async () => {
+    const { svc } = build({
+      pending: [
+        { id: 'ie1', filingId: 'F1' },
+        { id: 'ie2', filingId: 'F2' },
+      ],
+      covers: [],
+    });
+
+    const res = await svc.linkAll();
+
+    expect(res).toMatchObject({
+      linked: 0,
+      considered: 2,
+      skippedNoCoverPage: 2,
+    });
+  });
+
+  it('is a no-op when no DbService is injected', async () => {
+    const svc = new IndependentExpenditureLinkerService();
+    const res = await svc.linkAll();
+    expect(res).toEqual({
+      linked: 0,
+      skippedNoCoverPage: 0,
+      skippedNoCommittee: 0,
+      considered: 0,
+    });
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/independent-expenditure-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/independent-expenditure-linker.service.ts
@@ -1,0 +1,158 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { batchTransaction } from '@opuspopuli/common';
+
+export interface IndependentExpenditureLinkResult {
+  /** IEs stamped with a resolved committee + target this run. */
+  linked: number;
+  /** Pending IE whose FILING_ID has no Form 496 cover page in cvr_filings. */
+  skippedNoCoverPage: number;
+  /** Cover page found, but its FILER_ID matches no committee row. */
+  skippedNoCommittee: number;
+  /** Total unresolved (committee-less) IEs considered this run. */
+  considered: number;
+}
+
+/** A Form 496 cover-page row, reduced to the join + target fields the linker uses. */
+type CoverRow = {
+  filingId: string;
+  filerId: string;
+  candidateName: string | null;
+  propositionTitle: string | null;
+  supportOrOppose: string | null;
+};
+
+/**
+ * Attribute independent expenditures to their committee + target (#955).
+ *
+ * CAL-ACCESS `S496_CD` (Form 496 late-IE line items) carry only a `FILING_ID`
+ * — no committee, candidate, measure, or support/oppose. Those live on the
+ * Form 496 cover page (`CVR_CAMPAIGN_DISCLOSURE_CD`, `FORM_TYPE=F496`), which
+ * the sync persists to `cvr_filings`. Each IE is ingested with a null
+ * `committeeId` + its `filingId`; this linker joins
+ * `IndependentExpenditure.filingId → CvrFiling.filingId → CvrFiling.filerId →
+ * Committee.externalId` and stamps the committee, committee name, and target
+ * (candidate/measure + support/oppose) onto the IE.
+ *
+ * Post-sync and idempotent: only rows with `committeeId == null` are
+ * considered, so re-running only touches still-unresolved IEs (never
+ * re-writes or unlinks a resolved one). Runs before the proposition linker so
+ * the `propositionTitle` it stamps gets resolved to a `propositionId`.
+ */
+@Injectable()
+export class IndependentExpenditureLinkerService {
+  private readonly logger = new Logger(
+    IndependentExpenditureLinkerService.name,
+  );
+
+  constructor(@Optional() private readonly db?: DbService) {}
+
+  /** Index cover pages by FILING_ID (one per filing; first wins on duplicates). */
+  private indexCoversByFiling(covers: CoverRow[]): Map<string, CoverRow> {
+    const byFiling = new Map<string, CoverRow>();
+    for (const c of covers) {
+      if (!byFiling.has(c.filingId)) byFiling.set(c.filingId, c);
+    }
+    return byFiling;
+  }
+
+  async linkAll(): Promise<IndependentExpenditureLinkResult> {
+    const empty: IndependentExpenditureLinkResult = {
+      linked: 0,
+      skippedNoCoverPage: 0,
+      skippedNoCommittee: 0,
+      considered: 0,
+    };
+    if (!this.db) return empty;
+
+    // IEs awaiting committee attribution — the S496 line items. FEC IEs and
+    // already-linked rows carry a committeeId and are skipped by this filter.
+    const pending = await this.db.independentExpenditure.findMany({
+      where: { committeeId: null, filingId: { not: null } },
+      select: { id: true, filingId: true },
+    });
+    if (pending.length === 0) return empty;
+
+    // Cover-page map: FILING_ID -> filer + target. One cover page per filing;
+    // guard against duplicates (first wins — the upsert dedups by filingId too).
+    const covers = await this.db.cvrFiling.findMany({
+      select: {
+        filingId: true,
+        filerId: true,
+        candidateName: true,
+        propositionTitle: true,
+        supportOrOppose: true,
+      },
+    });
+    const coverByFiling = this.indexCoversByFiling(covers);
+    if (coverByFiling.size === 0) {
+      return {
+        ...empty,
+        considered: pending.length,
+        skippedNoCoverPage: pending.length,
+      };
+    }
+
+    // Resolve each cover page's FILER_ID to a committee row. FILER_ID shares the
+    // committees.external_id id space (populated by the Committees roster source).
+    const filerIds = [...new Set(covers.map((c) => c.filerId))];
+    const committees = await this.db.committee.findMany({
+      where: { externalId: { in: filerIds }, deletedAt: null },
+      select: { externalId: true, id: true, name: true },
+    });
+    const committeeByExternal = new Map(
+      committees.map((c) => [c.externalId, c]),
+    );
+
+    let linked = 0;
+    let skippedNoCoverPage = 0;
+    let skippedNoCommittee = 0;
+    const updates = [];
+
+    for (const ie of pending) {
+      const cover = ie.filingId ? coverByFiling.get(ie.filingId) : undefined;
+      if (!cover) {
+        skippedNoCoverPage++;
+        continue;
+      }
+      const committee = committeeByExternal.get(cover.filerId);
+      if (!committee) {
+        skippedNoCommittee++;
+        continue;
+      }
+      updates.push(
+        this.db.independentExpenditure.update({
+          where: { id: ie.id },
+          data: {
+            committeeId: committee.id,
+            committeeName: committee.name,
+            candidateName: cover.candidateName ?? undefined,
+            propositionTitle: cover.propositionTitle ?? undefined,
+            // Only overwrite the defaulted 'support' when the cover page states one.
+            ...(cover.supportOrOppose
+              ? { supportOrOppose: cover.supportOrOppose }
+              : {}),
+          },
+        }),
+      );
+      linked++;
+    }
+
+    if (updates.length > 0) {
+      await batchTransaction(this.db, updates);
+    }
+
+    this.logger.log(
+      `Independent-expenditure linker: linked=${linked} ` +
+        `noCoverPage=${skippedNoCoverPage} noCommittee=${skippedNoCommittee} ` +
+        `(of ${pending.length} unresolved IEs)`,
+    );
+
+    return {
+      linked,
+      skippedNoCoverPage,
+      skippedNoCommittee,
+      considered: pending.length,
+    };
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
@@ -326,6 +326,9 @@ export class PropositionFinanceLinkerService {
     const seen = new Set<string>();
     for (const r of [...expRows, ...ieRows]) {
       if (!r.propositionId) continue;
+      // IE.committeeId is nullable since #955 (unresolved S496 rows) — skip any
+      // not yet attributed to a committee; they can't seed a measure position.
+      if (!r.committeeId) continue;
       const position = this.mapPosition(r.supportOrOppose ?? null);
       if (!position) continue;
       const key = `${r.committeeId}:${r.propositionId}:${position}`;

--- a/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
@@ -1089,20 +1089,22 @@ describe('RegionQueryService — query methods', () => {
   describe('getIndependentExpenditure', () => {
     it('should return a single independent expenditure by ID', async () => {
       const mockIE = { id: '1', committeeName: 'Test IE Committee' };
-      mockDb.independentExpenditure.findUnique.mockResolvedValue(
+      mockDb.independentExpenditure.findFirst.mockResolvedValue(
         mockIE as never,
       );
 
       const result = await service.getIndependentExpenditure('1');
 
       expect(result).toEqual(mockIE);
-      expect(mockDb.independentExpenditure.findUnique).toHaveBeenCalledWith({
-        where: { id: '1' },
+      // findFirst (not findUnique) so it can also require a resolved committee —
+      // unresolved S496 staging rows are treated as not-found for GraphQL (#955).
+      expect(mockDb.independentExpenditure.findFirst).toHaveBeenCalledWith({
+        where: { id: '1', committeeId: { not: null } },
       });
     });
 
     it('should return null if independent expenditure not found', async () => {
-      mockDb.independentExpenditure.findUnique.mockResolvedValue(null);
+      mockDb.independentExpenditure.findFirst.mockResolvedValue(null);
 
       const result = await service.getIndependentExpenditure('nonexistent');
 

--- a/apps/backend/src/apps/region/src/domains/region-query.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.ts
@@ -212,23 +212,6 @@ type ExpenditureRecord = {
   updatedAt: Date;
 };
 
-type IndependentExpenditureRecord = {
-  id: string;
-  externalId: string;
-  committeeId: string;
-  committeeName: string;
-  candidateName: string | null;
-  propositionTitle: string | null;
-  supportOrOppose: string;
-  amount: Prisma.Decimal;
-  date: Date;
-  electionDate: Date | null;
-  description: string | null;
-  sourceSystem: string;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
 interface LegislativeActionFeedItem {
   id: string;
   externalId: string;
@@ -1179,11 +1162,15 @@ export class RegionQueryService {
     supportOrOppose?: string,
     sourceSystem?: string,
   ): Promise<PaginatedIndependentExpenditures> {
-    const where: Record<string, unknown> = {};
+    // Only surface resolved IEs: S496 line items sit with a null committeeId
+    // until IndependentExpenditureLinkerService attributes them (#955).
+    // Unresolved rows are staging, not public money-trail data, and the GraphQL
+    // committeeId is non-null — exclude them from every IE query.
+    const where: Record<string, unknown> = { committeeId: { not: null } };
     if (committeeId) where.committeeId = committeeId;
     if (supportOrOppose) where.supportOrOppose = supportOrOppose;
     if (sourceSystem) where.sourceSystem = sourceSystem;
-    const whereClause = Object.keys(where).length > 0 ? where : undefined;
+    const whereClause = where;
 
     const [items, total] = await Promise.all([
       this.db.independentExpenditure.findMany({
@@ -1199,8 +1186,10 @@ export class RegionQueryService {
     const paginatedItems = items.slice(0, take);
 
     return {
-      items: paginatedItems.map((item: IndependentExpenditureRecord) => ({
+      items: paginatedItems.map((item) => ({
         ...item,
+        // Non-null by the committeeId filter above; Prisma's type stays nullable.
+        committeeId: item.committeeId as string,
         amount: Number(item.amount),
         candidateName: item.candidateName ?? undefined,
         propositionTitle: item.propositionTitle ?? undefined,
@@ -1213,7 +1202,11 @@ export class RegionQueryService {
   }
 
   async getIndependentExpenditure(id: string) {
-    return this.db.independentExpenditure.findUnique({ where: { id } });
+    // findFirst (not findUnique) so we can also require a resolved committee —
+    // an unresolved S496 staging row is treated as not-found for GraphQL (#955).
+    return this.db.independentExpenditure.findFirst({
+      where: { id, committeeId: { not: null } },
+    });
   }
 
   // ─── County supervisors ───────────────────────────────────────────────────────

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
@@ -2465,6 +2465,7 @@ describe('RegionSyncService — campaign finance sync', () => {
       },
     ],
     committeeMeasureFilings: [],
+    cvrFilings: [],
   };
 
   beforeEach(async () => {
@@ -2611,6 +2612,7 @@ describe('RegionSyncService — campaign finance sync', () => {
       expenditures: [],
       independentExpenditures: [],
       committeeMeasureFilings: [],
+      cvrFilings: [],
     });
 
     const results = await service.syncAll();
@@ -2650,6 +2652,7 @@ describe('RegionSyncService — campaign finance sync', () => {
         },
       ],
       committeeMeasureFilings: [],
+      cvrFilings: [],
     });
 
     await service.syncAll();
@@ -3085,6 +3088,7 @@ describe('RegionSyncService — proposition finance wiring', () => {
       expenditures: [],
       independentExpenditures: [],
       committeeMeasureFilings: [],
+      cvrFilings: [],
     });
 
     const mockPlugin = {

--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -51,6 +51,7 @@ import { PropositionAnalysisService } from './proposition-analysis.service';
 import { MinutesSummaryService } from './minutes-summary.service';
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
 import { CandidateCommitteeLinkerService } from './candidate-committee-linker.service';
+import { IndependentExpenditureLinkerService } from './independent-expenditure-linker.service';
 import { PropositionFundingService } from './proposition-funding.service';
 import { RepresentativeFundingService } from './representative-funding.service';
 import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
@@ -218,6 +219,7 @@ const promptClientAsyncConfig = {
     MinutesSummaryService,
     PropositionFinanceLinkerService,
     CandidateCommitteeLinkerService,
+    IndependentExpenditureLinkerService,
     PropositionFundingService,
     RepresentativeFundingService,
     LegislativeCommitteeLinkerService,

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -829,6 +829,8 @@ export class RegionResolver {
     if (!result) return null;
     return {
       ...result,
+      // Non-null: getIndependentExpenditure filters committeeId != null (#955).
+      committeeId: result.committeeId as string,
       amount: Number(result.amount),
       candidateName: result.candidateName ?? undefined,
       propositionTitle: result.propositionTitle ?? undefined,

--- a/apps/backend/src/apps/region/src/scripts/run-independent-expenditure-linker.ts
+++ b/apps/backend/src/apps/region/src/scripts/run-independent-expenditure-linker.ts
@@ -1,0 +1,47 @@
+/**
+ * One-off: run IndependentExpenditureLinkerService.linkAll() against the data
+ * already in the DB — attribute independent expenditures (S496 line items) to
+ * their committee + target via the Form 496 cover pages, WITHOUT re-triggering a
+ * full campaign-finance sync.
+ *
+ * Note: unlike the candidate-committee linker, this only helps once the S496
+ * rows + cvr_filings cover pages are present. If a deploy predates the #955
+ * ingestion mappings, run a full finance sync first so those rows exist, then
+ * this script (or a later sync) resolves them. Idempotent: only IEs with a null
+ * committeeId are considered, so re-running is safe.
+ *
+ * Usage (after `pnpm --filter backend build:region`):
+ *   node apps/backend/dist/src/apps/region/apps/region/src/scripts/run-independent-expenditure-linker.js
+ */
+
+import { NestFactory } from '@nestjs/core';
+import { Logger } from '@nestjs/common';
+import { AppModule } from '../app.module';
+import { IndependentExpenditureLinkerService } from '../domains/independent-expenditure-linker.service';
+
+async function main(): Promise<void> {
+  const logger = new Logger('run-independent-expenditure-linker');
+  const app = await NestFactory.createApplicationContext(AppModule, {
+    logger: ['log', 'warn', 'error'],
+  });
+  try {
+    const linker = app.get(IndependentExpenditureLinkerService, {
+      strict: false,
+    });
+    logger.log('Starting independent-expenditure linker pass…');
+    const result = await linker.linkAll();
+    logger.log(
+      `Done. linked=${result.linked} ` +
+        `noCoverPage=${result.skippedNoCoverPage} ` +
+        `noCommittee=${result.skippedNoCommittee} ` +
+        `(of ${result.considered} unresolved IEs)`,
+    );
+  } finally {
+    await app.close();
+  }
+}
+
+main().catch((err) => {
+  console.error('Linker run failed:', err);
+  process.exit(1);
+});

--- a/docs/plans/955-independent-expenditure-committee-link.md
+++ b/docs/plans/955-independent-expenditure-committee-link.md
@@ -1,0 +1,51 @@
+# Plan of record: fix independent-expenditure committee join (#955)
+
+| | |
+|---|---|
+| **Issue** | [OpusPopuli/opuspopuli#955](https://github.com/OpusPopuli/opuspopuli/issues/955) (part of epic #936, supersedes the S496 note in #950) |
+| **Date** | 2026-08-05 |
+| **Author** | Rodney Gagnon (AI-assisted; plan approved in-session) |
+| **Data classification** | None — operates on **public CAL-ACCESS campaign-finance data** (committee/candidate/measure names, expenditure amounts). No PHI/PII, nothing sent to a model, no end-user data. |
+| **Branch (monorepo)** | `fix/independent-expenditure-committee-link-955` |
+| **Branch (regions)** | `feat/ie-cover-pages-955` (separate `opuspopuli-regions` repo, merges to `main`) |
+
+## Root cause (confirmed against production, 2026-08-05)
+
+`independent_expenditures = 0` on prod while `expenditures = 286,630` and `committees = 77,328` are fully populated — so this is precisely the S496 validation-drop, not a sync failure.
+
+- `S496_CD.TSV` (Form 496 line-item detail) carries **no committee id**; the IE mapper's `committeeId: z.string().min(1)` (`packages/scraping-pipeline/src/mapping/domain-mapper.service.ts:806`) rejects every row.
+- The filer committee + IE target (candidate/measure, support/oppose) live on the **F496 cover page** (`CVR_CAMPAIGN_DISCLOSURE_CD`, `FORM_TYPE=F496`), joined to S496 only by `FILING_ID`.
+- The declarative `BulkDownloadConfig` is single-file/single-row (**no join primitive**), and cover-page `FILING_ID` is currently discarded (the roster dedups to committees by `FILER_ID`). So no persisted `FILING_ID → committee` map exists — the join must be **code**, mirroring `PropositionFinanceLinkerService`.
+
+## Design — self-staging + post-sync linker
+
+Persist F496 cover-page filings, ingest S496 with a **nullable** committee, then a post-sync linker resolves committee + target by `FILING_ID`. Consistent with the model's existing nullable-then-linked `propositionId`; avoids a second staging table.
+
+## Subtasks
+
+1. **Config — `@opuspopuli/regions` (separate repo, version bump).** In `regions/california/california.json`: add `FILING_ID → filingId` to the **S496_CD** source; add a new **"CAL-ACCESS IE Cover Pages"** source (`CVR_CAMPAIGN_DISCLOSURE_CD`, `filters: {FORM_TYPE: F496}`) mapping `FILING_ID→filingId, FILER_ID→filerId, CAND_NAML→candidateName, OFFICE_CD→candidateOffice, BAL_NAME→propositionTitle, SUP_OPP_CD→supportOrOppose`. Bump version, publish, bump the dep in the monorepo. *Cross-repo — the config half can't ship from this repo alone.*
+2. **Prisma + migrations (`packages/relationaldb-provider`).** New model `CvrFiling` `@@map("cvr_filings")` (`filingId` indexed, `filerId`, `candidateName?`, `candidateOffice?`, `propositionTitle?`, `supportOrOppose?`, `sourceSystem`; `externalId` unique = filingId). Alter `independent_expenditures`: `committee_id` **DROP NOT NULL**, add `filing_id` + `@@index([filingId])`. Both additive/widening — no drops/renames. Generate via `/op-migration`.
+3. **Domain mapper (`domain-mapper.service.ts`).** Relax `IndependentExpenditureSchema.committeeId` → optional (`:806`), add `filingId?`; add `CvrFilingSchema` + `mapCvrFiling`, route the new category in `mapCampaignFinanceItem` (`:99–117`). Tests: add a regression fixture of a **real S496 row without committeeId** (existing specs at `:1043–1129` cheat with `committeeId:"C001"`); add CvrFiling mapping test.
+4. **Sync service (`campaign-finance-sync.service.ts`).** New `sortItems` bucket + `upsertBatch` for `cvr_filings` (mirror cvr2 `:381–392`); guard the IE committeeId externalId→UUID rewrite when absent (`:215–217, 265–267`); persist IE rows with nullable committeeId + filingId (`:365–380`).
+5. **New `IndependentExpenditureLinkerService.linkAll()`** (region domains). Build `filingId → committee` from `cvr_filings` (`filerId → committees.external_id → committee.id`); for each null-committee IE, stamp `committeeId`, `committeeName`, `candidateName`/`propositionTitle`, `supportOrOppose`; resolve `propositionId` for measures. Idempotent + reconcile (mirror candidate/proposition linkers). Wire post-sync (`:168–176`); add `run-independent-expenditure-linker.ts` one-off script. Co-located spec (resolve / unmatched / idempotent / ambiguous).
+6. **GraphQL/federation.** IE is exposed on the region subgraph money-trail. `committeeId` becoming nullable means the resolver must **filter unresolved (null-committee) IEs** to preserve the non-null contract — verify the IE type field and validate at the API gateway.
+7. **Deploy + verify (prod).** Requires a **full campaign-finance re-sync** (S496 isn't persisted today — must re-download + re-parse `dbwebexport.zip` with the new mappings), then run the IE linker. Verify `0 → N` and spot-check FILING_ID joins + support/oppose on ~10 IEs.
+
+## Risk register (severity × likelihood → mitigation)
+
+1. Cross-repo `@opuspopuli/regions` bump — **medium × likely** → publish + version bump + dep update before the code half is testable end-to-end.
+2. Full prod finance re-sync required (heavy, re-download ~286k+ rows) — **medium × likely** → run off-peak; the linker itself is cheap to re-run after.
+3. `committee_id` → nullable migration — **low × possible** → widening ALTER (additive-safe, 0 existing rows); no drop/rename; verify GraphQL non-null contract + resolver filter.
+4. FILING_ID key-space mismatch (the existing `extractFilingId` prefix trick in the proposition linker is fragile) — **medium × possible** → use the explicit mapped `filingId` column, not the prefix hack; validate join hit-rate on a prod S496 sample first.
+5. Mis-join S496 → wrong cover page — **low × rare** → FILING_ID is a strong 1:1 key; spot-check support/oppose + target on ~10 linked IEs.
+6. Unresolved IEs linger (null committee) — **low × possible** → idempotent linker + reconcile; filter from GraphQL; log unresolved count.
+7. FEC IEs out of scope (blocked by federal-sync #630/#631) — noted, not addressed here.
+8. AGPL / deps — **low × rare** → no new dependencies.
+
+## Effort
+
+~2–3 focused sessions (config + 2 migrations + mapper + sync + new linker + tests) — heavier than #953 — plus a full prod finance re-sync at deploy (ops).
+
+## Design alternative considered
+
+Issue's option 1 (two staging tables: separate S496 staging + cover-page map). Rejected in favor of self-staging (nullable committee on the IE table, matching the existing nullable `propositionId`) to avoid a second table. Revisit if we decide IEs should never exist without a committee.

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -587,7 +587,8 @@ export interface Expenditure {
  */
 export interface IndependentExpenditure {
   externalId: string;
-  committeeId: string;
+  committeeId?: string; // resolved post-sync by IndependentExpenditureLinkerService via filingId (#955)
+  filingId?: string; // CalAccess FILING_ID from S496_CD — join key to the Form 496 cover page (#955)
   committeeName: string;
   candidateName?: string;
   propositionTitle?: string;
@@ -618,6 +619,24 @@ export interface CommitteeMeasureFiling {
 }
 
 /**
+ * Raw Form 496 cover page (CVR_CAMPAIGN_DISCLOSURE_CD filtered to FORM_TYPE=F496)
+ * from CalAccess. S496_CD line items carry only FILING_ID — the filer committee
+ * (FILER_ID) and the IE target (candidate/measure + support/oppose) live here.
+ * Persisted so IndependentExpenditureLinkerService can resolve each S496 line to
+ * its committee + target by FILING_ID, decoupled from the bulk-download cycle (#955).
+ */
+export interface CvrFiling {
+  externalId: string; // FILING_ID (one cover page per filing)
+  filingId: string; // FILING_ID — join key from S496_CD line items
+  filerId: string; // FILER_ID — same id space as Committee.externalId
+  candidateName?: string; // CAND_NAML — IE target candidate
+  candidateOffice?: string; // OFFICE_CD
+  propositionTitle?: string; // BAL_NAME — IE target measure
+  supportOrOppose?: "support" | "oppose"; // mapped from SUP_OPP_CD
+  sourceSystem: "cal_access" | "fec";
+}
+
+/**
  * Aggregated result from campaign finance data fetch
  */
 export interface CampaignFinanceResult {
@@ -626,6 +645,7 @@ export interface CampaignFinanceResult {
   expenditures: Expenditure[];
   independentExpenditures: IndependentExpenditure[];
   committeeMeasureFilings: CommitteeMeasureFiling[];
+  cvrFilings: CvrFiling[];
 }
 
 /**

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.72"
+    "@opuspopuli/regions": "^1.0.76"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/src/declarative/declarative-region-plugin.ts
+++ b/packages/region-provider/src/declarative/declarative-region-plugin.ts
@@ -228,6 +228,7 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
       [];
     const committeeMeasureFilings: CampaignFinanceResult["committeeMeasureFilings"] =
       [];
+    const cvrFilings: CampaignFinanceResult["cvrFilings"] = [];
 
     for (const item of allItems) {
       const rec = item;
@@ -242,6 +243,12 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
       } else if ("supportOrOppose" in rec && "committeeName" in rec) {
         independentExpenditures.push(
           rec as unknown as CampaignFinanceResult["independentExpenditures"][0],
+        );
+      } else if ("filerId" in rec && "filingId" in rec) {
+        // Form 496 cover page — has filerId + filingId (no committeeName, no
+        // ballot fields). Feeds the IE linker's FILING_ID -> committee join (#955).
+        cvrFilings.push(
+          rec as unknown as CampaignFinanceResult["cvrFilings"][0],
         );
       } else if (
         "filingId" in rec &&
@@ -266,6 +273,7 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
       expenditures,
       independentExpenditures,
       committeeMeasureFilings,
+      cvrFilings,
     };
   }
 

--- a/packages/relationaldb-provider/prisma/migrations/20260805000000_independent_expenditure_committee_link/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260805000000_independent_expenditure_committee_link/migration.sql
@@ -1,0 +1,42 @@
+-- #955: attribute independent expenditures to their committee + target.
+-- S496_CD line items carry no committee id — the filer committee (FILER_ID) and
+-- the IE target (candidate/measure + support/oppose) live on the Form 496 cover
+-- page (CVR_CAMPAIGN_DISCLOSURE_CD, FORM_TYPE=F496), joined by FILING_ID. This
+-- migration persists those cover pages (cvr_filings) and lets
+-- IndependentExpenditureLinkerService stamp the committee post-sync.
+--
+-- Additive + widening only: a new table, a new nullable column, and relaxing an
+-- existing NOT NULL — no drops/renames. Prod-safe: independent_expenditures is
+-- currently empty on prod, so relaxing committee_id NOT NULL rewrites nothing.
+-- Data classification: none — public CAL-ACCESS campaign-finance data (committee/
+-- candidate/measure names). No PHI/PII; no RLS/masking concerns.
+
+-- Form 496 cover-page map (mirrors cvr2_filings; persisted so the IE linker can
+-- resolve filing_id -> filer_id -> committee independently of the sync cycle).
+CREATE TABLE "cvr_filings" (
+    "id" TEXT NOT NULL,
+    "external_id" TEXT NOT NULL,
+    "filing_id" VARCHAR(50) NOT NULL,
+    "filer_id" VARCHAR(50) NOT NULL,
+    "candidate_name" TEXT,
+    "candidate_office" VARCHAR(50),
+    "proposition_title" TEXT,
+    "support_or_oppose" VARCHAR(10),
+    "source_system" VARCHAR(20) NOT NULL,
+    "created_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "cvr_filings_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "cvr_filings_external_id_key" ON "cvr_filings"("external_id");
+CREATE INDEX "cvr_filings_filing_id_idx" ON "cvr_filings"("filing_id");
+CREATE INDEX "cvr_filings_filer_id_idx" ON "cvr_filings"("filer_id");
+
+-- S496 line items arrive with no committee; committee_id is stamped post-sync by
+-- the linker. Relax NOT NULL (FK stays ON DELETE RESTRICT) and add the FILING_ID
+-- join key. Existing propositionId already follows this nullable-then-linked shape.
+ALTER TABLE "independent_expenditures" ALTER COLUMN "committee_id" DROP NOT NULL;
+ALTER TABLE "independent_expenditures" ADD COLUMN "filing_id" VARCHAR(50);
+
+CREATE INDEX "independent_expenditures_filing_id_idx" ON "independent_expenditures"("filing_id");

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -242,8 +242,8 @@ model UserProfile {
   // localStorage as a fast-path cache.
   onboardingCompletedAt DateTime? @map("onboarding_completed_at") @db.Timestamptz
 
-  createdAt            DateTime              @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt            DateTime              @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
@@ -1648,30 +1648,30 @@ enum CommitteeMeasurePositionType {
 /// Campaign committee — the entity that raises and spends money.
 /// Covers candidate committees, ballot measure committees, PACs, Super PACs, and party committees.
 model Committee {
-  id              String    @id @default(uuid())
-  externalId      String    @unique @map("external_id")
-  name            String
-  type            String    @db.VarChar(50) /// candidate, ballot_measure, pac, super_pac, party, small_contributor, other
-  candidateName   String?   @map("candidate_name")
-  candidateOffice String?   @map("candidate_office")
-  propositionId   String?   @map("proposition_id")
+  id               String    @id @default(uuid())
+  externalId       String    @unique @map("external_id")
+  name             String
+  type             String    @db.VarChar(50) /// candidate, ballot_measure, pac, super_pac, party, small_contributor, other
+  candidateName    String?   @map("candidate_name")
+  candidateOffice  String?   @map("candidate_office")
+  propositionId    String?   @map("proposition_id")
   /// Resolved by the candidate-committee → representative linker from
   /// candidateName + candidateOffice (#941). Null for non-candidate committees
   /// or when the candidate doesn't match a tracked representative.
-  representativeId String?  @map("representative_id")
-  party           String?   @db.VarChar(50)
-  status          String    @default("active") @db.VarChar(20)
-  sourceSystem    String    @map("source_system") @db.VarChar(20) /// cal_access, fec
-  sourceUrl       String?   @map("source_url")
-  createdAt       DateTime  @default(now()) @map("created_at") @db.Timestamptz
-  updatedAt       DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
-  deletedAt       DateTime? @map("deleted_at") @db.Timestamptz
+  representativeId String?   @map("representative_id")
+  party            String?   @db.VarChar(50)
+  status           String    @default("active") @db.VarChar(20)
+  sourceSystem     String    @map("source_system") @db.VarChar(20) /// cal_access, fec
+  sourceUrl        String?   @map("source_url")
+  createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+  deletedAt        DateTime? @map("deleted_at") @db.Timestamptz
 
   contributions           Contribution[]
   expenditures            Expenditure[]
   independentExpenditures IndependentExpenditure[]
   measurePositions        CommitteeMeasurePosition[]
-  representative          Representative? @relation(fields: [representativeId], references: [id], onDelete: SetNull)
+  representative          Representative?            @relation(fields: [representativeId], references: [id], onDelete: SetNull)
 
   @@index([name])
   @@index([type])
@@ -1724,6 +1724,30 @@ model Cvr2Filing {
   @@index([filingId])
   @@index([ballotName])
   @@map("cvr2_filings")
+}
+
+/// Raw Form 496 cover pages (CVR_CAMPAIGN_DISCLOSURE_CD filtered to
+/// FORM_TYPE=F496). S496_CD line items carry only FILING_ID — the filer
+/// committee (FILER_ID) and the IE target (candidate/measure + support/oppose)
+/// live here. Persisted (like Cvr2Filing) so IndependentExpenditureLinkerService
+/// can resolve each S496 line to its committee + target by FILING_ID, decoupled
+/// from the bulk-download cycle (#955).
+model CvrFiling {
+  id               String   @id @default(uuid())
+  externalId       String   @unique @map("external_id") /// FILING_ID (one cover page per filing)
+  filingId         String   @map("filing_id") @db.VarChar(50)
+  filerId          String   @map("filer_id") @db.VarChar(50) /// CalAccess FILER_ID — same id space as committees.external_id
+  candidateName    String?  @map("candidate_name")
+  candidateOffice  String?  @map("candidate_office") @db.VarChar(50)
+  propositionTitle String?  @map("proposition_title")
+  supportOrOppose  String?  @map("support_or_oppose") @db.VarChar(10) /// CalAccess SUP_OPP_CD: 'S' or 'O'
+  sourceSystem     String   @map("source_system") @db.VarChar(20)
+  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt        DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([filingId])
+  @@index([filerId])
+  @@map("cvr_filings")
 }
 
 /// Campaign contribution — money received by a committee from a donor.
@@ -1792,7 +1816,12 @@ model Expenditure {
 model IndependentExpenditure {
   id               String    @id @default(uuid())
   externalId       String    @unique @map("external_id")
-  committeeId      String    @map("committee_id")
+  /// Nullable + resolved post-sync by IndependentExpenditureLinkerService:
+  /// S496_CD line items carry no committee, so committeeId is stamped by joining
+  /// filingId -> the Form 496 cover page (cvr_filings) -> committee (#955).
+  committeeId      String?   @map("committee_id")
+  /// CalAccess FILING_ID from S496_CD — the join key to the Form 496 cover page.
+  filingId         String?   @map("filing_id") @db.VarChar(50)
   committeeName    String    @map("committee_name")
   candidateName    String?   @map("candidate_name")
   propositionTitle String?   @map("proposition_title")
@@ -1808,10 +1837,11 @@ model IndependentExpenditure {
   createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz
   updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
-  committee   Committee    @relation(fields: [committeeId], references: [id])
+  committee   Committee?   @relation(fields: [committeeId], references: [id], onDelete: Restrict)
   proposition Proposition? @relation(fields: [propositionId], references: [id], onDelete: SetNull)
 
   @@index([committeeId])
+  @@index([filingId])
   @@index([candidateName])
   @@index([propositionTitle])
   @@index([propositionId])
@@ -1911,25 +1941,25 @@ model PipelineExecutionBatch {
 /// Canonical job history — BullMQ Redis state is ephemeral (removeOnComplete/removeOnFail).
 /// Template for future job families: each queue gets its own status table.
 model PipelineJob {
-  id            String    @id @default(uuid())
-  bullmqJobId   String    @map("bullmq_job_id")
-  triggerSource String    @map("trigger_source")
-  regionId      String?   @map("region_id")
-  dataTypes     String[]  @map("data_types")
-  depth         String?
-  maxReps       Int?      @map("max_reps")
-  maxBills      Int?      @map("max_bills")
-  maxDocuments  Int?      @map("max_documents") /// Meetings pdf_archive maxNew override (API backfill)
-  resetWatermark Boolean? @map("reset_watermark") /// Ignore ingestion watermark for this run (API backfill)
-  status        String
-  attempts      Int       @default(0)
-  enqueuedBy    String?   @map("enqueued_by")
-  enqueuedAt    DateTime  @default(now()) @map("enqueued_at") @db.Timestamptz
-  startedAt     DateTime? @map("started_at") @db.Timestamptz
-  finishedAt    DateTime? @map("finished_at") @db.Timestamptz
-  errorMessage  String?   @map("error_message")
-  result        Json?
-  createdAt     DateTime  @default(now()) @map("created_at") @db.Timestamptz
+  id             String    @id @default(uuid())
+  bullmqJobId    String    @map("bullmq_job_id")
+  triggerSource  String    @map("trigger_source")
+  regionId       String?   @map("region_id")
+  dataTypes      String[]  @map("data_types")
+  depth          String?
+  maxReps        Int?      @map("max_reps")
+  maxBills       Int?      @map("max_bills")
+  maxDocuments   Int?      @map("max_documents") /// Meetings pdf_archive maxNew override (API backfill)
+  resetWatermark Boolean?  @map("reset_watermark") /// Ignore ingestion watermark for this run (API backfill)
+  status         String
+  attempts       Int       @default(0)
+  enqueuedBy     String?   @map("enqueued_by")
+  enqueuedAt     DateTime  @default(now()) @map("enqueued_at") @db.Timestamptz
+  startedAt      DateTime? @map("started_at") @db.Timestamptz
+  finishedAt     DateTime? @map("finished_at") @db.Timestamptz
+  errorMessage   String?   @map("error_message")
+  result         Json?
+  createdAt      DateTime  @default(now()) @map("created_at") @db.Timestamptz
 
   executions PipelineExecution[]
 

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1158,6 +1158,43 @@ describe("DomainMapperService", () => {
         amount: 50000,
       });
     });
+
+    it("maps a real S496 line item that has no committeeId (#955)", () => {
+      // S496_CD carries only TRAN_ID/FILING_ID/AMOUNT/EXP_DATE/EXPN_DSCR — no
+      // committee. Before #955 the required committeeId dropped every such row,
+      // leaving independent_expenditures at 0. It must now validate, carrying
+      // filingId for the linker and no committeeId until it is resolved post-sync.
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "TRAN-496-1",
+              filingId: "F-100200",
+              amount: "12000",
+              date: "2026-10-15",
+              description: "Mailer opposing candidate",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Independent Expenditures",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        externalId: "TRAN-496-1",
+        filingId: "F-100200",
+        amount: 12000,
+        committeeName: "Unknown", // defaulted; the linker fills it post-sync
+      });
+      expect(
+        (result.items[0] as { committeeId?: string }).committeeId,
+      ).toBeUndefined();
+    });
   });
 
   describe("campaign finance — category routing", () => {
@@ -1211,6 +1248,38 @@ describe("DomainMapperService", () => {
       expect(result.success).toBe(true);
       expect(result.items[0]).toMatchObject({
         committeeName: "Late IE PAC",
+        supportOrOppose: "oppose",
+      });
+    });
+
+    it("routes 'IE Cover Pages' (Form 496) to cvr filings with filer + target (#955)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              filingId: "F-100200",
+              filerId: "C0099",
+              candidateName: "Jane Doe",
+              candidateOffice: "ASM",
+              supportOrOppose: "O",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS IE Cover Pages",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        externalId: "F-100200", // keyed by FILING_ID for the cvr_filings upsert
+        filingId: "F-100200",
+        filerId: "C0099",
+        candidateName: "Jane Doe",
+        candidateOffice: "ASM",
         supportOrOppose: "oppose",
       });
     });
@@ -1337,9 +1406,9 @@ describe("schema rejection diagnostics (#966 W1)", () => {
     expect(
       reject!.schemaIssues!.some((i) => i.startsWith("Proposition.")),
     ).toBe(true);
-    expect(
-      result.warnings.some((w) => w.includes("rejected by the")),
-    ).toBe(true);
+    expect(result.warnings.some((w) => w.includes("rejected by the"))).toBe(
+      true,
+    );
   });
 
   it("passes extractor selectorFailures through to the mapped result", () => {

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -20,6 +20,7 @@ import {
   type Expenditure,
   type IndependentExpenditure,
   type CommitteeMeasureFiling,
+  type CvrFiling,
   type RawExtractionResult,
   type ExtractionResult,
   type DataSourceConfig,
@@ -164,6 +165,7 @@ export class DomainMapperService {
     | Expenditure
     | IndependentExpenditure
     | CommitteeMeasureFiling
+    | CvrFiling
     | null {
     switch (source.dataType) {
       case DataType.PROPOSITIONS:
@@ -192,6 +194,7 @@ export class DomainMapperService {
     | Expenditure
     | IndependentExpenditure
     | CommitteeMeasureFiling
+    | CvrFiling
     | null {
     const cat = (category ?? "").toLowerCase();
 
@@ -203,6 +206,12 @@ export class DomainMapperService {
     // formed (#936).
     if (cat.includes("committee position") || cat.includes("cvr2")) {
       return this.mapCommitteeMeasureFiling(record, diag);
+    } else if (cat.includes("cover page")) {
+      // Form 496 cover pages (CVR_CAMPAIGN_DISCLOSURE_CD, FORM_TYPE=F496).
+      // Checked before the "committee"/"independent" branches: the category is
+      // "CAL-ACCESS IE Cover Pages" and must route to the cvr_filings map the IE
+      // linker joins S496 line items against, not to a committee/IE row (#955).
+      return this.mapCvrFiling(record, diag);
     } else if (cat.includes("independent") || cat.includes("s496")) {
       return this.mapIndependentExpenditure(record, diag);
     } else if (cat.includes("committee")) {
@@ -229,7 +238,12 @@ export class DomainMapperService {
       ...record,
       sourceUrl: record.sourceUrl ?? record.detailUrl,
     };
-    return this.parseOrCollect(PropositionSchema, enriched, "Proposition", diag);
+    return this.parseOrCollect(
+      PropositionSchema,
+      enriched,
+      "Proposition",
+      diag,
+    );
   }
 
   private mapMeeting(
@@ -368,6 +382,19 @@ export class DomainMapperService {
       "IndependentExpenditure",
       diag,
     );
+  }
+
+  private mapCvrFiling(
+    record: Record<string, unknown>,
+    diag: MappingDiagnostics,
+  ): CvrFiling | null {
+    // The config maps FILING_ID -> filingId; the sync upserts cvr_filings by
+    // externalId, so key each cover page by its FILING_ID (one row per filing).
+    const enriched = {
+      ...record,
+      externalId: record.externalId ?? record.filingId,
+    };
+    return this.parseOrCollect(CvrFilingSchema, enriched, "CvrFiling", diag);
   }
 }
 
@@ -962,7 +989,10 @@ const ExpenditureSchema = z
 
 const IndependentExpenditureSchema = z.object({
   externalId: z.string().min(1),
-  committeeId: z.string().min(1),
+  // Optional: S496_CD line items carry no committee — resolved post-sync by
+  // IndependentExpenditureLinkerService via filingId -> Form 496 cover page (#955).
+  committeeId: z.string().min(1).optional(),
+  filingId: z.string().min(1).optional(),
   committeeName: z
     .string()
     .nullable()
@@ -992,6 +1022,37 @@ const IndependentExpenditureSchema = z.object({
     .nullable()
     .transform((v) => v ?? undefined)
     .optional(),
+  sourceSystem: z.enum(["cal_access", "fec"]),
+});
+
+// Form 496 cover page (CVR_CAMPAIGN_DISCLOSURE_CD, FORM_TYPE=F496). externalId
+// keys the cvr_filings upsert (= FILING_ID); filingId is the join key S496 line
+// items resolve against; filerId resolves to a committee. Target fields
+// (candidate/measure + support/oppose) attribute the IE downstream (#955).
+const CvrFilingSchema = z.object({
+  externalId: z.string().min(1),
+  filingId: z.string().min(1),
+  filerId: z.string().min(1),
+  candidateName: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined)
+    .optional(),
+  candidateOffice: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined)
+    .optional(),
+  propositionTitle: z
+    .string()
+    .nullable()
+    .transform((v) => v ?? undefined)
+    .optional(),
+  supportOrOppose: z
+    .string()
+    .nullable()
+    .optional()
+    .transform((val) => (val ? supportOpposeTransform(val) : undefined)),
   sourceSystem: z.enum(["cal_access", "fec"]),
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,8 +190,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.72
-        version: 1.0.72
+        specifier: ^1.0.76
+        version: 1.0.76
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -1009,8 +1009,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.72
-        version: 1.0.72
+        specifier: ^1.0.76
+        version: 1.0.76
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4913,8 +4913,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.72':
-    resolution: {integrity: sha512-zur6I0JM0dReOk1wklbB36llvAbalZdzmSsLpiy2yYmI5eZHGeXvMk1JyV5NBIZIv+eh8+z57ZVxthpIYAw1PQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.72/bb277b2ecc3ed9af58d3c91bb7bb34549feb240d}
+  '@opuspopuli/regions@1.0.76':
+    resolution: {integrity: sha512-fwzZ5Yh1ZNGh6Fubp0bBoDcr5zXBw4elKx4Wtk2rsNUOzIlctUTdky0o57xYERqyMRg5aFLNymQCXK+/qphIdg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.76/2421750779394a5eb95f8fe17016c6139f3d8556}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -16588,7 +16588,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.72':
+  '@opuspopuli/regions@1.0.76':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)


### PR DESCRIPTION
## Release: develop → main

Surgical **single-commit** promotion — `main` was brought current by the #953 release, so this carries only #955.

### Runtime change
- **fix(region) #955** — attribute independent expenditures to their committee + target via the Form 496 cover-page join (`FILING_ID → cvr_filings → committee`). New `IndependentExpenditureLinkerService`, `CvrFiling` model + additive migration, `independent_expenditures.committee_id` nullable + `filing_id`, mapper + sync ingestion for the F496 cover pages, GraphQL filters unresolved (staging) IEs. Consumes `@opuspopuli/regions 1.0.76`.

### Deploy note
Merging to `main` triggers `release.yml` → publishes `ghcr.io/opuspopuli/{region,region-worker}`. **Unlike #953, prod needs a full campaign-finance re-sync** after deploy (S496 line items + F496 cover pages were never persisted before), then the IE linker runs. Verify `independent_expenditures` `0 → N`.

### Data classification
None — public CAL-ACCESS campaign-finance data; no PHI/PII.

🤖 Generated with [Claude Code](https://claude.com/claude-code)