### PR TITLE
fix(pipeline): make resume-session identity unique per source, not per file

### DIFF
--- a/packages/scraping-pipeline/__tests__/bulk-download.handler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/bulk-download.handler.spec.ts
@@ -660,7 +660,8 @@ describe("BulkDownloadHandler", () => {
       expect(tracker.startExecution).toHaveBeenCalledWith({
         pipelineJobId: "job-1",
         regionId: "california",
-        sourceUrl: "https://example.com/data.csv",
+        // Identity carries a per-source discriminator beyond the URL (#984).
+        sourceUrl: expect.stringContaining("https://example.com/data.csv"),
         dataType: "campaign_finance",
       });
       expect(tracker.recordBatch).toHaveBeenCalledTimes(3);
@@ -762,9 +763,10 @@ describe("BulkDownloadHandler", () => {
     // tables come from dbwebexport.zip). The execution identity must include
     // the extracted filePattern, else same-URL sources collide on one
     // checkpoint and every source after the first skips its whole stream.
-    function createArchiveSource(filePattern: string) {
+    function createArchiveSource(filePattern: string, category = "Receipts") {
       return createSource({
         url: "https://example.com/dbwebexport.zip",
+        category,
         bulk: {
           format: "csv", // filePattern drives the tracked identity regardless of format
           filePattern,
@@ -788,7 +790,7 @@ describe("BulkDownloadHandler", () => {
       expect(tracker.startExecution).toHaveBeenCalledWith({
         pipelineJobId: "job-1",
         regionId: "california",
-        sourceUrl: "https://example.com/dbwebexport.zip#RCPT_CD.TSV",
+        sourceUrl: "https://example.com/dbwebexport.zip#RCPT_CD.TSV#Receipts",
         dataType: "campaign_finance",
       });
     });
@@ -822,11 +824,108 @@ describe("BulkDownloadHandler", () => {
         (c) => (c[0] as { sourceUrl: string }).sourceUrl,
       );
       expect(trackedUrls).toEqual([
-        "https://example.com/dbwebexport.zip#RCPT_CD.TSV",
-        "https://example.com/dbwebexport.zip#CVR_CAMPAIGN_DISCLOSURE_CD.TSV",
+        "https://example.com/dbwebexport.zip#RCPT_CD.TSV#Receipts",
+        "https://example.com/dbwebexport.zip#CVR_CAMPAIGN_DISCLOSURE_CD.TSV#Receipts",
       ]);
       // Both sources fully ingested (3 batches each) — no cross-source skip.
       expect(onBatch).toHaveBeenCalledTimes(6);
+    });
+
+    // #984: #950's filePattern discriminator is not enough. Two sources can
+    // read the SAME file from the SAME archive for different purposes —
+    // california.json reads CVR_CAMPAIGN_DISCLOSURE_CD.TSV once for Form 496
+    // IE cover pages and once for the committee roster. Those collided on one
+    // execution row and the second skipped its whole stream, silently.
+    it("gives same-file sources distinct identities when only their purpose differs (#984)", async () => {
+      const tracker = createTracker(new Set());
+      handler = new BulkDownloadHandler(mapper, tracker);
+      (globalThis.fetch as jest.Mock).mockImplementation(() =>
+        Promise.resolve(mockStreamResponse(csvContent)),
+      );
+
+      const onBatch = jest.fn().mockResolvedValue(undefined);
+      const file = "CVR_CAMPAIGN_DISCLOSURE_CD.TSV";
+      await handler.execute(
+        createArchiveSource(file, "CAL-ACCESS IE Cover Pages"),
+        "california",
+        onBatch,
+        "job-1",
+      );
+      await handler.execute(
+        createArchiveSource(file, "CAL-ACCESS Committees"),
+        "california",
+        onBatch,
+        "job-1",
+      );
+
+      const trackedUrls = tracker.startExecution.mock.calls.map(
+        (c) => (c[0] as { sourceUrl: string }).sourceUrl,
+      );
+      expect(new Set(trackedUrls).size).toBe(2);
+      expect(trackedUrls).toEqual([
+        `https://example.com/dbwebexport.zip#${file}#CAL-ACCESS IE Cover Pages`,
+        `https://example.com/dbwebexport.zip#${file}#CAL-ACCESS Committees`,
+      ]);
+      // Neither source skipped the other's batches.
+      expect(onBatch).toHaveBeenCalledTimes(6);
+    });
+
+    it("falls back to a contentGoal digest when a source has no category (#984)", async () => {
+      const tracker = createTracker(new Set());
+      handler = new BulkDownloadHandler(mapper, tracker);
+      (globalThis.fetch as jest.Mock).mockImplementation(() =>
+        Promise.resolve(mockStreamResponse(csvContent)),
+      );
+
+      const onBatch = jest.fn().mockResolvedValue(undefined);
+      const base = {
+        url: "https://example.com/dbwebexport.zip",
+        bulk: {
+          format: "csv" as const,
+          filePattern: "CVR.TSV",
+          columnMappings: { CMTE_ID: "committeeId", NAME: "donorName" },
+          batchSize: 2,
+        },
+      };
+      // contentGoal is required by DataSourceConfig and necessarily differs
+      // between two sources over one file, so it backstops category.
+      await handler.execute(
+        createSource({ ...base, contentGoal: "Extract IE cover pages" }),
+        "california",
+        onBatch,
+        "job-1",
+      );
+      await handler.execute(
+        createSource({ ...base, contentGoal: "Extract the committee roster" }),
+        "california",
+        onBatch,
+        "job-1",
+      );
+
+      const trackedUrls = tracker.startExecution.mock.calls.map(
+        (c) => (c[0] as { sourceUrl: string }).sourceUrl,
+      );
+      expect(new Set(trackedUrls).size).toBe(2);
+      expect(onBatch).toHaveBeenCalledTimes(6);
+    });
+
+    it("keeps the identity bounded when a category is very long (#984)", async () => {
+      const tracker = createTracker(new Set());
+      handler = new BulkDownloadHandler(mapper, tracker);
+
+      // source_url is VarChar(1000) — an unbounded category would throw on
+      // insert and take the whole sync down.
+      await handler.execute(
+        createArchiveSource("RCPT_CD.TSV", "X".repeat(5000)),
+        "california",
+        jest.fn().mockResolvedValue(undefined),
+        "job-1",
+      );
+
+      const { sourceUrl } = tracker.startExecution.mock
+        .calls[0][0] as unknown as { sourceUrl: string };
+      expect(sourceUrl.length).toBeLessThan(1000);
+      expect(sourceUrl).toContain("RCPT_CD.TSV");
     });
   });
 });

--- a/packages/scraping-pipeline/src/handlers/api-ingest.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/api-ingest.handler.ts
@@ -25,6 +25,7 @@ import {
   buildFailureResult,
   mapAndReturn,
   mapBatchItems,
+  sessionSourceKey,
 } from "./handler-utils.js";
 
 /** Maximum pages to fetch in a single pipeline run (safety limit) */
@@ -68,7 +69,10 @@ export class ApiIngestHandler {
             pipelineJobId,
             {
               regionId,
-              sourceUrl: source.url,
+              // Unique per source, not per URL — two API sources pointed at
+              // one endpoint would otherwise share an execution row and the
+              // second would skip its stream (#984).
+              sourceUrl: sessionSourceKey(source),
               dataType: source.dataType,
             },
           );

--- a/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
@@ -38,6 +38,7 @@ import {
   buildFailureResult,
   mapAndReturn,
   mapBatchItems,
+  sessionSourceKey,
 } from "./handler-utils.js";
 
 /** Download timeout: 30 minutes for very large files (FEC indiv26.zip is ~1.4GB) */
@@ -118,19 +119,11 @@ export class BulkDownloadHandler {
         // On retry, the session exposes already-applied batch indexes so we
         // skip re-sending them to onBatch. Disabled sessions are silent.
         //
-        // The resume session is keyed by (job, sourceUrl, dataType) and
-        // `batchIndex` restarts at 0 for each source. Multiple bulk sources
-        // routinely share ONE archive URL — every CAL-ACCESS table
-        // (RCPT/EXPN/S496/CVR/CVR2) is extracted from the same
-        // dbwebexport.zip. Without a per-file discriminator the second and
-        // later same-URL sources resume the first source's execution row,
-        // inherit its applied-batch set, and (having fewer batches) skip
-        // their entire stream — silently ingesting nothing (#950). Encode the
-        // extracted filePattern into the tracked identity so each file in a
-        // shared archive gets its own execution row + batch checkpoint.
-        const trackingUrl = bulk.filePattern
-          ? `${source.url}#${bulk.filePattern}`
-          : source.url;
+        // The resume session is keyed by (job, sourceUrl) and `batchIndex`
+        // restarts at 0 for each source, so the tracked identity must be
+        // unique per source. See sessionSourceKey for why url + filePattern
+        // alone is insufficient (#950, #984).
+        const trackingUrl = sessionSourceKey(source, bulk.filePattern);
         const session: ExecutionSession =
           await ExecutionTrackerService.beginSession(
             this.executionTracker,

--- a/packages/scraping-pipeline/src/handlers/handler-utils.ts
+++ b/packages/scraping-pipeline/src/handlers/handler-utils.ts
@@ -5,12 +5,70 @@
  * inferSourceSystem logic. Centralising it here eliminates the clone.
  */
 
+import { createHash } from "node:crypto";
 import type {
   DataSourceConfig,
   ExtractionResult,
   RawExtractionResult,
 } from "@opuspopuli/common";
 import type { DomainMapperService } from "../mapping/domain-mapper.service.js";
+
+/** Characters of the digest kept when a readable discriminator isn't usable. */
+const DIGEST_LEN = 8;
+
+/**
+ * Longest category inlined verbatim. `pipeline_executions.source_url` is
+ * VarChar(1000); anything longer is digested instead of truncated, so the
+ * identity stays bounded without two long categories sharing a prefix.
+ */
+const MAX_DISCRIMINATOR_LEN = 80;
+
+function digest(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, DIGEST_LEN);
+}
+
+/**
+ * A token that differs between any two sources over the same file. Prefers the
+ * category because it stays greppable in the database — that readability is
+ * what lets an operator diagnose an empty source.
+ */
+function discriminatorFor(source: DataSourceConfig): string {
+  const category = source.category?.trim();
+  if (category && category.length <= MAX_DISCRIMINATOR_LEN) return category;
+  // No category, or one too long to inline. `contentGoal` is required by
+  // DataSourceConfig and necessarily differs between two sources over one
+  // file, so it backstops a category-less config.
+  return digest(category || source.contentGoal || "");
+}
+
+/**
+ * Build the resume-session identity for a source.
+ *
+ * `pipeline_executions` is keyed on `(pipeline_job_id, source_url)`, so this
+ * string must be unique per **source**, not per file. #950 appended the
+ * extracted `filePattern` because several CAL-ACCESS tables come out of one
+ * `dbwebexport.zip`. That is still not enough: two sources can read the *same
+ * file* from the *same URL* for different purposes — `california.json` reads
+ * `CVR_CAMPAIGN_DISCLOSURE_CD.TSV` twice, once for Form 496 IE cover pages
+ * (#955) and once for the committee roster (#936). Those share one execution
+ * row, so whichever runs second can inherit the first's applied-batch set and
+ * skip its stream — silently, since `items_failed` stays 0. That makes
+ * ingestion depend on source ordering (#984).
+ *
+ * See `discriminatorFor` for what separates two sources over one file.
+ *
+ * Changing this format is safe: sessions are scoped to `pipelineJobId`, which
+ * is new on every run, so no cross-run resume state depends on it.
+ */
+export function sessionSourceKey(
+  source: DataSourceConfig,
+  filePattern?: string,
+): string {
+  const parts = [source.url];
+  if (filePattern) parts.push(filePattern);
+  parts.push(discriminatorFor(source));
+  return parts.join("#");
+}
 
 /**
  * Build a RawExtractionResult, run it through the domain mapper, stamp


### PR DESCRIPTION
Closes #984. Unblocks #980.

## Why

`pipeline_executions` is keyed on `(pipeline_job_id, source_url)` — `dataType` is passed to `startExecution` but is **not** part of the lookup. #950 appended the extracted `filePattern` so the CAL-ACCESS tables sharing one `dbwebexport.zip` stopped colliding. That discriminator is still insufficient.

`california.json` reads `CVR_CAMPAIGN_DISCLOSURE_CD.TSV` **twice**:

| Source | Purpose | Target |
|---|---|---|
| `dataSources[10]` | Form 496 IE cover pages (#955) | `cvr_filings` |
| `dataSources[12]` | Committee/filer roster (#936) | `committees` |

Same `url`, same `filePattern`, same `dataType` → one execution row. Whichever runs second can inherit the first's applied-batch set and skip its stream, silently, because `items_failed` stays 0. Ingestion ends up depending on source ordering.

`pipeline_executions` on the us-ca node shows one row for that file, not two:

```
dbwebexport.zip#CVR_CAMPAIGN_DISCLOSURE_CD.TSV | campaign_finance | 662,076 | 2026-08-05
```

**Scope honesty:** both `committees` (82,250) and `cvr_filings` (31,418) currently hold plausible data, so a total skip is not in evidence — the impact may be partial or order-dependent. The shared identity is a defect regardless. My original issue claimed `cvr_filings` at 31,418 was proof of loss; that was wrong (`dataSources[10]` has `filters: {FORM_TYPE: 'F496'}`, so 31,418 is the F496 subset by design) and the issue is corrected.

## What changed

`sessionSourceKey()` in `handler-utils.ts`, used by both handlers.

The discriminator prefers `category` because it stays greppable in the database — that readability is what an operator has when a source looks empty. `contentGoal` is required by `DataSourceConfig` and necessarily differs between two sources over one file, so it backstops category-less configs.

**`api-ingest.handler.ts` had the same defect in a worse form** — it passed `sourceUrl: source.url` with no discriminator at all, so two API sources on one endpoint collided unconditionally. Fixed via the same helper rather than leaving a second instance.

## Review found one blocker, fixed before commit

`source_url` is `VarChar(1000)`, and my first cut appended an **unbounded** `category`. A long category in any region config would throw on insert and take the whole sync down — worse than the bug being fixed. Now capped at 80 chars, **digested rather than truncated** so two long categories can't collide on a shared prefix. Covered by a test asserting the identity stays under 1000.

## Safety

Changing the identity format is safe: sessions are scoped to `pipelineJobId`, which is new on every run, so no cross-run resume state depends on the old format.

## Tests

399 passing across 24 suites. `handler-utils.ts` at 100% statements / 95% branch.

Three new cases — same-file/different-purpose sources get distinct identities and neither skips; category-less sources fall back to the `contentGoal` digest; a 5000-char category stays under the column limit. The two #950 tests are updated for the new format and still assert their original property.

## Review status

⚠️ **Self-review** — authored and reviewed under the same identity. Needs a second person's countersignature for the change control record (SOC 2 / 21 CFR Part 11).

Security review: no findings. Pure string construction over config values, Prisma-parameterized write, `sha256` used as a discriminator rather than a security control, no PII or secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
