### PR TITLE
fix(region): reject same-surname relatives in candidate-committee linker

### DIFF
--- a/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.spec.ts
@@ -4,6 +4,9 @@ import {
   isCandidateOwnCommittee,
   chamberFromName,
   candidateSurname,
+  committeeGivenNames,
+  givenNamesMatch,
+  representativeGivenName,
 } from './candidate-committee-linker.service';
 
 interface Rep {
@@ -23,6 +26,8 @@ interface LinkedCmte {
   id: string;
   name: string;
   candidateName: string | null;
+  /** The linked rep, joined so the given-name gate can run (#979). */
+  representative?: { name: string; lastName: string } | null;
 }
 
 function build(reps: Rep[], committees: Cmte[], linked: LinkedCmte[] = []) {
@@ -109,6 +114,147 @@ describe('isCandidateOwnCommittee (#953)', () => {
     // "Vo" (2 chars) would substring-match "vote"/"advocacy"; fall back to
     // office/name matching for these rather than false-reject.
     expect(isCandidateOwnCommittee('Committee to Elect Vo', 'Vo')).toBe(true);
+  });
+});
+
+describe('given-name gate (#979)', () => {
+  it('rejects a same-surname predecessor or relative committee', () => {
+    // Rob Bonta held this Assembly seat before Mia Bonta, so his committees
+    // share surname + chamber and the ambiguity guard (current reps only)
+    // never fired — ~$1.07M of his money showed on her page.
+    expect(
+      isCandidateOwnCommittee('Rob Bonta for Assembly 2014', 'Bonta', 'Mia'),
+    ).toBe(false);
+    expect(
+      isCandidateOwnCommittee(
+        'Ian Calderon for Assembly 2016',
+        'Calderon',
+        'Lisa',
+      ),
+    ).toBe(false);
+    expect(
+      isCandidateOwnCommittee(
+        'Eduardo Garcia for Assembly 2020',
+        'Garcia',
+        'Robert',
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the representative's own committee", () => {
+    expect(
+      isCandidateOwnCommittee('Mia Bonta for Assembly 2024', 'Bonta', 'Mia'),
+    ).toBe(true);
+    expect(
+      isCandidateOwnCommittee(
+        'Lisa Calderon for Assembly 2022',
+        'Calderon',
+        'Lisa',
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps a committee filed under a diminutive of the given name', () => {
+    expect(
+      isCandidateOwnCommittee('Tom Umberg for Senate 2018', 'Umberg', 'Thomas'),
+    ).toBe(true);
+    expect(
+      isCandidateOwnCommittee(
+        'Stephen Bennett for Assembly 2024',
+        'Bennett',
+        'Steve',
+      ),
+    ).toBe(true);
+    // Prefix rule covers short forms the nickname table omits.
+    expect(
+      isCandidateOwnCommittee('Dan Rivera for Assembly', 'Rivera', 'Daniel'),
+    ).toBe(true);
+  });
+
+  it('keeps titles carrying a middle name, compound surname, or office', () => {
+    expect(
+      isCandidateOwnCommittee(
+        'Maria Elena Durazo for State Senate 2026',
+        'Durazo',
+        'Maria',
+      ),
+    ).toBe(true);
+    expect(
+      isCandidateOwnCommittee(
+        'Rick Chavez Zbur for Assembly 2022',
+        'Zbur',
+        'Rick',
+      ),
+    ).toBe(true);
+    expect(
+      isCandidateOwnCommittee(
+        'Speaker Rivas Legal Defense Fund',
+        'Rivas',
+        'Robert',
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects the inverted CAL-ACCESS "SURNAME FOR OFFICE; FIRST" form', () => {
+    expect(
+      isCandidateOwnCommittee(
+        'GARCIA FOR ASSEMBLY 2024; VICTORIA',
+        'Garcia',
+        'Robert',
+      ),
+    ).toBe(false);
+    expect(
+      isCandidateOwnCommittee(
+        'GARCIA FOR STATE ASSEMBLY 2024; COMMITTEE TO ELECT EDGARD',
+        'Garcia',
+        'Robert',
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps a title that names nobody before the surname', () => {
+    // No given name anywhere to discriminate on — stay conservative rather
+    // than drop a link the data cannot disprove.
+    expect(
+      isCandidateOwnCommittee('BONTA FOR ASSEMBLY 2021', 'Bonta', 'Mia'),
+    ).toBe(true);
+    expect(
+      isCandidateOwnCommittee('Garcia for Assembly 2024', 'Garcia', 'Robert'),
+    ).toBe(true);
+  });
+
+  it('is unchanged when no representative given name is supplied', () => {
+    expect(
+      isCandidateOwnCommittee('Rob Bonta for Assembly 2014', 'Bonta'),
+    ).toBe(true);
+  });
+
+  it('extracts given-name candidates around the surname', () => {
+    expect(committeeGivenNames('Rob Bonta for Assembly 2014', 'Bonta')).toEqual(
+      ['rob'],
+    );
+    expect(
+      committeeGivenNames('Maria Elena Durazo for Senate', 'Durazo'),
+    ).toEqual(['maria', 'elena']);
+    expect(committeeGivenNames('BONTA FOR ASSEMBLY 2021', 'Bonta')).toEqual([]);
+    expect(
+      committeeGivenNames('GARCIA FOR ASSEMBLY 2024; VICTORIA', 'Garcia'),
+    ).toEqual(['victoria']);
+  });
+
+  it('matches given names across nicknames and prefixes only', () => {
+    expect(givenNamesMatch('Tom', 'Thomas')).toBe(true);
+    expect(givenNamesMatch('Steve', 'Stephen')).toBe(true);
+    expect(givenNamesMatch('Dan', 'Daniel')).toBe(true);
+    expect(givenNamesMatch('Rob', 'Mia')).toBe(false);
+    expect(givenNamesMatch('Eduardo', 'Robert')).toBe(false);
+    expect(givenNamesMatch('Luz', 'Robert')).toBe(false);
+  });
+
+  it('reads a representative given name past honorifics', () => {
+    expect(representativeGivenName('Dr. Corey A. Jackson')).toBe('corey');
+    expect(representativeGivenName('Mia Bonta')).toBe('mia');
+    expect(representativeGivenName('Rosilicie Ochoa Bogh')).toBe('rosilicie');
   });
 });
 
@@ -513,6 +659,59 @@ describe('CandidateCommitteeLinkerService (#941)', () => {
     });
     expect(update).not.toHaveBeenCalledWith({
       where: { id: 'c-good' },
+      data: { representativeId: null },
+    });
+  });
+
+  it('self-heals a predecessor committee already linked to a sitting member (#979)', async () => {
+    // The production path that clears the bad rows: Rob Bonta's Assembly-era
+    // committees are already linked to Mia Bonta, and reconcile must drop them
+    // on the next run. `Rob Bonta for Assembly 2018` also has a blank
+    // CAND_NAML, so the surname has to come from the linked rep.
+    const rep = { name: 'Mia Bonta', lastName: 'Bonta' };
+    const { svc, update } = build(
+      [
+        {
+          id: 'rep-1',
+          lastName: 'Bonta',
+          name: 'Mia Bonta',
+          chamber: 'Assembly',
+        },
+      ],
+      [],
+      [
+        {
+          id: 'c-rob-2014',
+          name: 'Rob Bonta for Assembly 2014',
+          candidateName: 'Bonta',
+          representative: rep,
+        },
+        {
+          id: 'c-rob-2018',
+          name: 'Rob Bonta for Assembly 2018',
+          candidateName: null,
+          representative: rep,
+        },
+        {
+          id: 'c-mia-2024',
+          name: 'Mia Bonta for Assembly 2024',
+          candidateName: 'Bonta',
+          representative: rep,
+        },
+      ],
+    );
+
+    const res = await svc.linkAll();
+
+    expect(res.reconciledUnlinked).toBe(2);
+    for (const id of ['c-rob-2014', 'c-rob-2018']) {
+      expect(update).toHaveBeenCalledWith({
+        where: { id },
+        data: { representativeId: null },
+      });
+    }
+    expect(update).not.toHaveBeenCalledWith({
+      where: { id: 'c-mia-2024' },
       data: { representativeId: null },
     });
   });

--- a/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/candidate-committee-linker.service.ts
@@ -74,6 +74,7 @@ const SURNAME_MIN_GATE_LEN = 3;
 export function isCandidateOwnCommittee(
   committeeName: string,
   surname: string,
+  repGivenName?: string,
 ): boolean {
   const softened = soften(committeeName);
   if (NON_CONTROLLED_MARKERS.some((marker) => softened.includes(marker))) {
@@ -81,7 +82,176 @@ export function isCandidateOwnCommittee(
   }
   const surnameKey = alnumKey(surname);
   if (surnameKey.length < SURNAME_MIN_GATE_LEN) return true;
-  return alnumKey(committeeName).includes(surnameKey);
+  if (!alnumKey(committeeName).includes(surnameKey)) return false;
+  return givenNameAgrees(committeeName, surname, repGivenName);
+}
+
+/**
+ * Tokens that can sit immediately before a surname without being a given name
+ * ("Friends of Rivas", "Committee to Elect Lee"). When one of these precedes
+ * the surname the title carries no candidate given name to compare against.
+ */
+const NON_GIVEN_TOKENS = new Set([
+  'for',
+  'of',
+  'the',
+  'to',
+  'and',
+  'a',
+  'an',
+  'friends',
+  'committee',
+  'elect',
+  'reelect',
+  're',
+  'citizens',
+  'californians',
+  'people',
+  'voters',
+  'taxpayers',
+  'neighbors',
+  // Office/honorific titles — "Speaker Rivas Legal Defense Fund" is Robert
+  // Rivas's own committee; without these the title reads as a given name and
+  // the committee is wrongly unlinked.
+  'speaker',
+  'senator',
+  'assemblymember',
+  'assemblyman',
+  'assemblywoman',
+  'councilmember',
+  'supervisor',
+  'mayor',
+  'dr',
+  'hon',
+]);
+
+/**
+ * Diminutive ↔ formal given-name groups, first entry canonical. Deliberately
+ * small: an over-broad table re-admits the cross-attribution this gate exists
+ * to stop. Short forms that are a prefix of the formal name (Dan/Daniel,
+ * Chris/Christopher) need no entry — the prefix rule below covers them.
+ */
+const NICKNAME_GROUPS = [
+  ['thomas', 'tom', 'tommy'],
+  ['stephen', 'steven', 'steve'],
+  ['michael', 'mike'],
+  ['robert', 'rob', 'bob', 'bobby'],
+  ['william', 'will', 'bill', 'billy'],
+  ['james', 'jim', 'jimmy'],
+  ['joseph', 'joe', 'joey'],
+  ['richard', 'rick', 'dick'],
+  ['charles', 'charlie', 'chuck'],
+  ['john', 'jack', 'johnny'],
+  ['edward', 'ed', 'eddie'],
+  ['margaret', 'maggie', 'peggy'],
+  ['elizabeth', 'liz', 'beth'],
+  ['katherine', 'kathryn', 'kate', 'kathy'],
+  ['patricia', 'patty', 'trish'],
+  ['susan', 'sue'],
+  ['lawrence', 'larry'],
+  ['anthony', 'tony'],
+  ['francisco', 'paco'],
+  ['manuel', 'manny'],
+];
+
+const NICKNAME_CANON = new Map<string, string>(
+  NICKNAME_GROUPS.flatMap((group) =>
+    group.map((name) => [name, group[0]] as [string, string]),
+  ),
+);
+
+/** Shortest prefix that may stand in for a formal given name (Dan → Daniel). */
+const GIVEN_PREFIX_MIN = 3;
+
+/** Honorifics dropped before taking a representative's given name. */
+const NAME_TITLES = new Set([
+  'dr',
+  'mr',
+  'mrs',
+  'ms',
+  'rev',
+  'hon',
+  'sen',
+  'asm',
+  'prof',
+]);
+
+/**
+ * True when two given names plausibly denote the same person: identical, a
+ * known diminutive pair, or one a prefix of the other. Keeps legitimate links
+ * intact — "Tom Umberg for Senate" really is Thomas Umberg's committee, and
+ * "Stephen Bennett for Assembly 2024" really is Steve Bennett's.
+ */
+export function givenNamesMatch(a: string, b: string): boolean {
+  const x = alnumKey(a);
+  const y = alnumKey(b);
+  if (!x || !y) return true;
+  if (x === y) return true;
+  const canonX = NICKNAME_CANON.get(x);
+  const canonY = NICKNAME_CANON.get(y);
+  if (canonX && canonY && canonX === canonY) return true;
+  const [short, long] = x.length <= y.length ? [x, y] : [y, x];
+  return short.length >= GIVEN_PREFIX_MIN && long.startsWith(short);
+}
+
+/**
+ * The personal-name tokens a committee title carries before the surname —
+ * "Rob Bonta for Assembly 2014" → ["rob"]. ALL preceding tokens are returned,
+ * not just the adjacent one: legislators have middle names ("Maria Elena
+ * Durazo") and compound surnames ("Rick Chavez Zbur") where the adjacent token
+ * is not the given name, and matching on it alone unlinked their own
+ * committees. Empty when the title names nobody before the surname ("BONTA FOR
+ * ASSEMBLY 2021", "Friends of Rivas") — no signal, so the caller keeps it.
+ */
+export function committeeGivenNames(
+  committeeName: string,
+  surname: string,
+): string[] {
+  const surnameTokens = soften(surname).split(' ').filter(Boolean);
+  const anchor = surnameTokens.at(-1);
+  if (!anchor) return [];
+  const surnameSet = new Set(surnameTokens);
+  const keep = (t: string) =>
+    !NON_GIVEN_TOKENS.has(t) && !surnameSet.has(t) && !/^\d+$/.test(t);
+
+  // CAL-ACCESS also files the inverted form "SURNAME FOR OFFICE YEAR; FIRST"
+  // ("GARCIA FOR ASSEMBLY 2024; VICTORIA"). Nothing precedes the surname
+  // there, so read the trailing segment as given-name candidates too —
+  // otherwise Victoria Garcia's committee lands on Robert Garcia.
+  const [head, ...rest] = committeeName.split(';');
+  const headTokens = soften(head).split(' ').filter(Boolean);
+  const at = headTokens.indexOf(anchor);
+  const leading = at >= 1 ? headTokens.slice(0, at).filter(keep) : [];
+  const trailing = soften(rest.join(' '))
+    .split(' ')
+    .filter(Boolean)
+    .filter(keep);
+  return [...leading, ...trailing];
+}
+
+/** A tracked rep's given name — "Dr. Corey A. Jackson" → "corey". */
+export function representativeGivenName(fullName: string): string {
+  const tokens = soften(fullName).split(' ').filter(Boolean);
+  return tokens.find((t) => !NAME_TITLES.has(t)) ?? '';
+}
+
+/**
+ * Reject a committee whose title names a DIFFERENT person sharing the surname.
+ * Former officeholders and relatives share surname + chamber with a sitting
+ * member, so the ambiguity guard — which only sees *current* reps — lets them
+ * through: "Rob Bonta for Assembly 2014" was attributed to Mia Bonta, and
+ * "Ian Calderon for Assembly" to Lisa Calderon. Absent a given name on either
+ * side there is nothing to discriminate on, so the committee is kept.
+ */
+function givenNameAgrees(
+  committeeName: string,
+  surname: string,
+  repGivenName?: string,
+): boolean {
+  if (!repGivenName) return true;
+  const given = committeeGivenNames(committeeName, surname);
+  if (given.length === 0) return true;
+  return given.some((g) => givenNamesMatch(g, repGivenName));
 }
 
 /**
@@ -167,6 +337,11 @@ export class CandidateCommitteeLinkerService {
 
     const reps = await this.loadReps();
     const repIndex = this.buildRepIndex(reps);
+    // repId → given name, so the controlled-committee gate can reject a
+    // same-surname relative or predecessor's committee (#979).
+    const givenNameById = new Map(
+      reps.map((r) => [r.id, representativeGivenName(r.name)]),
+    );
     // Guard: an empty rep index means reps aren't loaded (transient/degenerate)
     // — do NOT reconcile then, or a bad load would nuke every existing link.
     if (repIndex.size === 0) return empty;
@@ -212,7 +387,13 @@ export class CandidateCommitteeLinkerService {
         skippedAmbiguous++;
       } else if (res.kind === 'unmatched') {
         unmatched++;
-      } else if (!isCandidateOwnCommittee(c.name, res.surname)) {
+      } else if (
+        !isCandidateOwnCommittee(
+          c.name,
+          res.surname,
+          givenNameById.get(res.repId),
+        )
+      ) {
         // Matched a rep, but the committee only references the candidate
         // (IE/ballot-measure/sponsored/PAC) — not their controlled committee.
         // Never attribute it, or the money trail shows money that isn't the
@@ -269,15 +450,17 @@ export class CandidateCommitteeLinkerService {
         sourceSystem: 'cal_access',
         deletedAt: null,
       },
-      select: { id: true, name: true, candidateName: true },
+      select: {
+        id: true,
+        name: true,
+        candidateName: true,
+        // The linked rep's name drives the given-name gate, so pre-#979 links
+        // that absorbed a relative's or predecessor's committee are unlinked
+        // on the next run without manual SQL.
+        representative: { select: { name: true, lastName: true } },
+      },
     });
-    const stale = linked.filter(
-      (c) =>
-        !isCandidateOwnCommittee(
-          c.name,
-          candidateSurname(c.candidateName ?? ''),
-        ),
-    );
+    const stale = linked.filter((c) => !this.stillControlledBy(c));
     if (stale.length > 0) {
       await batchTransaction(
         this.db!,
@@ -290,6 +473,30 @@ export class CandidateCommitteeLinkerService {
       );
     }
     return stale.length;
+  }
+
+  /**
+   * Re-apply the controlled-committee gate to one already-linked committee.
+   * CAND_NAML is often blank on older filings ("Rob Bonta for Assembly 2018"),
+   * which would yield an empty surname and pass the gate on the length check
+   * before the given-name comparison ever ran — so fall back to the linked
+   * representative's own surname, which is what the title must agree with.
+   */
+  private stillControlledBy(c: {
+    name: string;
+    candidateName: string | null;
+    representative: { name: string; lastName: string } | null;
+  }): boolean {
+    const rep = c.representative;
+    const surname =
+      candidateSurname(c.candidateName ?? '') ||
+      rep?.lastName ||
+      (rep ? this.lastNameOf(rep.name) : '');
+    return isCandidateOwnCommittee(
+      c.name,
+      surname,
+      rep ? representativeGivenName(rep.name) : undefined,
+    );
   }
 
   /** Load tracked (non-federal) reps once; both index builders read the result. */

--- a/apps/frontend/components/region/RepresentativeFundingPanel.tsx
+++ b/apps/frontend/components/region/RepresentativeFundingPanel.tsx
@@ -57,6 +57,15 @@ export function RepresentativeFundingPanel({
     );
   }
 
+  // CAL-ACCESS itemization reaches us thinly (~11 contributions per committee),
+  // so these counts describe donors we could identify from the filings on hand,
+  // not everyone who gave. The labels say so rather than overstating (#980).
+  // Employer is frequently filed as a literal "N/A" placeholder — showing that
+  // as a top employer reads as a finding when it is a blank field.
+  const namedEmployers = funding.topEmployers.filter(
+    (e) => e.employer && !/^(n\/?a|none|unknown)$/i.test(e.employer.trim()),
+  );
+
   return (
     <section aria-label={t("repFinance.heading")} className="space-y-5">
       <dl className="grid grid-cols-2 sm:grid-cols-4 gap-3">
@@ -78,6 +87,10 @@ export function RepresentativeFundingPanel({
         />
       </dl>
 
+      <p className="text-xs text-content-dim">
+        {t("repFinance.itemizationNote")}
+      </p>
+
       {funding.topDonors.length > 0 && (
         <MoneyList
           heading={t("repFinance.topDonors")}
@@ -92,10 +105,10 @@ export function RepresentativeFundingPanel({
         />
       )}
 
-      {funding.topEmployers.length > 0 && (
+      {namedEmployers.length > 0 && (
         <MoneyList
           heading={t("repFinance.topEmployers")}
-          rows={funding.topEmployers.map((e) => ({
+          rows={namedEmployers.map((e) => ({
             key: e.employer,
             name: e.employer,
             amount: e.totalAmount,

--- a/apps/frontend/locales/en/civics.json
+++ b/apps/frontend/locales/en/civics.json
@@ -82,13 +82,14 @@
     "empty": "No campaign-finance filings are linked to this representative yet.",
     "totalRaised": "Total raised",
     "totalSpent": "Total spent",
-    "donors": "Donors",
+    "donors": "Identified donors",
     "committees": "Committees",
-    "topDonors": "Top donors",
+    "topDonors": "Top identified donors",
     "topEmployers": "Top employers behind the money",
     "throughCommittees": "Money flows through these committees",
     "contributions_one": "{{count}} gift",
-    "contributions_other": "{{count}} gifts"
+    "contributions_other": "{{count}} gifts",
+    "itemizationNote": "Donor figures cover only contributions itemized in the filings we have on file, so they understate the true number of donors."
   },
   "finance": {
     "disclaimerLabel": "Campaign-finance data disclaimer",

--- a/apps/frontend/locales/es/civics.json
+++ b/apps/frontend/locales/es/civics.json
@@ -82,13 +82,14 @@
     "empty": "Aún no hay informes de financiamiento de campaña vinculados a este representante.",
     "totalRaised": "Total recaudado",
     "totalSpent": "Total gastado",
-    "donors": "Donantes",
+    "donors": "Donantes identificados",
     "committees": "Comités",
-    "topDonors": "Principales donantes",
+    "topDonors": "Principales donantes identificados",
     "topEmployers": "Principales empleadores detrás del dinero",
     "throughCommittees": "El dinero fluye a través de estos comités",
     "contributions_one": "{{count}} aporte",
-    "contributions_other": "{{count}} aportes"
+    "contributions_other": "{{count}} aportes",
+    "itemizationNote": "Las cifras de donantes abarcan únicamente las contribuciones detalladas en los informes que tenemos registrados, por lo que subestiman el número real de donantes."
   },
   "finance": {
     "disclaimerLabel": "Aviso sobre los datos de financiamiento de campaña",


### PR DESCRIPTION
Closes #979. Mitigates #980 (labeling only). Related to #962.

## Why

Mia Bonta's Campaign Finance page attributed roughly **$1.07M of Rob Bonta's** money to her — her husband, the sitting CA Attorney General, and the previous holder of AD-18. Four of her top six "donors" were his committees.

The linker keys on `normalize(lastName)|chamber`, and the controlled-committee gate only checked that the **surname** appeared in the committee name. The ambiguity guard skips a key only when two *sitting* members share a surname, so a former officeholder or a relative merged in silently. The two records are indistinguishable on every matched field:

```
Mia Bonta for Assembly 2024  | candidate_name: Bonta | candidate_office: ASM
Rob Bonta for Assembly 2014  | candidate_name: Bonta | candidate_office: ASM
```

This was not isolated: **143 of 586 live links were wrong** across ~26 legislators — Robert Garcia (17, from Eduardo/Cristina/Monica/Carmelita), Lisa Calderon (15, from Ian/Charles/Tom/Ron), Jeff Gonzalez (12, from Lorena), Mike Fong (10), Robert Rivas (6, from Luz).

These are false, specific financial claims about named real people, several with politically sensitive associations. The site disclaimer covers data being *incomplete*, not *wrong*.

## What changed

**`candidate-committee-linker.service.ts`** — the gate now compares given names, not just surnames. Cases it had to get right:

| Case | Behavior |
|---|---|
| `Rob Bonta for Assembly 2014` vs Mia Bonta | rejected |
| `Tom Umberg for Senate` vs Thomas Umberg | kept (diminutive) |
| `Stephen Bennett for Assembly 2024` vs Steve Bennett | kept |
| `Maria Elena Durazo for State Senate` | kept (middle name — adjacent token isn't the given name) |
| `Rick Chavez Zbur for Assembly 2022` | kept (compound surname) |
| `Speaker Rivas Legal Defense Fund` vs Robert Rivas | kept (office title) |
| `GARCIA FOR ASSEMBLY 2024; VICTORIA` vs Robert Garcia | rejected (inverted CAL-ACCESS form) |
| `BONTA FOR ASSEMBLY 2021` vs Mia Bonta | kept — no given name to disprove it |

`reconcileExistingLinks` re-validates on every run, so the 143 stale rows **self-heal on the next region sync** with no manual SQL. It now falls back to the linked rep's surname, because `candidate_name` is blank on older filings like `Rob Bonta for Assembly 2018` — without that, those rows would have survived the gate on the surname-length check.

**`RepresentativeFundingPanel.tsx`** — donor figures relabeled "Identified donors" / "Top identified donors" with an itemization note (en + es). Per #980, CAL-ACCESS gives us ~11.5 contributions per committee, so `donorCount` is an accurate count of a thin join, not of everyone who gave. "Donors: 12" beside "$1.3M raised" reads as a false claim; the new labels are true statements about partial data. Also drops employers filed as the literal placeholder `N/A`.

## Verification

Ran the gate over **all 586 live rep↔committee links** on the us-ca node: **443 kept, 143 unlinked**, with every representative retaining their own committees. Spot-checked Bonta, Calderon and Garcia individually — own committees kept in every case.

40 unit tests (10 new), 99.7% statement / 91.5% branch coverage on the linker. Full backend suite green (2297 tests).

## Review status

⚠️ **Self-review** — authored and reviewed under the same identity. Per SOC 2 / 21 CFR Part 11 separation of duties this needs a **second person's countersignature** before it counts as an independent review for the change control record.

Security review: no HIGH or MEDIUM findings. Pure string comparison over DB-sourced public-record data; no SQL construction, no new GraphQL exposure, no PHI/PII. The change net-*reduces* attributed data.

## Known residual

- `givenNamesMatch`'s prefix rule (min 3 chars) would match `Ana`→`Anabel`. It errs toward *keeping* links, so it can preserve a misattribution rather than create one.
- Surnames under 3 alnum chars still bypass the gate (pre-existing `SURNAME_MIN_GATE_LEN` behavior).
- The lexicon (nicknames, stopwords) is hardcoded; moving it to DB-backed config is tracked separately — it needs a code-side fallback so an empty table can't silently loosen attribution.

## Deploy note

The bad rows persist in production until the linker runs again. A region sync is needed for the fix to take effect on the us-ca node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
