### PR TITLE
feat(region): withhold donor employer, occupation and ZIP from GraphQL (#980)

### DIFF
--- a/apps/backend/src/apps/region/src/domains/models/contribution.model.ts
+++ b/apps/backend/src/apps/region/src/domains/models/contribution.model.ts
@@ -43,20 +43,20 @@ export class ContributionModel {
   @Field()
   donorType!: string;
 
-  @Field({ nullable: true })
-  donorEmployer?: string;
-
-  @Field({ nullable: true })
-  donorOccupation?: string;
+  // donorEmployer, donorOccupation and donorZip are deliberately NOT exposed
+  // over GraphQL (#980). They are still ingested and stored — CAL-ACCESS
+  // publishes them and they support internal analysis — but name + employer +
+  // occupation + ZIP+4 together approach an individually identifying record,
+  // and the re-ingest takes this table to ~17M rows. No UI ever rendered them:
+  // the contributions page selects donorName/donorType/amount/date, and the
+  // single-contribution query that did select them had no consumer at all.
+  // Read them through a privileged path if a real use case appears.
 
   @Field({ nullable: true })
   donorCity?: string;
 
   @Field({ nullable: true })
   donorState?: string;
-
-  @Field({ nullable: true })
-  donorZip?: string;
 
   @Field(() => Float)
   amount!: number;

--- a/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.spec.ts
@@ -894,11 +894,11 @@ describe('RegionQueryService — query methods', () => {
           committeeId: 'comm-1',
           donorName: 'Jane Smith',
           donorType: 'individual',
-          donorEmployer: null,
-          donorOccupation: null,
+          donorEmployer: 'Acme Corp',
+          donorOccupation: 'Engineer',
           donorCity: null,
           donorState: null,
-          donorZip: null,
+          donorZip: '95814-1234',
           amount: { toNumber: () => 500 } as unknown as Prisma.Decimal,
           date: new Date(),
           electionType: null,
@@ -917,8 +917,15 @@ describe('RegionQueryService — query methods', () => {
       expect(result.total).toBe(1);
       expect(result.hasMore).toBe(false);
       expect(typeof result.items[0].amount).toBe('number');
-      expect(result.items[0].donorEmployer).toBeUndefined();
       expect(result.items[0].electionType).toBeUndefined();
+
+      // Withheld from GraphQL (#980) — and stripped from the object, not just
+      // left off the model, so nothing downstream can serialize them by
+      // accident. The fixture carries real values so this cannot pass vacuously.
+      const item = result.items[0] as unknown as Record<string, unknown>;
+      expect('donorEmployer' in item).toBe(false);
+      expect('donorOccupation' in item).toBe(false);
+      expect('donorZip' in item).toBe(false);
     });
 
     it('should filter by committeeId and sourceSystem', async () => {

--- a/apps/backend/src/apps/region/src/domains/region-query.service.ts
+++ b/apps/backend/src/apps/region/src/domains/region-query.service.ts
@@ -197,6 +197,37 @@ type ContributionRecord = {
   updatedAt: Date;
 };
 
+/**
+ * Project a contribution row onto the fields that may leave the service.
+ *
+ * An allowlist, deliberately, rather than spreading the row and deleting the
+ * sensitive keys: donor employer, occupation and ZIP+4 are withheld (#980), and
+ * with a denylist the next PII column added to the Prisma model would flow
+ * straight out until someone remembered to exclude it. Here it stays in until
+ * someone adds it on purpose.
+ */
+export function toPublicContribution(item: ContributionRecord) {
+  return {
+    id: item.id,
+    externalId: item.externalId,
+    // Non-null by the committeeId filter on every read path; Prisma's type
+    // stays nullable because unattributed staging rows exist (#980).
+    committeeId: item.committeeId as string,
+    filingId: item.filingId ?? undefined,
+    donorName: item.donorName,
+    donorType: item.donorType,
+    donorCity: item.donorCity ?? undefined,
+    donorState: item.donorState ?? undefined,
+    amount: Number(item.amount),
+    date: item.date,
+    electionType: item.electionType ?? undefined,
+    contributionType: item.contributionType ?? undefined,
+    sourceSystem: item.sourceSystem,
+    createdAt: item.createdAt,
+    updatedAt: item.updatedAt,
+  };
+}
+
 type ExpenditureRecord = {
   id: string;
   externalId: string;
@@ -1103,19 +1134,7 @@ export class RegionQueryService {
     const paginatedItems = items.slice(0, take);
 
     return {
-      items: paginatedItems.map((item: ContributionRecord) => ({
-        ...item,
-        // Non-null by the committeeId filter above; Prisma's type stays nullable.
-        committeeId: item.committeeId as string,
-        amount: Number(item.amount),
-        donorEmployer: item.donorEmployer ?? undefined,
-        donorOccupation: item.donorOccupation ?? undefined,
-        donorCity: item.donorCity ?? undefined,
-        donorState: item.donorState ?? undefined,
-        donorZip: item.donorZip ?? undefined,
-        electionType: item.electionType ?? undefined,
-        contributionType: item.contributionType ?? undefined,
-      })),
+      items: paginatedItems.map(toPublicContribution),
       total,
       hasMore,
     };

--- a/apps/backend/src/apps/region/src/domains/region.resolver.ts
+++ b/apps/backend/src/apps/region/src/domains/region.resolver.ts
@@ -94,6 +94,7 @@ import {
   BoundarySkipReason,
 } from './models/boundary-load-result.model';
 import { BoundaryLoaderService } from './boundary-loader.service';
+import { toPublicContribution } from './region-query.service';
 
 /**
  * Region Resolver
@@ -742,19 +743,9 @@ export class RegionResolver {
   ): Promise<ContributionModel | null> {
     const result = await this.regionService.getContribution(id);
     if (!result) return null;
-    return {
-      ...result,
-      // Non-null: getContribution filters committeeId != null (#980).
-      committeeId: result.committeeId as string,
-      amount: Number(result.amount),
-      donorEmployer: result.donorEmployer ?? undefined,
-      donorOccupation: result.donorOccupation ?? undefined,
-      donorCity: result.donorCity ?? undefined,
-      donorState: result.donorState ?? undefined,
-      donorZip: result.donorZip ?? undefined,
-      electionType: result.electionType ?? undefined,
-      contributionType: result.contributionType ?? undefined,
-    };
+    // Same allowlist the list query uses — donor employer/occupation/ZIP never
+    // leave the service (#980).
+    return toPublicContribution(result);
   }
 
   /**

--- a/apps/backend/src/common/utils/pii-masker.spec.ts
+++ b/apps/backend/src/common/utils/pii-masker.spec.ts
@@ -9,6 +9,30 @@ import {
 
 describe('PII Masker', () => {
   describe('maskSensitiveData', () => {
+    it('redacts CAL-ACCESS donor fields outright (#980)', () => {
+      const masked = maskSensitiveData({
+        donorName: 'Jane Q. Public',
+        donorEmployer: 'Acme Corporation',
+        donorOccupation: 'Software Engineer',
+        donorZip: '95814-1234',
+        donorCity: 'Sacramento',
+        amount: 250,
+      }) as Record<string, unknown>;
+
+      expect(masked.donorName).toBe('[REDACTED]');
+      expect(masked.donorEmployer).toBe('[REDACTED]');
+      expect(masked.donorOccupation).toBe('[REDACTED]');
+      // Full redaction, not partialMask: that keeps the last four characters,
+      // which for a ZIP+4 is the +4 itself — the household-identifying part.
+      expect(masked.donorZip).toBe('[REDACTED]');
+      expect(masked.donorZip).not.toContain('1234');
+
+      // City and amount stay legible — they are not identifying on their own
+      // and are what makes a log line useful.
+      expect(masked.donorCity).toBe('Sacramento');
+      expect(masked.amount).toBe(250);
+    });
+
     it('should return null for null input', () => {
       expect(maskSensitiveData(null)).toBeNull();
     });

--- a/apps/backend/src/common/utils/pii-masker.ts
+++ b/apps/backend/src/common/utils/pii-masker.ts
@@ -18,6 +18,17 @@ const SENSITIVE_FIELDS = new Set([
   'cardnumber',
   'cvv',
   'cvc',
+  // CAL-ACCESS donor fields (#980). Fully redacted rather than partially
+  // masked: partialMask keeps the last four characters, and for a ZIP+4 those
+  // four ARE the +4 — the household-identifying part — while for a name they
+  // are most of a short surname. There is no diagnostic value in a half-masked
+  // donor identity, so redact outright. Nothing logs a contribution row today;
+  // this exists so the first `logger.debug({ contribution })` someone writes
+  // does not quietly put donor PII into Loki.
+  'donorname',
+  'donoremployer',
+  'donoroccupation',
+  'donorzip',
 ]);
 
 const PARTIAL_MASK_FIELDS = new Set(['email', 'phone', 'phonenumber']);

--- a/apps/frontend/lib/graphql/region.ts
+++ b/apps/frontend/lib/graphql/region.ts
@@ -455,11 +455,8 @@ export interface Contribution {
   committeeId: string;
   donorName: string;
   donorType: string;
-  donorEmployer?: string;
-  donorOccupation?: string;
   donorCity?: string;
   donorState?: string;
-  donorZip?: string;
   amount: number;
   date: string;
   electionType?: string;
@@ -1299,11 +1296,8 @@ export const GET_CONTRIBUTION = gql`
       committeeId
       donorName
       donorType
-      donorEmployer
-      donorOccupation
       donorCity
       donorState
-      donorZip
       amount
       date
       electionType


### PR DESCRIPTION
## Description

Implements the PII decision gating #980's data rebuild: **keep ingesting these fields, stop exposing them.**

CAL-ACCESS publishes donor employer, occupation and ZIP+4, so ingesting them is lawful and they support internal analysis. But name + employer + occupation + ZIP+4 together approach an individually identifying record, and the rebuild takes `contributions` from ~204k rows to **~17M**. That volume change is what moves this from "public record" to "a bulk donor database".

**No feature is lost.** The contributions page selects `donorName`, `donorType`, `amount`, `date`. The single-contribution query that *did* select employer/occupation/ZIP had **no UI consumer at all** — those fields were crossing the wire, reachable by any anonymous client, to be rendered nowhere.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Infrastructure/DevOps change

Breaking in the strict sense — three nullable fields leave `ContributionModel`. No resolver signature changes, and no query the frontend still issues selects them.

## Related Issues

Relates to #980 — the PII pre-cutover gate. Does not close it.

## Two decisions worth reviewing

**Allowlist, not denylist.** First cut destructured the three fields out of the spread; SonarJS flagged the unused bindings, which pushed toward explicitly projecting what *may* leave. That's the better boundary regardless: with a denylist, the next PII column added to the Prisma model flows straight out until someone remembers to exclude it. `toPublicContribution` is now shared by the list and by-id paths.

**Donor fields go in `SENSITIVE_FIELDS`, not `PARTIAL_MASK_FIELDS`.** I nearly got this wrong. `partialMask` preserves the **last four characters** — for `95814-1234` that leaks `1234`, the +4 itself, which is the household-identifying part; for a short surname it leaks most of it. A half-masked donor identity has no diagnostic value, so they're fully redacted. The test asserts against a real ZIP+4 (`expect(masked.donorZip).not.toContain('1234')`) so a regression to partial masking fails loudly.

## Deliberately unchanged

- **`@Public()` access and pagination limits** — decided: revisit post-launch. Recorded as a choice, not an oversight.
- **The employer aggregate** on representative funding (`representative-funding.service.ts:206`) — `groupBy` + `_sum`, so it reports what a company's employees gave in total, not who any of them are. Legitimate transparency. Worth knowing that at very low counts an employer aggregate can approach identifying a single donor; that's a k-anonymity question for the post-launch revisit, not this change.
- **Ingest and the DB columns** — the data is still stored.

## Checklist

### Code Quality
- [x] My code follows the project's coding standards
- [x] I have run `pnpm lint` and fixed any issues
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests for new functionality

2310 backend · 1455 frontend · 23 integration. SonarJS clean on both packages.

### Documentation
- [x] I have updated relevant documentation (comments explain *why* each field is withheld, at the model and the mask)
- [x] I have added JSDoc comments for new public APIs (`toPublicContribution`)

### Accessibility
- [ ] UI changes meet WCAG 2.2 Level AA requirements (n/a — no UI changes; the removed fields were never rendered)
- [ ] I have tested with keyboard navigation (n/a)

### Architecture Reminder
- [x] I confirm this PR contains platform code, not region-specific configuration

## Additional Notes

**Review status: self-review**, as with #986 — needs a countersignature to count as independent for the change record.

Remaining #980 pre-rebuild items after this: rebuild duration (needs Studio access) and the retention decision, which has no precedent in the codebase to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)