### PR TITLE
fix(region): attribute CAL-ACCESS finance to the filing committee (#980)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ How it works:
 
 ## SDLC tooling (Claude Code plugin)
 
-The `op-*` workflow commands — `/op-review`, `/op-issue-plan`, `/op-release`, `/op-verify`, `/op-phi-scan`, `/op-trace`, `/op-change-record`, `/op-validate`, and the rest — ship as the shared **[opuspopuli-sdlc](https://github.com/OpusPopuli/opuspopuli-sdlc)** Claude Code plugin. It's auto-enabled in every session (local or remote) via the committed `.claude/settings.json`; the only per-developer step is trusting the repo folder once. Repo-specific commands (`/op-migration`) live in `.claude/skills/`. The plugin's `docs/compliance-model.md` maps the lifecycle to HIPAA / SOC 2 / 21 CFR Part 11 controls.
+The `op-*` workflow commands — `/op-review`, `/op-issue-plan`, `/op-release`, `/op-verify`, `/op-data-scan`, `/op-trace`, `/op-change-record`, `/op-validate`, and the rest — ship as the shared **[opuspopuli-sdlc](https://github.com/OpusPopuli/opuspopuli-sdlc)** Claude Code plugin. It's auto-enabled in every session (local or remote) via the committed `.claude/settings.json`; the only per-developer step is trusting the repo folder once. Repo-specific commands (`/op-migration`) live in `.claude/skills/`. The plugin's `docs/compliance-model.md` maps the lifecycle to HIPAA / SOC 2 / 21 CFR Part 11 controls.
 
 ## Pre-push workflow (mandatory)
 

--- a/apps/backend/__tests__/integration/region/contribution-cover-page-columns.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/contribution-cover-page-columns.integration.spec.ts
@@ -1,0 +1,295 @@
+/**
+ * Schema-shape integration tests for the #980 cover-page join columns.
+ *
+ * `RCPT_CD` / `EXPN_CD` line items carry no filer id — the recipient (or
+ * spender) is only reachable by joining `FILING_ID` to the campaign-disclosure
+ * cover page. So `contributions` / `expenditures` gain a nullable `filing_id`,
+ * and `committee_id` relaxes to nullable because the linker stamps it
+ * post-sync (the same shape #955 gave `independent_expenditures`).
+ *
+ * These assertions run against the REAL `postgres_test` schema (gated by
+ * `assertTestDatabase()` inside `cleanDatabase`) rather than a mock, because
+ * the thing under test IS the migration. Two failure modes in particular are
+ * invisible to unit tests:
+ *
+ *  1. The migration not being applied at all — a mocked Prisma client happily
+ *     accepts `filingId` whether or not the column exists.
+ *  2. The foreign key silently changing semantics. Prisma defaults an OPTIONAL
+ *     relation to `onDelete: SetNull`; had the schema omitted the explicit
+ *     `onDelete: Restrict`, relaxing NOT NULL would also have converted the FK,
+ *     so deleting a committee would silently orphan its finance rows to NULL —
+ *     which is exactly the state the linker treats as "unresolved, please
+ *     stamp". That would turn a delete into silent data corruption.
+ *
+ * See opuspopuli#980 (subtask 3).
+ */
+
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { RegionQueryService } from '../../../src/apps/region/src/domains/region-query.service';
+import type { RegionCacheService } from '../../../src/apps/region/src/domains/region-cache.service';
+import { cleanDatabase, disconnectDatabase, getDbService } from '../utils';
+
+interface ColumnMeta {
+  column_name: string;
+  is_nullable: 'YES' | 'NO';
+  data_type: string;
+  character_maximum_length: number | null;
+}
+
+const FINANCE_TABLES = ['contributions', 'expenditures'] as const;
+
+describe('#980 cover-page join columns', () => {
+  let db: DbService;
+
+  beforeAll(async () => {
+    db = await getDbService();
+  });
+
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  afterAll(async () => {
+    await disconnectDatabase();
+  });
+
+  const describeColumn = async (
+    table: string,
+    column: string,
+  ): Promise<ColumnMeta | undefined> => {
+    const rows = await db.$queryRaw<ColumnMeta[]>`
+      SELECT column_name, is_nullable, data_type, character_maximum_length
+        FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = ${table}
+         AND column_name = ${column}`;
+    return rows[0];
+  };
+
+  describe.each(FINANCE_TABLES)('%s', (table) => {
+    it('has a nullable filing_id of VARCHAR(50)', async () => {
+      const column = await describeColumn(table, 'filing_id');
+
+      expect(column).toBeDefined();
+      expect(column?.is_nullable).toBe('YES');
+      expect(column?.data_type).toBe('character varying');
+      expect(column?.character_maximum_length).toBe(50);
+    });
+
+    it('has relaxed committee_id to nullable', async () => {
+      const column = await describeColumn(table, 'committee_id');
+
+      expect(column?.is_nullable).toBe('YES');
+    });
+
+    it('indexes filing_id so the linker can look rows up by cover page', async () => {
+      const indexes = await db.$queryRaw<
+        Array<{ indexname: string; indexdef: string }>
+      >`SELECT indexname, indexdef FROM pg_indexes
+         WHERE schemaname = 'public' AND tablename = ${table}`;
+
+      const index = indexes.find(
+        (i) => i.indexname === `${table}_filing_id_idx`,
+      );
+      // Assert the definition, not just the name — an index of the right name
+      // over the wrong column would otherwise pass. Written to still hold if
+      // this later becomes a partial index.
+      expect(index?.indexdef).toContain('(filing_id)');
+    });
+  });
+
+  it('accepts a contribution with no committee — the pre-link shape', async () => {
+    const contribution = await db.contribution.create({
+      data: {
+        externalId: '1234567:0:1:ABC123',
+        filingId: '1234567',
+        committeeId: null,
+        donorName: 'Jane Q. Public',
+        donorType: 'individual',
+        amount: '250.00',
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+    expect(contribution.committeeId).toBeNull();
+    expect(contribution.filingId).toBe('1234567');
+  });
+
+  it('accepts an expenditure with no committee — the pre-link shape', async () => {
+    const expenditure = await db.expenditure.create({
+      data: {
+        externalId: '7654321:0:1:XYZ789',
+        filingId: '7654321',
+        committeeId: null,
+        payeeName: 'Some Print Shop',
+        amount: '1000.00',
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+    expect(expenditure.committeeId).toBeNull();
+    expect(expenditure.filingId).toBe('7654321');
+  });
+
+  it('still RESTRICTs deleting a committee that has contributions', async () => {
+    const committee = await db.committee.create({
+      data: {
+        externalId: 'FILER-980-A',
+        name: 'Committee to Elect Someone',
+        type: 'candidate',
+        sourceSystem: 'cal_access',
+      },
+    });
+    await db.contribution.create({
+      data: {
+        externalId: '1111111:0:1:AAA',
+        filingId: '1111111',
+        committeeId: committee.id,
+        donorName: 'Jane Q. Public',
+        donorType: 'individual',
+        amount: '250.00',
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+    // If the FK had degraded to SET NULL, this would succeed and quietly
+    // reset committee_id — indistinguishable from an unlinked row.
+    await expect(
+      db.committee.delete({ where: { id: committee.id } }),
+    ).rejects.toThrow();
+
+    const survivor = await db.contribution.findUnique({
+      where: { externalId: '1111111:0:1:AAA' },
+    });
+    expect(survivor?.committeeId).toBe(committee.id);
+  });
+
+  describe('query filters, against real rows', () => {
+    // getContributions/getExpenditures touch no cache path, so a bare stub is
+    // enough. The DB itself is real — that is the point of these two cases.
+    const service = () =>
+      new RegionQueryService(db, {} as unknown as RegionCacheService);
+
+    const seedPair = async () => {
+      const committee = await db.committee.create({
+        data: {
+          externalId: 'FILER-980-C',
+          name: 'Attributed Committee',
+          type: 'candidate',
+          sourceSystem: 'cal_access',
+        },
+      });
+      await db.contribution.createMany({
+        data: [
+          {
+            externalId: '3333333:0:1:CCC',
+            filingId: '3333333',
+            committeeId: committee.id,
+            donorName: 'Attributed Donor',
+            donorType: 'individual',
+            amount: '100.00',
+            date: new Date('2026-03-01'),
+            sourceSystem: 'cal_access',
+          },
+          {
+            externalId: '4444444:0:1:DDD',
+            filingId: '4444444',
+            committeeId: null,
+            donorName: 'Unattributed Donor',
+            donorType: 'individual',
+            amount: '999.00',
+            date: new Date('2026-03-02'), // newer, so it would sort FIRST
+            sourceSystem: 'cal_access',
+          },
+        ],
+      });
+      await db.expenditure.createMany({
+        data: [
+          {
+            externalId: '5555555:0:1:EEE',
+            filingId: '5555555',
+            committeeId: committee.id,
+            payeeName: 'Attributed Payee',
+            amount: '100.00',
+            date: new Date('2026-03-01'),
+            sourceSystem: 'cal_access',
+          },
+          {
+            externalId: '6666666:0:1:FFF',
+            filingId: '6666666',
+            committeeId: null,
+            payeeName: 'Unattributed Payee',
+            amount: '999.00',
+            date: new Date('2026-03-02'),
+            sourceSystem: 'cal_access',
+          },
+        ],
+      });
+    };
+
+    it('omits unattributed contributions from list results and total', async () => {
+      await seedPair();
+
+      const page = await service().getContributions();
+
+      // The unattributed row is both newer and larger, so it would lead the
+      // `date desc, amount desc` ordering if the filter regressed.
+      expect(page.items.map((i) => i.donorName)).toEqual(['Attributed Donor']);
+      expect(page.total).toBe(1);
+    });
+
+    it('omits unattributed expenditures from list results and total', async () => {
+      await seedPair();
+
+      const page = await service().getExpenditures();
+
+      expect(page.items.map((i) => i.payeeName)).toEqual(['Attributed Payee']);
+      expect(page.total).toBe(1);
+    });
+
+    it('treats an unattributed row as not-found when fetched by id', async () => {
+      await seedPair();
+      const unattributed = await db.contribution.findUniqueOrThrow({
+        where: { externalId: '4444444:0:1:DDD' },
+      });
+
+      // The GraphQL field is non-null, so surfacing this row would throw
+      // "Cannot return null for non-nullable field" rather than fail closed.
+      expect(await service().getContribution(unattributed.id)).toBeNull();
+    });
+  });
+
+  it('still RESTRICTs deleting a committee that has expenditures', async () => {
+    const committee = await db.committee.create({
+      data: {
+        externalId: 'FILER-980-B',
+        name: 'Another Committee',
+        type: 'pac',
+        sourceSystem: 'cal_access',
+      },
+    });
+    await db.expenditure.create({
+      data: {
+        externalId: '2222222:0:1:BBB',
+        filingId: '2222222',
+        committeeId: committee.id,
+        payeeName: 'Some Print Shop',
+        amount: '1000.00',
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+    await expect(
+      db.committee.delete({ where: { id: committee.id } }),
+    ).rejects.toThrow();
+
+    const survivor = await db.expenditure.findUnique({
+      where: { externalId: '2222222:0:1:BBB' },
+    });
+    expect(survivor?.committeeId).toBe(committee.id);
+  });
+});

--- a/apps/backend/__tests__/integration/region/cover-page-linker.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/cover-page-linker.integration.spec.ts
@@ -240,6 +240,24 @@ describe('CoverPageLinkerService (#980)', () => {
     expect(row.committeeId).toBeNull();
   });
 
+  it('rejects a second cover page for the same filing', async () => {
+    // Load-bearing constraint, not hygiene: the linker joins on filing_id and
+    // assumes one cover page per filing. Two rows would let the UPDATE stamp an
+    // arbitrary filer onto donor money, and drive skippedNoCoverPage negative.
+    await seedFiler('FILER-1', '900001');
+
+    await expect(
+      db.cvrFiling.create({
+        data: {
+          externalId: '900001-duplicate',
+          filingId: '900001',
+          filerId: 'FILER-OTHER',
+          sourceSystem: 'cal_access',
+        },
+      }),
+    ).rejects.toThrow();
+  });
+
   it('links many rows across filings in one pass', async () => {
     const filerA = await seedFiler('FILER-A', '900010');
     const filerB = await seedFiler('FILER-B', '900011');

--- a/apps/backend/__tests__/integration/region/cover-page-linker.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/cover-page-linker.integration.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * CoverPageLinkerService integration tests (#980).
+ *
+ * The linker resolves the committee that FILED each contribution/expenditure by
+ * joining `filing_id -> cvr_filings.filer_id -> committees.external_id`, in a
+ * single set-based `UPDATE … FROM` per table. Because that join is raw SQL, a
+ * mocked Prisma proves nothing about it — the unit spec covers orchestration,
+ * and everything that could actually be *wrong about the join* lives here:
+ * column names, the deleted-committee guard, idempotency, and the direction of
+ * attribution (filer, not counterparty — the whole point of #980).
+ *
+ * Runs against the real `postgres_test` schema, gated by `assertTestDatabase()`
+ * inside `cleanDatabase`.
+ */
+
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { CoverPageLinkerService } from '../../../src/apps/region/src/domains/cover-page-linker.service';
+import { cleanDatabase, disconnectDatabase, getDbService } from '../utils';
+
+describe('CoverPageLinkerService (#980)', () => {
+  let db: DbService;
+  let linker: CoverPageLinkerService;
+
+  beforeAll(async () => {
+    db = await getDbService();
+    linker = new CoverPageLinkerService(db);
+  });
+
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  afterAll(async () => {
+    await disconnectDatabase();
+  });
+
+  /** The filer — the committee that submitted the filing and received the money. */
+  const seedFiler = async (filerId = 'FILER-1', filingId = '900001') => {
+    const committee = await db.committee.create({
+      data: {
+        externalId: filerId,
+        name: 'Committee to Elect Someone',
+        type: 'candidate',
+        sourceSystem: 'cal_access',
+      },
+    });
+    await db.cvrFiling.create({
+      data: {
+        externalId: filingId,
+        filingId,
+        filerId,
+        sourceSystem: 'cal_access',
+      },
+    });
+    return committee;
+  };
+
+  const seedContribution = (filingId: string | null, externalId: string) =>
+    db.contribution.create({
+      data: {
+        externalId,
+        filingId,
+        committeeId: null,
+        donorName: 'Jane Q. Public',
+        donorType: 'individual',
+        amount: '250.00',
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+  it('attributes a contribution to the filer via the cover page', async () => {
+    const filer = await seedFiler();
+    await seedContribution('900001', '900001:0:1:AAA');
+
+    const result = await linker.linkAll();
+
+    expect(result.contributions).toMatchObject({ considered: 1, linked: 1 });
+    const row = await db.contribution.findUniqueOrThrow({
+      where: { externalId: '900001:0:1:AAA' },
+    });
+    expect(row.committeeId).toBe(filer.id);
+  });
+
+  it('attributes an expenditure to the filer via the cover page', async () => {
+    const filer = await seedFiler();
+    await db.expenditure.create({
+      data: {
+        externalId: '900001:0:2:BBB',
+        filingId: '900001',
+        committeeId: null,
+        payeeName: 'Some Print Shop',
+        amount: '1000.00',
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+    const result = await linker.linkAll();
+
+    expect(result.expenditures).toMatchObject({ considered: 1, linked: 1 });
+    const row = await db.expenditure.findUniqueOrThrow({
+      where: { externalId: '900001:0:2:BBB' },
+    });
+    expect(row.committeeId).toBe(filer.id);
+  });
+
+  it('attributes to the filer even when a counterparty committee exists', async () => {
+    // The #980 defect in miniature: RCPT_CD's CMTE_ID names the *contributor*.
+    // A linker that followed it would stamp the donor's committee here.
+    const filer = await seedFiler();
+    const contributor = await db.committee.create({
+      data: {
+        externalId: 'FILER-CONTRIBUTOR',
+        name: 'Some Other PAC',
+        type: 'pac',
+        sourceSystem: 'cal_access',
+      },
+    });
+    await seedContribution('900001', '900001:0:1:AAA');
+
+    await linker.linkAll();
+
+    const row = await db.contribution.findUniqueOrThrow({
+      where: { externalId: '900001:0:1:AAA' },
+    });
+    expect(row.committeeId).toBe(filer.id);
+    expect(row.committeeId).not.toBe(contributor.id);
+  });
+
+  it('is idempotent — a second run rewrites nothing', async () => {
+    const filer = await seedFiler();
+    await seedContribution('900001', '900001:0:1:AAA');
+
+    await linker.linkAll();
+    const second = await linker.linkAll();
+
+    expect(second.contributions).toMatchObject({ considered: 0, linked: 0 });
+    const row = await db.contribution.findUniqueOrThrow({
+      where: { externalId: '900001:0:1:AAA' },
+    });
+    expect(row.committeeId).toBe(filer.id);
+  });
+
+  it('never re-attributes a row that already has a committee', async () => {
+    const filer = await seedFiler();
+    const other = await db.committee.create({
+      data: {
+        externalId: 'FILER-OTHER',
+        name: 'Already Linked Committee',
+        type: 'pac',
+        sourceSystem: 'cal_access',
+      },
+    });
+    await db.contribution.create({
+      data: {
+        externalId: '900001:0:9:ZZZ',
+        filingId: '900001', // cover page points at `filer`, but this row is taken
+        committeeId: other.id,
+        donorName: 'Jane Q. Public',
+        donorType: 'individual',
+        amount: '250.00',
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+    await linker.linkAll();
+
+    const row = await db.contribution.findUniqueOrThrow({
+      where: { externalId: '900001:0:9:ZZZ' },
+    });
+    expect(row.committeeId).toBe(other.id);
+    expect(row.committeeId).not.toBe(filer.id);
+  });
+
+  it('leaves a row unlinked when no cover page matches its filing', async () => {
+    await seedFiler();
+    await seedContribution('999999', '999999:0:1:CCC'); // no cover page
+
+    const result = await linker.linkAll();
+
+    expect(result.contributions).toMatchObject({
+      considered: 1,
+      linked: 0,
+      skippedNoCoverPage: 1,
+      skippedNoCommittee: 0,
+    });
+  });
+
+  it('reports a cover page whose filer matches no committee', async () => {
+    await db.cvrFiling.create({
+      data: {
+        externalId: '900002',
+        filingId: '900002',
+        filerId: 'FILER-UNKNOWN',
+        sourceSystem: 'cal_access',
+      },
+    });
+    await seedContribution('900002', '900002:0:1:DDD');
+
+    const result = await linker.linkAll();
+
+    expect(result.contributions).toMatchObject({
+      considered: 1,
+      linked: 0,
+      skippedNoCoverPage: 0,
+      skippedNoCommittee: 1,
+    });
+  });
+
+  it('ignores soft-deleted committees', async () => {
+    // A soft-deleted committee is not a valid attribution target; without the
+    // deleted_at guard the money would be assigned to a retired row.
+    await db.committee.create({
+      data: {
+        externalId: 'FILER-GONE',
+        name: 'Dissolved Committee',
+        type: 'pac',
+        sourceSystem: 'cal_access',
+        deletedAt: new Date('2026-01-01'),
+      },
+    });
+    await db.cvrFiling.create({
+      data: {
+        externalId: '900003',
+        filingId: '900003',
+        filerId: 'FILER-GONE',
+        sourceSystem: 'cal_access',
+      },
+    });
+    await seedContribution('900003', '900003:0:1:EEE');
+
+    const result = await linker.linkAll();
+
+    expect(result.contributions.linked).toBe(0);
+    const row = await db.contribution.findUniqueOrThrow({
+      where: { externalId: '900003:0:1:EEE' },
+    });
+    expect(row.committeeId).toBeNull();
+  });
+
+  it('links many rows across filings in one pass', async () => {
+    const filerA = await seedFiler('FILER-A', '900010');
+    const filerB = await seedFiler('FILER-B', '900011');
+    await seedContribution('900010', '900010:0:1:A1');
+    await seedContribution('900010', '900010:0:2:A2');
+    await seedContribution('900011', '900011:0:1:B1');
+    await seedContribution(null, 'no-filing:1'); // not considered at all
+
+    const result = await linker.linkAll();
+
+    expect(result.contributions).toMatchObject({ considered: 3, linked: 3 });
+    const rows = await db.contribution.findMany({
+      select: { externalId: true, committeeId: true },
+    });
+    const byExternal = new Map(rows.map((r) => [r.externalId, r.committeeId]));
+    expect(byExternal.get('900010:0:1:A1')).toBe(filerA.id);
+    expect(byExternal.get('900010:0:2:A2')).toBe(filerA.id);
+    expect(byExternal.get('900011:0:1:B1')).toBe(filerB.id);
+    expect(byExternal.get('no-filing:1')).toBeNull();
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
@@ -150,3 +150,70 @@ describe('CampaignFinanceSyncService.enrichCommittees (#939)', () => {
     expect($transaction).not.toHaveBeenCalled();
   });
 });
+
+describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () => {
+  function buildWithLinkers() {
+    const db = {
+      committee: {
+        upsert: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      $transaction: jest.fn().mockResolvedValue([]),
+    } as unknown as DbService;
+
+    const linker = (name: string) => ({
+      linkAll: jest.fn().mockResolvedValue({ name }),
+    });
+    const propositionFinanceLinker = linker('proposition');
+    const candidateCommitteeLinker = linker('candidate');
+    const independentExpenditureLinker = linker('ie');
+    const coverPageLinker = linker('coverPage');
+
+    const svc = new CampaignFinanceSyncService(
+      db,
+      propositionFinanceLinker as never,
+      candidateCommitteeLinker as never,
+      independentExpenditureLinker as never,
+      coverPageLinker as never,
+    );
+
+    const provider = {
+      fetchCampaignFinance: jest.fn().mockResolvedValue(result([])),
+    };
+
+    return {
+      svc,
+      provider,
+      coverPageLinker,
+      propositionFinanceLinker,
+      independentExpenditureLinker,
+    };
+  }
+
+  it('runs the cover-page linker BEFORE the proposition linker', async () => {
+    // Load-bearing ordering, not a preference. The proposition linker derives
+    // measure positions from `filing_id -> committee_id`, which only exists
+    // once the cover-page linker has stamped it. Reverse these and proposition
+    // funding silently reads $0 — no exception, nothing fails.
+    const { svc, provider, coverPageLinker, propositionFinanceLinker } =
+      buildWithLinkers();
+
+    await svc.sync(provider as never);
+
+    expect(coverPageLinker.linkAll).toHaveBeenCalled();
+    expect(propositionFinanceLinker.linkAll).toHaveBeenCalled();
+    expect(coverPageLinker.linkAll.mock.invocationCallOrder[0]).toBeLessThan(
+      propositionFinanceLinker.linkAll.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('still runs the proposition linker when the cover-page linker throws', async () => {
+    const { svc, provider, coverPageLinker, propositionFinanceLinker } =
+      buildWithLinkers();
+    coverPageLinker.linkAll.mockRejectedValue(new Error('boom'));
+
+    await expect(svc.sync(provider as never)).resolves.toBeDefined();
+
+    expect(propositionFinanceLinker.linkAll).toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -7,6 +7,7 @@ import {
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
 import { CandidateCommitteeLinkerService } from './candidate-committee-linker.service';
 import { IndependentExpenditureLinkerService } from './independent-expenditure-linker.service';
+import { CoverPageLinkerService } from './cover-page-linker.service';
 import {
   campaignFinanceSyncTracker,
   type SyncPhaseTracker,
@@ -66,6 +67,8 @@ export class CampaignFinanceSyncService {
     private readonly candidateCommitteeLinker?: CandidateCommitteeLinkerService,
     @Optional()
     private readonly independentExpenditureLinker?: IndependentExpenditureLinkerService,
+    @Optional()
+    private readonly coverPageLinker?: CoverPageLinkerService,
   ) {}
 
   async sync(
@@ -184,6 +187,19 @@ export class CampaignFinanceSyncService {
       } catch (error) {
         this.logger.warn(
           `Independent-expenditure linker failed: ${(error as Error).message}`,
+        );
+      }
+    }
+
+    // Attribute contributions/expenditures to their FILING committee (#980) —
+    // also before the proposition linker, which derives measure positions from
+    // the committees stamped here.
+    if (this.coverPageLinker) {
+      try {
+        await this.coverPageLinker.linkAll();
+      } catch (error) {
+        this.logger.warn(
+          `Cover-page linker failed: ${(error as Error).message}`,
         );
       }
     }

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -178,59 +178,45 @@ export class CampaignFinanceSyncService {
       emptyExtractTracker.complete();
     }
 
-    // Attribute independent expenditures to their committee + target (#955) —
-    // runs BEFORE the proposition linker so the propositionTitle it stamps onto
-    // S496 IEs gets resolved to a propositionId in the same pass.
-    if (this.independentExpenditureLinker) {
-      try {
-        await this.independentExpenditureLinker.linkAll();
-      } catch (error) {
-        this.logger.warn(
-          `Independent-expenditure linker failed: ${(error as Error).message}`,
-        );
-      }
-    }
-
-    // Attribute contributions/expenditures to their FILING committee (#980) —
-    // also before the proposition linker, which derives measure positions from
-    // the committees stamped here.
-    if (this.coverPageLinker) {
-      try {
-        await this.coverPageLinker.linkAll();
-      } catch (error) {
-        this.logger.warn(
-          `Cover-page linker failed: ${(error as Error).message}`,
-        );
-      }
-    }
-
-    if (this.propositionFinanceLinker) {
-      try {
-        await this.propositionFinanceLinker.linkAll();
-      } catch (error) {
-        this.logger.warn(
-          `Proposition finance linker failed: ${(error as Error).message}`,
-        );
-      }
-    }
-
-    // Attribute candidate committees to representatives (#941) — runs after
-    // enrichment so it sees committees with their real candidateName/office.
-    if (this.candidateCommitteeLinker) {
-      try {
-        await this.candidateCommitteeLinker.linkAll();
-      } catch (error) {
-        this.logger.warn(
-          `Candidate-committee linker failed: ${(error as Error).message}`,
-        );
-      }
-    }
+    await this.runPostSyncLinkers();
 
     return {
       processed: totalProcessed,
       created: totalCreated,
       updated: totalUpdated,
     };
+  }
+
+  /**
+   * Run the attribution linkers, in order. Each is optional (they are
+   * `@Optional()` injections) and each is isolated: one failing must not cost
+   * the sync its upserted data or stop the others running.
+   *
+   * **The order is load-bearing.** Both the IE linker (#955) and the
+   * cover-page linker (#980) stamp `committeeId` onto rows the proposition
+   * linker then reads to derive measure positions — run it first and it sees
+   * nothing, silently writing no positions. The candidate-committee linker
+   * (#941) runs last so it sees committees carrying their enriched
+   * candidateName/office. Covered by campaign-finance-sync.service.spec.ts.
+   */
+  private async runPostSyncLinkers(): Promise<void> {
+    const linkers: Array<
+      [string, { linkAll(): Promise<unknown> } | undefined]
+    > = [
+      ['Independent-expenditure', this.independentExpenditureLinker],
+      ['Cover-page', this.coverPageLinker],
+      ['Proposition finance', this.propositionFinanceLinker],
+      ['Candidate-committee', this.candidateCommitteeLinker],
+    ];
+
+    for (const [name, linker] of linkers) {
+      if (!linker) continue;
+      try {
+        await linker.linkAll();
+      } catch (error) {
+        this.logger.warn(`${name} linker failed: ${(error as Error).message}`);
+      }
+    }
   }
 
   /**

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -291,19 +291,19 @@ export class CampaignFinanceSyncService {
       allCommittees.map((c: CommitteeRecord) => [c.externalId, c.id]),
     );
 
-    for (const c of data.contributions) {
-      c.committeeId = idMap.get(c.committeeId) ?? c.committeeId;
-    }
-    for (const e of data.expenditures) {
-      e.committeeId = idMap.get(e.committeeId) ?? e.committeeId;
-    }
-    for (const ie of data.independentExpenditures) {
-      // S496 IEs arrive with no committeeId (resolved later by the IE linker) —
-      // only rewrite the externalId -> UUID for IEs that reference one (#955).
-      if (ie.committeeId) {
-        ie.committeeId = idMap.get(ie.committeeId) ?? ie.committeeId;
+    // RCPT/EXPN line items arrive with no committeeId once the region config
+    // stops mapping CMTE_ID — the filer is resolved later from the cover page
+    // (#980), exactly as S496 IEs have been since #955. Only rewrite the
+    // externalId -> UUID for rows that actually reference a committee.
+    const resolveCommittee = (row: { committeeId?: string }) => {
+      if (row.committeeId) {
+        row.committeeId = idMap.get(row.committeeId) ?? row.committeeId;
       }
-    }
+    };
+
+    data.contributions.forEach(resolveCommittee);
+    data.expenditures.forEach(resolveCommittee);
+    data.independentExpenditures.forEach(resolveCommittee);
   }
 
   /**
@@ -440,6 +440,7 @@ export class CampaignFinanceSyncService {
         model: this.db.contribution,
         fields: [
           'committeeId',
+          'filingId',
           'donorName',
           'donorType',
           'donorEmployer',
@@ -459,6 +460,7 @@ export class CampaignFinanceSyncService {
         model: this.db.expenditure,
         fields: [
           'committeeId',
+          'filingId',
           'payeeName',
           'amount',
           'date',

--- a/apps/backend/src/apps/region/src/domains/cover-page-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/cover-page-linker.service.spec.ts
@@ -1,0 +1,131 @@
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { CoverPageLinkerService } from './cover-page-linker.service';
+
+/**
+ * These cover orchestration only — which statements run, in what order, and how
+ * the counters are derived. The join itself is raw SQL, so its correctness is
+ * asserted against a real database in
+ * `__tests__/integration/region/cover-page-linker.integration.spec.ts`.
+ */
+function build(opts: {
+  contributionCount?: number;
+  expenditureCount?: number;
+  updated?: number[];
+  hadCoverPage?: number;
+}) {
+  const executeRawUnsafe = jest.fn();
+  for (const n of opts.updated ?? [0, 0]) {
+    executeRawUnsafe.mockResolvedValueOnce(n);
+  }
+  const queryRawUnsafe = jest
+    .fn()
+    .mockResolvedValue([{ count: BigInt(opts.hadCoverPage ?? 0) }]);
+
+  const db = {
+    contribution: {
+      count: jest.fn().mockResolvedValue(opts.contributionCount ?? 0),
+    },
+    expenditure: {
+      count: jest.fn().mockResolvedValue(opts.expenditureCount ?? 0),
+    },
+    $executeRawUnsafe: executeRawUnsafe,
+    $queryRawUnsafe: queryRawUnsafe,
+  } as unknown as DbService;
+
+  return {
+    svc: new CoverPageLinkerService(db),
+    executeRawUnsafe,
+    queryRawUnsafe,
+    db,
+  };
+}
+
+describe('CoverPageLinkerService (#980)', () => {
+  it('returns empty counts when no db is injected', async () => {
+    const res = await new CoverPageLinkerService().linkAll();
+
+    expect(res.contributions.considered).toBe(0);
+    expect(res.expenditures.considered).toBe(0);
+  });
+
+  it('skips the UPDATE entirely when nothing is unattributed', async () => {
+    const { svc, executeRawUnsafe } = build({});
+
+    const res = await svc.linkAll();
+
+    // The common steady-state case: a re-sync with everything already linked
+    // must not scan or write.
+    expect(executeRawUnsafe).not.toHaveBeenCalled();
+    expect(res.contributions).toMatchObject({ considered: 0, linked: 0 });
+  });
+
+  it('only considers unattributed rows that carry a filingId', async () => {
+    const { svc, db } = build({ contributionCount: 1, updated: [1, 0] });
+
+    await svc.linkAll();
+
+    // Idempotency: an already-linked row must never be rewritten or unlinked.
+    expect(db.contribution.count).toHaveBeenCalledWith({
+      where: { committeeId: null, filingId: { not: null } },
+    });
+  });
+
+  it('links both tables in one statement each', async () => {
+    const { svc, executeRawUnsafe } = build({
+      contributionCount: 1200000,
+      expenditureCount: 400000,
+      updated: [1200000, 400000],
+    });
+
+    const res = await svc.linkAll();
+
+    // One UPDATE per table — not one per row. At 1.2M rows the row-by-row
+    // shape #955 uses would mean 1.2M promises across ~2,400 transactions.
+    expect(executeRawUnsafe).toHaveBeenCalledTimes(2);
+    expect(res.contributions.linked).toBe(1200000);
+    expect(res.expenditures.linked).toBe(400000);
+
+    const statements = executeRawUnsafe.mock.calls.map((c) => c[0] as string);
+    expect(statements[0]).toContain('UPDATE "contributions"');
+    expect(statements[1]).toContain('UPDATE "expenditures"');
+    for (const sql of statements) {
+      expect(sql).toContain('"committee_id" IS NULL');
+      expect(sql).toContain('"deleted_at" IS NULL');
+    }
+  });
+
+  it('does not run the breakdown query when everything resolved', async () => {
+    const { svc, queryRawUnsafe } = build({
+      contributionCount: 10,
+      expenditureCount: 0,
+      updated: [10, 0],
+    });
+
+    const res = await svc.linkAll();
+
+    expect(queryRawUnsafe).not.toHaveBeenCalled();
+    expect(res.contributions).toMatchObject({
+      linked: 10,
+      skippedNoCoverPage: 0,
+      skippedNoCommittee: 0,
+    });
+  });
+
+  it('splits leftovers into no-cover-page vs no-committee', async () => {
+    const { svc } = build({
+      contributionCount: 10,
+      expenditureCount: 0,
+      updated: [6, 0],
+      hadCoverPage: 3, // of the 4 unlinked, 3 have a cover page whose filer is unknown
+    });
+
+    const res = await svc.linkAll();
+
+    expect(res.contributions).toMatchObject({
+      considered: 10,
+      linked: 6,
+      skippedNoCommittee: 3,
+      skippedNoCoverPage: 1,
+    });
+  });
+});

--- a/apps/backend/src/apps/region/src/domains/cover-page-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/cover-page-linker.service.spec.ts
@@ -13,10 +13,23 @@ function build(opts: {
   updated?: number[];
   hadCoverPage?: number;
 }) {
-  const executeRawUnsafe = jest.fn();
-  for (const n of opts.updated ?? [0, 0]) {
-    executeRawUnsafe.mockResolvedValueOnce(n);
-  }
+  // The service links in batches until an UPDATE returns 0, and runs both
+  // tables concurrently. Dispatch on the SQL text rather than call order — a
+  // mockResolvedValueOnce queue would depend on how the two concurrent chains
+  // interleave, which is not a guarantee the service makes.
+  const [contribUpdated, expendUpdated] = opts.updated ?? [0, 0];
+  const remaining = new Map<string, number>([
+    ['contributions', contribUpdated],
+    ['expenditures', expendUpdated],
+  ]);
+  const executeRawUnsafe = jest.fn(async (sql: string) => {
+    const table = sql.includes('UPDATE "contributions"')
+      ? 'contributions'
+      : 'expenditures';
+    const left = remaining.get(table) ?? 0;
+    remaining.set(table, 0);
+    return left;
+  });
   const queryRawUnsafe = jest
     .fn()
     .mockResolvedValue([{ count: BigInt(opts.hadCoverPage ?? 0) }]);
@@ -79,9 +92,9 @@ describe('CoverPageLinkerService (#980)', () => {
 
     const res = await svc.linkAll();
 
-    // One UPDATE per table — not one per row. At 1.2M rows the row-by-row
-    // shape #955 uses would mean 1.2M promises across ~2,400 transactions.
-    expect(executeRawUnsafe).toHaveBeenCalledTimes(2);
+    // Batched, not one statement per row: the row-by-row shape #955 uses would
+    // mean 1.2M promises across ~2,400 transactions at this scale.
+    expect(executeRawUnsafe.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(res.contributions.linked).toBe(1200000);
     expect(res.expenditures.linked).toBe(400000);
 

--- a/apps/backend/src/apps/region/src/domains/cover-page-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/cover-page-linker.service.ts
@@ -26,6 +26,13 @@ export interface CoverPageLinkResult {
 const LINKED_TABLES = ['contributions', 'expenditures'] as const;
 type LinkedTable = (typeof LINKED_TABLES)[number];
 
+/**
+ * Rows attributed per transaction. Bounds WAL, lock duration and dead-tuple
+ * churn on the first post-rebuild run without making the ~1.2M-row backfill
+ * take a meaningfully different amount of total work.
+ */
+const LINK_BATCH_SIZE = 50_000;
+
 const EMPTY_TABLE_RESULT: CoverPageLinkTableResult = {
   considered: 0,
   linked: 0,
@@ -78,10 +85,19 @@ export class CoverPageLinkerService {
   }
 
   /**
-   * Resolve one table in a single statement.
+   * Resolve one table, in bounded batches.
    *
-   * `cvr_filings.external_id` IS the FILING_ID and carries a unique constraint,
-   * so there is exactly one cover page per filing and the join cannot fan out.
+   * `cvr_filings.filing_id` is `@unique`, so exactly one cover page exists per
+   * filing and the join cannot fan out. (That constraint is load-bearing, not
+   * decorative — without it the UPDATE would pick an arbitrary filer.)
+   *
+   * Batched rather than one statement: the first post-rebuild run faces ~1.2M
+   * unattributed rows, and a single transaction there means multi-GB of WAL,
+   * ~1.2M dead tuples across seven indexes, and a lock held for the whole build.
+   * Worse, any statement timeout rolls the entire thing back and the next sync
+   * restarts from zero. Batching costs the same total work but is resumable,
+   * bounds each transaction, and reports progress. Steady-state runs resolve a
+   * handful of rows and exit after one iteration.
    */
   private async linkTable(
     table: LinkedTable,
@@ -89,24 +105,30 @@ export class CoverPageLinkerService {
     const considered = await this.countUnattributed(table);
     if (considered === 0) return { ...EMPTY_TABLE_RESULT };
 
-    const linked = await this.db!.$executeRawUnsafe(
-      `UPDATE "${table}" AS t
-          SET "committee_id" = c."id",
-              "updated_at"   = NOW()
-         FROM "cvr_filings" AS f
-         JOIN "committees"  AS c
-           ON c."external_id" = f."filer_id"
-          AND c."deleted_at" IS NULL
-        WHERE t."committee_id" IS NULL
-          AND t."filing_id" IS NOT NULL
-          AND f."filing_id" = t."filing_id"`,
-    );
+    // Bounded rather than `while (true)`: the loop's exit depends on a value
+    // the database returns, so a driver that ever answered with something
+    // non-numeric would spin forever inside a sync. `+2` covers the final
+    // zero-row probe and any rows inserted while we run.
+    const maxBatches = Math.ceil(considered / LINK_BATCH_SIZE) + 2;
+    let linked = 0;
+    for (let i = 0; i < maxBatches; i++) {
+      const batch = await this.linkBatch(table);
+      if (!batch) break;
+      linked += batch;
+      if (linked < considered) {
+        this.logger.debug(
+          `Cover-page linker (${table}): ${linked}/${considered}`,
+        );
+      }
+    }
 
     const result = {
       ...EMPTY_TABLE_RESULT,
       considered,
       linked,
-      ...(await this.explainRemaining(table, considered - linked)),
+      // max(0): `considered` is counted before the UPDATE, so a concurrent
+      // insert could otherwise drive this negative.
+      ...(await this.explainRemaining(table, Math.max(0, considered - linked))),
     };
 
     this.logger.log(
@@ -116,6 +138,42 @@ export class CoverPageLinkerService {
     );
 
     return result;
+  }
+
+  /**
+   * Attribute up to {@link LINK_BATCH_SIZE} rows; returns how many were stamped.
+   *
+   * The subquery re-applies the full join rather than just filtering on
+   * `committee_id IS NULL`. That matters: rows whose filing has no cover page,
+   * or whose filer matches no committee, are legitimately unresolvable. If the
+   * batch could select those, a batch made up entirely of them would update 0
+   * rows and end the loop while resolvable rows remained further along — a
+   * silent partial link. Selecting only rows that *will* resolve means a
+   * short batch can only mean "nothing left to do".
+   */
+  private async linkBatch(table: LinkedTable): Promise<number> {
+    return this.db!.$executeRawUnsafe(
+      `UPDATE "${table}" AS t
+          SET "committee_id" = c."id",
+              "updated_at"   = NOW()
+         FROM "cvr_filings" AS f
+         JOIN "committees"  AS c
+           ON c."external_id" = f."filer_id"
+          AND c."deleted_at" IS NULL
+        WHERE t."ctid" IN (
+                SELECT s."ctid"
+                  FROM "${table}" AS s
+                  JOIN "cvr_filings" AS sf ON sf."filing_id" = s."filing_id"
+                  JOIN "committees"  AS sc
+                    ON sc."external_id" = sf."filer_id"
+                   AND sc."deleted_at" IS NULL
+                 WHERE s."committee_id" IS NULL
+                   AND s."filing_id" IS NOT NULL
+                 LIMIT ${LINK_BATCH_SIZE}
+              )
+          AND t."committee_id" IS NULL
+          AND f."filing_id" = t."filing_id"`,
+    );
   }
 
   private async countUnattributed(table: LinkedTable): Promise<number> {
@@ -142,12 +200,19 @@ export class CoverPageLinkerService {
       return { skippedNoCoverPage: 0, skippedNoCommittee: 0 };
     }
 
+    // EXISTS, not JOIN: a join would count (row, cover page) pairs rather than
+    // rows, so any fan-out would make hadCoverPage exceed `remaining` and drive
+    // skippedNoCoverPage negative. The unique constraint on cvr_filings.filing_id
+    // should prevent that; this is the belt to its braces.
     const rows = await this.db!.$queryRawUnsafe<Array<{ count: bigint }>>(
       `SELECT COUNT(*)::bigint AS count
          FROM "${table}" AS t
-         JOIN "cvr_filings" AS f ON f."filing_id" = t."filing_id"
         WHERE t."committee_id" IS NULL
-          AND t."filing_id" IS NOT NULL`,
+          AND t."filing_id" IS NOT NULL
+          AND EXISTS (
+                SELECT 1 FROM "cvr_filings" AS f
+                 WHERE f."filing_id" = t."filing_id"
+              )`,
     );
     const hadCoverPage = Number(rows[0]?.count ?? 0);
 

--- a/apps/backend/src/apps/region/src/domains/cover-page-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/cover-page-linker.service.ts
@@ -1,0 +1,159 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+export interface CoverPageLinkTableResult {
+  /** Unattributed rows with a filingId considered this run. */
+  considered: number;
+  /** Rows stamped with a resolved committee this run. */
+  linked: number;
+  /** Still unresolved: no cover page for the filingId. */
+  skippedNoCoverPage: number;
+  /** Cover page found, but its FILER_ID matches no committee row. */
+  skippedNoCommittee: number;
+}
+
+export interface CoverPageLinkResult {
+  contributions: CoverPageLinkTableResult;
+  expenditures: CoverPageLinkTableResult;
+}
+
+/**
+ * The two tables this linker attributes. Declared as a const tuple because the
+ * table name is interpolated into SQL (an identifier, which cannot be bound as
+ * a parameter) — so the only values that can ever reach the statement are these
+ * two compile-time literals, never anything derived from data or user input.
+ */
+const LINKED_TABLES = ['contributions', 'expenditures'] as const;
+type LinkedTable = (typeof LINKED_TABLES)[number];
+
+const EMPTY_TABLE_RESULT: CoverPageLinkTableResult = {
+  considered: 0,
+  linked: 0,
+  skippedNoCoverPage: 0,
+  skippedNoCommittee: 0,
+};
+
+/**
+ * Attribute contributions and expenditures to the committee that FILED them (#980).
+ *
+ * CAL-ACCESS `RCPT_CD` and `EXPN_CD` line items carry no `FILER_ID`, and their
+ * `CMTE_ID` names the *counterparty* — the contributor on a receipt, the payee
+ * on an expenditure — not the filer. The filer lives on the campaign-disclosure
+ * cover page (`CVR_CAMPAIGN_DISCLOSURE_CD`), which the sync persists to
+ * `cvr_filings`. Each row is ingested with a null `committeeId` + its
+ * `filingId`; this linker joins
+ * `filingId → CvrFiling.filingId → CvrFiling.filerId → Committee.externalId`
+ * and stamps the committee.
+ *
+ * Same join as {@link IndependentExpenditureLinkerService} (#955), but set-based
+ * rather than row-by-row. That linker builds one `update()` per pending row for
+ * `batchTransaction`, which is fine for tens of thousands of IEs; contributions
+ * reach ~1.2M rows, where the same shape would mean 1.2M promises across ~2,400
+ * transactions. A single `UPDATE … FROM` does it in one statement per table.
+ *
+ * Post-sync and idempotent: only rows with `committeeId IS NULL` are touched, so
+ * re-running never rewrites or unlinks an already-attributed row. Must run
+ * BEFORE `PropositionFinanceLinkerService` so the committees it stamps are
+ * visible when measure positions are derived.
+ */
+@Injectable()
+export class CoverPageLinkerService {
+  private readonly logger = new Logger(CoverPageLinkerService.name);
+
+  constructor(@Optional() private readonly db?: DbService) {}
+
+  async linkAll(): Promise<CoverPageLinkResult> {
+    if (!this.db) {
+      return {
+        contributions: { ...EMPTY_TABLE_RESULT },
+        expenditures: { ...EMPTY_TABLE_RESULT },
+      };
+    }
+
+    const [contributions, expenditures] = await Promise.all(
+      LINKED_TABLES.map((table) => this.linkTable(table)),
+    );
+
+    return { contributions, expenditures };
+  }
+
+  /**
+   * Resolve one table in a single statement.
+   *
+   * `cvr_filings.external_id` IS the FILING_ID and carries a unique constraint,
+   * so there is exactly one cover page per filing and the join cannot fan out.
+   */
+  private async linkTable(
+    table: LinkedTable,
+  ): Promise<CoverPageLinkTableResult> {
+    const considered = await this.countUnattributed(table);
+    if (considered === 0) return { ...EMPTY_TABLE_RESULT };
+
+    const linked = await this.db!.$executeRawUnsafe(
+      `UPDATE "${table}" AS t
+          SET "committee_id" = c."id",
+              "updated_at"   = NOW()
+         FROM "cvr_filings" AS f
+         JOIN "committees"  AS c
+           ON c."external_id" = f."filer_id"
+          AND c."deleted_at" IS NULL
+        WHERE t."committee_id" IS NULL
+          AND t."filing_id" IS NOT NULL
+          AND f."filing_id" = t."filing_id"`,
+    );
+
+    const result = {
+      ...EMPTY_TABLE_RESULT,
+      considered,
+      linked,
+      ...(await this.explainRemaining(table, considered - linked)),
+    };
+
+    this.logger.log(
+      `Cover-page linker (${table}): linked=${result.linked} ` +
+        `noCoverPage=${result.skippedNoCoverPage} ` +
+        `noCommittee=${result.skippedNoCommittee} (of ${considered} unattributed)`,
+    );
+
+    return result;
+  }
+
+  private async countUnattributed(table: LinkedTable): Promise<number> {
+    // Branch rather than hold the delegate in a variable: the union of Prisma's
+    // two count() overload sets has no callable signature.
+    const where = { committeeId: null, filingId: { not: null } };
+    return table === 'contributions'
+      ? this.db!.contribution.count({ where })
+      : this.db!.expenditure.count({ where });
+  }
+
+  /**
+   * Split the rows the UPDATE did not reach into "no cover page" vs "cover page
+   * but no committee". Only runs when something was actually left behind, so the
+   * common fully-resolved case costs nothing.
+   */
+  private async explainRemaining(
+    table: LinkedTable,
+    remaining: number,
+  ): Promise<
+    Pick<CoverPageLinkTableResult, 'skippedNoCoverPage' | 'skippedNoCommittee'>
+  > {
+    if (remaining <= 0) {
+      return { skippedNoCoverPage: 0, skippedNoCommittee: 0 };
+    }
+
+    const rows = await this.db!.$queryRawUnsafe<Array<{ count: bigint }>>(
+      `SELECT COUNT(*)::bigint AS count
+         FROM "${table}" AS t
+         JOIN "cvr_filings" AS f ON f."filing_id" = t."filing_id"
+        WHERE t."committee_id" IS NULL
+          AND t."filing_id" IS NOT NULL`,
+    );
+    const hadCoverPage = Number(rows[0]?.count ?? 0);
+
+    return {
+      skippedNoCoverPage: remaining - hadCoverPage,
+      skippedNoCommittee: hadCoverPage,
+    };
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/independent-expenditure-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/independent-expenditure-linker.service.ts
@@ -75,7 +75,18 @@ export class IndependentExpenditureLinkerService {
 
     // Cover-page map: FILING_ID -> filer + target. One cover page per filing;
     // guard against duplicates (first wins — the upsert dedups by filingId too).
+    //
+    // Scoped to the pending filings rather than loading the table: #955 built
+    // this against an F496-only cvr_filings of ~31k rows, but #980 broadens the
+    // source to every campaign-disclosure form type (~662k), and the cost of an
+    // unfiltered read would keep scaling with the table.
+    const pendingFilingIds = [
+      ...new Set(
+        pending.map((ie) => ie.filingId).filter((id): id is string => !!id),
+      ),
+    ];
     const covers = await this.db.cvrFiling.findMany({
+      where: { filingId: { in: pendingFilingIds } },
       select: {
         filingId: true,
         filerId: true,

--- a/apps/backend/src/apps/region/src/domains/independent-expenditure-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/independent-expenditure-linker.service.ts
@@ -13,6 +13,12 @@ export interface IndependentExpenditureLinkResult {
   considered: number;
 }
 
+/**
+ * Ids per `in` clause. Well under Postgres's 32,767-bind-parameter ceiling,
+ * which Prisma does not chunk for you.
+ */
+const FILING_ID_CHUNK = 10_000;
+
 /** A Form 496 cover-page row, reduced to the join + target fields the linker uses. */
 type CoverRow = {
   filingId: string;
@@ -80,21 +86,34 @@ export class IndependentExpenditureLinkerService {
     // this against an F496-only cvr_filings of ~31k rows, but #980 broadens the
     // source to every campaign-disclosure form type (~662k), and the cost of an
     // unfiltered read would keep scaling with the table.
+    //
+    // Chunked because Prisma binds one parameter per `in` element and Postgres
+    // caps a prepared statement at 32,767 of them. `pending` is unbounded — the
+    // first run after a rebuild has every S496 row awaiting a committee — and
+    // the sync swallows this linker's failures as a warning, so blowing the
+    // limit would look like "IEs quietly stopped linking".
     const pendingFilingIds = [
       ...new Set(
         pending.map((ie) => ie.filingId).filter((id): id is string => !!id),
       ),
     ];
-    const covers = await this.db.cvrFiling.findMany({
-      where: { filingId: { in: pendingFilingIds } },
-      select: {
-        filingId: true,
-        filerId: true,
-        candidateName: true,
-        propositionTitle: true,
-        supportOrOppose: true,
-      },
-    });
+    const covers: CoverRow[] = [];
+    for (let i = 0; i < pendingFilingIds.length; i += FILING_ID_CHUNK) {
+      covers.push(
+        ...(await this.db.cvrFiling.findMany({
+          where: {
+            filingId: { in: pendingFilingIds.slice(i, i + FILING_ID_CHUNK) },
+          },
+          select: {
+            filingId: true,
+            filerId: true,
+            candidateName: true,
+            propositionTitle: true,
+            supportOrOppose: true,
+          },
+        })),
+      );
+    }
     const coverByFiling = this.indexCoversByFiling(covers);
     if (coverByFiling.size === 0) {
       return {

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.spec.ts
@@ -14,6 +14,8 @@ interface PropRow {
 
 interface ContribRow {
   externalId: string;
+  /// Read directly since #980 — no longer parsed out of externalId.
+  filingId: string | null;
   /// Nullable since #980 — unattributed until the cover-page linker runs.
   committeeId: string | null;
 }
@@ -21,6 +23,7 @@ interface ContribRow {
 interface ExpRow {
   id: string;
   externalId: string;
+  filingId?: string | null;
   committeeId: string;
   propositionTitle: string | null;
   propositionId: string | null;
@@ -67,7 +70,7 @@ function expenditureFindMany(args: any, rows: ExpRow[]): unknown[] {
       .map((e) => ({ id: e.id, propositionTitle: e.propositionTitle }));
   }
   return rows.map((e) => ({
-    externalId: e.externalId,
+    filingId: e.filingId ?? null,
     committeeId: e.committeeId,
   }));
 }
@@ -189,7 +192,7 @@ describe('PropositionFinanceLinkerService', () => {
       contribution: {
         findMany: jest.fn(async () =>
           contributions.map((c) => ({
-            externalId: c.externalId,
+            filingId: c.filingId,
             committeeId: c.committeeId,
           })),
         ),
@@ -283,7 +286,11 @@ describe('PropositionFinanceLinkerService', () => {
         ],
         contributions: [
           // FILING_ID 12345 → committeeId C-A
-          { externalId: '12345:1', committeeId: 'committee-A' },
+          {
+            externalId: '12345:1',
+            filingId: '12345',
+            committeeId: 'committee-A',
+          },
         ],
         cvr2Filings: [
           {
@@ -321,8 +328,12 @@ describe('PropositionFinanceLinkerService', () => {
           // Same FILING_ID, but this row has not been attributed yet. Indexing
           // it would map filing 12345 -> null and, because the index keeps the
           // FIRST hit per filing, shadow the resolved row that follows.
-          { externalId: '12345:1', committeeId: null },
-          { externalId: '12345:2', committeeId: 'committee-A' },
+          { externalId: '12345:1', filingId: '12345', committeeId: null },
+          {
+            externalId: '12345:2',
+            filingId: '12345',
+            committeeId: 'committee-A',
+          },
         ],
         cvr2Filings: [
           {
@@ -454,7 +465,13 @@ describe('PropositionFinanceLinkerService', () => {
             electionDate: new Date(),
           },
         ],
-        contributions: [{ externalId: '12345:1', committeeId: 'committee-A' }],
+        contributions: [
+          {
+            externalId: '12345:1',
+            filingId: '12345',
+            committeeId: 'committee-A',
+          },
+        ],
         cvr2Filings: [
           {
             filingId: '12345',
@@ -497,7 +514,13 @@ describe('PropositionFinanceLinkerService', () => {
             electionDate: new Date(),
           },
         ],
-        contributions: [{ externalId: '12345:1', committeeId: 'committee-A' }],
+        contributions: [
+          {
+            externalId: '12345:1',
+            filingId: '12345',
+            committeeId: 'committee-A',
+          },
+        ],
         cvr2Filings: [
           {
             filingId: '12345',
@@ -531,7 +554,13 @@ describe('PropositionFinanceLinkerService', () => {
             electionDate: new Date(),
           },
         ],
-        contributions: [{ externalId: '12345:1', committeeId: 'committee-A' }],
+        contributions: [
+          {
+            externalId: '12345:1',
+            filingId: '12345',
+            committeeId: 'committee-A',
+          },
+        ],
         cvr2Filings: [
           {
             filingId: '12345',
@@ -560,7 +589,13 @@ describe('PropositionFinanceLinkerService', () => {
             electionDate: ancient,
           },
         ],
-        contributions: [{ externalId: '12345:1', committeeId: 'committee-A' }],
+        contributions: [
+          {
+            externalId: '12345:1',
+            filingId: '12345',
+            committeeId: 'committee-A',
+          },
+        ],
         cvr2Filings: [
           {
             filingId: '12345',

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.spec.ts
@@ -14,7 +14,8 @@ interface PropRow {
 
 interface ContribRow {
   externalId: string;
-  committeeId: string;
+  /// Nullable since #980 — unattributed until the cover-page linker runs.
+  committeeId: string | null;
 }
 
 interface ExpRow {
@@ -304,6 +305,41 @@ describe('PropositionFinanceLinkerService', () => {
       expect(primary?.propositionId).toBe('prop-1');
       expect(primary?.position).toBe('support');
       expect(primary?.sourceFiling).toBe('12345');
+    });
+
+    it('ignores unattributed contributions when indexing filings (#980)', async () => {
+      const built = await buildService({
+        propositions: [
+          {
+            id: 'prop-1',
+            externalId: 'ACA 13',
+            title: 'Voting thresholds',
+            electionDate: new Date(),
+          },
+        ],
+        contributions: [
+          // Same FILING_ID, but this row has not been attributed yet. Indexing
+          // it would map filing 12345 -> null and, because the index keeps the
+          // FIRST hit per filing, shadow the resolved row that follows.
+          { externalId: '12345:1', committeeId: null },
+          { externalId: '12345:2', committeeId: 'committee-A' },
+        ],
+        cvr2Filings: [
+          {
+            filingId: '12345',
+            ballotName: 'Voting thresholds',
+            ballotNumber: 'ACA 13',
+            supportOrOppose: 'S',
+          },
+        ],
+      });
+
+      await built.service.linkAll();
+
+      const primary = built.positionsTable.find(
+        (p) => p.isPrimaryFormation === true,
+      );
+      expect(primary?.committeeId).toBe('committee-A');
     });
 
     it('skips CVR2 rows whose filing or ballot cannot be resolved', async () => {

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.spec.ts
@@ -69,10 +69,7 @@ function expenditureFindMany(args: any, rows: ExpRow[]): unknown[] {
       .filter((e) => e.propositionId === null && e.propositionTitle)
       .map((e) => ({ id: e.id, propositionTitle: e.propositionTitle }));
   }
-  return rows.map((e) => ({
-    filingId: e.filingId ?? null,
-    committeeId: e.committeeId,
-  }));
+  return [];
 }
 
 /** Same shape as expenditureFindMany but for IndependentExpenditure rows. */
@@ -190,12 +187,7 @@ describe('PropositionFinanceLinkerService', () => {
         }),
       },
       contribution: {
-        findMany: jest.fn(async () =>
-          contributions.map((c) => ({
-            filingId: c.filingId,
-            committeeId: c.committeeId,
-          })),
-        ),
+        findMany: jest.fn(async () => []),
       },
       expenditure: {
         findMany: jest.fn(async (args?: any) =>
@@ -222,6 +214,26 @@ describe('PropositionFinanceLinkerService', () => {
       cvr2Filing: {
         findMany: jest.fn(async () => cvr2Filings),
       },
+      // buildFilingToCommitteeIndex now de-duplicates in SQL (#980), so serve
+      // snake_case rows the way Postgres would, one per filing.
+      $queryRawUnsafe: jest.fn(async (sql: string) => {
+        const rows = sql.includes('"contributions"')
+          ? contributions.map((c) => ({
+              filing_id: c.filingId,
+              committee_id: c.committeeId,
+            }))
+          : expRows.map((e) => ({
+              filing_id: e.filingId ?? null,
+              committee_id: e.committeeId,
+            }));
+        const seen = new Set<string>();
+        return rows.filter((r) => {
+          if (!r.filing_id || !r.committee_id) return false;
+          if (seen.has(r.filing_id)) return false;
+          seen.add(r.filing_id);
+          return true;
+        });
+      }),
       committeeMeasurePosition: {
         upsert: upsertPosition,
       },

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
@@ -14,8 +14,8 @@ import { readPositiveInt } from './config-helpers';
  *
  * 1) **CVR2 (FPPC Form 410, authoritative)**: every `cvr2_filings` row gives
  *    `(filingId, ballotName, supportOrOppose)`. We resolve `filingId →
- *    committeeId` by reading `Contribution`/`Expenditure.externalId` (which
- *    encodes FILING_ID per the bulk-download convention), and resolve
+ *    committeeId` by reading the `filing_id` column on
+ *    `Contribution`/`Expenditure` (stamped by `CoverPageLinkerService`), and resolve
  *    `ballotName → propositionId` via the title lookup. Each row that
  *    resolves writes a `CommitteeMeasurePosition` with
  *    `isPrimaryFormation = true` and `sourceFiling = filingId`.
@@ -155,11 +155,7 @@ export class PropositionFinanceLinkerService {
 
   /**
    * Build `filingId → committeeId` from existing Contribution / Expenditure
-   * rows. The bulk-download handler stores externalIds shaped like
-   * `<FILING_ID>:<row index>` (or similar); we extract the FILING_ID prefix
-   * and pair it with the row's `committeeId`.
-   *
-   * Reads the `filing_id` column directly (#980). It previously recovered the
+   * rows, reading the `filing_id` column directly (#980). It previously recovered the
    * filing id by splitting `externalId` on its first `:`/`-`, which the
    * composite `externalId` would have quietly broken — every CVR2 row would
    * have fallen into the `skipped` branch and proposition funding would read

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
@@ -158,14 +158,22 @@ export class PropositionFinanceLinkerService {
    * rows. The bulk-download handler stores externalIds shaped like
    * `<FILING_ID>:<row index>` (or similar); we extract the FILING_ID prefix
    * and pair it with the row's `committeeId`.
+   *
+   * Unattributed rows are excluded in SQL: since #980 the committee is stamped
+   * post-sync by the cover-page linker, so a row with a null `committeeId` has
+   * nothing to contribute to this index yet. Filtering in the query (rather
+   * than after hydration) matters because these reads are unpaginated — once
+   * the re-ingest lands, the unfiltered set is ~1.2M rows.
    */
   private async buildFilingToCommitteeIndex(): Promise<Map<string, string>> {
     const map = new Map<string, string>();
+    const attributed = { committeeId: { not: null } };
 
     const addRows = async (
-      rows: Array<{ externalId: string; committeeId: string }>,
+      rows: Array<{ externalId: string; committeeId: string | null }>,
     ) => {
       for (const r of rows) {
+        if (!r.committeeId) continue;
         const filingId = this.extractFilingId(r.externalId);
         if (filingId && !map.has(filingId)) {
           map.set(filingId, r.committeeId);
@@ -175,11 +183,13 @@ export class PropositionFinanceLinkerService {
 
     await addRows(
       await this.db!.contribution.findMany({
+        where: attributed,
         select: { externalId: true, committeeId: true },
       }),
     );
     await addRows(
       await this.db!.expenditure.findMany({
+        where: attributed,
         select: { externalId: true, committeeId: true },
       }),
     );
@@ -326,8 +336,10 @@ export class PropositionFinanceLinkerService {
     const seen = new Set<string>();
     for (const r of [...expRows, ...ieRows]) {
       if (!r.propositionId) continue;
-      // IE.committeeId is nullable since #955 (unresolved S496 rows) — skip any
-      // not yet attributed to a committee; they can't seed a measure position.
+      // committeeId is nullable on IEs since #955 (unresolved S496 rows) and on
+      // expenditures since #980 (unattributed EXPN rows) — skip any not yet
+      // attributed to a committee; they can't seed a measure position, and
+      // upsertPosition would hit the committee FK.
       if (!r.committeeId) continue;
       const position = this.mapPosition(r.supportOrOppose ?? null);
       if (!position) continue;

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
@@ -164,39 +164,39 @@ export class PropositionFinanceLinkerService {
    * The "first hit per filing wins" rule is now well-defined rather than
    * arbitrary: since the cover-page linker stamps every row of a filing with
    * that filing's *filer*, all rows sharing a `filingId` also share a
-   * `committeeId`. Rows still awaiting attribution are excluded in SQL — both
-   * because they have nothing to contribute, and because these reads are
-   * unpaginated and the table reaches ~1.2M rows.
+   * `committeeId`.
+   *
+   * De-duplicated in SQL via `DISTINCT ON`, not in JS. The map only ever holds
+   * one entry per filing (~662k), but a `findMany` would hydrate one object per
+   * *line item* (~1.2M contributions plus expenditures) to build it — hundreds
+   * of MB of throwaway objects in region-worker at the tail of every sync.
+   * Filtering on `committeeId IS NOT NULL` does not help there: once the
+   * cover-page linker succeeds, nearly every row passes it.
    */
   private async buildFilingToCommitteeIndex(): Promise<Map<string, string>> {
     const map = new Map<string, string>();
-    const attributed = {
-      committeeId: { not: null },
-      filingId: { not: null },
-    };
-    const columns = { filingId: true, committeeId: true };
 
     const addRows = (
-      rows: Array<{ filingId: string | null; committeeId: string | null }>,
+      rows: Array<{ filing_id: string; committee_id: string }>,
     ) => {
       for (const r of rows) {
-        if (!r.filingId || !r.committeeId) continue;
-        if (!map.has(r.filingId)) map.set(r.filingId, r.committeeId);
+        if (!map.has(r.filing_id)) map.set(r.filing_id, r.committee_id);
       }
     };
 
-    addRows(
-      await this.db!.contribution.findMany({
-        where: attributed,
-        select: columns,
-      }),
-    );
-    addRows(
-      await this.db!.expenditure.findMany({
-        where: attributed,
-        select: columns,
-      }),
-    );
+    for (const table of ['contributions', 'expenditures'] as const) {
+      addRows(
+        await this.db!.$queryRawUnsafe<
+          Array<{ filing_id: string; committee_id: string }>
+        >(
+          `SELECT DISTINCT ON ("filing_id") "filing_id", "committee_id"
+             FROM "${table}"
+            WHERE "committee_id" IS NOT NULL
+              AND "filing_id" IS NOT NULL
+            ORDER BY "filing_id"`,
+        ),
+      );
+    }
 
     return map;
   }

--- a/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
+++ b/apps/backend/src/apps/region/src/domains/proposition-finance-linker.service.ts
@@ -159,38 +159,46 @@ export class PropositionFinanceLinkerService {
    * `<FILING_ID>:<row index>` (or similar); we extract the FILING_ID prefix
    * and pair it with the row's `committeeId`.
    *
-   * Unattributed rows are excluded in SQL: since #980 the committee is stamped
-   * post-sync by the cover-page linker, so a row with a null `committeeId` has
-   * nothing to contribute to this index yet. Filtering in the query (rather
-   * than after hydration) matters because these reads are unpaginated — once
-   * the re-ingest lands, the unfiltered set is ~1.2M rows.
+   * Reads the `filing_id` column directly (#980). It previously recovered the
+   * filing id by splitting `externalId` on its first `:`/`-`, which the
+   * composite `externalId` would have quietly broken — every CVR2 row would
+   * have fallen into the `skipped` branch and proposition funding would read
+   * $0 with no error raised.
+   *
+   * The "first hit per filing wins" rule is now well-defined rather than
+   * arbitrary: since the cover-page linker stamps every row of a filing with
+   * that filing's *filer*, all rows sharing a `filingId` also share a
+   * `committeeId`. Rows still awaiting attribution are excluded in SQL — both
+   * because they have nothing to contribute, and because these reads are
+   * unpaginated and the table reaches ~1.2M rows.
    */
   private async buildFilingToCommitteeIndex(): Promise<Map<string, string>> {
     const map = new Map<string, string>();
-    const attributed = { committeeId: { not: null } };
+    const attributed = {
+      committeeId: { not: null },
+      filingId: { not: null },
+    };
+    const columns = { filingId: true, committeeId: true };
 
-    const addRows = async (
-      rows: Array<{ externalId: string; committeeId: string | null }>,
+    const addRows = (
+      rows: Array<{ filingId: string | null; committeeId: string | null }>,
     ) => {
       for (const r of rows) {
-        if (!r.committeeId) continue;
-        const filingId = this.extractFilingId(r.externalId);
-        if (filingId && !map.has(filingId)) {
-          map.set(filingId, r.committeeId);
-        }
+        if (!r.filingId || !r.committeeId) continue;
+        if (!map.has(r.filingId)) map.set(r.filingId, r.committeeId);
       }
     };
 
-    await addRows(
+    addRows(
       await this.db!.contribution.findMany({
         where: attributed,
-        select: { externalId: true, committeeId: true },
+        select: columns,
       }),
     );
-    await addRows(
+    addRows(
       await this.db!.expenditure.findMany({
         where: attributed,
-        select: { externalId: true, committeeId: true },
+        select: columns,
       }),
     );
 
@@ -458,17 +466,5 @@ export class PropositionFinanceLinkerService {
       .replaceAll(/[^a-z0-9\s]/g, ' ')
       .replaceAll(/\s+/g, ' ')
       .trim();
-  }
-
-  /**
-   * Pull the FILING_ID prefix out of an externalId. The bulk-download
-   * handler concatenates FILING_ID + a row discriminator with either ':'
-   * or '-' as the separator; we conservatively split on either. If no
-   * separator exists, the entire externalId is treated as the filing id.
-   */
-  private extractFilingId(externalId: string): string | null {
-    if (!externalId) return null;
-    const idx = externalId.search(/[:-]/);
-    return idx >= 0 ? externalId.slice(0, idx) : externalId;
   }
 }

--- a/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
@@ -933,23 +933,40 @@ describe('RegionQueryService — query methods', () => {
         }),
       );
     });
+
+    it('excludes unattributed rows when no committee filter is given (#980)', async () => {
+      mockDb.contribution.findMany.mockResolvedValue([]);
+      mockDb.contribution.count.mockResolvedValue(0);
+
+      await service.getContributions();
+
+      // RCPT line items sit unattributed until the cover-page linker resolves
+      // filingId -> recipient; they are staging, not public money-trail data.
+      const expected = { where: { committeeId: { not: null } } };
+      expect(mockDb.contribution.findMany).toHaveBeenCalledWith(
+        expect.objectContaining(expected),
+      );
+      expect(mockDb.contribution.count).toHaveBeenCalledWith(expected);
+    });
   });
 
   describe('getContribution', () => {
     it('should return a single contribution by ID', async () => {
       const mockContrib = { id: '1', donorName: 'Jane Smith' };
-      mockDb.contribution.findUnique.mockResolvedValue(mockContrib as never);
+      mockDb.contribution.findFirst.mockResolvedValue(mockContrib as never);
 
       const result = await service.getContribution('1');
 
       expect(result).toEqual(mockContrib);
-      expect(mockDb.contribution.findUnique).toHaveBeenCalledWith({
-        where: { id: '1' },
+      // findFirst (not findUnique) so it can also require a resolved committee —
+      // unattributed RCPT staging rows are treated as not-found for GraphQL (#980).
+      expect(mockDb.contribution.findFirst).toHaveBeenCalledWith({
+        where: { id: '1', committeeId: { not: null } },
       });
     });
 
     it('should return null if contribution not found', async () => {
-      mockDb.contribution.findUnique.mockResolvedValue(null);
+      mockDb.contribution.findFirst.mockResolvedValue(null);
 
       const result = await service.getContribution('nonexistent');
 
@@ -1002,23 +1019,37 @@ describe('RegionQueryService — query methods', () => {
         }),
       );
     });
+
+    it('excludes unattributed rows when no committee filter is given (#980)', async () => {
+      mockDb.expenditure.findMany.mockResolvedValue([]);
+      mockDb.expenditure.count.mockResolvedValue(0);
+
+      await service.getExpenditures();
+
+      const expected = { where: { committeeId: { not: null } } };
+      expect(mockDb.expenditure.findMany).toHaveBeenCalledWith(
+        expect.objectContaining(expected),
+      );
+      expect(mockDb.expenditure.count).toHaveBeenCalledWith(expected);
+    });
   });
 
   describe('getExpenditure', () => {
     it('should return a single expenditure by ID', async () => {
       const mockExp = { id: '1', payeeName: 'Ad Agency Inc' };
-      mockDb.expenditure.findUnique.mockResolvedValue(mockExp as never);
+      mockDb.expenditure.findFirst.mockResolvedValue(mockExp as never);
 
       const result = await service.getExpenditure('1');
 
       expect(result).toEqual(mockExp);
-      expect(mockDb.expenditure.findUnique).toHaveBeenCalledWith({
-        where: { id: '1' },
+      // Same as getContribution: unattributed EXPN staging rows read as not-found (#980).
+      expect(mockDb.expenditure.findFirst).toHaveBeenCalledWith({
+        where: { id: '1', committeeId: { not: null } },
       });
     });
 
     it('should return null if expenditure not found', async () => {
-      mockDb.expenditure.findUnique.mockResolvedValue(null);
+      mockDb.expenditure.findFirst.mockResolvedValue(null);
 
       const result = await service.getExpenditure('nonexistent');
 

--- a/apps/backend/src/apps/region/src/domains/region-query.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.ts
@@ -178,7 +178,9 @@ type CommitteeRecord = {
 type ContributionRecord = {
   id: string;
   externalId: string;
-  committeeId: string;
+  /// Null until the cover-page linker attributes the filing (#980).
+  committeeId: string | null;
+  filingId: string | null;
   donorName: string;
   donorType: string;
   donorEmployer: string | null;
@@ -198,7 +200,9 @@ type ContributionRecord = {
 type ExpenditureRecord = {
   id: string;
   externalId: string;
-  committeeId: string;
+  /// Null until the cover-page linker attributes the filing (#980).
+  committeeId: string | null;
+  filingId: string | null;
   payeeName: string;
   amount: Prisma.Decimal;
   date: Date;
@@ -1073,10 +1077,17 @@ export class RegionQueryService {
     committeeId?: string,
     sourceSystem?: string,
   ): Promise<PaginatedContributions> {
-    const where: Record<string, unknown> = {};
+    // Only surface attributed contributions: RCPT_CD line items sit with a null
+    // committeeId until the cover-page linker resolves filingId -> recipient
+    // (#980). Unresolved rows are staging, not public money-trail data, and the
+    // GraphQL committeeId is non-null — exclude them, as IEs do (#955).
+    const where: Record<string, unknown> = { committeeId: { not: null } };
+    // Overwriting the guard is safe *only* because an explicit id is non-null,
+    // which is strictly narrower. A future filter on a nullable column (e.g.
+    // filingId) must merge rather than replace.
     if (committeeId) where.committeeId = committeeId;
     if (sourceSystem) where.sourceSystem = sourceSystem;
-    const whereClause = Object.keys(where).length > 0 ? where : undefined;
+    const whereClause = where;
 
     const [items, total] = await Promise.all([
       this.db.contribution.findMany({
@@ -1094,6 +1105,8 @@ export class RegionQueryService {
     return {
       items: paginatedItems.map((item: ContributionRecord) => ({
         ...item,
+        // Non-null by the committeeId filter above; Prisma's type stays nullable.
+        committeeId: item.committeeId as string,
         amount: Number(item.amount),
         donorEmployer: item.donorEmployer ?? undefined,
         donorOccupation: item.donorOccupation ?? undefined,
@@ -1109,7 +1122,12 @@ export class RegionQueryService {
   }
 
   async getContribution(id: string) {
-    return this.db.contribution.findUnique({ where: { id } });
+    // findFirst (not findUnique) so we can also require a resolved committee —
+    // an unattributed RCPT staging row is treated as not-found for GraphQL,
+    // mirroring getIndependentExpenditure (#980).
+    return this.db.contribution.findFirst({
+      where: { id, committeeId: { not: null } },
+    });
   }
 
   async getExpenditures(
@@ -1118,10 +1136,15 @@ export class RegionQueryService {
     committeeId?: string,
     sourceSystem?: string,
   ): Promise<PaginatedExpenditures> {
-    const where: Record<string, unknown> = {};
+    // Same as contributions above: EXPN_CD line items are unattributed until the
+    // cover-page linker resolves filingId -> spender (#980).
+    const where: Record<string, unknown> = { committeeId: { not: null } };
+    // Overwriting the guard is safe *only* because an explicit id is non-null,
+    // which is strictly narrower. A future filter on a nullable column (e.g.
+    // filingId) must merge rather than replace.
     if (committeeId) where.committeeId = committeeId;
     if (sourceSystem) where.sourceSystem = sourceSystem;
-    const whereClause = Object.keys(where).length > 0 ? where : undefined;
+    const whereClause = where;
 
     const [items, total] = await Promise.all([
       this.db.expenditure.findMany({
@@ -1139,6 +1162,8 @@ export class RegionQueryService {
     return {
       items: paginatedItems.map((item: ExpenditureRecord) => ({
         ...item,
+        // Non-null by the committeeId filter above; Prisma's type stays nullable.
+        committeeId: item.committeeId as string,
         amount: Number(item.amount),
         purposeDescription: item.purposeDescription ?? undefined,
         expenditureCode: item.expenditureCode ?? undefined,
@@ -1152,7 +1177,10 @@ export class RegionQueryService {
   }
 
   async getExpenditure(id: string) {
-    return this.db.expenditure.findUnique({ where: { id } });
+    // Same as getContribution: unattributed EXPN staging rows read as not-found.
+    return this.db.expenditure.findFirst({
+      where: { id, committeeId: { not: null } },
+    });
   }
 
   async getIndependentExpenditures(

--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -52,6 +52,7 @@ import { MinutesSummaryService } from './minutes-summary.service';
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
 import { CandidateCommitteeLinkerService } from './candidate-committee-linker.service';
 import { IndependentExpenditureLinkerService } from './independent-expenditure-linker.service';
+import { CoverPageLinkerService } from './cover-page-linker.service';
 import { PropositionFundingService } from './proposition-funding.service';
 import { RepresentativeFundingService } from './representative-funding.service';
 import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
@@ -220,6 +221,7 @@ const promptClientAsyncConfig = {
     PropositionFinanceLinkerService,
     CandidateCommitteeLinkerService,
     IndependentExpenditureLinkerService,
+    CoverPageLinkerService,
     PropositionFundingService,
     RepresentativeFundingService,
     LegislativeCommitteeLinkerService,

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -744,6 +744,8 @@ export class RegionResolver {
     if (!result) return null;
     return {
       ...result,
+      // Non-null: getContribution filters committeeId != null (#980).
+      committeeId: result.committeeId as string,
       amount: Number(result.amount),
       donorEmployer: result.donorEmployer ?? undefined,
       donorOccupation: result.donorOccupation ?? undefined,
@@ -786,6 +788,8 @@ export class RegionResolver {
     if (!result) return null;
     return {
       ...result,
+      // Non-null: getExpenditure filters committeeId != null (#980).
+      committeeId: result.committeeId as string,
       amount: Number(result.amount),
       purposeDescription: result.purposeDescription ?? undefined,
       expenditureCode: result.expenditureCode ?? undefined,

--- a/docs/plans/980-cal-access-contribution-mapping.md
+++ b/docs/plans/980-cal-access-contribution-mapping.md
@@ -7,10 +7,10 @@
 | **Related** | [#979](https://github.com/OpusPopuli/opuspopuli/issues/979), [#962](https://github.com/OpusPopuli/opuspopuli/issues/962), [#982](https://github.com/OpusPopuli/opuspopuli/issues/982), [#983](https://github.com/OpusPopuli/opuspopuli/issues/983), [#954](https://github.com/OpusPopuli/opuspopuli/issues/954) |
 | **Date** | 2026-08-09 (rewritten around the clean cutover) |
 | **Author** | Rodney Gagnon |
-| **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases ~6x when this lands. |
+| **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases ~83x when this lands (see the C4 blocker — the file holds 20.2M rows, not the 1.21M previously assumed). |
 | **Branch** | `fix/980-cal-access-contribution-mapping` (+ `opuspopuli-regions`) |
 | **Effort** | 3–4 focused sessions + one supervised cutover |
-| **Status** | Code complete through C3. Next: C4 — the supervised truncate + rebuild. |
+| **Status** | Code complete through C3. **C4 blocked**: pipeline reads ~6% of RCPT_CD (20.2M rows in file vs 1.21M extracted). |
 
 ## Problem
 
@@ -64,8 +64,10 @@ happen downstream of it, which is why nothing surfaced as a failure.
 exactly equal to the name of the committee their `committee_id` points at; the remainder are the
 same entities under different spellings (#954). A recipient does not donate to itself 40,003 times.
 
-**Secondary — `TRAN_ID` is not unique** across filings, but the sync upserts on `externalId`. Real
-key is `FILING_ID + AMEND_ID + LINE_ITEM + TRAN_ID`. `EXPN_CD` shares the pattern.
+**Secondary — `TRAN_ID` is not unique** across filings, but the sync upserts on `externalId`.
+Key is `FILING_ID + LINE_ITEM + TRAN_ID`. `EXPN_CD` shares the pattern. (This spike originally
+concluded `AMEND_ID` belonged in the key; measuring the file later showed that double-counts
+restated amendments — see "Amendment double-count" below.)
 
 ## What already exists
 
@@ -287,28 +289,49 @@ Applied after a three-lens review of C1–C3:
   when it throws — the ordering the whole design rests on, previously unasserted; plus the
   one-cover-page-per-filing constraint.
 
-### ⚠️ C4 gate — verify amendment handling before rebuilding
+### Amendment double-count ✅ settled (2026-08-09) — `AMEND_ID` dropped
 
-**Unresolved, and it can invert the fix.** CAL-ACCESS retains every amendment of a filing in
-`RCPT_CD`/`EXPN_CD` — same `FILING_ID`, incremented `AMEND_ID` — and an amendment restates the whole
-schedule. `cvr_filings` is deduped by `FILING_ID` (`domain-mapper.service.ts:395`), but line items
-now are not: `AMEND_ID` sits in the composite key, so an amended $500 receipt lands twice and the
-linker stamps both with the same filer. `totalRaised` reads $1,000.
+**Confirmed against the real file**, not inferred. Downloaded the 2026-08-09 `dbwebexport.zip`
+(1,575,315,615 bytes, byte-verified) and counted in one streaming pass:
 
-The old `TRAN_ID`-only key accidentally deduped this. So C1 fixes cross-filing collisions and may
-introduce amendment inflation **on the exact metric this issue exists to correct**. Note the extract
-counts (1,210,475 → 203,945) were attributed to blank-`CMTE_ID` rejections plus `TRAN_ID` collisions;
-if a meaningful share was actually amendment restatements, the new key inflates.
+| | `RCPT_CD` | `EXPN_CD` |
+|---|---:|---:|
+| Data rows | 20,177,193 | 15,742,863 |
+| Distinct **with** `AMEND_ID` (shipped 1.0.77) | 20,177,187 | 15,742,863 |
+| Distinct **without** `AMEND_ID` | 17,000,354 | 13,834,048 |
+| **Restatements** | **3,176,833** (~16%) | **1,908,815** (~12%) |
 
-Check against the bulk file before any rebuild:
+31.7% of `RCPT_CD` rows carry a non-zero `AMEND_ID`; 178,040 distinct `(FILING_ID, AMEND_ID)` pairs
+against 142,264 filings. So CAL-ACCESS restates the whole schedule on amendment, and **~5.09M rows
+would have been double-counted** — inflating the exact metric this issue exists to correct.
 
-```
-awk -F'\t' 'NR>1{print $1"\t"$2}' RCPT_CD.TSV | sort -u | cut -f1 | uniq -d | wc -l
-```
+Fixed in `opuspopuli-regions` PR #66 (config v1.11.0), which **supersedes 1.0.77**. A later
+amendment now upserts over the earlier version.
 
-Non-zero ⇒ either drop `AMEND_ID` from the `compositeKey` (last amendment upserts over earlier ones)
-or add a latest-amendment filter. Either way it is a `@opuspopuli/regions` change, so settle it
-before publishing the version the rebuild consumes.
+**Known residual, accepted deliberately.** Of 29,420 filings with more than one version: 18,655 keep
+their row count, 9,052 grow, and **1,713 shrink** — the amendment *removed* transactions, which have
+nothing to overwrite them and will persist. That is ~0.2% of rows against ~16% for the shipped key.
+Proper fix (follow-up): store `amend_id` and supersede non-latest versions post-sync — which also
+preserves the audit trail, arguably the right shape for a transparency platform. Same follow-up
+removes the last-write-wins nondeterminism from the 454 rows where `AMEND_ID` decreases in file order.
+
+### ⚠️ C4 blocker — the pipeline reads ~6% of the source
+
+**`RCPT_CD.TSV` has 20,177,193 data rows. The production run recorded `items_extracted: 1,210,475`.**
+A 16× gap, found while settling the amendment question.
+
+This resets the scale assumptions this plan was written against:
+
+- post-fix `contributions` is **~17M rows, not ~1.2M**
+- PII volume grows **~83×** from today's 203,945, not the ~6× recorded below
+- rebuild duration, batch sizing, index strategy, and the `@Public()` bulk-scrape question all get
+  materially worse
+
+`MAX_RECORDS = 100_000` in `bulk-download.handler.ts` sits on the non-streaming path, so it does not
+explain 1.21M. Not diagnosed further: dev holds no finance rows and the Studio was unreachable.
+
+**This blocks C4.** Rebuilding against a pipeline that reads 6% of the source yields confidently
+wrong figures — a worse failure than today's, because they look plausible.
 
 ### C4. Truncate + rebuild
 

--- a/docs/plans/980-cal-access-contribution-mapping.md
+++ b/docs/plans/980-cal-access-contribution-mapping.md
@@ -11,7 +11,7 @@
 | **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases ~6x if this lands. |
 | **Branch** | `fix/980-cal-access-contribution-mapping` (+ `opuspopuli-regions`, + migration) |
 | **Effort** | 4–6 focused sessions |
-| **Status** | Plan rewritten. Subtask 1 (spike) complete — findings below. |
+| **Status** | Subtasks 0, 1, 3 complete. Next: 2 and 5, then 4. |
 
 ## Problem
 
@@ -87,11 +87,54 @@ broadened cover-page source no longer risks colliding with a sibling over the sa
 - Add optional `compositeKey: string[]` joining source columns with a stable separator.
 - **Tests:** key construction, collision behavior, back-compat when absent.
 
-### 3. `filing_id` on contributions and expenditures
+### 3. `filing_id` on contributions and expenditures ✅ done (2026-08-09)
 
-- **Where:** `supabase/migrations/` (use `/op-migration`), `packages/relationaldb-provider/prisma/schema.prisma`
-- Additive only: nullable `filing_id` + index. No drops, no renames.
-- **Tests:** integration test against the real test DB (never mock the DB layer).
+- **Migration:** `packages/relationaldb-provider/prisma/migrations/20260809000000_contribution_expenditure_cover_page_join/`
+  — not `supabase/migrations/`, which holds only `99_vault_functions.sql`; schema migrations are
+  Prisma-managed here, as #955's was.
+- Additive + widening: nullable `filing_id` VARCHAR(50) + index on both tables. No drops, no renames.
+  Both `ALTER`s are catalog-only in Postgres, so neither rewrites the ~204k-row table.
+
+**Scope correction.** The plan said "nullable `filing_id` + index" only, but dropping the
+`CMTE_ID → committeeId` mapping (subtask 5) makes a `NOT NULL committee_id` unsatisfiable — so
+`ALTER COLUMN committee_id DROP NOT NULL` had to ride along on both tables, exactly as #955 did for
+`independent_expenditures`. Consequences handled here:
+
+- **The FK footgun.** Prisma defaults an *optional* relation to `onDelete: SetNull`. Left implicit,
+  relaxing NOT NULL would have silently converted both FKs, so deleting a committee would orphan its
+  finance rows to `committee_id = NULL` — indistinguishable from "unresolved, please stamp". The
+  schema pins `onDelete: Restrict`; verified in the DB as `confdeltype = 'r'` and covered by two
+  integration tests.
+- **GraphQL stays non-null.** `getContributions`/`getExpenditures` (and the by-id fetches, now
+  `findFirst`) filter `committeeId: { not: null }`, so unattributed staging rows never surface —
+  the same treatment #955 gave S496 rows. No federation schema change, so the nullability question
+  in subtask 4 stays open rather than being pre-decided.
+- `PropositionFinanceLinkerService.buildFilingToCommitteeIndex` now skips null-committee rows. It
+  keeps the *first* hit per filing, so an unattributed row would otherwise shadow a resolved one.
+
+**Tests:** `apps/backend/__tests__/integration/region/contribution-cover-page-columns.integration.spec.ts`
+— 10 cases against real `postgres_test` (column shape, nullability, indexes, pre-link inserts, FK
+RESTRICT on both tables), plus unit coverage for the new query filters and the linker skip.
+Full backend suite green (2301 tests); `tsc --noEmit` adds no new errors over baseline.
+
+> Note for whoever runs this locally: `pnpm test:integration` gates on all five HTTP services being
+> up, though `bootstrapTestDatabase()` (which applies the migration) runs first, before that gate.
+
+**Rollback** (no down-file convention here — Prisma-managed, and #955 shipped none):
+
+```sql
+DROP INDEX IF EXISTS "expenditures_filing_id_idx";
+DROP INDEX IF EXISTS "contributions_filing_id_idx";
+ALTER TABLE "expenditures"  DROP COLUMN IF EXISTS "filing_id";
+ALTER TABLE "contributions" DROP COLUMN IF EXISTS "filing_id";
+
+-- NOT reversible unattended: SET NOT NULL scans the table and FAILS if the linker
+-- left any row unresolved. Resolve or remove those first, e.g.
+--   DELETE FROM "expenditures"  WHERE "committee_id" IS NULL;
+--   DELETE FROM "contributions" WHERE "committee_id" IS NULL;
+ALTER TABLE "expenditures"  ALTER COLUMN "committee_id" SET NOT NULL;
+ALTER TABLE "contributions" ALTER COLUMN "committee_id" SET NOT NULL;
+```
 
 ### 4. Cover-page-join resolution
 
@@ -99,6 +142,30 @@ broadened cover-page source no longer risks colliding with a sibling over the sa
 - Resolve `contributions.filing_id → cvr_filings.filer_id → committees.external_id`.
 - Follow `IndependentExpenditureLinkerService` (#955) — same shape, already reviewed.
 - **Tests:** unit tests for resolution + reconcile; integration test for the full join.
+
+### 4b. Write path for `filing_id` — **hard prerequisite for 5** (found in review, 2026-08-09)
+
+Subtask 3 added the column; nothing can populate it yet. Three edits are needed, and #955 did all
+three for `independent_expenditures` — copy that shape:
+
+1. `packages/scraping-pipeline/src/mapping/domain-mapper.service.ts:898,935` — `ContributionSchema`
+   / `ExpenditureSchema` need `filingId` added and `committeeId` relaxed to `.optional()`.
+   `z.object()` **strips unknown keys**, so without this the mapper deletes `filingId` before the
+   sync ever sees it, no matter what the region config maps.
+2. `packages/common/src/providers/region/types.ts` — same shape change on the `Contribution` /
+   `Expenditure` interfaces.
+3. `apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts:441,460` — add
+   `'filingId'` to both `fields` projections. `upsertRecordsByFields` picks *only* the listed
+   fields, so the column stays NULL otherwise.
+
+**Sequencing trap:** relaxing `committeeId` in the zod schema *before* the region config drops the
+`CMTE_ID → committeeId` mapping would admit ~1M currently-dropped rows carrying the **wrong**
+committee. Relax it and change the config in the same deploy. Conversely, if the config changes
+first without the schema relax, every RCPT/EXPN row fails `safeParse` and is dropped with only a
+`logger.debug` — a sync that reports success having ingested zero contributions.
+
+**Also:** the new cover-page linker must run *before* `propositionFinanceLinker.linkAll()` in
+`campaign-finance-sync.service.ts:181-199`, the way the IE linker already is.
 
 ### 5. Column mappings
 
@@ -129,6 +196,49 @@ broadened cover-page source no longer risks colliding with a sibling over the sa
   `pnpm test:a11y`.
 
 **Ordering:** #984 first. Then 2, 3, 5 in parallel; 4 after 3; 6 after all; 7–8 after 6.
+
+**Deploy ordering (added 2026-08-09).** The migration is inert on its own — nothing writes a NULL
+committee until subtask 5 ships. But between 5 landing and the linker (4) running, freshly-ingested
+rows sit unattributed and are excluded from GraphQL, so `totalRaised` reads *low* rather than wrong.
+That's the intended failure mode, and it argues for 4 shipping before 5, not merely before 6.
+
+## Found in review of subtask 3 (2026-08-09) — not yet filed
+
+**`committee_measure_positions` is never purged, and it is downstream of the bad attribution.**
+`PropositionFinanceLinkerService` only ever `upsert`s (`:380`); nothing deletes. Two consequences:
+
+- `buildFilingToCommitteeIndex` maps `filingId → contribution.committeeId`, which per this issue's
+  own premise is the **counterparty**, and writes it as a position with `isPrimaryFormation = true`.
+  `PropositionFundingService.computeSide` then sums those committees' money into public
+  `totalRaised` / `totalSpent`. So proposition support/oppose totals are wrong today by the same
+  mechanism as representative totals — this issue's scope is wider than the `contributions` table.
+- Once subtask 4 stamps correct committees, the correct positions are **added alongside** the stale
+  wrong ones and both get summed. Subtask 6 therefore needs to purge and re-link
+  `committee_measure_positions`, not just delete and re-ingest the finance rows.
+
+**`extractFilingId` breaks silently when subtask 2 lands.** It recovers FILING_ID by splitting
+`externalId` on the first `:`/`-` (`:462`). Once `compositeKey` changes that layout, it returns
+garbage, every CVR2 row hits the `skipped` branch, and proposition funding quietly reads $0 — no
+exception, and the specs hardcode `12345:1` so nothing fails. Subtask 4 should re-point the linker
+at the new `filing_id` column, which also removes the unpaginated full-table load and the
+nondeterministic "first hit per filing wins" (those `findMany`s have no `orderBy`, so a filing with
+several contributors resolves to a different committee run to run).
+
+**Re-sync alone will not clear the existing bad `committee_id`s.** `upsertRecordsByFields`'s `pick`
+(`campaign-finance-sync.service.ts:556`) emits `committeeId: undefined` for absent fields, and
+Prisma treats `undefined` in `update` as *leave unchanged*. This is the mechanism behind subtask 6's
+"upsert will not converge" note — the scoped delete is mandatory, not merely tidier.
+
+**PII masking gap (confirms an open question above).** `PARTIAL_MASK_FIELDS` in
+`apps/backend/src/common/utils/pii-masker.ts:23` is only `email`/`phone`/`phonenumber` — no donor
+fields. Harmless today (the audit interceptor logs args, never results), but any future
+`logger.debug({ contribution })` writes unmasked donor PII to Loki.
+
+**Bulk-scrape exposure at 6x volume.** `contributions`, `contribution(id)` and `expenditures` are
+`@Public()` (pre-existing, unchanged here), and `PaginationArgs` caps `take` at 100 but leaves
+`skip` unbounded. Today that's a ~20-minute anonymous scrape of 204k donor records; after subtask 6
+it is ~1.2M. Public record under CA law, but name + employer + occupation + ZIP+4 in bulk is a
+different risk profile than record-by-record lookup. Worth an explicit decision before 6 lands.
 
 ## Adjacent defects — split out
 

--- a/docs/plans/980-cal-access-contribution-mapping.md
+++ b/docs/plans/980-cal-access-contribution-mapping.md
@@ -1,196 +1,177 @@
-# Plan: CAL-ACCESS contribution column mapping (#980)
+# Plan: RCPT contributions cover-page join (#980)
 
 | | |
 |---|---|
 | **Issue** | [#980](https://github.com/OpusPopuli/opuspopuli/issues/980) |
-| **Related** | [#979](https://github.com/OpusPopuli/opuspopuli/issues/979) (linker attribution), [#962](https://github.com/OpusPopuli/opuspopuli/issues/962) (P0 false-attribution liability), [#954](https://github.com/OpusPopuli/opuspopuli/issues/954) (donor-name fragmentation, closed) |
-| **Date** | 2026-08-08 |
+| **Blocked by** | [#984](https://github.com/OpusPopuli/opuspopuli/issues/984) — cover-page source silently skipped |
+| **Precedent** | [#955](https://github.com/OpusPopuli/opuspopuli/issues/955) — the same join, already solved for S496 |
+| **Related** | [#979](https://github.com/OpusPopuli/opuspopuli/issues/979), [#962](https://github.com/OpusPopuli/opuspopuli/issues/962), [#982](https://github.com/OpusPopuli/opuspopuli/issues/982), [#983](https://github.com/OpusPopuli/opuspopuli/issues/983), [#954](https://github.com/OpusPopuli/opuspopuli/issues/954) |
+| **Date** | 2026-08-08 (rewritten after raw-file verification) |
 | **Author** | Rodney Gagnon |
-| **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases materially if this lands. |
-| **Branch** | `fix/980-cal-access-contribution-mapping` (+ matching branch in `opuspopuli-regions`) |
-| **Effort** | 3–5 focused sessions |
-| **Status** | Approved. Defect A confirmed empirically 2026-08-08; subtask 1 narrowed to fix-design details |
+| **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases ~6x if this lands. |
+| **Branch** | `fix/980-cal-access-contribution-mapping` (+ `opuspopuli-regions`, + migration) |
+| **Effort** | 4–6 focused sessions |
+| **Status** | Plan rewritten. Subtask 1 (spike) complete — findings below. |
 
-## Problem restatement
+## Problem
 
-The issue was filed as "itemization is shallow." Investigation indicates that is a *symptom* of two
-defects in the `RCPT_CD.TSV` column mapping in
-`opuspopuli-regions/regions/california/california.json` (`config.dataSources[7]`).
+`RCPT_CD.TSV` maps `CMTE_ID → committeeId`. `CMTE_ID` is the **contributing** committee. `RCPT_CD`
+contains no recipient column, so the recipient is only reachable by joining `FILING_ID` to the
+`CVR_CAMPAIGN_DISCLOSURE_CD` cover page.
 
-### Defect A — `CMTE_ID` is the wrong source column for `committeeId` ✅ confirmed
+Because `ContributionSchema` requires `committeeId: z.string().min(1)`, every row with a blank
+`CMTE_ID` — every individual donor — is dropped by the mapper. What survives is committee-to-committee
+transfers, attributed backwards: `totalRaised` sums money each committee **paid out**.
 
-In CAL-ACCESS, `FILER_ID` identifies the committee that filed the report — the one **receiving** the
-contribution. `CMTE_ID` is populated on the **contributor** side when a committee gives to another
-committee.
+This is [#955](https://github.com/OpusPopuli/opuspopuli/issues/955)'s defect in the contributions
+table. That issue's title was almost verbatim the same problem for S496.
 
-`ContributionSchema` in `packages/scraping-pipeline/src/mapping/domain-mapper.service.ts` requires
-`committeeId: z.string().min(1)`, so every row with a blank `CMTE_ID` is dropped silently by the
-mapper. Live data matches that prediction:
+## Subtask 1 — spike ✅ complete (2026-08-08)
+
+Verified against the 2026-08-08 bulk export (1.58 GB zip; `RCPT_CD.TSV` is 3.8 GB uncompressed,
+under the handler's 10 GB `MAX_UNCOMPRESSED_SIZE`). Archive paths are `CalAccess/DATA/…`, not
+`CAL-ACCESS/DATA/…`.
+
+**`RCPT_CD` has 63 columns and no `FILER_ID`.** The originally-planned "map `FILER_ID` instead of
+`CMTE_ID`" fix is impossible. Relevant columns:
+
+| # | Column | Role |
+|---|---|---|
+| 1 | `FILING_ID` | joins to the cover page → recipient |
+| 2 | `AMEND_ID` | composite key component |
+| 3 | `LINE_ITEM` | composite key component |
+| 6 | `TRAN_ID` | composite key component (not unique alone) |
+| 25 | `CMTE_ID` | **contributor's** committee — sits inside the `CTRIB_*` block |
+
+**`CVR_CAMPAIGN_DISCLOSURE_CD` supplies the recipient:** `FILING_ID` (1), `FILER_ID` (5),
+`FILER_NAML` (7).
+
+**The data arrives; we lose it.** `pipeline_executions`, us-ca node:
 
 ```
-committee  151,986   ← CMTE_ID populated, survives
-individual  29,809   ← CMTE_ID mostly blank, dropped
-party       12,492
-other        9,658
+RCPT_CD.TSV   2026-08-05   items_extracted: 1,210,475   items_failed: 0
+contributions (source_system='cal_access'):                203,945
 ```
 
-Individual donors outnumbering committees ~5:1 is the real-world shape; the stored data is the
-inverse. This also explains the Mia Bonta page anomaly, where "Top donors" mirrored the committee
-list with near-identical amounts — `donorName` and `committeeId` were describing the *same*
-contributing committee.
+~1M rows dropped after the extraction counter — schema rejects and `TRAN_ID` upsert collapse both
+happen downstream of it, which is why nothing surfaced as a failure.
 
-Contribution attribution is therefore **semantically inverted**: money the committee paid *out* is
-being counted as money it *raised*.
+**Defect A confirmed empirically.** Of 151,986 committee-donor rows, 40,003 have a `donor_name`
+exactly equal to the name of the committee their `committee_id` points at; the remainder are the
+same entities under different spellings (#954). A recipient does not donate to itself 40,003 times.
 
-#### Confirmation (2026-08-08)
+**Secondary — `TRAN_ID` is not unique** across filings, but the sync upserts on `externalId`. Real
+key is `FILING_ID + AMEND_ID + LINE_ITEM + TRAN_ID`. `EXPN_CD` shares the pattern.
 
-Tested directly against the us-ca node. If `committee_id` were the *recipient*, a committee-type
-donor's name would essentially never equal the name of the committee the row points at. Result:
+## What already exists
 
-```
-committee-donor rows           151,986
-exact name match                40,003   (26.3%)
-normalized (alnum-only) match            (28.8%)
-```
+- `committees.external_id` **is** `FILER_ID` (via `dataSources[12]`)
+- `cvr_filings` already stores `filing_id → filer_id` (via `dataSources[10]`, built for #955)
+- `IndependentExpenditureLinkerService` is a working reference implementation of this join
 
-40,003 exact self-matches refutes the recipient reading outright. The remaining ~71% are the *same
-entities under different spellings* — #954 donor-name fragmentation defeating the string comparison,
-not a different relationship:
-
-| `committees.name` (via `committee_id`) | `contributions.donor_name` |
-|---|---|
-| RAYTHEON CALIFORNIA POLITICAL ACTION COMMITTEE | Raytheon California PAC |
-| Orange County Employees Association Political Action Committee | Orange County Employees Assoc. |
-| Turkish Coalition California PAC (TC-CAL PAC) | Turkish Coalition California PAC |
-| Howard F. Ahmanson/Fieldstead & Company | Fieldstead & Company |
-
-Defect A is confirmed. No bulk download was required to establish it.
-
-### Defect B — `TRAN_ID` is not a globally unique key
-
-`TRAN_ID` is unique within a filing, not across filings. `CampaignFinanceSyncService` upserts on
-`externalId`, so rows sharing a `TRAN_ID` overwrite each other. The real key is
-`FILING_ID + AMEND_ID + LINE_ITEM + TRAN_ID`.
-
-`EXPN_CD.TSV` (`dataSources[8]`) carries the identical `CMTE_ID`/`TRAN_ID` pattern, which is the
-likely reason `totalSpent` exceeds `totalRaised` for some representatives — the two joins have
-different coverage of the same defect.
-
-### Adjacent defects — split out, not in scope here
-
-Two further problems surfaced while sampling committee-donor rows. Both are independent of the
-column mapping and are tracked separately so #980 can close cleanly:
-
-- **[#982](https://github.com/OpusPopuli/opuspopuli/issues/982)** — committee rows whose `name` is a
-  bare numeric filer ID (`1318941`, `1363306`), rendering as a bare number on the public money-trail
-  lists.
-- **[#983](https://github.com/OpusPopuli/opuspopuli/issues/983)** — refunds filed as negative
-  receipts net against `totalRaised` with no sign handling, while still incrementing
-  `contributionCount` and donor buckets.
-
-#983 has no ingestion dependency and can land well before this work.
+Two gaps: `contributions` has no `filing_id` column and `RCPT` never extracts `FILING_ID`; and
+`cvr_filings` covers only F496 IE cover pages (31,418 rows) — contributions need F460 too, which is
+blocked by #984.
 
 ## Subtasks
 
-### 1. Spike — raw source details ⚠️ gates the mapping change
+### 0. Unblock — #984 ⚠️ blocks everything
 
-Defect A no longer depends on this (confirmed above), but the *fix* does. Pull `RCPT_CD.TSV` from
-`dbwebexport.zip` and confirm:
+Two sources over `CVR_CAMPAIGN_DISCLOSURE_CD.TSV` collide on one resume session, so one silently
+ingests nothing. The F460 cover-page map cannot be populated until this is fixed. Not part of this
+branch — see #984.
 
-- The actual column list, so the replacement column is one we have seen rather than one inferred
-  from CAL-ACCESS convention. `FILER_ID` is the expected recipient column — verify before mapping to it.
-- `TRAN_ID` collision rate across filings — sizes Defect B.
-- Whether `EXPN_CD.TSV` and `S496_CD.TSV` need the mirror-image fix.
+### 2. Composite `externalId`
 
-Header and a few sample rows are sufficient; the ~1GB TSV need not be extracted:
+- **Where:** `packages/scraping-pipeline/src/handlers/bulk-download.handler.ts`, `BulkDownloadConfig`;
+  `opuspopuli-regions/schema/region-plugin.schema.json`
+- Add optional `compositeKey: string[]` joining source columns with a stable separator.
+- **Tests:** key construction, collision behavior, back-compat when absent.
 
-```bash
-curl -o /tmp/dbwebexport.zip https://campaignfinance.cdn.sos.ca.gov/dbwebexport.zip
-unzip -l /tmp/dbwebexport.zip | grep -iE 'RCPT_CD|EXPN_CD|S496_CD'
-unzip -p /tmp/dbwebexport.zip 'CAL-ACCESS/DATA/RCPT_CD.TSV' | head -3
-```
+### 3. `filing_id` on contributions and expenditures
 
-### 2. Composite `externalId` support
+- **Where:** `supabase/migrations/` (use `/op-migration`), `packages/relationaldb-provider/prisma/schema.prisma`
+- Additive only: nullable `filing_id` + index. No drops, no renames.
+- **Tests:** integration test against the real test DB (never mock the DB layer).
 
-- **Where:** `packages/scraping-pipeline` — `handlers/bulk-download.handler.ts`, `BulkDownloadConfig`
-- **Also:** `opuspopuli-regions/schema/region-plugin.schema.json`
-- Config can currently map only one column to `externalId`. Add a `compositeKey: string[]` that joins
-  source columns with a stable separator.
-- **Tests:** composite key construction, collision behavior, back-compat when `compositeKey` is absent.
-- No migration. No GraphQL change.
+### 4. Cover-page-join resolution
 
-### 3. Correct the column mappings
+- **Where:** `apps/backend/src/apps/region/src/domains/` — new linker or extension of `CampaignFinanceSyncService`
+- Resolve `contributions.filing_id → cvr_filings.filer_id → committees.external_id`.
+- Follow `IndependentExpenditureLinkerService` (#955) — same shape, already reviewed.
+- **Tests:** unit tests for resolution + reconcile; integration test for the full join.
 
-- **Where:** `opuspopuli-regions` (separate repo — merges direct to `main`, publishes `@opuspopuli/regions`)
-- `RCPT_CD.TSV` and `EXPN_CD.TSV`: `committeeId` ← correct filer column; `externalId` ← composite key.
+### 5. Column mappings
+
+- **Where:** `opuspopuli-regions` (merges to `main`, publishes `@opuspopuli/regions`)
+- `RCPT_CD` / `EXPN_CD`: add `FILING_ID → filingId`; `externalId` ← composite key; drop or repurpose
+  the `CMTE_ID → committeeId` mapping.
+- Broaden cover-page ingestion to F460 (depends on #984).
 - Version bump, publish, consume in the monorepo.
-- **Tests:** schema validation in the regions repo.
 
-### 4. Re-ingest
+### 6. Re-ingest
 
-- **Where:** `apps/backend` region-worker
-- Existing rows carry both a wrong `committee_id` and an unstable `externalId`, so upsert **will not
-  converge** — a scoped delete of `source_system='cal_access'` contributions and expenditures is
-  required before re-ingest.
-- Snapshot the production DB first. Scope the delete by `source_system`; never run against the dev
-  `postgres` database (#796 discipline).
-- **Acceptance gate:** `/op-data-scan` pass on the resulting data.
+- **Where:** region-worker
+- Existing rows carry a wrong `committee_id` and an unstable `externalId`, so upsert **will not
+  converge** — scoped delete of `source_system='cal_access'` contributions and expenditures first.
+- DB snapshot beforehand. Scope by `source_system`. Never target the dev `postgres` DB (#796).
+- **Acceptance gate:** `/op-data-scan`.
 
-### 5. Verify and re-check aggregation semantics
+### 7. Verify aggregation semantics
 
-- **Where:** `apps/backend/src/apps/region/src/domains/representative-funding.service.ts`
-- Confirm `totalRaised` now means raised rather than contributed-out, and that
-  `totalSpent <= totalRaised` holds for a sample.
-- Cross-check 5–10 representatives against official CAL-ACCESS filings before it reaches production.
+- **Where:** `representative-funding.service.ts`
+- Confirm `totalRaised` means raised, and `totalSpent <= totalRaised` for a sample.
+- Cross-check 5–10 representatives against official CAL-ACCESS filings before production.
 
-### 6. Revisit #980 labeling
+### 8. Revisit labeling
 
-- **Where:** `apps/frontend/components/region/RepresentativeFundingPanel.tsx`, `locales/{en,es}/civics.json`
-- The interim "Identified donors" wording (shipped in the #979 PR) may revert to plain "Donors" once
-  counts are real. Re-run `pnpm test:a11y`.
+- **Where:** `RepresentativeFundingPanel.tsx`, `locales/{en,es}/civics.json`
+- The interim "Identified donors" wording may revert to "Donors" once counts are real. Re-run
+  `pnpm test:a11y`.
 
-**Ordering:** 2 and 3 may run in parallel after 1. 4 blocks on both. 5 and 6 follow 4.
-[#982](https://github.com/OpusPopuli/opuspopuli/issues/982) and
-[#983](https://github.com/OpusPopuli/opuspopuli/issues/983) are independent and can be scheduled
-separately.
+**Ordering:** #984 first. Then 2, 3, 5 in parallel; 4 after 3; 6 after all; 7–8 after 6.
+
+## Adjacent defects — split out
+
+- [#982](https://github.com/OpusPopuli/opuspopuli/issues/982) — committee rows whose `name` is a bare
+  numeric filer ID
+- [#983](https://github.com/OpusPopuli/opuspopuli/issues/983) — refunds netting against totals with no
+  sign handling (no ingestion dependency; can land any time)
 
 ## Data classification
 
-**PII, no PHI.** Individual contributor rows carry name, employer, occupation, city, state, and ZIP+4.
-All of it is published public record under California law, so ingestion is lawful — but volume changes
-the risk profile. Today ~29,809 individual rows survive; correcting the mapping could bring in
-millions.
+**PII, no PHI.** Individual contributor rows carry name, employer, occupation, city, state, ZIP+4 —
+published public record under CA law, so ingestion is lawful, but volume changes the risk profile.
+Today ~29,809 individual rows survive; the fix brings the stored total from 203,945 toward the
+1.21M extracted.
 
-Required considerations before subtask 4 lands:
+Required before subtask 6 lands:
 
 - **ZIP+4 minimization.** Name + employer + ZIP+4 approaches individually identifying. Decide whether
   ZIP+4 is needed or ZIP5 suffices.
 - **No model exposure.** Confirm contributor rows never reach prompts, embeddings, or the RAG index.
-  The knowledge service must not be indexing donor PII.
 - **Log masking.** Verify donor fields are in the audit-log masked set.
-- **Retention.** Campaign finance has no equivalent of the 90-day audit-log expiry. Needs an explicit
-  decision.
+- **Retention.** No equivalent of the 90-day audit-log expiry exists here. Needs an explicit decision.
 
 ## Risk register
 
 | Risk | Severity | Likelihood | Mitigation |
 |---|---|---|---|
-| Re-ingest requires deleting existing cal_access rows | high | likely | Scope delete by `source_system`; verify counts before/after; DB snapshot first; never target dev `postgres` (#796) |
-| Public-facing dollar figures change substantially | high | likely | Expected and correct, but re-verify a sample against official filings before production — same false-attribution exposure as #979 / #962 |
-| `FILER_ID` is not the correct replacement column | medium | possible | Defect A itself is confirmed; subtask 1 verifies the column name against the raw file before any mapping is written |
-| Refund handling (#983) changes published totals again | medium | possible | Land #983 deliberately with a matching UI label rather than as a silent numeric shift |
-| PII volume increase (29k → millions of individual rows) | medium | likely | See data classification; `/op-data-scan` as acceptance gate on subtask 4 |
-| Row-count growth degrades query performance | medium | likely | Verify index coverage on `contributions(committee_id)`; funding aggregation already caps its donor scan at 1000 |
-| Region config lives in a separate repo/package | low | likely | Coordinate `@opuspopuli/regions` publish before the monorepo consumes it |
-| Breaking change to `BulkDownloadConfig` | low | possible | `compositeKey` is additive and optional; existing configs unaffected |
+| Blocked by #984; F460 cover pages cannot populate | high | certain | Fix #984 first; do not start subtask 5 before it lands |
+| Re-ingest requires deleting existing cal_access rows | high | likely | Scope by `source_system`; verify counts before/after; snapshot first; never target dev `postgres` (#796) |
+| Public dollar figures change substantially | high | likely | Expected and correct, but re-verify a sample against official filings before production — same exposure as #979 / #962 |
+| Row count grows 203,945 → ~1.2M | medium | likely | Verify index coverage on `contributions(committee_id, filing_id)`; donor scan already capped at 1000 |
+| PII volume increase (~6x) | medium | likely | See data classification; `/op-data-scan` gate on subtask 6 |
+| Migration on a large existing table | medium | possible | Additive nullable column + concurrent index; no backfill in the migration itself |
+| Region config in a separate repo | low | likely | Publish `@opuspopuli/regions` before the monorepo consumes it |
 | AGPL-3.0 dependency constraint | low | rare | No new dependencies anticipated |
 
 ## Open questions
 
-1. Should this block launch? It is arguably a sibling of #979 rather than a follow-up — if the spike
-   confirms Defect A, every representative's dollar figures are currently measuring the wrong thing.
-2. Does the same `CMTE_ID` assumption affect `S496_CD.TSV` (independent expenditures), recently
-   reworked in #955?
-3. ~~Are Defects C and D in scope for #980?~~ Resolved — split into
-   [#982](https://github.com/OpusPopuli/opuspopuli/issues/982) and
-   [#983](https://github.com/OpusPopuli/opuspopuli/issues/983).
+1. Should this block launch? Every representative's dollar figures currently measure money paid out
+   rather than raised, over a ~17% sample. That is arguably a sibling of #979, not a follow-up.
+2. ~~Does `EXPN_CD` need the same cover-page join?~~ **Yes — verified.** `EXPN_CD` also has no
+   `FILER_ID`, carries the same `FILING_ID`/`AMEND_ID`/`LINE_ITEM`/`TRAN_ID` key columns, and its
+   `CMTE_ID` (col 26) sits in the payee block — so it identifies the *payee's* committee, not the
+   spender. `totalSpent` is inverted the same way `totalRaised` is.
+3. Should `cvr_filings` broaden to all form types, or gain a sibling table for F460?

--- a/docs/plans/980-cal-access-contribution-mapping.md
+++ b/docs/plans/980-cal-access-contribution-mapping.md
@@ -10,7 +10,7 @@
 | **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases ~6x when this lands. |
 | **Branch** | `fix/980-cal-access-contribution-mapping` (+ `opuspopuli-regions`) |
 | **Effort** | 3–4 focused sessions + one supervised cutover |
-| **Status** | Subtasks 0, 1, 3 and cutover steps C1–C2 complete. Next: C3 (linker + region config). |
+| **Status** | Code complete through C3. Next: C4 — the supervised truncate + rebuild. |
 
 ## Problem
 
@@ -201,7 +201,33 @@ All of C1–C3 land together, in one deploy, followed by the supervised C4/C5 re
 so behavior is unchanged — the only live effect is that a blank `CMTE_ID` no longer fails
 validation, and nothing produces such rows today.
 
-### C3. Cover-page-join linker + region config
+### C3. Cover-page-join linker + region config ✅ done (2026-08-09)
+
+**Monorepo:** new `CoverPageLinkerService` (`cover-page-linker.service.ts`), registered in
+`region.module.ts` and run from the sync *before* the proposition linker.
+
+- **Set-based, not row-by-row.** One `UPDATE … FROM cvr_filings JOIN committees` per table. #955's
+  shape — one `update()` per pending row through `batchTransaction` — is fine for tens of thousands
+  of IEs but would mean ~1.2M promises across ~2,400 transactions here.
+- The table name is interpolated (SQL identifiers cannot be bound), so it comes from a `const`
+  tuple: the only values that can reach the statement are two compile-time literals.
+- The leftover breakdown query runs **only** when the UPDATE left something behind, so the
+  steady-state re-sync costs one `count` per table and nothing else.
+- `PropositionFinanceLinkerService` now reads `filing_id` directly; `extractFilingId` is deleted.
+  Its "first hit per filing wins" rule is *now well-defined* rather than arbitrary — every row of a
+  filing shares that filing's filer, so the map has one possible value per key.
+- `IndependentExpenditureLinkerService`'s cover-page read is scoped to the pending filing IDs
+  (it was unfiltered, sized for an F496-only 31k-row table).
+
+**Region config** (`opuspopuli-regions`, `feat/composite-key-schema-980`, config v1.10.0):
+`CMTE_ID → committeeId` dropped from both tables, `FILING_ID → filingId` added, `compositeKey` set,
+and the cover-page source's `FORM_TYPE=F496` filter removed.
+
+**Tests:** 6 unit (orchestration) + 9 integration against real `postgres_test` — including the one
+that matters, that a contribution is attributed to the **filer** even when a counterparty committee
+row exists, plus idempotency, the soft-deleted-committee guard, and both skip reasons.
+
+<details><summary>Original scope notes</summary>
 
 **Linker** (`apps/backend/src/apps/region/src/domains/`):
 
@@ -224,6 +250,8 @@ validation, and nothing produces such rows today.
   `CMTE_ID → committeeId` mapping.
 - Broaden cover-page ingestion to all form types (see Decisions).
 - Version bump, publish, then consume in the monorepo. **Publish before the monorepo consumes it.**
+</details>
+
 
 ### C4. Truncate + rebuild
 

--- a/docs/plans/980-cal-access-contribution-mapping.md
+++ b/docs/plans/980-cal-access-contribution-mapping.md
@@ -3,15 +3,14 @@
 | | |
 |---|---|
 | **Issue** | [#980](https://github.com/OpusPopuli/opuspopuli/issues/980) |
-| **Blocked by** | [#984](https://github.com/OpusPopuli/opuspopuli/issues/984) — cover-page source silently skipped |
 | **Precedent** | [#955](https://github.com/OpusPopuli/opuspopuli/issues/955) — the same join, already solved for S496 |
 | **Related** | [#979](https://github.com/OpusPopuli/opuspopuli/issues/979), [#962](https://github.com/OpusPopuli/opuspopuli/issues/962), [#982](https://github.com/OpusPopuli/opuspopuli/issues/982), [#983](https://github.com/OpusPopuli/opuspopuli/issues/983), [#954](https://github.com/OpusPopuli/opuspopuli/issues/954) |
-| **Date** | 2026-08-08 (rewritten after raw-file verification) |
+| **Date** | 2026-08-09 (rewritten around the clean cutover) |
 | **Author** | Rodney Gagnon |
-| **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases ~6x if this lands. |
-| **Branch** | `fix/980-cal-access-contribution-mapping` (+ `opuspopuli-regions`, + migration) |
-| **Effort** | 4–6 focused sessions |
-| **Status** | Subtasks 0, 1, 3 complete. Next: 2 and 5, then 4. |
+| **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases ~6x when this lands. |
+| **Branch** | `fix/980-cal-access-contribution-mapping` (+ `opuspopuli-regions`) |
+| **Effort** | 3–4 focused sessions + one supervised cutover |
+| **Status** | Subtasks 0, 1, 3 complete. Next: the cutover work (C1–C5). |
 
 ## Problem
 
@@ -25,6 +24,11 @@ transfers, attributed backwards: `totalRaised` sums money each committee **paid 
 
 This is [#955](https://github.com/OpusPopuli/opuspopuli/issues/955)'s defect in the contributions
 table. That issue's title was almost verbatim the same problem for S496.
+
+`EXPN_CD` is inverted the same way — its `CMTE_ID` (col 26) sits in the payee block, so `totalSpent`
+is the payee's money, not the spender's. And the same bad attribution propagates into
+`committee_measure_positions`, so **proposition** funding totals are wrong by this mechanism too
+(see C4). The blast radius is the whole campaign-finance dataset, not just the contributions table.
 
 ## Subtask 1 — spike ✅ complete (2026-08-08)
 
@@ -69,84 +73,113 @@ key is `FILING_ID + AMEND_ID + LINE_ITEM + TRAN_ID`. `EXPN_CD` shares the patter
 - `cvr_filings` already stores `filing_id → filer_id` (via `dataSources[10]`, built for #955)
 - `IndependentExpenditureLinkerService` is a working reference implementation of this join
 
-Two gaps: `contributions` has no `filing_id` column and `RCPT` never extracts `FILING_ID`; and
-`cvr_filings` covers only F496 IE cover pages (31,418 rows) — contributions need F460 too, which is
-blocked by #984.
+---
 
-## Subtasks
+## Approach: one clean cutover
+
+**Decided 2026-08-09.** Rather than sequencing schema, mappings, linker and re-ingest as separate
+deploys that each leave the data in a partially-correct state, land them together and rebuild the
+campaign-finance dataset from scratch.
+
+### Why this is safe here
+
+The campaign-finance FK graph is **closed** — verified against the live schema:
+
+```
+committees ← contributions, expenditures,
+             independent_expenditures, committee_measure_positions
+```
+
+Nothing outside that set references it. (`Minutes.committeeId` and `LegislativeAction.committeeId`
+point at *legislative* committees — a different table. `CommitteeRelevanceCache` likewise.) Outbound
+FKs from `committees` → `representatives` / `propositions` point *away*, so dropping finance rows
+cannot damage civic data. `user_events.objectId` is a free-form string with no FK, and that table is
+empty, so there is no view/bookmark history to dangle.
+
+Every row is 100% derived from a public bulk export that can be re-downloaded. **This is the crux:
+the additive-only rule exists to protect data that cannot be recreated. That rationale does not
+apply to derived, reproducible data — and the data being "protected" today is wrong.**
+
+### Deliberate exception to the additive-only rule
+
+`CLAUDE.md` says *additive only on existing tables in production*. This cutover truncates five
+tables in production. That is a **conscious, reasoned exception**, recorded here so the history does
+not read as the rule being ignored:
+
+- the data is fully reproducible from CAL-ACCESS,
+- the current contents are actively incorrect,
+- no user-generated or hand-curated data lives in or references these tables,
+- and this is pre-launch.
+
+The schema migration itself (`20260809000000`, already merged) remains additive — no table is
+dropped or renamed. Only *rows* are removed.
+
+### What the cutover buys
+
+It deletes most of the old risk register rather than mitigating it:
+
+- **No sequencing trap.** Relaxing the zod `committeeId` before the config change would admit ~1M
+  wrong-committee rows; changing the config first would drop every row behind a `logger.debug`.
+  Landing them together makes the question moot.
+- **No upsert-convergence trap.** `upsertRecordsByFields`'s `pick` emits `committeeId: undefined`
+  for absent fields, and Prisma treats `undefined` in `update` as *leave unchanged* — so a re-sync
+  over existing rows would never clear the bad values. With an empty table there is nothing to
+  converge.
+- **No append-vs-purge problem** for `committee_measure_positions`.
+- **No back-compat burden** for the composite `externalId`.
+- **No degraded window** where correct and incorrect figures coexist.
+
+---
+
+## Completed
 
 ### 0. Unblock — #984 ✅ done
 
 Resolved by #985 (`b5cde99` on develop): resume-session identity is now unique per source, so the
 broadened cover-page source no longer risks colliding with a sibling over the same file.
 
-### 2. Composite `externalId`
-
-- **Where:** `packages/scraping-pipeline/src/handlers/bulk-download.handler.ts`, `BulkDownloadConfig`;
-  `opuspopuli-regions/schema/region-plugin.schema.json`
-- Add optional `compositeKey: string[]` joining source columns with a stable separator.
-- **Tests:** key construction, collision behavior, back-compat when absent.
-
-### 3. `filing_id` on contributions and expenditures ✅ done (2026-08-09)
+### 3. `filing_id` on contributions and expenditures ✅ done (2026-08-09, `91e7f66`)
 
 - **Migration:** `packages/relationaldb-provider/prisma/migrations/20260809000000_contribution_expenditure_cover_page_join/`
   — not `supabase/migrations/`, which holds only `99_vault_functions.sql`; schema migrations are
   Prisma-managed here, as #955's was.
-- Additive + widening: nullable `filing_id` VARCHAR(50) + index on both tables. No drops, no renames.
-  Both `ALTER`s are catalog-only in Postgres, so neither rewrites the ~204k-row table.
-
-**Scope correction.** The plan said "nullable `filing_id` + index" only, but dropping the
-`CMTE_ID → committeeId` mapping (subtask 5) makes a `NOT NULL committee_id` unsatisfiable — so
-`ALTER COLUMN committee_id DROP NOT NULL` had to ride along on both tables, exactly as #955 did for
-`independent_expenditures`. Consequences handled here:
-
+- Additive + widening: nullable `filing_id` VARCHAR(50) + index on both tables, and
+  `committee_id DROP NOT NULL` (required — once the config stops mapping `CMTE_ID`, a filed row has
+  no committee until the linker stamps it). Both `ALTER`s are catalog-only in Postgres.
 - **The FK footgun.** Prisma defaults an *optional* relation to `onDelete: SetNull`. Left implicit,
   relaxing NOT NULL would have silently converted both FKs, so deleting a committee would orphan its
   finance rows to `committee_id = NULL` — indistinguishable from "unresolved, please stamp". The
-  schema pins `onDelete: Restrict`; verified in the DB as `confdeltype = 'r'` and covered by two
-  integration tests.
+  schema pins `onDelete: Restrict`; verified in the DB as `confdeltype = 'r'`.
 - **GraphQL stays non-null.** `getContributions`/`getExpenditures` (and the by-id fetches, now
   `findFirst`) filter `committeeId: { not: null }`, so unattributed staging rows never surface —
-  the same treatment #955 gave S496 rows. No federation schema change, so the nullability question
-  in subtask 4 stays open rather than being pre-decided.
-- `PropositionFinanceLinkerService.buildFilingToCommitteeIndex` now skips null-committee rows. It
-  keeps the *first* hit per filing, so an unattributed row would otherwise shadow a resolved one.
+  the same treatment #955 gave S496 rows. No federation schema change.
 
 **Tests:** `apps/backend/__tests__/integration/region/contribution-cover-page-columns.integration.spec.ts`
-— 10 cases against real `postgres_test` (column shape, nullability, indexes, pre-link inserts, FK
-RESTRICT on both tables), plus unit coverage for the new query filters and the linker skip.
-Full backend suite green (2301 tests); `tsc --noEmit` adds no new errors over baseline.
+— 13 cases against real `postgres_test` (column shape, nullability, index definitions, pre-link
+inserts, FK RESTRICT, and real-row proof that unattributed rows are excluded from list and by-id
+reads). Mutation-checked: removing the filter fails exactly the two list cases.
 
 > Note for whoever runs this locally: `pnpm test:integration` gates on all five HTTP services being
 > up, though `bootstrapTestDatabase()` (which applies the migration) runs first, before that gate.
 
-**Rollback** (no down-file convention here — Prisma-managed, and #955 shipped none):
+---
 
-```sql
-DROP INDEX IF EXISTS "expenditures_filing_id_idx";
-DROP INDEX IF EXISTS "contributions_filing_id_idx";
-ALTER TABLE "expenditures"  DROP COLUMN IF EXISTS "filing_id";
-ALTER TABLE "contributions" DROP COLUMN IF EXISTS "filing_id";
+## The cutover
 
--- NOT reversible unattended: SET NOT NULL scans the table and FAILS if the linker
--- left any row unresolved. Resolve or remove those first, e.g.
---   DELETE FROM "expenditures"  WHERE "committee_id" IS NULL;
---   DELETE FROM "contributions" WHERE "committee_id" IS NULL;
-ALTER TABLE "expenditures"  ALTER COLUMN "committee_id" SET NOT NULL;
-ALTER TABLE "contributions" ALTER COLUMN "committee_id" SET NOT NULL;
-```
+All of C1–C3 land together, in one deploy, followed by the supervised C4/C5 rebuild.
 
-### 4. Cover-page-join resolution
+### C1. Composite `externalId`
 
-- **Where:** `apps/backend/src/apps/region/src/domains/` — new linker or extension of `CampaignFinanceSyncService`
-- Resolve `contributions.filing_id → cvr_filings.filer_id → committees.external_id`.
-- Follow `IndependentExpenditureLinkerService` (#955) — same shape, already reviewed.
-- **Tests:** unit tests for resolution + reconcile; integration test for the full join.
+- **Where:** `packages/scraping-pipeline/src/handlers/bulk-download.handler.ts`, `BulkDownloadConfig`;
+  `opuspopuli-regions/schema/region-plugin.schema.json`
+- Add optional `compositeKey: string[]` joining source columns with a stable separator. Real key is
+  `FILING_ID + AMEND_ID + LINE_ITEM + TRAN_ID`; `TRAN_ID` alone is not unique across filings.
+- **Tests:** key construction, collision behavior, back-compat when absent.
 
-### 4b. Write path for `filing_id` — **hard prerequisite for 5** (found in review, 2026-08-09)
+### C2. Write path for `filing_id`
 
-Subtask 3 added the column; nothing can populate it yet. Three edits are needed, and #955 did all
-three for `independent_expenditures` — copy that shape:
+Subtask 3 added the column; nothing can populate it yet. #955 did all three of these for
+`independent_expenditures` — copy that shape:
 
 1. `packages/scraping-pipeline/src/mapping/domain-mapper.service.ts:898,935` — `ContributionSchema`
    / `ExpenditureSchema` need `filingId` added and `committeeId` relaxed to `.optional()`.
@@ -158,87 +191,103 @@ three for `independent_expenditures` — copy that shape:
    `'filingId'` to both `fields` projections. `upsertRecordsByFields` picks *only* the listed
    fields, so the column stays NULL otherwise.
 
-**Sequencing trap:** relaxing `committeeId` in the zod schema *before* the region config drops the
-`CMTE_ID → committeeId` mapping would admit ~1M currently-dropped rows carrying the **wrong**
-committee. Relax it and change the config in the same deploy. Conversely, if the config changes
-first without the schema relax, every RCPT/EXPN row fails `safeParse` and is dropped with only a
-`logger.debug` — a sync that reports success having ingested zero contributions.
+### C3. Cover-page-join linker + region config
 
-**Also:** the new cover-page linker must run *before* `propositionFinanceLinker.linkAll()` in
-`campaign-finance-sync.service.ts:181-199`, the way the IE linker already is.
+**Linker** (`apps/backend/src/apps/region/src/domains/`):
 
-### 5. Column mappings
+- Resolve `contributions.filing_id → cvr_filings.filer_id → committees.external_id`.
+- Follow `IndependentExpenditureLinkerService` (#955), with two deliberate improvements: scope the
+  `cvrFiling.findMany()` to the pending filing IDs rather than loading the table, and prefer a
+  set-based `UPDATE … FROM cvr_filings` over 1.2M individual `update()` calls in `batchTransaction`.
+- Must run **before** `propositionFinanceLinker.linkAll()` in `campaign-finance-sync.service.ts:181-199`,
+  the way the IE linker already is.
+- **Re-point `PropositionFinanceLinkerService` at the new `filing_id` column.** Today
+  `buildFilingToCommitteeIndex` recovers FILING_ID by splitting `externalId` on the first `:`/`-`
+  (`:462`), which C1 breaks — silently: every CVR2 row would hit the `skipped` branch and
+  proposition funding would read $0 with no exception, and the specs hardcode `12345:1` so nothing
+  fails. Reading `filing_id` directly also removes the unpaginated full-table load and the
+  nondeterministic "first hit per filing wins" (those `findMany`s have no `orderBy`).
 
-- **Where:** `opuspopuli-regions` (merges to `main`, publishes `@opuspopuli/regions`)
-- `RCPT_CD` / `EXPN_CD`: add `FILING_ID → filingId`; `externalId` ← composite key; drop or repurpose
-  the `CMTE_ID → committeeId` mapping.
-- Broaden cover-page ingestion to F460 (depends on #984).
-- Version bump, publish, consume in the monorepo.
+**Region config** (`opuspopuli-regions`, merges to `main`, publishes `@opuspopuli/regions`):
 
-### 6. Re-ingest
+- `RCPT_CD` / `EXPN_CD`: add `FILING_ID → filingId`; `externalId` ← composite key; drop the
+  `CMTE_ID → committeeId` mapping.
+- Broaden cover-page ingestion to all form types (see Decisions).
+- Version bump, publish, then consume in the monorepo. **Publish before the monorepo consumes it.**
 
-- **Where:** region-worker
-- Existing rows carry a wrong `committee_id` and an unstable `externalId`, so upsert **will not
-  converge** — scoped delete of `source_system='cal_access'` contributions and expenditures first.
-- DB snapshot beforehand. Scope by `source_system`. Never target the dev `postgres` DB (#796).
+### C4. Truncate + rebuild
+
+- **Snapshot prod first** — for rollback *and* because C5 needs the old figures to diff against.
+- Truncate, scoped to `source_system='cal_access'` where the column exists:
+  `committee_measure_positions`, `contributions`, `expenditures`, `independent_expenditures`,
+  `committees` (in FK order). Never target the dev `postgres` DB (#796).
+- Re-sync from the region worker.
+- **Re-run the candidate-committee linker** afterwards — `committees.representative_id` is derived
+  and must be rebuilt (#981's same-surname fix is in that path). Same for the proposition linker.
 - **Acceptance gate:** `/op-data-scan`.
 
-### 7. Verify aggregation semantics
+### C5. Verify
 
-- **Where:** `representative-funding.service.ts`
 - Confirm `totalRaised` means raised, and `totalSpent <= totalRaised` for a sample.
-- Cross-check 5–10 representatives against official CAL-ACCESS filings before production.
+- Cross-check 5–10 representatives against official CAL-ACCESS filings before calling it done.
+- Diff against the pre-cutover snapshot: which figures moved, by how much, and in the expected
+  direction. This is why the snapshot is taken even though the old data is wrong.
+- Re-verify `independentExpenditures` counts — C3 broadens `cvr_filings` beyond F496.
 
-### 8. Revisit labeling
+### C6. Revisit labeling
 
 - **Where:** `RepresentativeFundingPanel.tsx`, `locales/{en,es}/civics.json`
 - The interim "Identified donors" wording may revert to "Donors" once counts are real. Re-run
   `pnpm test:a11y`.
 
-**Ordering:** #984 first. Then 2, 3, 5 in parallel; 4 after 3; 6 after all; 7–8 after 6.
+---
 
-**Deploy ordering (added 2026-08-09).** The migration is inert on its own — nothing writes a NULL
-committee until subtask 5 ships. But between 5 landing and the linker (4) running, freshly-ingested
-rows sit unattributed and are excluded from GraphQL, so `totalRaised` reads *low* rather than wrong.
-That's the intended failure mode, and it argues for 4 shipping before 5, not merely before 6.
+## Pre-cutover requirements (PII)
 
-## Found in review of subtask 3 (2026-08-09) — not yet filed
+These gate C4, not the code work:
 
-**`committee_measure_positions` is never purged, and it is downstream of the bad attribution.**
-`PropositionFinanceLinkerService` only ever `upsert`s (`:380`); nothing deletes. Two consequences:
+- **ZIP+4 minimization.** Name + employer + ZIP+4 approaches individually identifying. Decide
+  whether ZIP+4 is needed or ZIP5 suffices — cheapest to decide *before* reloading 1.2M rows.
+- **Log masking.** ❌ Confirmed gap: `PARTIAL_MASK_FIELDS` in
+  `apps/backend/src/common/utils/pii-masker.ts:23` is only `email`/`phone`/`phonenumber`. Harmless
+  today (the audit interceptor logs args, never results), but any future `logger.debug({ contribution })`
+  writes unmasked donor PII to Loki. Add the donor fields.
+- **Public bulk exposure.** `contributions`, `contribution(id)` and `expenditures` are `@Public()`,
+  and `PaginationArgs` caps `take` at 100 but leaves `skip` unbounded — a ~20-minute anonymous
+  scrape today, ~2 hours at 1.2M. Public record under CA law, but name + employer + occupation +
+  ZIP+4 *in bulk* is a different risk profile than record-by-record lookup. Needs an explicit
+  decision, not an inherited default.
+- **No model exposure.** Confirm contributor rows never reach prompts, embeddings, or the RAG index.
+- **Retention.** No equivalent of the 90-day audit-log expiry exists here. Needs a decision.
 
-- `buildFilingToCommitteeIndex` maps `filingId → contribution.committeeId`, which per this issue's
-  own premise is the **counterparty**, and writes it as a position with `isPrimaryFormation = true`.
-  `PropositionFundingService.computeSide` then sums those committees' money into public
-  `totalRaised` / `totalSpent`. So proposition support/oppose totals are wrong today by the same
-  mechanism as representative totals — this issue's scope is wider than the `contributions` table.
-- Once subtask 4 stamps correct committees, the correct positions are **added alongside** the stale
-  wrong ones and both get summed. Subtask 6 therefore needs to purge and re-link
-  `committee_measure_positions`, not just delete and re-ingest the finance rows.
+## Risk register
 
-**`extractFilingId` breaks silently when subtask 2 lands.** It recovers FILING_ID by splitting
-`externalId` on the first `:`/`-` (`:462`). Once `compositeKey` changes that layout, it returns
-garbage, every CVR2 row hits the `skipped` branch, and proposition funding quietly reads $0 — no
-exception, and the specs hardcode `12345:1` so nothing fails. Subtask 4 should re-point the linker
-at the new `filing_id` column, which also removes the unpaginated full-table load and the
-nondeterministic "first hit per filing wins" (those `findMany`s have no `orderBy`, so a filing with
-several contributors resolves to a different committee run to run).
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| Outage while the dataset rebuilds | high | certain | Duration is **unmeasured** — the Studio was unreachable at planning time. Measure before scheduling. Representative/proposition pages read $0 meanwhile. Pre-launch, so acceptable, but pick the window deliberately |
+| From-empty sync path never exercised | high | possible | Every sync so far ran against populated tables. Rehearse the full rebuild on `postgres_test` or a restored snapshot **before** touching prod. #985's resume-session fix helps if it dies partway |
+| Public dollar figures change substantially | high | certain | Expected and correct — that is the point. Verify a sample against official filings (C5) before calling it done. Same exposure as #979 / #962 |
+| Snapshot missing or unrestorable | high | rare | Verify the snapshot restores *before* truncating, not after |
+| Derived linkages not rebuilt | medium | likely | `committees.representative_id` and the proposition links are derived; C4 explicitly re-runs both linkers |
+| Broadened `cvr_filings` regresses the #955 IE linker | low | possible | The linker looks up by `FILING_ID`, unique per filing, so extra non-F496 rows sit unused rather than mis-matching. Still add a test with non-F496 rows present, and re-verify counts in C5 |
+| `cvr_filings` grows 31,418 → ~662,076 | low | certain | `IndependentExpenditureLinkerService` does an unfiltered `cvrFiling.findMany()` (line 78). Worker is capped at 6G so ~662k rows fits, but C3 scopes the query anyway |
+| PII volume increase (~6x) | medium | certain | See pre-cutover requirements; `/op-data-scan` gate on C4 |
+| Region config in a separate repo | low | likely | Publish `@opuspopuli/regions` before the monorepo consumes it |
+| AGPL-3.0 dependency constraint | low | rare | No new dependencies anticipated |
 
-**Re-sync alone will not clear the existing bad `committee_id`s.** `upsertRecordsByFields`'s `pick`
-(`campaign-finance-sync.service.ts:556`) emits `committeeId: undefined` for absent fields, and
-Prisma treats `undefined` in `update` as *leave unchanged*. This is the mechanism behind subtask 6's
-"upsert will not converge" note — the scoped delete is mandatory, not merely tidier.
+## Decisions
 
-**PII masking gap (confirms an open question above).** `PARTIAL_MASK_FIELDS` in
-`apps/backend/src/common/utils/pii-masker.ts:23` is only `email`/`phone`/`phonenumber` — no donor
-fields. Harmless today (the audit interceptor logs args, never results), but any future
-`logger.debug({ contribution })` writes unmasked donor PII to Loki.
+**Launch gate — this blocks launch** (2026-08-08). Every representative page currently sums money
+paid *out* as money *raised*, over ~17% of the available rows. Same false-attribution class as #979,
+which was treated as launch-blocking.
 
-**Bulk-scrape exposure at 6x volume.** `contributions`, `contribution(id)` and `expenditures` are
-`@Public()` (pre-existing, unchanged here), and `PaginationArgs` caps `take` at 100 but leaves
-`skip` unbounded. Today that's a ~20-minute anonymous scrape of 204k donor records; after subtask 6
-it is ~1.2M. Public record under CA law, but name + employer + occupation + ZIP+4 in bulk is a
-different risk profile than record-by-record lookup. Worth an explicit decision before 6 lands.
+**Clean cutover over incremental migration** (2026-08-09). See "Approach" above — the data is
+derived and reproducible, the FK graph is closed, and the incremental path's transition states are
+strictly worse than a short rebuild.
+
+**Cover pages — broaden the existing source** (2026-08-08). Drop `filters: {FORM_TYPE: 'F496'}` from
+`dataSources[10]` so `cvr_filings` covers all campaign-disclosure cover pages, rather than adding a
+second F460-filtered source or a sibling table. One source, one table, one ingest pass.
 
 ## Adjacent defects — split out
 
@@ -247,59 +296,16 @@ different risk profile than record-by-record lookup. Worth an explicit decision 
 - [#983](https://github.com/OpusPopuli/opuspopuli/issues/983) — refunds netting against totals with no
   sign handling (no ingestion dependency; can land any time)
 
-## Data classification
-
-**PII, no PHI.** Individual contributor rows carry name, employer, occupation, city, state, ZIP+4 —
-published public record under CA law, so ingestion is lawful, but volume changes the risk profile.
-Today ~29,809 individual rows survive; the fix brings the stored total from 203,945 toward the
-1.21M extracted.
-
-Required before subtask 6 lands:
-
-- **ZIP+4 minimization.** Name + employer + ZIP+4 approaches individually identifying. Decide whether
-  ZIP+4 is needed or ZIP5 suffices.
-- **No model exposure.** Confirm contributor rows never reach prompts, embeddings, or the RAG index.
-- **Log masking.** Verify donor fields are in the audit-log masked set.
-- **Retention.** No equivalent of the 90-day audit-log expiry exists here. Needs an explicit decision.
-
-## Risk register
-
-| Risk | Severity | Likelihood | Mitigation |
-|---|---|---|---|
-| ~~Blocked by #984~~ | — | — | Resolved — #985 merged to develop as `b5cde99` |
-| Broadening `cvr_filings` regresses the #955 IE linker | low | possible | Checked: the linker starts from S496 line items (`committeeId: null, filingId != null`) and looks each up by `FILING_ID`, which is unique per filing — so extra non-F496 rows sit unused rather than mis-matching. Still add a test with non-F496 rows present, and re-verify `independentExpenditures` counts after re-ingest |
-| `cvr_filings` grows 31,418 → ~662,076 | low | certain | `IndependentExpenditureLinkerService` does an **unfiltered** `cvrFiling.findMany()` (line 78), so the whole table lands in memory. region-worker is capped at 6G, so ~662k rows is comfortable — but scoping that query to the pending filing IDs is cheap hardening and stops the cost scaling with table size |
-| Re-ingest requires deleting existing cal_access rows | high | likely | Scope by `source_system`; verify counts before/after; snapshot first; never target dev `postgres` (#796) |
-| Public dollar figures change substantially | high | likely | Expected and correct, but re-verify a sample against official filings before production — same exposure as #979 / #962 |
-| Row count grows 203,945 → ~1.2M | medium | likely | Verify index coverage on `contributions(committee_id, filing_id)`; donor scan already capped at 1000 |
-| PII volume increase (~6x) | medium | likely | See data classification; `/op-data-scan` gate on subtask 6 |
-| Migration on a large existing table | medium | possible | Additive nullable column + concurrent index; no backfill in the migration itself |
-| Region config in a separate repo | low | likely | Publish `@opuspopuli/regions` before the monorepo consumes it |
-| AGPL-3.0 dependency constraint | low | rare | No new dependencies anticipated |
-
-## Decisions
-
-**Launch gate — this blocks launch** (decided 2026-08-08). Every representative page currently sums
-money paid *out* as money *raised*, over ~17% of the available rows. Same false-attribution class as
-#979, which was treated as launch-blocking.
-
-**Cover pages — broaden the existing source** (decided 2026-08-08). Drop
-`filters: {FORM_TYPE: 'F496'}` from `dataSources[10]` so `cvr_filings` covers all campaign-disclosure
-cover pages, rather than adding a second F460-filtered source or a sibling table. One source, one
-table, one ingest pass.
-
-Consequence to verify: `cvr_filings` grows from 31,418 toward the 662,076 rows extracted, and
-`IndependentExpenditureLinkerService` (#955) must keep working against the larger set. It joins on
-`FILING_ID`, which is unaffected by admitting more form types — but the IE linker's behavior on
-non-F496 filings needs an explicit test before this ships, because #955 built it against an
-F496-only table and may assume every row is an IE cover page.
+**Not yet filed:** `committee_measure_positions` has no purge path at all —
+`PropositionFinanceLinkerService` only ever `upsert`s (`:380`). C4 truncates it, which resolves this
+cutover, but the underlying "derived table that can never be rebuilt cleanly" defect remains and
+deserves its own issue.
 
 ## Open questions
 
-1. ~~Should this block launch?~~ Resolved above — yes.
-2. ~~Does `EXPN_CD` need the same cover-page join?~~ **Yes — verified.** `EXPN_CD` also has no
-   `FILER_ID`, carries the same `FILING_ID`/`AMEND_ID`/`LINE_ITEM`/`TRAN_ID` key columns, and its
-   `CMTE_ID` (col 26) sits in the payee block — so it identifies the *payee's* committee, not the
-   spender. `totalSpent` is inverted the same way `totalRaised` is.
-3. ~~Should `cvr_filings` broaden to all form types, or gain a sibling table?~~ Resolved above —
-   broaden the existing source.
+1. ~~Should this block launch?~~ Resolved — yes.
+2. ~~Does `EXPN_CD` need the same cover-page join?~~ **Yes — verified.** Same missing `FILER_ID`,
+   same key columns, and its `CMTE_ID` (col 26) identifies the *payee*.
+3. ~~Should `cvr_filings` broaden to all form types, or gain a sibling table?~~ Resolved — broaden.
+4. ~~Incremental or clean cutover?~~ Resolved 2026-08-09 — clean cutover.
+5. **How long does a full rebuild take?** Unmeasured. Blocks scheduling C4, nothing else.

--- a/docs/plans/980-cal-access-contribution-mapping.md
+++ b/docs/plans/980-cal-access-contribution-mapping.md
@@ -75,11 +75,10 @@ blocked by #984.
 
 ## Subtasks
 
-### 0. Unblock — #984 ⚠️ blocks everything
+### 0. Unblock — #984 ✅ done
 
-Two sources over `CVR_CAMPAIGN_DISCLOSURE_CD.TSV` collide on one resume session, so one silently
-ingests nothing. The F460 cover-page map cannot be populated until this is fixed. Not part of this
-branch — see #984.
+Resolved by #985 (`b5cde99` on develop): resume-session identity is now unique per source, so the
+broadened cover-page source no longer risks colliding with a sibling over the same file.
 
 ### 2. Composite `externalId`
 
@@ -157,7 +156,9 @@ Required before subtask 6 lands:
 
 | Risk | Severity | Likelihood | Mitigation |
 |---|---|---|---|
-| Blocked by #984; F460 cover pages cannot populate | high | certain | Fix #984 first; do not start subtask 5 before it lands |
+| ~~Blocked by #984~~ | — | — | Resolved — #985 merged to develop as `b5cde99` |
+| Broadening `cvr_filings` regresses the #955 IE linker | low | possible | Checked: the linker starts from S496 line items (`committeeId: null, filingId != null`) and looks each up by `FILING_ID`, which is unique per filing — so extra non-F496 rows sit unused rather than mis-matching. Still add a test with non-F496 rows present, and re-verify `independentExpenditures` counts after re-ingest |
+| `cvr_filings` grows 31,418 → ~662,076 | low | certain | `IndependentExpenditureLinkerService` does an **unfiltered** `cvrFiling.findMany()` (line 78), so the whole table lands in memory. region-worker is capped at 6G, so ~662k rows is comfortable — but scoping that query to the pending filing IDs is cheap hardening and stops the cost scaling with table size |
 | Re-ingest requires deleting existing cal_access rows | high | likely | Scope by `source_system`; verify counts before/after; snapshot first; never target dev `postgres` (#796) |
 | Public dollar figures change substantially | high | likely | Expected and correct, but re-verify a sample against official filings before production — same exposure as #979 / #962 |
 | Row count grows 203,945 → ~1.2M | medium | likely | Verify index coverage on `contributions(committee_id, filing_id)`; donor scan already capped at 1000 |
@@ -166,12 +167,29 @@ Required before subtask 6 lands:
 | Region config in a separate repo | low | likely | Publish `@opuspopuli/regions` before the monorepo consumes it |
 | AGPL-3.0 dependency constraint | low | rare | No new dependencies anticipated |
 
+## Decisions
+
+**Launch gate — this blocks launch** (decided 2026-08-08). Every representative page currently sums
+money paid *out* as money *raised*, over ~17% of the available rows. Same false-attribution class as
+#979, which was treated as launch-blocking.
+
+**Cover pages — broaden the existing source** (decided 2026-08-08). Drop
+`filters: {FORM_TYPE: 'F496'}` from `dataSources[10]` so `cvr_filings` covers all campaign-disclosure
+cover pages, rather than adding a second F460-filtered source or a sibling table. One source, one
+table, one ingest pass.
+
+Consequence to verify: `cvr_filings` grows from 31,418 toward the 662,076 rows extracted, and
+`IndependentExpenditureLinkerService` (#955) must keep working against the larger set. It joins on
+`FILING_ID`, which is unaffected by admitting more form types — but the IE linker's behavior on
+non-F496 filings needs an explicit test before this ships, because #955 built it against an
+F496-only table and may assume every row is an IE cover page.
+
 ## Open questions
 
-1. Should this block launch? Every representative's dollar figures currently measure money paid out
-   rather than raised, over a ~17% sample. That is arguably a sibling of #979, not a follow-up.
+1. ~~Should this block launch?~~ Resolved above — yes.
 2. ~~Does `EXPN_CD` need the same cover-page join?~~ **Yes — verified.** `EXPN_CD` also has no
    `FILER_ID`, carries the same `FILING_ID`/`AMEND_ID`/`LINE_ITEM`/`TRAN_ID` key columns, and its
    `CMTE_ID` (col 26) sits in the payee block — so it identifies the *payee's* committee, not the
    spender. `totalSpent` is inverted the same way `totalRaised` is.
-3. Should `cvr_filings` broaden to all form types, or gain a sibling table for F460?
+3. ~~Should `cvr_filings` broaden to all form types, or gain a sibling table?~~ Resolved above —
+   broaden the existing source.

--- a/docs/plans/980-cal-access-contribution-mapping.md
+++ b/docs/plans/980-cal-access-contribution-mapping.md
@@ -10,7 +10,7 @@
 | **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases ~6x when this lands. |
 | **Branch** | `fix/980-cal-access-contribution-mapping` (+ `opuspopuli-regions`) |
 | **Effort** | 3–4 focused sessions + one supervised cutover |
-| **Status** | Subtasks 0, 1, 3 complete. Next: the cutover work (C1–C5). |
+| **Status** | Subtasks 0, 1, 3 and cutover steps C1–C2 complete. Next: C3 (linker + region config). |
 
 ## Problem
 
@@ -168,28 +168,38 @@ reads). Mutation-checked: removing the filter fails exactly the two list cases.
 
 All of C1–C3 land together, in one deploy, followed by the supervised C4/C5 rebuild.
 
-### C1. Composite `externalId`
+### C1. Composite `externalId` ✅ done (2026-08-09)
 
-- **Where:** `packages/scraping-pipeline/src/handlers/bulk-download.handler.ts`, `BulkDownloadConfig`;
-  `opuspopuli-regions/schema/region-plugin.schema.json`
-- Add optional `compositeKey: string[]` joining source columns with a stable separator. Real key is
-  `FILING_ID + AMEND_ID + LINE_ITEM + TRAN_ID`; `TRAN_ID` alone is not unique across filings.
-- **Tests:** key construction, collision behavior, back-compat when absent.
+- `BulkDownloadConfig.compositeKey?: string[]` (`packages/common`), consumed in
+  `bulk-download.handler.ts`; mirrored in `opuspopuli-regions/schema/region-plugin.schema.json`.
+- Segments join with `":"`. Chosen deliberately: it matches the shape single-column ids already have
+  (`<FILING_ID>:<LINE_ITEM>`), so with `FILING_ID` leading the key, existing prefix parsing keeps
+  working. C3 still re-points the linker at the `filing_id` column — this only removes the cliff.
+- **Two loud failures rather than silent collapse**, which is the whole point of the feature:
+  a key column absent from the file's headers **throws** (unlike `buildColumnIndices`, which warns
+  and continues — a missing key component shortens the key for *every* row); and a row whose
+  segments are all empty is dropped rather than upserted onto every other all-empty row.
+- Empty cells are preserved as empty segments so positions never shift (`a::7:b`, not `a:7:b`).
+- Takes precedence over any `externalId` in `columnMappings`.
+- **Tests:** 7 cases in `packages/scraping-pipeline/__tests__/bulk-download.handler.spec.ts`,
+  including the actual bug — two rows sharing a `TRAN_ID` across different filings staying distinct.
 
-### C2. Write path for `filing_id`
+### C2. Write path for `filing_id` ✅ done (2026-08-09)
 
-Subtask 3 added the column; nothing can populate it yet. #955 did all three of these for
-`independent_expenditures` — copy that shape:
-
-1. `packages/scraping-pipeline/src/mapping/domain-mapper.service.ts:898,935` — `ContributionSchema`
-   / `ExpenditureSchema` need `filingId` added and `committeeId` relaxed to `.optional()`.
-   `z.object()` **strips unknown keys**, so without this the mapper deletes `filingId` before the
-   sync ever sees it, no matter what the region config maps.
-2. `packages/common/src/providers/region/types.ts` — same shape change on the `Contribution` /
+1. `domain-mapper.service.ts` — `ContributionSchema` / `ExpenditureSchema` gained `filingId` and
+   relaxed `committeeId` to `.optional()`. `z.object()` **strips unknown keys**, so without this the
+   mapper deleted `filingId` before the sync ever saw it, whatever the region config mapped.
+2. `packages/common/src/providers/region/types.ts` — same shape on the `Contribution` /
    `Expenditure` interfaces.
-3. `apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts:441,460` — add
-   `'filingId'` to both `fields` projections. `upsertRecordsByFields` picks *only* the listed
-   fields, so the column stays NULL otherwise.
+3. `campaign-finance-sync.service.ts` — `'filingId'` added to both `fields` projections
+   (`upsertRecordsByFields` picks *only* the listed fields).
+4. **Fallout the review predicted:** `ensureCommitteeStubs` rewrote `committeeId` externalId→UUID
+   unconditionally for contributions/expenditures while guarding IEs, which became a compile error
+   the moment the type went optional. Now one shared `resolveCommittee` helper for all three.
+
+**These are inert until C3.** No region config maps `FILING_ID` yet and none has a `compositeKey`,
+so behavior is unchanged — the only live effect is that a blank `CMTE_ID` no longer fails
+validation, and nothing produces such rows today.
 
 ### C3. Cover-page-join linker + region config
 

--- a/docs/plans/980-cal-access-contribution-mapping.md
+++ b/docs/plans/980-cal-access-contribution-mapping.md
@@ -1,0 +1,196 @@
+# Plan: CAL-ACCESS contribution column mapping (#980)
+
+| | |
+|---|---|
+| **Issue** | [#980](https://github.com/OpusPopuli/opuspopuli/issues/980) |
+| **Related** | [#979](https://github.com/OpusPopuli/opuspopuli/issues/979) (linker attribution), [#962](https://github.com/OpusPopuli/opuspopuli/issues/962) (P0 false-attribution liability), [#954](https://github.com/OpusPopuli/opuspopuli/issues/954) (donor-name fragmentation, closed) |
+| **Date** | 2026-08-08 |
+| **Author** | Rodney Gagnon |
+| **Data classification** | **PII — no PHI.** Individual donor name, employer, occupation, city, state, ZIP+4. Public record under CA law. Volume increases materially if this lands. |
+| **Branch** | `fix/980-cal-access-contribution-mapping` (+ matching branch in `opuspopuli-regions`) |
+| **Effort** | 3–5 focused sessions |
+| **Status** | Approved. Defect A confirmed empirically 2026-08-08; subtask 1 narrowed to fix-design details |
+
+## Problem restatement
+
+The issue was filed as "itemization is shallow." Investigation indicates that is a *symptom* of two
+defects in the `RCPT_CD.TSV` column mapping in
+`opuspopuli-regions/regions/california/california.json` (`config.dataSources[7]`).
+
+### Defect A — `CMTE_ID` is the wrong source column for `committeeId` ✅ confirmed
+
+In CAL-ACCESS, `FILER_ID` identifies the committee that filed the report — the one **receiving** the
+contribution. `CMTE_ID` is populated on the **contributor** side when a committee gives to another
+committee.
+
+`ContributionSchema` in `packages/scraping-pipeline/src/mapping/domain-mapper.service.ts` requires
+`committeeId: z.string().min(1)`, so every row with a blank `CMTE_ID` is dropped silently by the
+mapper. Live data matches that prediction:
+
+```
+committee  151,986   ← CMTE_ID populated, survives
+individual  29,809   ← CMTE_ID mostly blank, dropped
+party       12,492
+other        9,658
+```
+
+Individual donors outnumbering committees ~5:1 is the real-world shape; the stored data is the
+inverse. This also explains the Mia Bonta page anomaly, where "Top donors" mirrored the committee
+list with near-identical amounts — `donorName` and `committeeId` were describing the *same*
+contributing committee.
+
+Contribution attribution is therefore **semantically inverted**: money the committee paid *out* is
+being counted as money it *raised*.
+
+#### Confirmation (2026-08-08)
+
+Tested directly against the us-ca node. If `committee_id` were the *recipient*, a committee-type
+donor's name would essentially never equal the name of the committee the row points at. Result:
+
+```
+committee-donor rows           151,986
+exact name match                40,003   (26.3%)
+normalized (alnum-only) match            (28.8%)
+```
+
+40,003 exact self-matches refutes the recipient reading outright. The remaining ~71% are the *same
+entities under different spellings* — #954 donor-name fragmentation defeating the string comparison,
+not a different relationship:
+
+| `committees.name` (via `committee_id`) | `contributions.donor_name` |
+|---|---|
+| RAYTHEON CALIFORNIA POLITICAL ACTION COMMITTEE | Raytheon California PAC |
+| Orange County Employees Association Political Action Committee | Orange County Employees Assoc. |
+| Turkish Coalition California PAC (TC-CAL PAC) | Turkish Coalition California PAC |
+| Howard F. Ahmanson/Fieldstead & Company | Fieldstead & Company |
+
+Defect A is confirmed. No bulk download was required to establish it.
+
+### Defect B — `TRAN_ID` is not a globally unique key
+
+`TRAN_ID` is unique within a filing, not across filings. `CampaignFinanceSyncService` upserts on
+`externalId`, so rows sharing a `TRAN_ID` overwrite each other. The real key is
+`FILING_ID + AMEND_ID + LINE_ITEM + TRAN_ID`.
+
+`EXPN_CD.TSV` (`dataSources[8]`) carries the identical `CMTE_ID`/`TRAN_ID` pattern, which is the
+likely reason `totalSpent` exceeds `totalRaised` for some representatives — the two joins have
+different coverage of the same defect.
+
+### Adjacent defects — split out, not in scope here
+
+Two further problems surfaced while sampling committee-donor rows. Both are independent of the
+column mapping and are tracked separately so #980 can close cleanly:
+
+- **[#982](https://github.com/OpusPopuli/opuspopuli/issues/982)** — committee rows whose `name` is a
+  bare numeric filer ID (`1318941`, `1363306`), rendering as a bare number on the public money-trail
+  lists.
+- **[#983](https://github.com/OpusPopuli/opuspopuli/issues/983)** — refunds filed as negative
+  receipts net against `totalRaised` with no sign handling, while still incrementing
+  `contributionCount` and donor buckets.
+
+#983 has no ingestion dependency and can land well before this work.
+
+## Subtasks
+
+### 1. Spike — raw source details ⚠️ gates the mapping change
+
+Defect A no longer depends on this (confirmed above), but the *fix* does. Pull `RCPT_CD.TSV` from
+`dbwebexport.zip` and confirm:
+
+- The actual column list, so the replacement column is one we have seen rather than one inferred
+  from CAL-ACCESS convention. `FILER_ID` is the expected recipient column — verify before mapping to it.
+- `TRAN_ID` collision rate across filings — sizes Defect B.
+- Whether `EXPN_CD.TSV` and `S496_CD.TSV` need the mirror-image fix.
+
+Header and a few sample rows are sufficient; the ~1GB TSV need not be extracted:
+
+```bash
+curl -o /tmp/dbwebexport.zip https://campaignfinance.cdn.sos.ca.gov/dbwebexport.zip
+unzip -l /tmp/dbwebexport.zip | grep -iE 'RCPT_CD|EXPN_CD|S496_CD'
+unzip -p /tmp/dbwebexport.zip 'CAL-ACCESS/DATA/RCPT_CD.TSV' | head -3
+```
+
+### 2. Composite `externalId` support
+
+- **Where:** `packages/scraping-pipeline` — `handlers/bulk-download.handler.ts`, `BulkDownloadConfig`
+- **Also:** `opuspopuli-regions/schema/region-plugin.schema.json`
+- Config can currently map only one column to `externalId`. Add a `compositeKey: string[]` that joins
+  source columns with a stable separator.
+- **Tests:** composite key construction, collision behavior, back-compat when `compositeKey` is absent.
+- No migration. No GraphQL change.
+
+### 3. Correct the column mappings
+
+- **Where:** `opuspopuli-regions` (separate repo — merges direct to `main`, publishes `@opuspopuli/regions`)
+- `RCPT_CD.TSV` and `EXPN_CD.TSV`: `committeeId` ← correct filer column; `externalId` ← composite key.
+- Version bump, publish, consume in the monorepo.
+- **Tests:** schema validation in the regions repo.
+
+### 4. Re-ingest
+
+- **Where:** `apps/backend` region-worker
+- Existing rows carry both a wrong `committee_id` and an unstable `externalId`, so upsert **will not
+  converge** — a scoped delete of `source_system='cal_access'` contributions and expenditures is
+  required before re-ingest.
+- Snapshot the production DB first. Scope the delete by `source_system`; never run against the dev
+  `postgres` database (#796 discipline).
+- **Acceptance gate:** `/op-data-scan` pass on the resulting data.
+
+### 5. Verify and re-check aggregation semantics
+
+- **Where:** `apps/backend/src/apps/region/src/domains/representative-funding.service.ts`
+- Confirm `totalRaised` now means raised rather than contributed-out, and that
+  `totalSpent <= totalRaised` holds for a sample.
+- Cross-check 5–10 representatives against official CAL-ACCESS filings before it reaches production.
+
+### 6. Revisit #980 labeling
+
+- **Where:** `apps/frontend/components/region/RepresentativeFundingPanel.tsx`, `locales/{en,es}/civics.json`
+- The interim "Identified donors" wording (shipped in the #979 PR) may revert to plain "Donors" once
+  counts are real. Re-run `pnpm test:a11y`.
+
+**Ordering:** 2 and 3 may run in parallel after 1. 4 blocks on both. 5 and 6 follow 4.
+[#982](https://github.com/OpusPopuli/opuspopuli/issues/982) and
+[#983](https://github.com/OpusPopuli/opuspopuli/issues/983) are independent and can be scheduled
+separately.
+
+## Data classification
+
+**PII, no PHI.** Individual contributor rows carry name, employer, occupation, city, state, and ZIP+4.
+All of it is published public record under California law, so ingestion is lawful — but volume changes
+the risk profile. Today ~29,809 individual rows survive; correcting the mapping could bring in
+millions.
+
+Required considerations before subtask 4 lands:
+
+- **ZIP+4 minimization.** Name + employer + ZIP+4 approaches individually identifying. Decide whether
+  ZIP+4 is needed or ZIP5 suffices.
+- **No model exposure.** Confirm contributor rows never reach prompts, embeddings, or the RAG index.
+  The knowledge service must not be indexing donor PII.
+- **Log masking.** Verify donor fields are in the audit-log masked set.
+- **Retention.** Campaign finance has no equivalent of the 90-day audit-log expiry. Needs an explicit
+  decision.
+
+## Risk register
+
+| Risk | Severity | Likelihood | Mitigation |
+|---|---|---|---|
+| Re-ingest requires deleting existing cal_access rows | high | likely | Scope delete by `source_system`; verify counts before/after; DB snapshot first; never target dev `postgres` (#796) |
+| Public-facing dollar figures change substantially | high | likely | Expected and correct, but re-verify a sample against official filings before production — same false-attribution exposure as #979 / #962 |
+| `FILER_ID` is not the correct replacement column | medium | possible | Defect A itself is confirmed; subtask 1 verifies the column name against the raw file before any mapping is written |
+| Refund handling (#983) changes published totals again | medium | possible | Land #983 deliberately with a matching UI label rather than as a silent numeric shift |
+| PII volume increase (29k → millions of individual rows) | medium | likely | See data classification; `/op-data-scan` as acceptance gate on subtask 4 |
+| Row-count growth degrades query performance | medium | likely | Verify index coverage on `contributions(committee_id)`; funding aggregation already caps its donor scan at 1000 |
+| Region config lives in a separate repo/package | low | likely | Coordinate `@opuspopuli/regions` publish before the monorepo consumes it |
+| Breaking change to `BulkDownloadConfig` | low | possible | `compositeKey` is additive and optional; existing configs unaffected |
+| AGPL-3.0 dependency constraint | low | rare | No new dependencies anticipated |
+
+## Open questions
+
+1. Should this block launch? It is arguably a sibling of #979 rather than a follow-up — if the spike
+   confirms Defect A, every representative's dollar figures are currently measuring the wrong thing.
+2. Does the same `CMTE_ID` assumption affect `S496_CD.TSV` (independent expenditures), recently
+   reworked in #955?
+3. ~~Are Defects C and D in scope for #980?~~ Resolved — split into
+   [#982](https://github.com/OpusPopuli/opuspopuli/issues/982) and
+   [#983](https://github.com/OpusPopuli/opuspopuli/issues/983).

--- a/docs/plans/980-cal-access-contribution-mapping.md
+++ b/docs/plans/980-cal-access-contribution-mapping.md
@@ -253,6 +253,63 @@ row exists, plus idempotency, the soft-deleted-committee guard, and both skip re
 </details>
 
 
+### C3b. Review hardening ✅ done (2026-08-09)
+
+Applied after a three-lens review of C1–C3:
+
+- **`cvr_filings.filing_id` is now `@unique`** (migration `20260809120000`). The linker joins on it
+  and requires one cover page per filing; that held only via three facts across two repos
+  (`external_id` unique + mapper defaulting `externalId = filingId` + the region config declining to
+  map one). Give the cover-page source a `compositeKey` — the feature C1 just added — and the join
+  fans out, attributing donor money to an arbitrary filer. Now a database guarantee.
+- **Partial `pending_link` indexes** on both tables. The plain `filing_id` index does not serve
+  `WHERE committee_id IS NULL`; the partial one stays tiny and empties as rows resolve.
+- **The 1.2M-row UPDATE is batched** (50k/transaction). One statement meant multi-GB WAL, ~1.2M dead
+  tuples across seven indexes, and a timeout rolling the whole thing back to restart from zero.
+  The batch subquery re-applies the full join, so a short batch can only mean "nothing left" —
+  filtering only on `committee_id IS NULL` would let a batch of unresolvable rows end the loop early
+  and silently half-link. Loop is bounded, not `while (true)`.
+- **`explainRemaining` uses `EXISTS`, not `JOIN`** — a join counts row/cover-page pairs, so any
+  fan-out would make `skippedNoCoverPage` negative. Plus a `max(0, …)` guard against concurrent
+  inserts landing between the count and the update.
+- **Donor PII no longer reaches error logs.** The `compositeKey` throw echoed the first ten cells of
+  the header row — and it fires *precisely* when that row isn't a header, i.e. when it holds donor
+  data. It propagates to the persisted pipeline `errors[]` and on to Loki. Now reports column count
+  only; the pre-existing `buildColumnIndices` warn was fixed the same way.
+- **IE linker `in` clause chunked** at 10k. Prisma binds one parameter per element against
+  Postgres's 32,767 ceiling, `pending` is unbounded, and the sync swallows the failure as a warning
+  — so overflowing would read as "IEs quietly stopped linking".
+- **`buildFilingToCommitteeIndex` de-duplicates in SQL** (`DISTINCT ON`). It built a ~662k-entry map
+  by hydrating ~1.2M row objects; the `committeeId IS NOT NULL` filter does not help, because after
+  the linker succeeds nearly every row passes it.
+- `processDataLine` takes a `ParseContext` (SonarCloud S107 caps parameters at 7; it had reached 8).
+- **Tests added:** the cover-page linker runs *before* the proposition linker, and still yields to it
+  when it throws — the ordering the whole design rests on, previously unasserted; plus the
+  one-cover-page-per-filing constraint.
+
+### ⚠️ C4 gate — verify amendment handling before rebuilding
+
+**Unresolved, and it can invert the fix.** CAL-ACCESS retains every amendment of a filing in
+`RCPT_CD`/`EXPN_CD` — same `FILING_ID`, incremented `AMEND_ID` — and an amendment restates the whole
+schedule. `cvr_filings` is deduped by `FILING_ID` (`domain-mapper.service.ts:395`), but line items
+now are not: `AMEND_ID` sits in the composite key, so an amended $500 receipt lands twice and the
+linker stamps both with the same filer. `totalRaised` reads $1,000.
+
+The old `TRAN_ID`-only key accidentally deduped this. So C1 fixes cross-filing collisions and may
+introduce amendment inflation **on the exact metric this issue exists to correct**. Note the extract
+counts (1,210,475 → 203,945) were attributed to blank-`CMTE_ID` rejections plus `TRAN_ID` collisions;
+if a meaningful share was actually amendment restatements, the new key inflates.
+
+Check against the bulk file before any rebuild:
+
+```
+awk -F'\t' 'NR>1{print $1"\t"$2}' RCPT_CD.TSV | sort -u | cut -f1 | uniq -d | wc -l
+```
+
+Non-zero ⇒ either drop `AMEND_ID` from the `compositeKey` (last amendment upserts over earlier ones)
+or add a latest-amendment filter. Either way it is a `@opuspopuli/regions` change, so settle it
+before publishing the version the rebuild consumes.
+
 ### C4. Truncate + rebuild
 
 - **Snapshot prod first** — for rollback *and* because C5 needs the old figures to diff against.

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -550,7 +550,8 @@ export interface Committee {
  */
 export interface Contribution {
   externalId: string;
-  committeeId: string;
+  committeeId?: string; // resolved post-sync by the cover-page linker via filingId (#980) — RCPT_CD's CMTE_ID is the contributor
+  filingId?: string; // CalAccess FILING_ID from RCPT_CD — join key to the campaign-disclosure cover page (#980)
   donorName: string;
   donorType: "individual" | "committee" | "party" | "self" | "other";
   donorEmployer?: string;
@@ -570,7 +571,8 @@ export interface Contribution {
  */
 export interface Expenditure {
   externalId: string;
-  committeeId: string;
+  committeeId?: string; // resolved post-sync by the cover-page linker via filingId (#980) — EXPN_CD's CMTE_ID is the payee
+  filingId?: string; // CalAccess FILING_ID from EXPN_CD — join key to the campaign-disclosure cover page (#980)
   payeeName: string;
   amount: number;
   date: Date;

--- a/packages/common/src/providers/scraping-pipeline/types.ts
+++ b/packages/common/src/providers/scraping-pipeline/types.ts
@@ -517,6 +517,21 @@ export interface BulkDownloadConfig {
   headers?: string[];
   /** Column name mappings: source column name → domain field name */
   columnMappings: Record<string, string>;
+  /**
+   * Source columns whose values are joined (with ":") to form `externalId`,
+   * for feeds where no single column is unique. Order is significant and must
+   * stay stable — it defines the upsert identity, so changing it re-keys every
+   * row. Takes precedence over any `externalId` in `columnMappings`.
+   *
+   * Empty cells are preserved as empty segments so positions never shift. If a
+   * listed column is absent from the file's headers the parse throws rather
+   * than emitting short keys, which would collapse distinct rows onto one
+   * `externalId` and silently discard data (opuspopuli#980).
+   *
+   * e.g. CAL-ACCESS RCPT_CD, where TRAN_ID repeats across filings:
+   * `["FILING_ID", "AMEND_ID", "LINE_ITEM", "TRAN_ID"]`
+   */
+  compositeKey?: string[];
   /** Filter expressions applied during parse (e.g., { "STATE": "CA" }) */
   filters?: Record<string, string>;
   /** Batch size for streaming processing (default: 10,000). Records are

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.77"
+    "@opuspopuli/regions": "^1.0.78"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.76"
+    "@opuspopuli/regions": "^1.0.77"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/relationaldb-provider/prisma/migrations/20260809000000_contribution_expenditure_cover_page_join/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260809000000_contribution_expenditure_cover_page_join/migration.sql
@@ -1,0 +1,42 @@
+-- #980: attribute contributions and expenditures to the FILING committee.
+-- RCPT_CD / EXPN_CD line items carry no FILER_ID, and their CMTE_ID identifies the
+-- *counterparty* (contributor / payee), not the filer — so today totalRaised sums
+-- money each committee paid out. The recipient/spender is only reachable by joining
+-- FILING_ID -> the campaign-disclosure cover page (CVR_CAMPAIGN_DISCLOSURE_CD,
+-- already persisted as cvr_filings for #955). This migration adds that join key and
+-- lets the linker stamp committee_id post-sync, mirroring independent_expenditures.
+--
+-- Additive + widening only: new nullable columns and relaxing an existing NOT NULL —
+-- no drops, no renames. Both ALTERs are catalog-only in PostgreSQL (ADD COLUMN with
+-- no default; DROP NOT NULL, which unlike SET NOT NULL needs no verification scan),
+-- so neither rewrites the ~204k-row contributions table.
+--
+-- Lock duration is set by the CREATE INDEXes below, not the ALTERs: Prisma runs each
+-- migration in one transaction, so the ACCESS EXCLUSIVE taken by the first ALTER on a
+-- table is held until COMMIT — i.e. across that table's index build. At ~204k rows
+-- that is a couple of seconds of blocked writes. CREATE INDEX CONCURRENTLY is not an
+-- option for the same reason (it cannot run inside a transaction block), and no
+-- migration in this repo uses it.
+--
+-- Data classification: PII, no PHI — and no new PII. filing_id is a public CAL-ACCESS
+-- filing identifier. The donor PII already on contributions (donor_name, employer,
+-- occupation, city, state, zip) is untouched here; the volume increase that fix
+-- causes is gated on subtask 6, not this migration. No RLS policies exist on these
+-- tables (none exist anywhere in this schema); access is mediated by the region
+-- service, so this changes no exposure surface.
+--
+-- Coordinated deploy: migration lands first and is inert on its own. Once the region
+-- config drops the CMTE_ID -> committeeId mapping (#980 subtask 5), rows arrive with
+-- a NULL committee until the cover-page linker (subtask 4) stamps them.
+
+-- Contributions: RCPT_CD FILING_ID -> cover page -> recipient committee.
+ALTER TABLE "contributions" ALTER COLUMN "committee_id" DROP NOT NULL;
+ALTER TABLE "contributions" ADD COLUMN "filing_id" VARCHAR(50);
+
+CREATE INDEX "contributions_filing_id_idx" ON "contributions"("filing_id");
+
+-- Expenditures: EXPN_CD FILING_ID -> cover page -> spending committee.
+ALTER TABLE "expenditures" ALTER COLUMN "committee_id" DROP NOT NULL;
+ALTER TABLE "expenditures" ADD COLUMN "filing_id" VARCHAR(50);
+
+CREATE INDEX "expenditures_filing_id_idx" ON "expenditures"("filing_id");

--- a/packages/relationaldb-provider/prisma/migrations/20260809120000_cvr_filing_unique_and_pending_link_index/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260809120000_cvr_filing_unique_and_pending_link_index/migration.sql
@@ -1,0 +1,35 @@
+-- #980 follow-up: enforce the invariant the cover-page join depends on, and
+-- index the rows it actually looks for.
+--
+-- 1) CoverPageLinkerService joins `contributions.filing_id = cvr_filings.filing_id`
+--    and assumes one cover page per filing. Until now that held only by accident:
+--    `external_id` is unique, the mapper defaults `externalId = filingId`, and the
+--    region config declines to map an externalId for that source. Three separate
+--    facts across two repos. Give the cover-page source a `compositeKey` — the
+--    feature #980 just added for RCPT/EXPN — and the join silently fans out,
+--    attributing donor money to an arbitrary filer and driving the linker's
+--    skipped-row arithmetic negative. Make it a database guarantee instead.
+--
+-- 2) The linker's steady-state query is "rows still awaiting attribution".
+--    A partial index over exactly those rows stays tiny (it holds only staging
+--    rows and empties as they resolve), costs nothing on write once a row is
+--    linked, and turns each incremental run into an index scan. The plain
+--    filing_id index added in 20260809000000 does not serve this predicate.
+--
+-- Additive: one constraint, two partial indexes. No drops, no renames, no
+-- rewrites. Existing data already satisfies the uniqueness (verified: external_id
+-- is unique and equals filing_id), so the constraint build cannot fail on it.
+
+CREATE UNIQUE INDEX "cvr_filings_filing_id_key" ON "cvr_filings"("filing_id");
+
+-- The plain index is now redundant — the unique index above serves every lookup
+-- it did. Dropping an index removes no data and is instantly reversible.
+DROP INDEX IF EXISTS "cvr_filings_filing_id_idx";
+
+CREATE INDEX "contributions_pending_link_idx"
+    ON "contributions"("filing_id")
+    WHERE "committee_id" IS NULL;
+
+CREATE INDEX "expenditures_pending_link_idx"
+    ON "expenditures"("filing_id")
+    WHERE "committee_id" IS NULL;

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -1735,7 +1735,9 @@ model Cvr2Filing {
 model CvrFiling {
   id               String   @id @default(uuid())
   externalId       String   @unique @map("external_id") /// FILING_ID (one cover page per filing)
-  filingId         String   @map("filing_id") @db.VarChar(50)
+  /// Unique: CoverPageLinkerService joins on this column and requires exactly one
+  /// cover page per filing, or donor money is attributed to an arbitrary filer (#980).
+  filingId         String   @unique @map("filing_id") @db.VarChar(50)
   filerId          String   @map("filer_id") @db.VarChar(50) /// CalAccess FILER_ID — same id space as committees.external_id
   candidateName    String?  @map("candidate_name")
   candidateOffice  String?  @map("candidate_office") @db.VarChar(50)
@@ -1745,7 +1747,6 @@ model CvrFiling {
   createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt        DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
-  @@index([filingId])
   @@index([filerId])
   @@map("cvr_filings")
 }

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -1754,7 +1754,13 @@ model CvrFiling {
 model Contribution {
   id               String   @id @default(uuid())
   externalId       String   @unique @map("external_id")
-  committeeId      String   @map("committee_id")
+  /// Nullable + resolved post-sync by the cover-page linker: RCPT_CD line items
+  /// carry no filer, so committeeId is stamped by joining filingId -> the
+  /// campaign-disclosure cover page (cvr_filings) -> committee (#980). The
+  /// CMTE_ID on RCPT_CD is the *contributor*, not the recipient.
+  committeeId      String?  @map("committee_id")
+  /// CalAccess FILING_ID from RCPT_CD — the join key to the cover page.
+  filingId         String?  @map("filing_id") @db.VarChar(50)
   donorName        String   @map("donor_name")
   donorType        String   @map("donor_type") @db.VarChar(20) /// individual, committee, party, self, other
   donorEmployer    String?  @map("donor_employer")
@@ -1770,9 +1776,10 @@ model Contribution {
   createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt        DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
-  committee Committee @relation(fields: [committeeId], references: [id])
+  committee Committee? @relation(fields: [committeeId], references: [id], onDelete: Restrict)
 
   @@index([committeeId])
+  @@index([filingId])
   @@index([donorName])
   @@index([date])
   @@index([amount])
@@ -1784,7 +1791,13 @@ model Contribution {
 model Expenditure {
   id                 String   @id @default(uuid())
   externalId         String   @unique @map("external_id")
-  committeeId        String   @map("committee_id")
+  /// Nullable + resolved post-sync by the cover-page linker: EXPN_CD line items
+  /// carry no filer, so committeeId is stamped by joining filingId -> the
+  /// campaign-disclosure cover page (cvr_filings) -> committee (#980). The
+  /// CMTE_ID on EXPN_CD is the *payee*, not the spender.
+  committeeId        String?  @map("committee_id")
+  /// CalAccess FILING_ID from EXPN_CD — the join key to the cover page.
+  filingId           String?  @map("filing_id") @db.VarChar(50)
   payeeName          String   @map("payee_name")
   amount             Decimal  @db.Decimal(12, 2)
   date               DateTime @db.Date
@@ -1800,10 +1813,11 @@ model Expenditure {
   createdAt          DateTime @default(now()) @map("created_at") @db.Timestamptz
   updatedAt          DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
 
-  committee   Committee    @relation(fields: [committeeId], references: [id])
+  committee   Committee?   @relation(fields: [committeeId], references: [id], onDelete: Restrict)
   proposition Proposition? @relation(fields: [propositionId], references: [id], onDelete: SetNull)
 
   @@index([committeeId])
+  @@index([filingId])
   @@index([payeeName])
   @@index([date])
   @@index([sourceSystem])

--- a/packages/scraping-pipeline/__tests__/bulk-download.handler.spec.ts
+++ b/packages/scraping-pipeline/__tests__/bulk-download.handler.spec.ts
@@ -928,4 +928,126 @@ describe("BulkDownloadHandler", () => {
       expect(sourceUrl).toContain("RCPT_CD.TSV");
     });
   });
+
+  describe("compositeKey externalId (#980)", () => {
+    /** Mirrors CAL-ACCESS RCPT_CD, where TRAN_ID alone repeats across filings. */
+    function createCompositeSource(
+      compositeKey: string[] | undefined,
+      columnMappings: Record<string, string> = {
+        TRAN_ID: "externalId",
+        AMOUNT: "amount",
+      },
+    ): DataSourceConfig {
+      return createSource({
+        bulk: {
+          format: "csv",
+          columnMappings,
+          compositeKey,
+        } as BulkDownloadConfig,
+      });
+    }
+
+    async function rawItemsFor(content: string, source: DataSourceConfig) {
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse(content),
+      );
+      await handler.execute(source, "california");
+      return mapper.map.mock.calls[0][0].items as Array<
+        Record<string, unknown>
+      >;
+    }
+
+    it("joins the configured columns in order", async () => {
+      const items = await rawItemsFor(
+        "FILING_ID,AMEND_ID,LINE_ITEM,TRAN_ID,AMOUNT\n2801843,0,7,ABC123,500",
+        createCompositeSource([
+          "FILING_ID",
+          "AMEND_ID",
+          "LINE_ITEM",
+          "TRAN_ID",
+        ]),
+      );
+
+      expect(items[0].externalId).toBe("2801843:0:7:ABC123");
+    });
+
+    it("keeps rows distinct when TRAN_ID repeats across filings", async () => {
+      // The bug this exists to prevent: both rows upsert onto one externalId,
+      // so the second silently overwrites the first.
+      const items = await rawItemsFor(
+        "FILING_ID,AMEND_ID,LINE_ITEM,TRAN_ID,AMOUNT\n" +
+          "2801843,0,7,ABC123,500\n" +
+          "2801999,0,7,ABC123,750",
+        createCompositeSource([
+          "FILING_ID",
+          "AMEND_ID",
+          "LINE_ITEM",
+          "TRAN_ID",
+        ]),
+      );
+
+      expect(items).toHaveLength(2);
+      expect(items[0].externalId).not.toBe(items[1].externalId);
+    });
+
+    it("preserves empty cells as empty segments so positions never shift", async () => {
+      const items = await rawItemsFor(
+        "FILING_ID,AMEND_ID,LINE_ITEM,TRAN_ID,AMOUNT\n2801843,,7,ABC123,500",
+        createCompositeSource([
+          "FILING_ID",
+          "AMEND_ID",
+          "LINE_ITEM",
+          "TRAN_ID",
+        ]),
+      );
+
+      // Not "2801843:7:ABC123" — that would collide with a row whose AMEND_ID
+      // is 7 and LINE_ITEM is ABC123.
+      expect(items[0].externalId).toBe("2801843::7:ABC123");
+    });
+
+    it("takes precedence over an externalId in columnMappings", async () => {
+      const items = await rawItemsFor(
+        "FILING_ID,LINE_ITEM,TRAN_ID,AMOUNT\n2801843,7,ABC123,500",
+        createCompositeSource(["FILING_ID", "LINE_ITEM"]),
+      );
+
+      expect(items[0].externalId).toBe("2801843:7");
+    });
+
+    it("leaves externalId to columnMappings when not configured", async () => {
+      const items = await rawItemsFor(
+        "FILING_ID,LINE_ITEM,TRAN_ID,AMOUNT\n2801843,7,ABC123,500",
+        createCompositeSource(undefined),
+      );
+
+      expect(items[0].externalId).toBe("ABC123");
+    });
+
+    it("throws when a key column is missing from the headers", async () => {
+      // Warning-and-continuing would shorten the key for every row and collapse
+      // distinct records onto one externalId — silent, total data loss.
+      (globalThis.fetch as jest.Mock).mockResolvedValue(
+        mockStreamResponse("FILING_ID,AMOUNT\n2801843,500"),
+      );
+
+      const result = await handler.execute(
+        createCompositeSource(["FILING_ID", "TRAN_ID"]),
+        "california",
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.errors.join(" ")).toContain("TRAN_ID");
+    });
+
+    it("drops a row whose key segments are all empty", async () => {
+      const items = await rawItemsFor(
+        "FILING_ID,TRAN_ID,AMOUNT\n2801843,ABC123,500\n,,750",
+        createCompositeSource(["FILING_ID", "TRAN_ID"]),
+      );
+
+      expect(items).toHaveLength(1);
+      expect(items[0].externalId).toBe("2801843:ABC123");
+    });
+  });
 });

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1195,6 +1195,78 @@ describe("DomainMapperService", () => {
         (result.items[0] as { committeeId?: string }).committeeId,
       ).toBeUndefined();
     });
+
+    it("maps an RCPT line item that has no committeeId (#980)", () => {
+      // RCPT_CD's CMTE_ID is the *contributor*, so the region config stops
+      // mapping it — the recipient comes from the cover page via filingId.
+      // While committeeId was required, every individual-donor row (blank
+      // CMTE_ID) was dropped here, which is why ~1M of 1.2M rows never landed.
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "2801843:0:7:ABC123",
+              filingId: "2801843",
+              donorName: "Jane Q. Public",
+              donorType: "individual",
+              amount: "250",
+              date: "2026-03-01",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Contributions",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        externalId: "2801843:0:7:ABC123",
+        filingId: "2801843",
+        donorName: "Jane Q. Public",
+        amount: 250,
+      });
+      expect(
+        (result.items[0] as { committeeId?: string }).committeeId,
+      ).toBeUndefined();
+    });
+
+    it("maps an EXPN line item that has no committeeId (#980)", () => {
+      // EXPN_CD's CMTE_ID is the *payee*; the spender comes from the cover page.
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "2801999:0:3:XYZ789",
+              filingId: "2801999",
+              payeeName: "Some Print Shop",
+              amount: "1000",
+              date: "2026-03-01",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Expenditures",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0]).toMatchObject({
+        externalId: "2801999:0:3:XYZ789",
+        filingId: "2801999",
+        payeeName: "Some Print Shop",
+        amount: 1000,
+      });
+      expect(
+        (result.items[0] as { committeeId?: string }).committeeId,
+      ).toBeUndefined();
+    });
   });
 
   describe("campaign finance — category routing", () => {

--- a/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
@@ -47,6 +47,13 @@ const DOWNLOAD_TIMEOUT_MS = 1_800_000;
 /** Default batch size for record processing (trades memory for fewer DB round-trips) */
 const DEFAULT_BATCH_SIZE = 10_000;
 
+/**
+ * Joins `compositeKey` column values into an `externalId`. Matches the shape
+ * single-column ids already have in this codebase (`<FILING_ID>:<LINE_ITEM>`),
+ * so downstream prefix parsing keeps working when FILING_ID leads the key.
+ */
+const COMPOSITE_KEY_SEPARATOR = ":";
+
 /** Callback invoked with each batch of mapped domain objects */
 export type OnBatchCallback<T> = (items: T[]) => Promise<void>;
 
@@ -414,22 +421,26 @@ export class BulkDownloadHandler {
     const delimiter = this.getDelimiter(bulk);
     const mappings = bulk.columnMappings;
     const filters = bulk.filters ?? {};
+    const compositeKey = bulk.compositeKey ?? [];
     const sourceSystem = inferSourceSystem(source);
     const headerSkip = bulk.headerLines ?? 0;
 
     let lineNum = 0;
     let colIndices: Record<string, number> = {};
     let filterIndices: Record<string, number> = {};
+    let compositeIndices: number[] = [];
 
     const hasExplicitHeaders = bulk.headers && bulk.headers.length > 0;
     if (hasExplicitHeaders) {
       const headers = bulk.headers!;
       colIndices = this.buildColumnIndices(headers, mappings);
       filterIndices = this.buildColumnIndices(headers, filters);
+      compositeIndices = this.buildCompositeIndices(headers, compositeKey);
     }
 
     const headerLineNum = headerSkip;
     const buildIndices = this.buildColumnIndices.bind(this);
+    const buildComposite = this.buildCompositeIndices.bind(this);
     const processData = this.processDataLine.bind(this);
 
     return {
@@ -445,6 +456,7 @@ export class BulkDownloadHandler {
             .map((h) => BulkDownloadHandler.stripQuotes(h));
           colIndices = buildIndices(headers, mappings);
           filterIndices = buildIndices(headers, filters);
+          compositeIndices = buildComposite(headers, compositeKey);
           lineNum++;
           return null;
         }
@@ -458,6 +470,7 @@ export class BulkDownloadHandler {
           colIndices,
           filterIndices,
           sourceSystem,
+          compositeIndices,
         );
       },
     };
@@ -475,6 +488,7 @@ export class BulkDownloadHandler {
     colIndices: Record<string, number>,
     filterIndices: Record<string, number>,
     sourceSystem: string | undefined,
+    compositeIndices: number[] = [],
   ): Record<string, unknown> | null {
     if (!line.trim()) return null;
 
@@ -483,6 +497,18 @@ export class BulkDownloadHandler {
     if (!this.passesFilters(values, filters, filterIndices)) return null;
 
     const record = this.mapRow(values, mappings, colIndices);
+
+    if (compositeIndices.length > 0) {
+      const segments = compositeIndices.map((idx) =>
+        BulkDownloadHandler.stripQuotes(values[idx] ?? ""),
+      );
+      // An all-empty key identifies nothing and would collide with every other
+      // all-empty row, so drop the line rather than upserting them onto each other.
+      if (segments.every((s) => !s)) return null;
+      // Overwrites any externalId from columnMappings — a feed that needs a
+      // composite key by definition has no single column that identifies a row.
+      record["externalId"] = segments.join(COMPOSITE_KEY_SEPARATOR);
+    }
 
     if (sourceSystem && !record["sourceSystem"]) {
       record["sourceSystem"] = sourceSystem;
@@ -540,6 +566,30 @@ export class BulkDownloadHandler {
       }
     }
     return indices;
+  }
+
+  /**
+   * Resolve `compositeKey` column names to their positions, in the order given.
+   *
+   * Throws on an unresolvable column instead of warning-and-continuing the way
+   * {@link buildColumnIndices} does. A missing mapped column costs one field;
+   * a missing key component silently shortens the key for *every* row, so
+   * distinct rows collapse onto one `externalId` and the upsert discards all
+   * but the last. That is the failure this feature exists to prevent
+   * (opuspopuli#980), so it must be loud.
+   */
+  private buildCompositeIndices(
+    headers: string[],
+    compositeKey: string[],
+  ): number[] {
+    const missing = compositeKey.filter((col) => !headers.includes(col));
+    if (missing.length > 0) {
+      throw new Error(
+        `compositeKey column(s) not found in file headers: ${missing.join(", ")}. ` +
+          `Available: ${headers.slice(0, 10).join(", ")}`,
+      );
+    }
+    return compositeKey.map((col) => headers.indexOf(col));
   }
 
   /**

--- a/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
+++ b/packages/scraping-pipeline/src/handlers/bulk-download.handler.ts
@@ -49,13 +49,33 @@ const DEFAULT_BATCH_SIZE = 10_000;
 
 /**
  * Joins `compositeKey` column values into an `externalId`. Matches the shape
- * single-column ids already have in this codebase (`<FILING_ID>:<LINE_ITEM>`),
- * so downstream prefix parsing keeps working when FILING_ID leads the key.
+ * single-column ids already have in this codebase (`<FILING_ID>:<LINE_ITEM>`).
+ *
+ * Note this is a display/identity convention only — nothing parses an id back
+ * apart. The one consumer that did (`extractFilingId`) was replaced by a real
+ * `filing_id` column in #980, precisely so that changing a key's layout can
+ * never silently break a downstream reader again.
  */
 const COMPOSITE_KEY_SEPARATOR = ":";
 
 /** Callback invoked with each batch of mapped domain objects */
 export type OnBatchCallback<T> = (items: T[]) => Promise<void>;
+
+/**
+ * Everything a single data line needs to become a record. Bundled rather than
+ * passed positionally — the parameter list had reached the point where adding
+ * one more (SonarCloud S107 caps it at 7) traded a readable signature for a
+ * lint waiver.
+ */
+interface ParseContext {
+  delimiter: string;
+  mappings: Record<string, string>;
+  filters: Record<string, string>;
+  colIndices: Record<string, number>;
+  filterIndices: Record<string, number>;
+  compositeIndices: number[];
+  sourceSystem: string | undefined;
+}
 
 @Injectable()
 export class BulkDownloadHandler {
@@ -443,6 +463,16 @@ export class BulkDownloadHandler {
     const buildComposite = this.buildCompositeIndices.bind(this);
     const processData = this.processDataLine.bind(this);
 
+    const context = (): ParseContext => ({
+      delimiter,
+      mappings,
+      filters,
+      colIndices,
+      filterIndices,
+      compositeIndices,
+      sourceSystem,
+    });
+
     return {
       processLine(line: string): Record<string, unknown> | null {
         if (lineNum < headerSkip) {
@@ -462,16 +492,7 @@ export class BulkDownloadHandler {
         }
 
         lineNum++;
-        return processData(
-          line,
-          delimiter,
-          mappings,
-          filters,
-          colIndices,
-          filterIndices,
-          sourceSystem,
-          compositeIndices,
-        );
+        return processData(line, context());
       },
     };
   }
@@ -482,21 +503,17 @@ export class BulkDownloadHandler {
    */
   private processDataLine(
     line: string,
-    delimiter: string,
-    mappings: Record<string, string>,
-    filters: Record<string, string>,
-    colIndices: Record<string, number>,
-    filterIndices: Record<string, number>,
-    sourceSystem: string | undefined,
-    compositeIndices: number[] = [],
+    ctx: ParseContext,
   ): Record<string, unknown> | null {
     if (!line.trim()) return null;
 
-    const values = line.split(delimiter);
+    const { compositeIndices, sourceSystem } = ctx;
+    const values = line.split(ctx.delimiter);
 
-    if (!this.passesFilters(values, filters, filterIndices)) return null;
+    if (!this.passesFilters(values, ctx.filters, ctx.filterIndices))
+      return null;
 
-    const record = this.mapRow(values, mappings, colIndices);
+    const record = this.mapRow(values, ctx.mappings, ctx.colIndices);
 
     if (compositeIndices.length > 0) {
       const segments = compositeIndices.map((idx) =>
@@ -558,8 +575,11 @@ export class BulkDownloadHandler {
     for (const col of Object.keys(columns)) {
       const idx = headers.indexOf(col);
       if (idx === -1) {
+        // Same reasoning as buildCompositeIndices: when the first line isn't
+        // actually a header row it holds donor data, so log its shape, not its
+        // cells (#980 review).
         this.logger.warn(
-          `Column '${col}' not found in file headers. Available: ${headers.slice(0, 10).join(", ")}`,
+          `Column '${col}' not found in file headers (${headers.length} column(s) present).`,
         );
       } else {
         indices[col] = idx;
@@ -584,9 +604,15 @@ export class BulkDownloadHandler {
   ): number[] {
     const missing = compositeKey.filter((col) => !headers.includes(col));
     if (missing.length > 0) {
+      // Report the shape of the header row, never its contents. `headers` is
+      // just the file's first non-skipped line — and this error fires precisely
+      // when that line ISN'T a header row, i.e. when it is a data row. Echoing
+      // its cells would put donor name/employer/city/ZIP into an error-level log
+      // that propagates to the persisted pipeline errors[] and on to Loki.
       throw new Error(
         `compositeKey column(s) not found in file headers: ${missing.join(", ")}. ` +
-          `Available: ${headers.slice(0, 10).join(", ")}`,
+          `Header row has ${headers.length} column(s); ` +
+          `expected columns are configured in the region plugin.`,
       );
     }
     return compositeKey.map((col) => headers.indexOf(col));

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -897,7 +897,12 @@ const CommitteeSchema = z.object({
  */
 const ContributionSchema = z.object({
   externalId: z.string().min(1),
-  committeeId: z.string().min(1),
+  // Optional: RCPT_CD line items carry no filer — its CMTE_ID is the
+  // *contributor*. The recipient is resolved post-sync by joining
+  // filingId -> the campaign-disclosure cover page (#980), the same shape
+  // IndependentExpenditureSchema has used since #955.
+  committeeId: z.string().min(1).optional(),
+  filingId: z.string().min(1).optional(),
   donorName: z.string().min(1),
   donorType: z.string().transform(donorTypeTransform).default("other"),
   donorEmployer: z
@@ -935,7 +940,10 @@ const ContributionSchema = z.object({
 const ExpenditureSchema = z
   .object({
     externalId: z.string().min(1),
-    committeeId: z.string().min(1),
+    // Optional for the same reason as ContributionSchema: EXPN_CD's CMTE_ID is
+    // the *payee*, so the spender comes from the cover page via filingId (#980).
+    committeeId: z.string().min(1).optional(),
+    filingId: z.string().min(1).optional(),
     payeeName: z.string().min(1),
     amount: z.coerce.number(),
     date: coerceFlexibleDate,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1010,8 +1010,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.77
-        version: 1.0.77
+        specifier: ^1.0.78
+        version: 1.0.78
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4918,8 +4918,8 @@ packages:
     resolution: {integrity: sha512-fwzZ5Yh1ZNGh6Fubp0bBoDcr5zXBw4elKx4Wtk2rsNUOzIlctUTdky0o57xYERqyMRg5aFLNymQCXK+/qphIdg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.76/2421750779394a5eb95f8fe17016c6139f3d8556}
     hasBin: true
 
-  '@opuspopuli/regions@1.0.77':
-    resolution: {integrity: sha512-q5nA4Y9CstYlF4dsHrvt15bqBxENA3QDm+KvulaXcSMuYVgyJ0Le8B8kmXJJ3zVL9M4+yu/rckelZWTGuzDqgQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.77/0e80d6ee1a99b41ac0e05bd2a2daeef41454e97f}
+  '@opuspopuli/regions@1.0.78':
+    resolution: {integrity: sha512-PvvhZdRCO80O2c9QAlUTqKk4/z9jAOUWCl2zXR2llTzTqECd/bGLAB6chehEfbrGDJ4MbCAOyCm/JWNAv0umbA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.78/65791c19c80bd4b34349cfedcd29573f2a1c63d6}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -16707,7 +16707,7 @@ snapshots:
       commander: 12.1.0
       ollama: 0.6.3
 
-  '@opuspopuli/regions@1.0.77':
+  '@opuspopuli/regions@1.0.78':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,13 +554,13 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.1.5
-        version: 16.2.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.0.1
         version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+        version: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-prettier:
         specifier: ^5.2.1
         version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.1)
@@ -572,7 +572,7 @@ importers:
         version: 16.5.0
       jest:
         specifier: ^30.2.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       jest-axe:
         specifier: ^10.0.0
         version: 10.0.0
@@ -590,7 +590,7 @@ importers:
         version: 4.2.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -633,7 +633,7 @@ importers:
         version: 7.0.11
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -642,7 +642,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -667,10 +667,10 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -713,7 +713,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -722,7 +722,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -740,7 +740,7 @@ importers:
         version: link:../config-provider
       '@xenova/transformers':
         specifier: ^2.17.2
-        version: 2.17.2(@types/node@25.5.0)
+        version: 2.17.2(@types/node@25.9.1)
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -753,7 +753,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -762,7 +762,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -805,7 +805,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -814,7 +814,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -839,7 +839,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -848,7 +848,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -876,10 +876,10 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -894,7 +894,7 @@ importers:
         version: link:../config-provider
       sharp:
         specifier: '>=0.35.0'
-        version: 0.35.3(@types/node@25.5.0)
+        version: 0.35.3(@types/node@25.9.1)
       tesseract.js:
         specifier: ^5.1.1
         version: 5.1.1(encoding@0.1.13)
@@ -910,7 +910,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -919,7 +919,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -947,10 +947,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -959,7 +959,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -990,13 +990,13 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1010,8 +1010,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.76
-        version: 1.0.76
+        specifier: ^1.0.77
+        version: 1.0.77
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -1024,7 +1024,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1033,7 +1033,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1061,10 +1061,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       prisma:
         specifier: '5'
         version: 5.22.0
@@ -1076,7 +1076,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1134,7 +1134,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       mupdf:
         specifier: ^1.27.0
         version: 1.27.0
@@ -1146,7 +1146,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1177,7 +1177,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1186,7 +1186,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1223,7 +1223,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)
+        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1232,7 +1232,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1260,13 +1260,13 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.5.0)
+        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -4916,6 +4916,10 @@ packages:
 
   '@opuspopuli/regions@1.0.76':
     resolution: {integrity: sha512-fwzZ5Yh1ZNGh6Fubp0bBoDcr5zXBw4elKx4Wtk2rsNUOzIlctUTdky0o57xYERqyMRg5aFLNymQCXK+/qphIdg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.76/2421750779394a5eb95f8fe17016c6139f3d8556}
+    hasBin: true
+
+  '@opuspopuli/regions@1.0.77':
+    resolution: {integrity: sha512-q5nA4Y9CstYlF4dsHrvt15bqBxENA3QDm+KvulaXcSMuYVgyJ0Le8B8kmXJJ3zVL9M4+yu/rckelZWTGuzDqgQ==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.77/0e80d6ee1a99b41ac0e05bd2a2daeef41454e97f}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -14753,6 +14757,41 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
+  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 25.8.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.3.0
+      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-haste-map: 30.3.0
+      jest-message-util: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-resolve-dependencies: 30.3.0
+      jest-runner: 30.3.0
+      jest-runtime: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      jest-watcher: 30.3.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.3.0
@@ -14769,6 +14808,76 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
       jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      jest-haste-map: 30.3.0
+      jest-message-util: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-resolve-dependencies: 30.3.0
+      jest-runner: 30.3.0
+      jest-runtime: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      jest-watcher: 30.3.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 25.8.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.3.0
+      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      jest-haste-map: 30.3.0
+      jest-message-util: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-resolve-dependencies: 30.3.0
+      jest-runner: 30.3.0
+      jest-runtime: 30.3.0
+      jest-snapshot: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      jest-watcher: 30.3.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))':
+    dependencies:
+      '@jest/console': 30.3.0
+      '@jest/pattern': 30.0.1
+      '@jest/reporters': 30.3.0
+      '@jest/test-result': 30.3.0
+      '@jest/transform': 30.3.0
+      '@jest/types': 30.3.0
+      '@types/node': 25.8.0
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      exit-x: 0.2.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 30.3.0
+      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -16598,6 +16707,15 @@ snapshots:
       commander: 12.1.0
       ollama: 0.6.3
 
+  '@opuspopuli/regions@1.0.77':
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      chalk: 5.6.2
+      cheerio: 1.2.0
+      commander: 12.1.0
+      ollama: 0.6.3
+
   '@paralleldrive/cuid2@2.3.1':
     dependencies:
       '@noble/hashes': 1.8.0
@@ -18335,6 +18453,16 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@xenova/transformers@2.17.2(@types/node@25.9.1)':
+    dependencies:
+      '@huggingface/jinja': 0.2.2
+      onnxruntime-web: 1.14.0
+      sharp: 0.35.3(@types/node@25.9.1)
+    optionalDependencies:
+      onnxruntime-node: 1.14.0
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -19839,13 +19967,13 @@ snapshots:
       source-map: 0.6.1
     optional: true
 
-  eslint-config-next@16.2.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  eslint-config-next@16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.1
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.7.0))
@@ -19871,7 +19999,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -19882,21 +20010,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19907,7 +20036,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19918,6 +20047,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -20893,7 +21024,7 @@ snapshots:
       jsonwebtoken: 9.0.3
       load-esm: 1.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.18.1(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.18.1)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -21259,34 +21390,15 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@22.19.15):
+  jest-cli@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.19.15)
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest-cli@30.3.0(@types/node@25.5.0):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -21316,7 +21428,45 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.3.0(@types/node@22.19.15):
+  jest-cli@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-config@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -21343,6 +21493,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.15
+      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21379,6 +21530,38 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.8.0
+      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -21407,6 +21590,102 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.8.0
       ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.8.0
+      ts-node: 10.9.2(@types/node@25.8.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.8.0
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.3.0
+      '@jest/types': 30.3.0
+      babel-jest: 30.3.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.3.0
+      jest-docblock: 30.2.0
+      jest-environment-node: 30.3.0
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.3.0
+      jest-runner: 30.3.0
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      parse-json: 5.2.0
+      pretty-format: 30.3.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.1
+      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21531,10 +21810,10 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
+  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       '@jest/globals': 30.3.0
-      jest: 30.3.0(@types/node@22.19.15)
+      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -21545,10 +21824,10 @@ snapshots:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
-  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3):
+  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       '@jest/globals': 30.3.0
-      jest: 30.3.0
+      jest: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -21720,38 +21999,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0:
+  jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@22.19.15):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.19.15)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.5.0):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.5.0)
+      jest-cli: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -21765,6 +22018,32 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -23602,7 +23881,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.18.1(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.18.1):
     dependencies:
       axios: 1.18.1(debug@4.4.3)
 
@@ -23822,6 +24101,39 @@ snapshots:
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
       '@types/node': 25.5.0
+
+  sharp@0.35.3(@types/node@25.9.1):
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 25.9.1
 
   shebang-command@2.0.0:
     dependencies:
@@ -24446,12 +24758,12 @@ snapshots:
 
   ts-graphviz@1.8.2: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@22.19.15)
+      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24486,12 +24798,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.5.0)
+      jest: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24506,12 +24818,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0
+      jest: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24554,6 +24866,25 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.19.15
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
   ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -24571,6 +24902,44 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.8.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
+
+  ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.9.1
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   ts-tqdm@0.8.6: {}
 


### PR DESCRIPTION
## Description

CAL-ACCESS campaign finance is attributed **backwards**. `RCPT_CD` and `EXPN_CD` have no `FILER_ID` column at all, and their `CMTE_ID` names the *counterparty* — the contributor on a receipt, the payee on an expenditure. Mapping it to `committeeId` meant every representative page summed the money a committee **paid out** as money it **raised**.

Two measurable symptoms on current production data:

- Of 151,986 committee-donor rows, **40,003** have a `donor_name` exactly equal to the name of the committee they point at. A recipient does not donate to itself 40,003 times.
- `1,210,475` rows extracted from `RCPT_CD`; **`203,945`** stored. Blank-`CMTE_ID` rows (every individual donor) failed validation, and `TRAN_ID` — not unique across filings — collapsed distinct line items onto one `externalId`.

The filer is only reachable by joining `FILING_ID` → the campaign-disclosure cover page. That is the same join [#955](https://github.com/OpusPopuli/opuspopuli/issues/955) already solved for S496 independent expenditures.

Plan of record: `docs/plans/980-cal-access-contribution-mapping.md`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Infrastructure/DevOps change

## Related Issues

Relates to #980 — this PR is the code half. The issue closes after the C4 rebuild, not on merge.

Depends on OpusPopuli/opuspopuli-regions#65 (merged, published as `1.0.77`).

## ⚠️ Do not merge standalone — two gates

**1. The dependency bump is the activation switch.** `c6f6984` is isolated on purpose. Merging it without the truncate-and-rebuild in the same window leaves old `TRAN_ID`-keyed rows beside new composite-keyed ones — double counted, and still attributed to the counterparty. Everything else in this PR is inert until that commit lands.

**2. Amendment handling is unverified and can invert the fix.** CAL-ACCESS keeps every amendment under the same `FILING_ID` with an incremented `AMEND_ID`, and amendments restate the whole schedule. `cvr_filings` dedupes by `FILING_ID`; line items now do not, because `AMEND_ID` is in the composite key. An amended $500 receipt would land twice and both get stamped with the same filer — `totalRaised` reads $1,000. The old `TRAN_ID`-only key accidentally deduped this.

Check before any rebuild:
```
awk -F'\t' 'NR>1{print $1"\t"$2}' RCPT_CD.TSV | sort -u | cut -f1 | uniq -d | wc -l
```
Non-zero ⇒ `AMEND_ID` comes out of the `compositeKey`, and `1.0.77` is superseded.

## What's here

| Commit | |
|---|---|
| `91e7f66` | Schema: nullable `filing_id` + index, `committee_id` relaxed to nullable |
| `aaab5dd` | `compositeKey` for `externalId`; `filing_id` write path end-to-end |
| `a256531` | `CoverPageLinkerService`; proposition linker re-pointed at the column |
| `3ee6a31` | Review hardening (below) |
| `c6f6984` | **Dependency bump — the activation switch** |
| `195036b` | Extract linker orchestration (SonarJS complexity gate) |

**The FK footgun.** Prisma defaults an *optional* relation to `onDelete: SetNull`. Left implicit, relaxing `NOT NULL` would have silently converted both FKs, so deleting a committee would orphan its finance rows to `committee_id = NULL` — indistinguishable from "unresolved, please stamp". Pinned to `Restrict`, verified as `confdeltype = 'r'`, covered by tests.

**Set-based, not row-by-row.** #955 builds one `update()` per pending row; contributions reach ~1.2M, where that means ~1.2M promises across ~2,400 transactions. This uses `UPDATE … FROM`, batched at 50k so a statement timeout can't roll back the whole backfill.

**Unattributed rows are withheld, not shown.** GraphQL stays non-null; list and by-id reads filter `committeeId: { not: null }`, as #955 does for S496. No federation schema change.

## Review hardening (`3ee6a31`)

Three independent review lenses converged on the same weak points:

- **`cvr_filings.filing_id` is now `@unique`.** The linker joins on it and needs one cover page per filing — that held only via three facts across two repos. Give that source a `compositeKey` (the feature this branch adds) and the join fans out, stamping donor money with an arbitrary filer.
- **Donor PII no longer reaches error logs.** The `compositeKey` throw echoed the first ten cells of the header row — and it fires *precisely when that row isn't a header*, i.e. when it holds donor data. It propagates to the persisted pipeline `errors[]` and on to Loki.
- IE linker `in` chunked below Postgres's 32,767-bind ceiling; `buildFilingToCommitteeIndex` de-duplicates in SQL instead of hydrating 1.2M rows for a 662k-entry map; partial `pending_link` indexes.

## Checklist

### Code Quality
- [x] My code follows the project's coding standards
- [x] I have run `pnpm lint` and fixed any issues
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for new functionality

2309 backend unit · 408 pipeline · 32 integration against real `postgres_test`. Pre-push gates all green: coverage, jscpd, SonarJS, `pnpm audit`, Trivy, gitleaks, both AI reviews.

Integration coverage includes the assertion that matters most — a contribution is attributed to the **filer** even when a counterparty committee row exists — plus idempotency, the soft-deleted-committee guard, the one-cover-page-per-filing constraint, and that the cover-page linker runs *before* the proposition linker (load-bearing ordering, previously unasserted).

### Documentation
- [x] I have updated relevant documentation
- [x] I have added JSDoc comments for new public APIs

### Accessibility
- [ ] UI changes meet WCAG 2.2 Level AA requirements (n/a — no UI changes)
- [ ] I have tested with keyboard navigation (n/a)

### Architecture Reminder
- [x] I confirm this PR contains platform code, not region-specific configuration

Region config ships separately in OpusPopuli/opuspopuli-regions#65.

## Additional Notes

**Review status: self-review.** Sole author on the branch, so under SOC 2 / Part 11 this needs a countersignature before it counts as independent.

**PII:** contribution volume grows ~204k → ~1.2M (name, employer, occupation, city, state, ZIP+4 — public record under CA law). Gates before the rebuild, in the plan: ZIP+4 minimization, donor fields missing from `PARTIAL_MASK_FIELDS`, and whether these `@Public()` queries stay public at 6× volume with `skip` unbounded.

**Rebuild duration is unmeasured** — the Studio was unreachable during planning. That blocks scheduling C4, nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)