### PR TITLE
feat(region): supersede amended filings and reconcile against Form 460 totals (#992)

### DIFF
--- a/apps/backend/__tests__/integration/region/amendment-ingest-supersede.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/amendment-ingest-supersede.integration.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * Ingest-then-supersede integration tests (#992).
+ *
+ * The two halves of the amendment fix are only correct *together*, and each is
+ * proven separately elsewhere: `campaign-finance-sync.service.spec.ts` asserts
+ * the write guard against mocks, `amendment-supersession.integration.spec.ts`
+ * asserts the delete against a real database. Neither covers the seam.
+ *
+ * The seam is where the damage would be. Supersession deletes every row below
+ * `max(amend_id)` for a filing, so it trusts the `amend_id` ingest stored. If a
+ * merged row keeps a stale one — which is what plain last-write-wins does for
+ * the 454 `RCPT_CD` rows whose `AMEND_ID` decreases in file order — supersession
+ * deletes a row the current amendment still contains, and the committee's total
+ * silently drops. Nothing throws. So these tests run the real write path into a
+ * real `postgres_test` and then run the real delete over the result.
+ */
+
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { CampaignFinanceSyncService } from '../../../src/apps/region/src/domains/campaign-finance-sync.service';
+import { AmendmentSupersessionService } from '../../../src/apps/region/src/domains/amendment-supersession.service';
+import { cleanDatabase, disconnectDatabase, getDbService } from '../utils';
+
+describe('amendment ingest + supersession (#992)', () => {
+  let db: DbService;
+  let sync: CampaignFinanceSyncService;
+  let supersession: AmendmentSupersessionService;
+
+  beforeAll(async () => {
+    db = await getDbService();
+    sync = new CampaignFinanceSyncService(db);
+    supersession = new AmendmentSupersessionService(db);
+  });
+
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  afterAll(async () => {
+    await disconnectDatabase();
+  });
+
+  /**
+   * A contribution as it reaches the upsert — the shape `sortItems` produces
+   * from a mapped RCPT_CD row.
+   */
+  const row = (
+    externalId: string,
+    amendId: number,
+    amount: number,
+    filingId = '2505994',
+  ) => ({
+    externalId,
+    filingId,
+    amendId,
+    donorName: 'Jane Q. Public',
+    donorType: 'individual',
+    amount,
+    date: new Date('2026-03-01'),
+    sourceSystem: 'cal_access',
+  });
+
+  /** Drive the real batch write path, exactly as a streamed batch would. */
+  const ingest = (contributions: ReturnType<typeof row>[]) =>
+    (
+      sync as unknown as {
+        upsertBatch: (d: unknown) => Promise<{ processed: number }>;
+      }
+    ).upsertBatch({
+      committees: [],
+      contributions,
+      expenditures: [],
+      independentExpenditures: [],
+      committeeMeasureFilings: [],
+      cvrFilings: [],
+      filingSummaries: [],
+    });
+
+  const stored = () =>
+    db.contribution.findMany({
+      select: { externalId: true, amendId: true, amount: true },
+      orderBy: { externalId: 'asc' },
+    });
+
+  const total = async () =>
+    (await stored()).reduce((sum, r) => sum + Number(r.amount), 0);
+
+  it('keeps the amended total when the restatement arrives first in the file', async () => {
+    // The failure this pair exists to prevent, end to end. Filing 2505994's
+    // amendment restates $170,988.25 across two rows; one of them reuses the
+    // original's identifier and so merges onto it. Here the amend-1 version of
+    // that row arrives BEFORE the amend-0 version, as it does for the 454 rows
+    // measured on the 2026-08-09 export.
+    //
+    // Without the write guard the merged row keeps amend_id 0, supersession
+    // reads it as superseded, deletes it, and the filing reports $80,988.25
+    // against an official $170,988.25 — a silent 53% under-count.
+    await ingest([
+      row('2505994:7:BBB', 1, 90000), // restatement, arrives first
+      row('2505994:7:BBB', 0, 68135), // superseded version of the same row
+      row('2505994:8:CCC', 1, 80988.25), // new row, only in the amendment
+    ]);
+
+    await supersession.supersedeAll();
+
+    const rows = await stored();
+    expect(rows.map((r) => r.externalId)).toEqual([
+      '2505994:7:BBB',
+      '2505994:8:CCC',
+    ]);
+    expect(rows.every((r) => r.amendId === 1)).toBe(true);
+    expect(await total()).toBeCloseTo(170988.25, 2);
+  });
+
+  it('keeps the amended total when the file is in ascending order', async () => {
+    // The ordinary case, asserted so the guard is not silently doing nothing.
+    await ingest([
+      row('2505994:7:BBB', 0, 68135),
+      row('2505994:7:BBB', 1, 90000),
+      row('2505994:8:CCC', 1, 80988.25),
+    ]);
+
+    await supersession.supersedeAll();
+
+    expect(await total()).toBeCloseTo(170988.25, 2);
+  });
+
+  it('holds when the versions arrive in separate batches, newest first', async () => {
+    // Cross-batch: the guard cannot see the older version in memory and has to
+    // consult what is already stored.
+    await ingest([row('2505994:7:BBB', 1, 90000)]);
+    await ingest([row('2505994:7:BBB', 0, 68135)]);
+
+    await supersession.supersedeAll();
+
+    const rows = await stored();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].amendId).toBe(1);
+    expect(Number(rows[0].amount)).toBeCloseTo(90000, 2);
+  });
+
+  it('applies the amendment when it arrives in a later batch', async () => {
+    await ingest([row('2505994:7:BBB', 0, 68135)]);
+    await ingest([row('2505994:7:BBB', 1, 90000)]);
+
+    await supersession.supersedeAll();
+
+    const rows = await stored();
+    expect(rows).toHaveLength(1);
+    expect(Number(rows[0].amount)).toBeCloseTo(90000, 2);
+  });
+
+  it('leaves an unamended filing at its full total', async () => {
+    // The safety property, from the ingest side: nothing about the guard or
+    // the delete may touch a filing that was never amended. 644009's itemized
+    // detail matched its raw file exactly during #980 verification.
+    await ingest([
+      row('644009:1:AAA', 0, 34250, '644009'),
+      row('644009:2:BBB', 0, 1000, '644009'),
+    ]);
+
+    await supersession.supersedeAll();
+
+    expect(await db.contribution.count({ where: { filingId: '644009' } })).toBe(
+      2,
+    );
+    expect(await total()).toBeCloseTo(35250, 2);
+  });
+
+  it('re-ingesting the same export changes nothing', async () => {
+    // A rebuild that runs twice, or a retried batch, must not shift a total.
+    const batch = [
+      row('2505994:7:BBB', 1, 90000),
+      row('2505994:8:CCC', 1, 80988.25),
+    ];
+
+    await ingest(batch);
+    await supersession.supersedeAll();
+    await ingest(batch);
+    await supersession.supersedeAll();
+
+    expect(await stored()).toHaveLength(2);
+    expect(await total()).toBeCloseTo(170988.25, 2);
+  });
+});

--- a/apps/backend/__tests__/integration/region/amendment-supersession.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/amendment-supersession.integration.spec.ts
@@ -1,0 +1,196 @@
+/**
+ * AmendmentSupersessionService integration tests (#992).
+ *
+ * This service DELETES production finance rows, so these run against a real
+ * `postgres_test` rather than a mock — the SQL is what needs proving, and a
+ * mocked Prisma would assert only that the code calls itself.
+ *
+ * The case that matters most is the negative one: a filing with a single
+ * amendment must be left completely alone. If the subquery were ever wrong in
+ * that direction, the service would quietly delete live contributions and every
+ * count it reports would still look plausible.
+ */
+
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { AmendmentSupersessionService } from '../../../src/apps/region/src/domains/amendment-supersession.service';
+import { cleanDatabase, disconnectDatabase, getDbService } from '../utils';
+
+describe('AmendmentSupersessionService (#992)', () => {
+  let db: DbService;
+  let svc: AmendmentSupersessionService;
+
+  beforeAll(async () => {
+    db = await getDbService();
+    svc = new AmendmentSupersessionService(db);
+  });
+
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  afterAll(async () => {
+    await disconnectDatabase();
+  });
+
+  /**
+   * Amendments restate with NEW TRAN_ID/LINE_ITEM values, so externalIds differ
+   * between versions — that is precisely why the composite key cannot merge
+   * them and this service exists.
+   */
+  const contribution = (
+    filingId: string,
+    amendId: number | null,
+    externalId: string,
+    amount: string,
+  ) =>
+    db.contribution.create({
+      data: {
+        externalId,
+        filingId,
+        amendId,
+        committeeId: null,
+        donorName: 'Jane Q. Public',
+        donorType: 'individual',
+        amount,
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+  it('removes the superseded version and keeps the latest', async () => {
+    // Modelled on filing 2505994: amend 0 held $168,135 and amend 1 restated
+    // the schedule at $170,988.25, which matched the official Form 460 total.
+    await contribution('2505994', 0, '2505994:1:AAA', '168135.00');
+    await contribution('2505994', 1, '2505994:7:BBB', '90000.00');
+    await contribution('2505994', 1, '2505994:8:CCC', '80988.25');
+
+    const res = await svc.supersedeAll();
+
+    expect(res.contributions).toMatchObject({
+      superseded: 1,
+      filingsAffected: 1,
+    });
+
+    const left = await db.contribution.findMany({
+      where: { filingId: '2505994' },
+      select: { externalId: true, amendId: true },
+      orderBy: { externalId: 'asc' },
+    });
+    expect(left.map((r) => r.externalId)).toEqual([
+      '2505994:7:BBB',
+      '2505994:8:CCC',
+    ]);
+    expect(left.every((r) => r.amendId === 1)).toBe(true);
+  });
+
+  it('leaves a single-amendment filing completely untouched', async () => {
+    // The safety property. A filing's only version IS the maximum, so it can
+    // never be below it — if this ever fails, the service is deleting live data.
+    await contribution('644009', 0, '644009:1:AAA', '35250.00');
+    await contribution('644009', 0, '644009:2:BBB', '1000.00');
+
+    const res = await svc.supersedeAll();
+
+    expect(res.contributions).toMatchObject({
+      superseded: 0,
+      filingsAffected: 0,
+    });
+    expect(await db.contribution.count({ where: { filingId: '644009' } })).toBe(
+      2,
+    );
+  });
+
+  it('never touches rows with a null amend_id', async () => {
+    // Rows ingested before #992 carry no amend_id. They must be inert here
+    // rather than being treated as "version null" and deleted.
+    await contribution('900100', null, '900100:1:AAA', '500.00');
+    await contribution('900100', null, '900100:2:BBB', '600.00');
+
+    await svc.supersedeAll();
+
+    expect(await db.contribution.count({ where: { filingId: '900100' } })).toBe(
+      2,
+    );
+  });
+
+  it('orders amendments numerically, not lexically', async () => {
+    // The reason amend_id is an integer. As text, '10' sorts below '9', so a
+    // filing amended ten times would keep version 9 and delete the current one
+    // — while reporting success.
+    await contribution('900200', 9, '900200:1:NINE', '100.00');
+    await contribution('900200', 10, '900200:2:TEN', '200.00');
+
+    await svc.supersedeAll();
+
+    const left = await db.contribution.findMany({
+      where: { filingId: '900200' },
+      select: { amendId: true },
+    });
+    expect(left).toHaveLength(1);
+    expect(left[0].amendId).toBe(10);
+  });
+
+  it('scopes supersession to each filing independently', async () => {
+    await contribution('900300', 0, '900300:1:A', '10.00');
+    await contribution('900300', 1, '900300:2:B', '20.00');
+    await contribution('900400', 0, '900400:1:C', '30.00');
+
+    await svc.supersedeAll();
+
+    // 900400's only version survives even though 900300 has a higher amend_id.
+    const rows = await db.contribution.findMany({
+      select: { filingId: true, amendId: true },
+      orderBy: { filingId: 'asc' },
+    });
+    expect(rows).toEqual([
+      { filingId: '900300', amendId: 1 },
+      { filingId: '900400', amendId: 0 },
+    ]);
+  });
+
+  it('is idempotent — a second run removes nothing', async () => {
+    await contribution('900500', 0, '900500:1:A', '10.00');
+    await contribution('900500', 2, '900500:2:B', '20.00');
+
+    await svc.supersedeAll();
+    const second = await svc.supersedeAll();
+
+    expect(second.contributions).toMatchObject({
+      superseded: 0,
+      filingsAffected: 0,
+    });
+    expect(await db.contribution.count()).toBe(1);
+  });
+
+  it('supersedes expenditures on the same rule', async () => {
+    const expenditure = (amendId: number, externalId: string, amt: string) =>
+      db.expenditure.create({
+        data: {
+          externalId,
+          filingId: '900600',
+          amendId,
+          committeeId: null,
+          payeeName: 'Some Print Shop',
+          amount: amt,
+          date: new Date('2026-03-01'),
+          sourceSystem: 'cal_access',
+        },
+      });
+    await expenditure(0, '900600:1:A', '500.00');
+    await expenditure(1, '900600:2:B', '750.00');
+
+    const res = await svc.supersedeAll();
+
+    expect(res.expenditures).toMatchObject({
+      superseded: 1,
+      filingsAffected: 1,
+    });
+    const left = await db.expenditure.findMany({ select: { amendId: true } });
+    expect(left).toEqual([{ amendId: 1 }]);
+  });
+
+  it('does nothing when no db is injected', async () => {
+    const res = await new AmendmentSupersessionService().supersedeAll();
+    expect(res.contributions.superseded).toBe(0);
+  });
+});

--- a/apps/backend/__tests__/integration/region/filing-reconciliation.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/filing-reconciliation.integration.spec.ts
@@ -1,0 +1,341 @@
+/**
+ * FilingReconciliationService integration tests (#992, subtask 4b).
+ *
+ * The whole service is one SQL statement, so a mocked Prisma would assert only
+ * that the code calls itself. These run against a real `postgres_test`.
+ *
+ * Two properties carry the weight:
+ *
+ *   1. Schedule discrimination. `RCPT_CD` holds every receipt schedule, and
+ *      Form 460 line 1 covers Schedule A alone. Measured across all 122,033
+ *      F460 filings, summing every schedule instead flags 29% of filings as
+ *      over-counting against a true rate of 0.31%. The test that proves this
+ *      is `ignores non-Schedule-A receipts` — delete the schedule filter from
+ *      the service and it fails.
+ *
+ *   2. Direction. Detail BELOW reported is expected (unitemized <$100 money);
+ *      detail ABOVE reported is a fault. Conflating them would make the table
+ *      report a third of California's filings as broken.
+ */
+
+import { DbService } from '@opuspopuli/relationaldb-provider';
+import { FilingReconciliationService } from '../../../src/apps/region/src/domains/filing-reconciliation.service';
+import { cleanDatabase, disconnectDatabase, getDbService } from '../utils';
+
+describe('FilingReconciliationService (#992)', () => {
+  let db: DbService;
+  let svc: FilingReconciliationService;
+
+  beforeAll(async () => {
+    db = await getDbService();
+    svc = new FilingReconciliationService(db);
+  });
+
+  beforeEach(async () => {
+    await cleanDatabase();
+  });
+
+  afterAll(async () => {
+    await disconnectDatabase();
+  });
+
+  /** One Form 460 summary line — what the committee reported about itself. */
+  const summary = (
+    filingId: string,
+    lineItem: string,
+    amountA: string,
+    amendId = 0,
+  ) =>
+    db.filingSummary.create({
+      data: {
+        externalId: `${filingId}:${amendId}:F460:${lineItem}`,
+        filingId,
+        amendId,
+        formType: 'F460',
+        lineItem,
+        amountA,
+        sourceSystem: 'cal_access',
+      },
+    });
+
+  const contribution = (
+    filingId: string,
+    externalId: string,
+    amount: string,
+    scheduleCode: string | null = 'A',
+    committeeId: string | null = null,
+  ) =>
+    db.contribution.create({
+      data: {
+        externalId,
+        filingId,
+        amendId: 0,
+        scheduleCode,
+        committeeId,
+        donorName: 'Jane Q. Public',
+        donorType: 'individual',
+        amount,
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+  const expenditure = (
+    filingId: string,
+    externalId: string,
+    amount: string,
+    scheduleCode: string | null = 'E',
+  ) =>
+    db.expenditure.create({
+      data: {
+        externalId,
+        filingId,
+        amendId: 0,
+        scheduleCode,
+        payeeName: 'Acme Printing',
+        amount,
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+  const verdict = (filingId: string) =>
+    db.filingReconciliation.findUnique({ where: { filingId } });
+
+  it('flags a filing whose detail exceeds what the committee reported', async () => {
+    // The defect this issue exists for. Filing 2505994 stored $339,123 against
+    // an official $170,988 before supersession — both amendment versions.
+    await summary('2505994', '1', '170988.25');
+    await contribution('2505994', '2505994:1:AAA', '168135.00');
+    await contribution('2505994', '2505994:7:BBB', '170988.25');
+
+    const res = await svc.reconcileAll();
+
+    expect(res.overItemizedContributions).toBe(1);
+
+    const row = await verdict('2505994');
+    expect(row?.contributionStatus).toBe('OVER_ITEMIZED');
+    expect(Number(row?.itemizedContributions)).toBeCloseTo(339123.25, 2);
+    expect(Number(row?.reportedContributions)).toBeCloseTo(170988.25, 2);
+    // Not unitemized money — we are over, not under.
+    expect(row?.unitemizedContributions).toBeNull();
+  });
+
+  it('records the unitemized gap when detail falls below reported', async () => {
+    // Filing 644009: our detail matched the raw file exactly at $35,250, while
+    // the official total was $36,694. The $1,444 difference is contributions
+    // under the $100 itemization threshold, which exist nowhere but here.
+    await summary('644009', '1', '36694.00');
+    await contribution('644009', '644009:1:AAA', '35250.00');
+
+    const res = await svc.reconcileAll();
+
+    expect(res.overItemizedContributions).toBe(0);
+    expect(res.withUnitemized).toBe(1);
+    expect(res.unitemizedTotal).toBeCloseTo(1444.0, 2);
+
+    const row = await verdict('644009');
+    expect(row?.contributionStatus).toBe('UNITEMIZED');
+    expect(Number(row?.unitemizedContributions)).toBeCloseTo(1444.0, 2);
+  });
+
+  it('reports MATCH when detail equals the reported total', async () => {
+    await summary('700001', '1', '5000.00');
+    await contribution('700001', '700001:1:AAA', '2000.00');
+    await contribution('700001', '700001:2:BBB', '3000.00');
+
+    await svc.reconcileAll();
+
+    const row = await verdict('700001');
+    expect(row?.contributionStatus).toBe('MATCH');
+    expect(row?.unitemizedContributions).toBeNull();
+  });
+
+  /**
+   * THE test for subtask 4a. Line 1 is monetary contributions — Schedule A.
+   * Schedule C (nonmonetary) and I (misc increases) share the source file and
+   * belong to other lines entirely. Counting them against line 1 turns a
+   * healthy filing into a false fault report.
+   */
+  it('ignores non-Schedule-A receipts when reconciling line 1', async () => {
+    await summary('700002', '1', '5000.00');
+    await contribution('700002', '700002:1:AAA', '5000.00', 'A');
+    // Would push the total to $9,500 and read as OVER_ITEMIZED if summed.
+    await contribution('700002', '700002:2:BBB', '3000.00', 'C');
+    await contribution('700002', '700002:3:CCC', '1500.00', 'I');
+
+    const res = await svc.reconcileAll();
+
+    expect(res.overItemizedContributions).toBe(0);
+
+    const row = await verdict('700002');
+    expect(row?.contributionStatus).toBe('MATCH');
+    expect(Number(row?.itemizedContributions)).toBeCloseTo(5000.0, 2);
+  });
+
+  /**
+   * The expenditure counterpart, and a sharper trap: Schedule D is a MEMO
+   * schedule restating payments Schedule E already counts, so summing both
+   * double-counts ~4.8M rows corpus-wide.
+   */
+  it('ignores the Schedule D memo rows when reconciling line 6', async () => {
+    await summary('700003', '6', '8000.00');
+    await expenditure('700003', '700003:1:AAA', '8000.00', 'E');
+    await expenditure('700003', '700003:2:BBB', '2500.00', 'D');
+
+    const res = await svc.reconcileAll();
+
+    expect(res.overItemizedExpenditures).toBe(0);
+
+    const row = await verdict('700003');
+    expect(row?.expenditureStatus).toBe('MATCH');
+    expect(Number(row?.itemizedExpenditures)).toBeCloseTo(8000.0, 2);
+  });
+
+  /**
+   * Rows ingested before the schedule mapping existed carry NULL. Summing
+   * `schedule_code = 'A'` over them yields 0, which would read as "the
+   * committee reported $36,694 of entirely unitemized money" — a confident,
+   * wrong answer. The service must decline instead.
+   */
+  it('declines to reconcile detail that carries no schedule', async () => {
+    await summary('700004', '1', '36694.00');
+    await contribution('700004', '700004:1:AAA', '35250.00', null);
+
+    const res = await svc.reconcileAll();
+
+    expect(res.unknownSchedule).toBe(1);
+    expect(res.withUnitemized).toBe(0);
+    expect(res.unitemizedTotal).toBe(0);
+
+    const row = await verdict('700004');
+    expect(row?.contributionStatus).toBe('UNKNOWN_SCHEDULE');
+    // Critically: no unitemized figure invented from an unreadable filing.
+    expect(row?.unitemizedContributions).toBeNull();
+    // And no itemized figure either. Storing 0 here would be a claim — "this
+    // filing itemized nothing" — about a filing we just declined to judge, and
+    // it would silently poison any SUM over the column.
+    expect(row?.itemizedContributions).toBeNull();
+  });
+
+  it('marks a filing with no matching summary line as NO_SUMMARY', async () => {
+    // Line 6 present, line 1 absent: expenditures are judged, contributions
+    // cannot be.
+    await summary('700005', '6', '900.00');
+    await contribution('700005', '700005:1:AAA', '1000.00');
+    await expenditure('700005', '700005:2:BBB', '900.00');
+
+    await svc.reconcileAll();
+
+    const row = await verdict('700005');
+    expect(row?.contributionStatus).toBe('NO_SUMMARY');
+    expect(row?.expenditureStatus).toBe('MATCH');
+  });
+
+  it('marks a reported total with no stored detail as NO_DETAIL', async () => {
+    await summary('700006', '1', '12000.00');
+
+    await svc.reconcileAll();
+
+    const row = await verdict('700006');
+    expect(row?.contributionStatus).toBe('NO_DETAIL');
+  });
+
+  /**
+   * Supersession keeps only the newest amendment's detail, so reconciliation
+   * must compare against the newest amendment's SUMMARY. Judging current detail
+   * against a superseded total would manufacture faults on every amended filing.
+   */
+  it('compares against the latest amendment of the summary', async () => {
+    await summary('700007', '1', '10000.00', 0);
+    await summary('700007', '1', '25000.00', 1);
+    await contribution('700007', '700007:9:ZZZ', '25000.00');
+
+    const res = await svc.reconcileAll();
+
+    expect(res.overItemizedContributions).toBe(0);
+
+    const row = await verdict('700007');
+    expect(row?.contributionStatus).toBe('MATCH');
+    expect(row?.amendId).toBe(1);
+    expect(Number(row?.reportedContributions)).toBeCloseTo(25000.0, 2);
+  });
+
+  it('stamps the committee the detail was attributed to', async () => {
+    const committee = await db.committee.create({
+      data: {
+        externalId: 'CMTE-1',
+        name: 'Committee to Elect Someone',
+        type: 'candidate',
+        sourceSystem: 'cal_access',
+      },
+    });
+
+    await summary('700008', '1', '4000.00');
+    await contribution('700008', '700008:1:AAA', '4000.00', 'A', committee.id);
+
+    await svc.reconcileAll();
+
+    expect((await verdict('700008'))?.committeeId).toBe(committee.id);
+  });
+
+  it('is idempotent — a second run upserts rather than duplicating', async () => {
+    await summary('700009', '1', '5000.00');
+    await contribution('700009', '700009:1:AAA', '4000.00');
+
+    const first = await svc.reconcileAll();
+    const second = await svc.reconcileAll();
+
+    expect(second.reconciled).toBe(first.reconciled);
+    expect(await db.filingReconciliation.count()).toBe(1);
+  });
+
+  it('re-judges a filing whose detail changed since the last run', async () => {
+    await summary('700010', '1', '5000.00');
+    await contribution('700010', '700010:1:AAA', '9000.00');
+
+    await svc.reconcileAll();
+    expect((await verdict('700010'))?.contributionStatus).toBe('OVER_ITEMIZED');
+
+    // Supersession removes the offending row; the verdict must follow.
+    await db.contribution.deleteMany({ where: { externalId: '700010:1:AAA' } });
+    await contribution('700010', '700010:2:BBB', '5000.00');
+
+    const res = await svc.reconcileAll();
+
+    expect(res.overItemizedContributions).toBe(0);
+    expect((await verdict('700010'))?.contributionStatus).toBe('MATCH');
+  });
+
+  it('reconciles only Form 460 summaries', async () => {
+    await db.filingSummary.create({
+      data: {
+        externalId: '700011:0:F450:1',
+        filingId: '700011',
+        amendId: 0,
+        formType: 'F450',
+        lineItem: '1',
+        amountA: '1000.00',
+        sourceSystem: 'cal_access',
+      },
+    });
+
+    const res = await svc.reconcileAll();
+
+    expect(res.reconciled).toBe(0);
+    expect(await verdict('700011')).toBeNull();
+  });
+
+  it('returns an empty summary when no database is wired', async () => {
+    const res = await new FilingReconciliationService().reconcileAll();
+
+    expect(res).toEqual({
+      reconciled: 0,
+      overItemizedContributions: 0,
+      overItemizedExpenditures: 0,
+      withUnitemized: 0,
+      unitemizedTotal: 0,
+      unknownSchedule: 0,
+    });
+  });
+});

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -87,7 +87,7 @@
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/queue-provider": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.76",
+    "@opuspopuli/regions": "^1.0.79",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -87,7 +87,7 @@
     "@opuspopuli/prompt-client": "workspace:*",
     "@opuspopuli/queue-provider": "workspace:*",
     "@opuspopuli/region-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.79",
+    "@opuspopuli/regions": "^1.0.80",
     "@opuspopuli/relationaldb-provider": "workspace:*",
     "@opuspopuli/scraping-pipeline": "workspace:*",
     "@opuspopuli/secrets-provider": "workspace:*",

--- a/apps/backend/src/apps/region/src/domains/amendment-supersession.service.ts
+++ b/apps/backend/src/apps/region/src/domains/amendment-supersession.service.ts
@@ -1,0 +1,144 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+export interface SupersessionTableResult {
+  /** Rows removed because a higher amend_id exists for the same filing. */
+  superseded: number;
+  /** Filings that carried more than one amendment version. */
+  filingsAffected: number;
+}
+
+export interface SupersessionResult {
+  contributions: SupersessionTableResult;
+  expenditures: SupersessionTableResult;
+}
+
+/**
+ * The two tables carrying amendable line items. A const tuple because the table
+ * name is interpolated into SQL (identifiers cannot be bound), so the only
+ * values reaching the statement are these compile-time literals.
+ */
+const AMENDABLE_TABLES = ['contributions', 'expenditures'] as const;
+type AmendableTable = (typeof AMENDABLE_TABLES)[number];
+
+/**
+ * Rows removed per transaction. Bounds WAL and lock duration on the first run
+ * after a rebuild, where the affected set is largest.
+ */
+const DELETE_BATCH_SIZE = 25_000;
+
+const EMPTY: SupersessionTableResult = { superseded: 0, filingsAffected: 0 };
+
+/**
+ * Drop superseded versions of amended filings (#992).
+ *
+ * CAL-ACCESS does not patch a filing when it is amended — it restates the whole
+ * schedule, using **new** `TRAN_ID` and `LINE_ITEM` values. The composite
+ * `externalId` (`FILING_ID:LINE_ITEM:TRAN_ID`) therefore cannot merge the
+ * versions, and both survive ingest:
+ *
+ * ```
+ * filing 2505994
+ *   AMEND_ID 0:  1 row,  $168,135.00
+ *   AMEND_ID 1:  2 rows, $170,988.25   <- official Form 460 line 1
+ *   stored:      3 rows, $339,123.25
+ * ```
+ *
+ * Measured on the #980 rebuild: 8 of 123 sampled filings (7%) over-counted this
+ * way, typically at ~2x the committee's own reported total.
+ *
+ * Only the highest `amend_id` per filing is retained. `amend_id` is an integer
+ * precisely so that comparison is numeric — under text ordering `'10' < '9'`
+ * and this would keep the wrong version while reporting success.
+ *
+ * **Runs before the cover-page linker** — attributing rows that are about to be
+ * deleted is wasted work, and the counts it reports would be misleading.
+ *
+ * Idempotent: a second run finds nothing above the maximum and deletes nothing.
+ */
+@Injectable()
+export class AmendmentSupersessionService {
+  private readonly logger = new Logger(AmendmentSupersessionService.name);
+
+  constructor(@Optional() private readonly db?: DbService) {}
+
+  async supersedeAll(): Promise<SupersessionResult> {
+    if (!this.db) {
+      return { contributions: { ...EMPTY }, expenditures: { ...EMPTY } };
+    }
+
+    const [contributions, expenditures] = await Promise.all(
+      AMENDABLE_TABLES.map((t) => this.supersedeTable(t)),
+    );
+    return { contributions, expenditures };
+  }
+
+  private async supersedeTable(
+    table: AmendableTable,
+  ): Promise<SupersessionTableResult> {
+    const filingsAffected = await this.countAffectedFilings(table);
+    if (filingsAffected === 0) return { ...EMPTY };
+
+    let superseded = 0;
+    // Bounded rather than `while (true)`: the exit depends on a value the
+    // database returns, and a driver answering oddly should not spin forever.
+    const maxBatches =
+      Math.ceil((filingsAffected * 50) / DELETE_BATCH_SIZE) + 10;
+    for (let i = 0; i < maxBatches; i++) {
+      const removed = await this.deleteBatch(table);
+      if (!removed) break;
+      superseded += removed;
+    }
+
+    this.logger.log(
+      `Amendment supersession (${table}): removed ${superseded} superseded row(s) ` +
+        `across ${filingsAffected} amended filing(s)`,
+    );
+    return { superseded, filingsAffected };
+  }
+
+  /**
+   * Filings carrying more than one amendment version. Used both to skip the
+   * work entirely when there is none, and to bound the batch loop.
+   */
+  private async countAffectedFilings(table: AmendableTable): Promise<number> {
+    const rows = await this.db!.$queryRawUnsafe<Array<{ count: bigint }>>(
+      `SELECT COUNT(*)::bigint AS count FROM (
+         SELECT "filing_id"
+           FROM "${table}"
+          WHERE "filing_id" IS NOT NULL AND "amend_id" IS NOT NULL
+          GROUP BY "filing_id"
+         HAVING COUNT(DISTINCT "amend_id") > 1
+       ) t`,
+    );
+    return Number(rows[0]?.count ?? 0);
+  }
+
+  /**
+   * Remove up to {@link DELETE_BATCH_SIZE} rows that a later amendment
+   * superseded.
+   *
+   * The subquery compares each row's `amend_id` against the maximum for its own
+   * filing, so a filing with a single amendment can never match: its only
+   * version *is* the maximum. That property is what keeps this from deleting
+   * live data, and it is asserted directly in the integration tests.
+   */
+  private async deleteBatch(table: AmendableTable): Promise<number> {
+    return this.db!.$executeRawUnsafe(
+      `DELETE FROM "${table}"
+        WHERE "ctid" IN (
+          SELECT r."ctid"
+            FROM "${table}" r
+            JOIN (
+              SELECT "filing_id", MAX("amend_id") AS latest
+                FROM "${table}"
+               WHERE "filing_id" IS NOT NULL AND "amend_id" IS NOT NULL
+               GROUP BY "filing_id"
+            ) m ON m."filing_id" = r."filing_id"
+           WHERE r."amend_id" IS NOT NULL
+             AND r."amend_id" < m."latest"
+           LIMIT ${DELETE_BATCH_SIZE}
+        )`,
+    );
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
@@ -165,6 +165,9 @@ describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () =
     const amendmentSupersession = {
       supersedeAll: jest.fn().mockResolvedValue({ name: 'supersession' }),
     };
+    const filingReconciliation = {
+      reconcileAll: jest.fn().mockResolvedValue({ name: 'reconciliation' }),
+    };
     const propositionFinanceLinker = linker('proposition');
     const candidateCommitteeLinker = linker('candidate');
     const independentExpenditureLinker = linker('ie');
@@ -177,6 +180,7 @@ describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () =
       independentExpenditureLinker as never,
       coverPageLinker as never,
       amendmentSupersession as never,
+      filingReconciliation as never,
     );
 
     const provider = {
@@ -190,6 +194,7 @@ describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () =
       propositionFinanceLinker,
       independentExpenditureLinker,
       amendmentSupersession,
+      filingReconciliation,
     };
   }
 
@@ -223,6 +228,30 @@ describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () =
     expect(
       amendmentSupersession.supersedeAll.mock.invocationCallOrder[0],
     ).toBeLessThan(coverPageLinker.linkAll.mock.invocationCallOrder[0]);
+  });
+
+  it('reconciles AFTER every linker has run (#992)', async () => {
+    // Also load-bearing, pointing the other way. Reconciliation judges the
+    // final state: it needs supersession to have dropped stale amendments and
+    // the cover-page linker to have stamped committeeId. Run it earlier and it
+    // reconciles rows about to vanish, and attributes its verdict to nobody.
+    const { svc, provider, filingReconciliation, coverPageLinker } =
+      buildWithLinkers();
+
+    await svc.sync(provider as never);
+
+    expect(filingReconciliation.reconcileAll).toHaveBeenCalled();
+    expect(
+      filingReconciliation.reconcileAll.mock.invocationCallOrder[0],
+    ).toBeGreaterThan(coverPageLinker.linkAll.mock.invocationCallOrder[0]);
+  });
+
+  it('still completes the sync when reconciliation throws', async () => {
+    // Reconciliation only reports; it must never cost the sync its data.
+    const { svc, provider, filingReconciliation } = buildWithLinkers();
+    filingReconciliation.reconcileAll.mockRejectedValue(new Error('boom'));
+
+    await expect(svc.sync(provider as never)).resolves.toBeDefined();
   });
 
   it('still attributes when supersession throws', async () => {

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
@@ -164,6 +164,9 @@ describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () =
     const linker = (name: string) => ({
       linkAll: jest.fn().mockResolvedValue({ name }),
     });
+    const amendmentSupersession = {
+      supersedeAll: jest.fn().mockResolvedValue({ name: 'supersession' }),
+    };
     const propositionFinanceLinker = linker('proposition');
     const candidateCommitteeLinker = linker('candidate');
     const independentExpenditureLinker = linker('ie');
@@ -175,6 +178,7 @@ describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () =
       candidateCommitteeLinker as never,
       independentExpenditureLinker as never,
       coverPageLinker as never,
+      amendmentSupersession as never,
     );
 
     const provider = {
@@ -187,6 +191,7 @@ describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () =
       coverPageLinker,
       propositionFinanceLinker,
       independentExpenditureLinker,
+      amendmentSupersession,
     };
   }
 
@@ -205,6 +210,31 @@ describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () =
     expect(coverPageLinker.linkAll.mock.invocationCallOrder[0]).toBeLessThan(
       propositionFinanceLinker.linkAll.mock.invocationCallOrder[0],
     );
+  });
+
+  it('supersedes amendments BEFORE attributing anything (#992)', async () => {
+    // Load-bearing. A superseded amendment's rows are stale duplicates; if the
+    // cover-page linker runs first it attributes rows that are about to be
+    // deleted, and reports a linked count describing them.
+    const { svc, provider, amendmentSupersession, coverPageLinker } =
+      buildWithLinkers();
+
+    await svc.sync(provider as never);
+
+    expect(amendmentSupersession.supersedeAll).toHaveBeenCalled();
+    expect(
+      amendmentSupersession.supersedeAll.mock.invocationCallOrder[0],
+    ).toBeLessThan(coverPageLinker.linkAll.mock.invocationCallOrder[0]);
+  });
+
+  it('still attributes when supersession throws', async () => {
+    const { svc, provider, amendmentSupersession, coverPageLinker } =
+      buildWithLinkers();
+    amendmentSupersession.supersedeAll.mockRejectedValue(new Error('boom'));
+
+    await expect(svc.sync(provider as never)).resolves.toBeDefined();
+
+    expect(coverPageLinker.linkAll).toHaveBeenCalled();
   });
 
   it('still runs the proposition linker when the cover-page linker throws', async () => {

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.spec.ts
@@ -1,5 +1,8 @@
 import { DbService } from '@opuspopuli/relationaldb-provider';
-import type { CampaignFinanceResult } from '@opuspopuli/common';
+import {
+  emptyCampaignFinanceResult,
+  type CampaignFinanceResult,
+} from '@opuspopuli/common';
 import { CampaignFinanceSyncService } from './campaign-finance-sync.service';
 
 type RosterCommittee = CampaignFinanceResult['committees'][number];
@@ -28,15 +31,10 @@ function committee(
   } as RosterCommittee;
 }
 
+// Spread the shared empty shape rather than listing buckets: a new table then
+// needs no edit here, and cannot be silently forgotten.
 function result(committees: RosterCommittee[]): CampaignFinanceResult {
-  return {
-    committees,
-    contributions: [],
-    expenditures: [],
-    independentExpenditures: [],
-    committeeMeasureFilings: [],
-    cvrFilings: [],
-  };
+  return { ...emptyCampaignFinanceResult(), committees };
 }
 
 const enrich = (svc: CampaignFinanceSyncService, data: CampaignFinanceResult) =>
@@ -245,5 +243,179 @@ describe('CampaignFinanceSyncService — post-sync linker ordering (#980)', () =
     await expect(svc.sync(provider as never)).resolves.toBeDefined();
 
     expect(propositionFinanceLinker.linkAll).toHaveBeenCalled();
+  });
+});
+
+describe('CampaignFinanceSyncService — newest amendment wins (#992)', () => {
+  type Row = Record<string, unknown>;
+
+  function buildUpsert(
+    stored: Array<{ externalId: string; amendId?: number }>,
+  ) {
+    const upsert = jest.fn((args: unknown) => ({ __op: args }));
+    const findMany = jest.fn().mockResolvedValue(stored);
+    const $transaction = jest.fn().mockResolvedValue([]);
+    const db = { $transaction } as unknown as DbService;
+    const svc = new CampaignFinanceSyncService(db);
+
+    const run = (records: Row[], amendable = true) =>
+      (
+        svc as unknown as {
+          upsertRecordsByFields: (c: unknown) => Promise<{
+            processed: number;
+            created: number;
+            updated: number;
+          }>;
+        }
+      ).upsertRecordsByFields({
+        records,
+        model: { findMany, upsert },
+        fields: ['filingId', 'amendId', 'amount'],
+        amendable,
+      });
+
+    // The rows that actually reached the database, in write order.
+    const written = () =>
+      upsert.mock.calls.map(
+        (c) => (c[0] as { update: Row }).update as { amendId?: number },
+      );
+
+    return { run, written, upsert, findMany };
+  }
+
+  const row = (over: Partial<Row> = {}): Row => ({
+    externalId: 'F1:1:T1',
+    filingId: 'F1',
+    amendId: 0,
+    amount: 100,
+    ...over,
+  });
+
+  it('keeps the newest version when a batch restates the same row out of order', async () => {
+    // The whole point: 454 RCPT_CD rows on the 2026-08-09 export list a
+    // DECREASING AMEND_ID, so plain last-write-wins stores the superseded
+    // version. Supersession then deletes it for sitting below the filing's
+    // max(amend_id), and real contributions vanish from the total.
+    const { run, written } = buildUpsert([]);
+
+    await run([
+      row({ amendId: 1, amount: 250 }),
+      row({ amendId: 0, amount: 100 }), // older, but arrives last
+    ]);
+
+    expect(written()).toHaveLength(1);
+    expect(written()[0].amendId).toBe(1);
+    expect(written()[0]).toMatchObject({ amount: 250 });
+  });
+
+  it('does not let an older amendment overwrite a newer one already stored', async () => {
+    // Cross-batch: the newer version landed in an earlier batch, so the guard
+    // has to consult the database, not just the batch.
+    const { run, upsert } = buildUpsert([
+      { externalId: 'F1:1:T1', amendId: 2 },
+    ]);
+
+    const res = await run([row({ amendId: 1, amount: 100 })]);
+
+    expect(upsert).not.toHaveBeenCalled();
+    expect(res).toEqual({ processed: 0, created: 0, updated: 0 });
+  });
+
+  it('re-writes the same amendment, so a re-sync stays idempotent', async () => {
+    const { run, upsert } = buildUpsert([
+      { externalId: 'F1:1:T1', amendId: 2 },
+    ]);
+
+    await run([row({ amendId: 2, amount: 100 })]);
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes a newer amendment over a stored older one', async () => {
+    const { run, written } = buildUpsert([
+      { externalId: 'F1:1:T1', amendId: 1 },
+    ]);
+
+    await run([row({ amendId: 3, amount: 400 })]);
+
+    expect(written()[0].amendId).toBe(3);
+  });
+
+  it('leaves rows carrying no amendId on arrival order', async () => {
+    // Sources with no AMEND_ID (FEC, and CAL-ACCESS rows predating the
+    // mapping) have nothing to order by — last write still wins there.
+    const { run, written } = buildUpsert([]);
+
+    await run([
+      row({ amendId: undefined, amount: 100 }),
+      row({ amendId: undefined, amount: 900 }),
+    ]);
+
+    expect(written()).toHaveLength(1);
+    expect(written()[0]).toMatchObject({ amount: 900 });
+  });
+
+  it('does not consult amendId on tables that are not amendable', async () => {
+    // Committees, cover pages and CVR2 rows are keyed one-per-filing and carry
+    // no amendment axis; the guard must not silently drop their rows.
+    const { run, upsert, findMany } = buildUpsert([]);
+
+    await run([row({ amendId: 1 }), row({ amendId: 0 })], false);
+
+    expect(upsert).toHaveBeenCalledTimes(2);
+    expect(findMany.mock.calls[0][0]).toMatchObject({
+      select: { externalId: true },
+    });
+  });
+
+  it('treats a stored row with a null amendId as overwritable', async () => {
+    // Rows ingested before the amend_id column existed. They must not be
+    // pinned in place by the guard, or a re-sync could never correct them.
+    const { run, upsert } = buildUpsert([
+      { externalId: 'F1:1:T1', amendId: undefined },
+    ]);
+
+    await run([row({ amendId: 0 })]);
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('CampaignFinanceSyncService — final flush covers every table (#992)', () => {
+  it('flushes a fetch carrying only filing summaries', async () => {
+    // The flush is gated on "did anything arrive?", and that gate has to name
+    // every table it writes. Miss one and its rows are dropped whenever no
+    // other table happens to carry data in the same fetch — silently, and only
+    // for that shape of config.
+    const upsert = jest.fn((args: unknown) => ({ __op: args }));
+    const findMany = jest.fn().mockResolvedValue([]);
+    const db = {
+      committee: { upsert, findMany },
+      filingSummary: { upsert, findMany },
+      $transaction: jest.fn().mockResolvedValue([]),
+    } as unknown as DbService;
+    const svc = new CampaignFinanceSyncService(db);
+
+    const provider = {
+      fetchCampaignFinance: jest.fn().mockResolvedValue({
+        ...result([]),
+        filingSummaries: [
+          {
+            externalId: '2505994:1:F460:1',
+            filingId: '2505994',
+            amendId: 1,
+            formType: 'F460',
+            lineItem: '1',
+            amountA: 170988.25,
+            sourceSystem: 'cal_access',
+          },
+        ],
+      }),
+    };
+
+    const res = await svc.sync(provider as never);
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(res.processed).toBe(1);
   });
 });

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -8,6 +8,7 @@ import { PropositionFinanceLinkerService } from './proposition-finance-linker.se
 import { CandidateCommitteeLinkerService } from './candidate-committee-linker.service';
 import { IndependentExpenditureLinkerService } from './independent-expenditure-linker.service';
 import { CoverPageLinkerService } from './cover-page-linker.service';
+import { AmendmentSupersessionService } from './amendment-supersession.service';
 import {
   campaignFinanceSyncTracker,
   type SyncPhaseTracker,
@@ -69,6 +70,8 @@ export class CampaignFinanceSyncService {
     private readonly independentExpenditureLinker?: IndependentExpenditureLinkerService,
     @Optional()
     private readonly coverPageLinker?: CoverPageLinkerService,
+    @Optional()
+    private readonly amendmentSupersession?: AmendmentSupersessionService,
   ) {}
 
   async sync(
@@ -200,21 +203,45 @@ export class CampaignFinanceSyncService {
    * candidateName/office. Covered by campaign-finance-sync.service.spec.ts.
    */
   private async runPostSyncLinkers(): Promise<void> {
-    const linkers: Array<
-      [string, { linkAll(): Promise<unknown> } | undefined]
-    > = [
-      ['Independent-expenditure', this.independentExpenditureLinker],
-      ['Cover-page', this.coverPageLinker],
-      ['Proposition finance', this.propositionFinanceLinker],
-      ['Candidate-committee', this.candidateCommitteeLinker],
+    // Uniform thunks rather than a shared interface, so each step can name its
+    // method for what it does (supersede vs link) instead of pretending to be
+    // a linker.
+    const steps: Array<[string, (() => Promise<unknown>) | undefined]> = [
+      // FIRST: a superseded amendment's rows are stale duplicates. Attributing
+      // them, or deriving measure positions from them, is wasted work — and
+      // every later step's counts would describe rows about to vanish (#992).
+      [
+        'Amendment-supersession',
+        this.amendmentSupersession &&
+          (() => this.amendmentSupersession!.supersedeAll()),
+      ],
+      [
+        'Independent-expenditure',
+        this.independentExpenditureLinker &&
+          (() => this.independentExpenditureLinker!.linkAll()),
+      ],
+      [
+        'Cover-page',
+        this.coverPageLinker && (() => this.coverPageLinker!.linkAll()),
+      ],
+      [
+        'Proposition finance',
+        this.propositionFinanceLinker &&
+          (() => this.propositionFinanceLinker!.linkAll()),
+      ],
+      [
+        'Candidate-committee',
+        this.candidateCommitteeLinker &&
+          (() => this.candidateCommitteeLinker!.linkAll()),
+      ],
     ];
 
-    for (const [name, linker] of linkers) {
-      if (!linker) continue;
+    for (const [name, run] of steps) {
+      if (!run) continue;
       try {
-        await linker.linkAll();
+        await run();
       } catch (error) {
-        this.logger.warn(`${name} linker failed: ${(error as Error).message}`);
+        this.logger.warn(`${name} step failed: ${(error as Error).message}`);
       }
     }
   }
@@ -443,6 +470,7 @@ export class CampaignFinanceSyncService {
         fields: [
           'committeeId',
           'filingId',
+          'amendId',
           'donorName',
           'donorType',
           'donorEmployer',
@@ -463,6 +491,7 @@ export class CampaignFinanceSyncService {
         fields: [
           'committeeId',
           'filingId',
+          'amendId',
           'payeeName',
           'amount',
           'date',

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger, Optional } from '@nestjs/common';
 import { DbService, Prisma } from '@opuspopuli/relationaldb-provider';
 import {
   batchTransaction,
+  sortCampaignFinanceItems,
   type CampaignFinanceResult,
 } from '@opuspopuli/common';
 import { PropositionFinanceLinkerService } from './proposition-finance-linker.service';
@@ -28,7 +29,9 @@ export interface CampaignFinanceProvider {
 }
 
 type PrismaModelDelegate = {
-  findMany(args: unknown): Promise<{ externalId: string }[]>;
+  findMany(
+    args: unknown,
+  ): Promise<{ externalId: string; amendId?: number | null }[]>;
   upsert(args: unknown): Prisma.PrismaPromise<unknown>;
 };
 
@@ -36,6 +39,12 @@ type UpsertConfig = {
   records: readonly unknown[];
   model: PrismaModelDelegate;
   fields: string[];
+  /**
+   * Rows on this table are amendable: the same `externalId` can arrive more
+   * than once, once per version of the filing, and only the newest version may
+   * win. Enables the `amendId` guard in {@link upsertRecordsByFields} (#992).
+   */
+  amendable?: boolean;
 };
 
 type CommitteeRecord = {
@@ -150,7 +159,11 @@ export class CampaignFinanceSyncService {
       data.expenditures.length > 0 ||
       data.independentExpenditures.length > 0 ||
       data.committeeMeasureFilings.length > 0 ||
-      data.cvrFilings.length > 0
+      data.cvrFilings.length > 0 ||
+      // Every table the flush can write must be listed here. Omitting one
+      // means its rows are dropped whenever no *other* table happens to carry
+      // data in the same fetch — silently, and only for that shape of config.
+      (data.filingSummaries?.length ?? 0) > 0
     ) {
       const tracker = ensureExtractTracker();
       await this.enrichCommittees(data);
@@ -397,62 +410,14 @@ export class CampaignFinanceSyncService {
   }
 
   /**
-   * Route a heterogeneous batch of records (everything CAL-ACCESS streams
-   * out) into the typed shape `CampaignFinanceResult` expects. Discrimination
-   * is by field presence rather than a wire-format type tag — the upstream
-   * bulk downloads don't carry one.
+   * Route a heterogeneous batch of records (everything CAL-ACCESS streams out)
+   * into the typed shape `CampaignFinanceResult` expects.
+   *
+   * The rules live in `@opuspopuli/common` because the region plugin sorts the
+   * same stream the same way, and two copies had to be edited in lockstep.
    */
   private sortItems(items: Record<string, unknown>[]): CampaignFinanceResult {
-    const committees: CampaignFinanceResult['committees'] = [];
-    const contributions: CampaignFinanceResult['contributions'] = [];
-    const expenditures: CampaignFinanceResult['expenditures'] = [];
-    const independentExpenditures: CampaignFinanceResult['independentExpenditures'] =
-      [];
-    const committeeMeasureFilings: CampaignFinanceResult['committeeMeasureFilings'] =
-      [];
-    const cvrFilings: CampaignFinanceResult['cvrFilings'] = [];
-
-    for (const rec of items) {
-      if ('donorName' in rec && 'amount' in rec) {
-        contributions.push(
-          rec as unknown as CampaignFinanceResult['contributions'][0],
-        );
-      } else if ('payeeName' in rec && 'amount' in rec) {
-        expenditures.push(
-          rec as unknown as CampaignFinanceResult['expenditures'][0],
-        );
-      } else if ('supportOrOppose' in rec && 'committeeName' in rec) {
-        independentExpenditures.push(
-          rec as unknown as CampaignFinanceResult['independentExpenditures'][0],
-        );
-      } else if ('filerId' in rec && 'filingId' in rec) {
-        // Form 496 cover page — filerId + filingId, no committeeName/ballot
-        // fields. Feeds the IE linker's FILING_ID -> committee join (#955).
-        cvrFilings.push(
-          rec as unknown as CampaignFinanceResult['cvrFilings'][0],
-        );
-      } else if (
-        'filingId' in rec &&
-        ('ballotName' in rec || 'ballotNumber' in rec)
-      ) {
-        committeeMeasureFilings.push(
-          rec as unknown as CampaignFinanceResult['committeeMeasureFilings'][0],
-        );
-      } else if ('sourceSystem' in rec && 'type' in rec) {
-        committees.push(
-          rec as unknown as CampaignFinanceResult['committees'][0],
-        );
-      }
-    }
-
-    return {
-      committees,
-      contributions,
-      expenditures,
-      independentExpenditures,
-      committeeMeasureFilings,
-      cvrFilings,
-    };
+    return sortCampaignFinanceItems(items);
   }
 
   /**
@@ -467,6 +432,7 @@ export class CampaignFinanceSyncService {
       {
         records: data.contributions,
         model: this.db.contribution,
+        amendable: true,
         fields: [
           'committeeId',
           'filingId',
@@ -488,6 +454,7 @@ export class CampaignFinanceSyncService {
       {
         records: data.expenditures,
         model: this.db.expenditure,
+        amendable: true,
         fields: [
           'committeeId',
           'filingId',
@@ -545,6 +512,23 @@ export class CampaignFinanceSyncService {
           'sourceSystem',
         ],
       },
+      {
+        records: data.filingSummaries,
+        model: this.db.filingSummary,
+        // Deliberately NOT `amendable`: AMEND_ID is part of this table's
+        // identity, so each amendment's summary is its own row and nothing
+        // supersedes anything. Reconciliation reads the latest one (#992).
+        fields: [
+          'filingId',
+          'amendId',
+          'formType',
+          'lineItem',
+          'amountA',
+          'amountB',
+          'amountC',
+          'sourceSystem',
+        ],
+      },
     ];
 
     let totalProcessed = 0;
@@ -552,7 +536,10 @@ export class CampaignFinanceSyncService {
     let totalUpdated = 0;
 
     for (const config of upsertConfigs) {
-      if (config.records.length === 0) continue;
+      // Optional chain, not `.length`: a provider built against an older
+      // CampaignFinanceResult omits newer arrays entirely, and dropping its
+      // rows beats throwing mid-sync.
+      if (!config.records?.length) continue;
       const result = await this.upsertRecordsByFields(config);
       totalProcessed += result.processed;
       totalCreated += result.created;
@@ -570,24 +557,36 @@ export class CampaignFinanceSyncService {
    * Low-level field-projection upsert used only by `upsertBatch`. Pulls
    * the configured `fields` off each record and upserts by `externalId`
    * inside a single batch transaction.
+   *
+   * On amendable tables the write is ordered by `amendId` rather than by
+   * arrival, so the newest version of a restated row always wins — see
+   * {@link keepNewestAmendment}.
    */
   private async upsertRecordsByFields(
     config: UpsertConfig,
   ): Promise<{ processed: number; created: number; updated: number }> {
     const { model, fields } = config;
-    const rows = config.records as Record<string, unknown>[];
-    const externalIds = rows.map((r) => r.externalId as string);
+    const incoming = config.records as Record<string, unknown>[];
+    const externalIds = incoming.map((r) => r.externalId as string);
 
     const existing = await model.findMany({
       where: { externalId: { in: externalIds } },
-      select: { externalId: true },
+      select: config.amendable
+        ? { externalId: true, amendId: true }
+        : { externalId: true },
     });
     const existingSet = new Set(
       existing.map((r: { externalId: string }) => r.externalId),
     );
 
+    const rows = config.amendable
+      ? this.keepNewestAmendment(incoming, existing)
+      : incoming;
+
     const pick = (r: Record<string, unknown>) =>
       Object.fromEntries(fields.map((f: string) => [f, r[f]]));
+
+    if (rows.length === 0) return { processed: 0, created: 0, updated: 0 };
 
     await batchTransaction(
       this.db,
@@ -609,4 +608,71 @@ export class CampaignFinanceSyncService {
       updated: rows.length - created,
     };
   }
+
+  /**
+   * Reduce restated rows to the newest version of each `externalId`, whether
+   * the older version arrives in the same batch or is already stored.
+   *
+   * CAL-ACCESS restates a filing's whole schedule on amendment, and the
+   * composite `externalId` deliberately omits `AMEND_ID` so a later version
+   * upserts over the earlier one (#980). That merge is last-write-wins, which
+   * assumes the export lists a filing's amendments in ascending order. It does
+   * not always: 454 `RCPT_CD` rows on the 2026-08-09 export carry a
+   * *decreasing* `AMEND_ID`, so the superseded version lands last and wins.
+   *
+   * That was harmless while nothing read `amend_id`. It is not harmless now —
+   * `AmendmentSupersessionService` deletes every row below `max(amend_id)` for
+   * a filing, so a current row left holding a stale `amend_id` is deleted
+   * outright and its money disappears from the committee's total. Ordering the
+   * write by `amendId` rather than by arrival removes the dependency on file
+   * order entirely (#992).
+   *
+   * Rows carrying no `amendId` keep the previous last-write-wins behaviour:
+   * with nothing to compare, arrival order is the only signal there is.
+   */
+  private keepNewestAmendment(
+    incoming: Record<string, unknown>[],
+    existing: { externalId: string; amendId?: number | null }[],
+  ): Record<string, unknown>[] {
+    const newest = new Map<string, Record<string, unknown>>();
+    for (const row of incoming) {
+      const id = row.externalId as string;
+      const held = newest.get(id);
+      if (!held || !isOlderAmendment(row, held)) newest.set(id, row);
+    }
+
+    const storedAmend = new Map(
+      existing.map((r) => [r.externalId, r.amendId ?? undefined]),
+    );
+    const kept = [...newest.values()].filter(
+      (row) =>
+        !isOlderAmendment(row, {
+          amendId: storedAmend.get(row.externalId as string),
+        }),
+    );
+
+    const dropped = incoming.length - kept.length;
+    if (dropped > 0) {
+      this.logger.debug(
+        `Collapsed ${dropped} row(s) in batch onto a same-or-newer version of ` +
+          `the same externalId`,
+      );
+    }
+    return kept;
+  }
+}
+
+/**
+ * True when `candidate` is an *older* version of the same row than `other`, and
+ * so must not overwrite it. Equal amendments may overwrite: re-syncing the same
+ * version has to stay idempotent. An absent `amendId` on either side yields
+ * `false` — unordered, so arrival order decides, as it did before #992.
+ */
+function isOlderAmendment(
+  candidate: { amendId?: unknown },
+  other: { amendId?: unknown },
+): boolean {
+  const a = candidate.amendId;
+  const b = other.amendId;
+  return typeof a === 'number' && typeof b === 'number' && a < b;
 }

--- a/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
+++ b/apps/backend/src/apps/region/src/domains/campaign-finance-sync.service.ts
@@ -10,6 +10,7 @@ import { CandidateCommitteeLinkerService } from './candidate-committee-linker.se
 import { IndependentExpenditureLinkerService } from './independent-expenditure-linker.service';
 import { CoverPageLinkerService } from './cover-page-linker.service';
 import { AmendmentSupersessionService } from './amendment-supersession.service';
+import { FilingReconciliationService } from './filing-reconciliation.service';
 import {
   campaignFinanceSyncTracker,
   type SyncPhaseTracker,
@@ -81,6 +82,8 @@ export class CampaignFinanceSyncService {
     private readonly coverPageLinker?: CoverPageLinkerService,
     @Optional()
     private readonly amendmentSupersession?: AmendmentSupersessionService,
+    @Optional()
+    private readonly filingReconciliation?: FilingReconciliationService,
   ) {}
 
   async sync(
@@ -246,6 +249,15 @@ export class CampaignFinanceSyncService {
         'Candidate-committee',
         this.candidateCommitteeLinker &&
           (() => this.candidateCommitteeLinker!.linkAll()),
+      ],
+      // LAST: it judges the result of everything above. Supersession must have
+      // dropped stale amendments and the cover-page linker must have stamped
+      // committeeId, or this reconciles rows that are about to vanish and
+      // attributes its verdict to nobody (#992).
+      [
+        'Filing-reconciliation',
+        this.filingReconciliation &&
+          (() => this.filingReconciliation!.reconcileAll()),
       ],
     ];
 
@@ -437,6 +449,7 @@ export class CampaignFinanceSyncService {
           'committeeId',
           'filingId',
           'amendId',
+          'scheduleCode',
           'donorName',
           'donorType',
           'donorEmployer',
@@ -459,6 +472,7 @@ export class CampaignFinanceSyncService {
           'committeeId',
           'filingId',
           'amendId',
+          'scheduleCode',
           'payeeName',
           'amount',
           'date',

--- a/apps/backend/src/apps/region/src/domains/filing-reconciliation.service.ts
+++ b/apps/backend/src/apps/region/src/domains/filing-reconciliation.service.ts
@@ -1,0 +1,337 @@
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import { DbService } from '@opuspopuli/relationaldb-provider';
+
+/**
+ * Verdict for one side (contributions or expenditures) of one filing.
+ *
+ * `UNITEMIZED` and `OVER_ITEMIZED` are the two readings of the same arithmetic,
+ * and keeping them apart is the reason this table exists — one is the source
+ * behaving normally, the other is us being wrong.
+ *
+ * Constants rather than bare string literals because each value appears in
+ * three places — this union, the classifying SQL, and the summary query. Bare
+ * literals let those drift silently: rename one and the check still runs, still
+ * reports success, and counts nothing.
+ */
+export const RECONCILIATION_STATUS = {
+  /** Detail equals the reported total, to the cent. */
+  MATCH: 'MATCH',
+  /** Detail is BELOW reported. Expected: the gap is money under the $100
+   *  itemization threshold, which appears only on the summary page. */
+  UNITEMIZED: 'UNITEMIZED',
+  /** Detail EXCEEDS reported. A fault — we are counting money the committee
+   *  never reported. This is the condition the check exists to catch. */
+  OVER_ITEMIZED: 'OVER_ITEMIZED',
+  /** The filing has no summary line to compare against. */
+  NO_SUMMARY: 'NO_SUMMARY',
+  /** A total was reported but no detail rows were stored for that schedule. */
+  NO_DETAIL: 'NO_DETAIL',
+  /** Detail rows exist but carry no schedule, so they cannot be attributed to
+   *  a summary line. Declines to guess rather than reconciling wrongly. */
+  UNKNOWN_SCHEDULE: 'UNKNOWN_SCHEDULE',
+} as const;
+
+export type ReconciliationStatus =
+  (typeof RECONCILIATION_STATUS)[keyof typeof RECONCILIATION_STATUS];
+
+export interface ReconciliationSummary {
+  /** Filings written. */
+  reconciled: number;
+  /** Filings whose detail exceeds the committee's own reported contributions. */
+  overItemizedContributions: number;
+  /** Same, for expenditures — the independent check #991 lacks. */
+  overItemizedExpenditures: number;
+  /** Filings carrying unitemized (<$100) contributions. */
+  withUnitemized: number;
+  /** Total unitemized contribution money made visible. */
+  unitemizedTotal: number;
+  /** Filings skipped because their detail rows carry no schedule. */
+  unknownSchedule: number;
+}
+
+/**
+ * Form 460 summary lines this reconciles against.
+ *
+ * Line 1 is monetary contributions and pairs with Schedule A. Line 6 is
+ * payments made and pairs with Schedule E. The pairing is exact and it matters:
+ * `RCPT_CD` and `EXPN_CD` each hold every schedule for their side, so summing a
+ * file wholesale compares a mixture against one of its parts (#992).
+ */
+const CONTRIBUTION_LINE = '1';
+const CONTRIBUTION_SCHEDULE = 'A';
+const EXPENDITURE_LINE = '6';
+/**
+ * Schedule E alone. Schedule D is a MEMO schedule — it itemizes payments
+ * supporting or opposing candidates and measures that Schedule E has already
+ * counted, so adding it double-counts ~4.8M rows.
+ */
+const EXPENDITURE_SCHEDULE = 'E';
+
+/** Cent tolerance. The source rounds to cents; anything inside this is a match. */
+const TOLERANCE = 0.01;
+
+const EMPTY: ReconciliationSummary = {
+  reconciled: 0,
+  overItemizedContributions: 0,
+  overItemizedExpenditures: 0,
+  withUnitemized: 0,
+  unitemizedTotal: 0,
+  unknownSchedule: 0,
+};
+
+/**
+ * Reconcile stored itemized detail against each filing's own Form 460 summary
+ * (#992, subtask 4b).
+ *
+ * Comparing our sums against the committee's reported totals is what found the
+ * amendment double-count in the first place. Run every sync, it stops being a
+ * manual exercise and becomes a standing property: if a future change starts
+ * counting money twice, `OVER_ITEMIZED` rises and says so.
+ *
+ * It also makes unitemized money visible. Schedule A itemizes only
+ * contributions of $100 or more, so smaller donations live nowhere but the
+ * summary page — 59% of filings report more than they itemize. Left
+ * unrecorded, a candidate funded by many small donors reads as less funded
+ * than one funded by a few large ones.
+ *
+ * **Runs last** among the post-sync steps: supersession must have removed
+ * stale amendments and the cover-page linker must have stamped `committeeId`,
+ * or this would reconcile rows that are about to vanish and attribute the
+ * result to nobody.
+ *
+ * Set-based and idempotent — one statement over the whole corpus, upserting on
+ * `filing_id`, mirroring `AmendmentSupersessionService`.
+ */
+@Injectable()
+export class FilingReconciliationService {
+  private readonly logger = new Logger(FilingReconciliationService.name);
+
+  constructor(@Optional() private readonly db?: DbService) {}
+
+  async reconcileAll(): Promise<ReconciliationSummary> {
+    if (!this.db) return { ...EMPTY };
+
+    await this.db.$executeRawUnsafe(this.buildReconciliationSql());
+    const summary = await this.summarise();
+
+    this.logger.log(
+      `Filing reconciliation: ${summary.reconciled} filing(s); ` +
+        `${summary.overItemizedContributions} over-itemized contributions, ` +
+        `${summary.overItemizedExpenditures} over-itemized expenditures; ` +
+        `${summary.withUnitemized} filing(s) carry ` +
+        `$${summary.unitemizedTotal.toFixed(2)} of unitemized contributions`,
+    );
+
+    if (summary.overItemizedContributions > 0) {
+      this.logger.warn(
+        `${summary.overItemizedContributions} filing(s) itemize MORE ` +
+          `contributions than the committee reported. Detail exceeding the ` +
+          `source is a fault, not a source quirk — inspect ` +
+          `filing_reconciliations WHERE contribution_status = 'OVER_ITEMIZED'.`,
+      );
+    }
+    if (summary.unknownSchedule > 0) {
+      this.logger.warn(
+        `${summary.unknownSchedule} filing(s) skipped: detail rows carry no ` +
+          `schedule_code. Expected only for rows ingested before #992's ` +
+          `mapping; a re-sync populates them.`,
+      );
+    }
+
+    return summary;
+  }
+
+  /**
+   * One statement: aggregate both sides per filing, classify, upsert.
+   *
+   * Driven from `filing_summaries` rather than from the detail tables, so a
+   * filing whose detail we failed to ingest still gets a row — silence about a
+   * filing we never stored would be indistinguishable from a clean bill.
+   */
+  private buildReconciliationSql(): string {
+    return `
+      WITH latest AS (
+        SELECT "filing_id", MAX("amend_id") AS amend_id
+          FROM "filing_summaries"
+         WHERE "form_type" = 'F460'
+         GROUP BY "filing_id"
+      ),
+      reported AS (
+        SELECT l."filing_id",
+               l.amend_id,
+               MAX(CASE WHEN s."line_item" = '${CONTRIBUTION_LINE}'
+                        THEN s."amount_a" END) AS reported_contributions,
+               MAX(CASE WHEN s."line_item" = '${EXPENDITURE_LINE}'
+                        THEN s."amount_a" END) AS reported_expenditures
+          FROM latest l
+          JOIN "filing_summaries" s
+            ON s."filing_id" = l."filing_id"
+           AND s."amend_id" IS NOT DISTINCT FROM l.amend_id
+           AND s."form_type" = 'F460'
+         GROUP BY l."filing_id", l.amend_id
+      ),
+      -- COUNT(*) alongside the filtered SUM so "no Schedule A rows" can be told
+      -- apart from "rows exist but none carry a schedule". The first is a real
+      -- finding; the second means we simply cannot judge this filing.
+      detail_c AS (
+        SELECT "filing_id",
+               SUM("amount") FILTER (
+                 WHERE "schedule_code" = '${CONTRIBUTION_SCHEDULE}') AS amt,
+               COUNT(*) FILTER (WHERE "schedule_code" IS NOT NULL) AS coded,
+               COUNT(*) AS total,
+               MIN("committee_id") FILTER (
+                 WHERE "committee_id" IS NOT NULL) AS committee_id
+          FROM "contributions"
+         WHERE "filing_id" IS NOT NULL
+         GROUP BY "filing_id"
+      ),
+      detail_e AS (
+        SELECT "filing_id",
+               SUM("amount") FILTER (
+                 WHERE "schedule_code" = '${EXPENDITURE_SCHEDULE}') AS amt,
+               COUNT(*) FILTER (WHERE "schedule_code" IS NOT NULL) AS coded,
+               COUNT(*) AS total,
+               MIN("committee_id") FILTER (
+                 WHERE "committee_id" IS NOT NULL) AS committee_id
+          FROM "expenditures"
+         WHERE "filing_id" IS NOT NULL
+         GROUP BY "filing_id"
+      )
+      INSERT INTO "filing_reconciliations" (
+        "id", "filing_id", "amend_id", "committee_id",
+        "reported_contributions", "itemized_contributions",
+        "unitemized_contributions", "contribution_status",
+        "reported_expenditures", "itemized_expenditures", "expenditure_status",
+        "reconciled_at", "created_at", "updated_at"
+      )
+      SELECT gen_random_uuid()::text,
+             r."filing_id",
+             r.amend_id,
+             COALESCE(c.committee_id, e.committee_id),
+
+             r.reported_contributions,
+             ${this.itemizedExpr('c')},
+             ${this.unitemizedExpr('r.reported_contributions', 'c')},
+             ${this.statusExpr('r.reported_contributions', 'c')},
+
+             r.reported_expenditures,
+             ${this.itemizedExpr('e')},
+             ${this.statusExpr('r.reported_expenditures', 'e')},
+
+             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+        FROM reported r
+        LEFT JOIN detail_c c ON c."filing_id" = r."filing_id"
+        LEFT JOIN detail_e e ON e."filing_id" = r."filing_id"
+      ON CONFLICT ("filing_id") DO UPDATE SET
+        "amend_id"                 = EXCLUDED."amend_id",
+        "committee_id"             = EXCLUDED."committee_id",
+        "reported_contributions"   = EXCLUDED."reported_contributions",
+        "itemized_contributions"   = EXCLUDED."itemized_contributions",
+        "unitemized_contributions" = EXCLUDED."unitemized_contributions",
+        "contribution_status"      = EXCLUDED."contribution_status",
+        "reported_expenditures"    = EXCLUDED."reported_expenditures",
+        "itemized_expenditures"    = EXCLUDED."itemized_expenditures",
+        "expenditure_status"       = EXCLUDED."expenditure_status",
+        "reconciled_at"            = CURRENT_TIMESTAMP,
+        "updated_at"               = CURRENT_TIMESTAMP
+    `;
+  }
+
+  /**
+   * Classify one side of one filing.
+   *
+   * Order is deliberate. "Rows exist but carry no schedule" is checked before
+   * any arithmetic, because under that condition the filtered sum is 0 and
+   * every comparison below would read as "the committee reported money we did
+   * not itemize" — a confident, wrong answer instead of an admission.
+   */
+  private statusExpr(reported: string, d: string): string {
+    const S = RECONCILIATION_STATUS;
+    return `CASE
+      WHEN ${reported} IS NULL THEN '${S.NO_SUMMARY}'
+      WHEN COALESCE(${d}.total, 0) > 0 AND COALESCE(${d}.coded, 0) = 0
+        THEN '${S.UNKNOWN_SCHEDULE}'
+      WHEN ${d}.amt IS NULL AND ${reported} <> 0 THEN '${S.NO_DETAIL}'
+      WHEN COALESCE(${d}.amt, 0) > ${reported} + ${TOLERANCE}
+        THEN '${S.OVER_ITEMIZED}'
+      WHEN COALESCE(${d}.amt, 0) < ${reported} - ${TOLERANCE}
+        THEN '${S.UNITEMIZED}'
+      ELSE '${S.MATCH}'
+    END`;
+  }
+
+  /**
+   * The itemized sum — NULL, not 0, when the rows carry no schedule.
+   *
+   * Zero is a claim: "this filing itemized nothing". For a filing we have
+   * explicitly declined to judge it is a false one, and it would quietly poison
+   * any SUM over this column. NULL says what is actually true — we do not know.
+   */
+  private itemizedExpr(d: string): string {
+    return `CASE
+      WHEN COALESCE(${d}.total, 0) > 0 AND COALESCE(${d}.coded, 0) = 0 THEN NULL
+      ELSE COALESCE(${d}.amt, 0)
+    END`;
+  }
+
+  /**
+   * The unitemized gap, recorded only where it is genuinely that: a positive
+   * shortfall against a schedule we could actually read. Left NULL otherwise,
+   * so an unreadable filing never contributes to a "small-donor money" figure.
+   */
+  private unitemizedExpr(reported: string, d: string): string {
+    return `CASE
+      WHEN ${reported} IS NULL THEN NULL
+      WHEN COALESCE(${d}.total, 0) > 0 AND COALESCE(${d}.coded, 0) = 0 THEN NULL
+      WHEN ${reported} - COALESCE(${d}.amt, 0) > ${TOLERANCE}
+        THEN ${reported} - COALESCE(${d}.amt, 0)
+      ELSE NULL
+    END`;
+  }
+
+  /** Read back the counts the log line and the caller report. */
+  private async summarise(): Promise<ReconciliationSummary> {
+    const rows = await this.db!.$queryRawUnsafe<
+      Array<{
+        reconciled: bigint;
+        over_c: bigint;
+        over_e: bigint;
+        with_unitemized: bigint;
+        unitemized_total: string | null;
+        unknown_schedule: bigint;
+      }>
+    >(`
+      SELECT COUNT(*)::bigint AS reconciled,
+             COUNT(*) FILTER (
+               WHERE "contribution_status"
+                     = '${RECONCILIATION_STATUS.OVER_ITEMIZED}')::bigint
+               AS over_c,
+             COUNT(*) FILTER (
+               WHERE "expenditure_status"
+                     = '${RECONCILIATION_STATUS.OVER_ITEMIZED}')::bigint
+               AS over_e,
+             COUNT(*) FILTER (
+               WHERE "unitemized_contributions" IS NOT NULL)::bigint
+               AS with_unitemized,
+             COALESCE(SUM("unitemized_contributions"), 0)::text
+               AS unitemized_total,
+             COUNT(*) FILTER (
+               WHERE "contribution_status"
+                     = '${RECONCILIATION_STATUS.UNKNOWN_SCHEDULE}')::bigint
+               AS unknown_schedule
+        FROM "filing_reconciliations"
+    `);
+
+    const r = rows[0];
+    if (!r) return { ...EMPTY };
+
+    return {
+      reconciled: Number(r.reconciled),
+      overItemizedContributions: Number(r.over_c),
+      overItemizedExpenditures: Number(r.over_e),
+      withUnitemized: Number(r.with_unitemized),
+      unitemizedTotal: Number(r.unitemized_total ?? 0),
+      unknownSchedule: Number(r.unknown_schedule),
+    };
+  }
+}

--- a/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
+++ b/apps/backend/src/apps/region/src/domains/region-sync.service.spec.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@nestjs/common';
+import { emptyCampaignFinanceResult } from '@opuspopuli/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import {
@@ -2466,6 +2467,7 @@ describe('RegionSyncService — campaign finance sync', () => {
     ],
     committeeMeasureFilings: [],
     cvrFilings: [],
+    filingSummaries: [],
   };
 
   beforeEach(async () => {
@@ -2607,12 +2609,7 @@ describe('RegionSyncService — campaign finance sync', () => {
 
   it('should handle empty campaign finance result via syncAll', async () => {
     mockPlugin.fetchCampaignFinance.mockResolvedValue({
-      committees: [],
-      contributions: [],
-      expenditures: [],
-      independentExpenditures: [],
-      committeeMeasureFilings: [],
-      cvrFilings: [],
+      ...emptyCampaignFinanceResult(),
     });
 
     const results = await service.syncAll();
@@ -2653,6 +2650,7 @@ describe('RegionSyncService — campaign finance sync', () => {
       ],
       committeeMeasureFilings: [],
       cvrFilings: [],
+      filingSummaries: [],
     });
 
     await service.syncAll();
@@ -3083,12 +3081,7 @@ describe('RegionSyncService — proposition finance wiring', () => {
     );
 
     const fetchCampaignFinance = jest.fn().mockResolvedValue({
-      committees: [],
-      contributions: [],
-      expenditures: [],
-      independentExpenditures: [],
-      committeeMeasureFilings: [],
-      cvrFilings: [],
+      ...emptyCampaignFinanceResult(),
     });
 
     const mockPlugin = {

--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -53,6 +53,7 @@ import { PropositionFinanceLinkerService } from './proposition-finance-linker.se
 import { CandidateCommitteeLinkerService } from './candidate-committee-linker.service';
 import { IndependentExpenditureLinkerService } from './independent-expenditure-linker.service';
 import { CoverPageLinkerService } from './cover-page-linker.service';
+import { AmendmentSupersessionService } from './amendment-supersession.service';
 import { PropositionFundingService } from './proposition-funding.service';
 import { RepresentativeFundingService } from './representative-funding.service';
 import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
@@ -222,6 +223,7 @@ const promptClientAsyncConfig = {
     CandidateCommitteeLinkerService,
     IndependentExpenditureLinkerService,
     CoverPageLinkerService,
+    AmendmentSupersessionService,
     PropositionFundingService,
     RepresentativeFundingService,
     LegislativeCommitteeLinkerService,

--- a/apps/backend/src/apps/region/src/domains/region.module.ts
+++ b/apps/backend/src/apps/region/src/domains/region.module.ts
@@ -54,6 +54,7 @@ import { CandidateCommitteeLinkerService } from './candidate-committee-linker.se
 import { IndependentExpenditureLinkerService } from './independent-expenditure-linker.service';
 import { CoverPageLinkerService } from './cover-page-linker.service';
 import { AmendmentSupersessionService } from './amendment-supersession.service';
+import { FilingReconciliationService } from './filing-reconciliation.service';
 import { PropositionFundingService } from './proposition-funding.service';
 import { RepresentativeFundingService } from './representative-funding.service';
 import { LegislativeCommitteeLinkerService } from './legislative-committee-linker.service';
@@ -224,6 +225,7 @@ const promptClientAsyncConfig = {
     IndependentExpenditureLinkerService,
     CoverPageLinkerService,
     AmendmentSupersessionService,
+    FilingReconciliationService,
     PropositionFundingService,
     RepresentativeFundingService,
     LegislativeCommitteeLinkerService,

--- a/docs/plans/992-amendment-supersession-and-filing-summaries.md
+++ b/docs/plans/992-amendment-supersession-and-filing-summaries.md
@@ -9,7 +9,7 @@
 | **Author** | Rodney Gagnon |
 | **Data classification** | **PII — no PHI.** No new donor fields. `SMRY_CD` is aggregate-only (amounts per filing), so it adds no PII of its own. |
 | **Branch** | `feat/992-amendment-supersession-and-summaries` (+ `opuspopuli-regions`, + migration) |
-| **Status** | Plan written. Implementation starting. |
+| **Status** | Subtasks 1–3 complete. 4 (reconciliation) next, then 5 (re-verify on a rebuild). |
 
 ## Problem
 
@@ -79,6 +79,21 @@ delete.
 expenditure and cash-position totals, which give #991 the same reconciliation lever — and #991 is
 currently a 60% shortfall with no independent check.
 
+**The newest amendment wins the upsert, by comparison rather than by arrival**
+(added 2026-08-11, during subtask 1). Storing `amend_id` turned a cosmetic defect into a
+destructive one, and the fix belongs here rather than in a follow-up.
+
+Because the composite key omits `AMEND_ID`, a restatement that *reuses* `TRAN_ID`/`LINE_ITEM` merges
+onto one row whose stored values are simply whichever version was written last. #980 measured **454
+`RCPT_CD` rows where `AMEND_ID` decreases in file order** — for those, the superseded version lands
+last and wins, and it was harmless while nothing read `amend_id`.
+
+It is not harmless now. Supersession deletes every row below `max(amend_id)` for a filing, so a
+current row left holding a stale `amend_id` is deleted outright and its money leaves the committee's
+total. The failure is silent and it under-counts — the same class of defect as #980, pointed the
+other way. `upsertRecordsByFields` now orders amendable writes by `amendId`, both within a batch and
+against what is already stored, so file order stops mattering.
+
 ## Subtasks
 
 ### 1. `amend_id` on contributions and expenditures
@@ -131,7 +146,7 @@ variance explained by unitemized amounts.
 
 | Risk | Severity | Mitigation |
 |---|---|---|
-| Supersession deletes rows it should keep | high | A filing with a single amendment must be untouched. Integration test asserts that explicitly before any bulk run |
+| Supersession deletes rows it should keep | high | A filing with a single amendment must be untouched. Integration test asserts that explicitly before any bulk run. Second path found and closed during subtask 1: a merged row holding a stale `amend_id` from out-of-order arrival — see the monotonic-write decision above |
 | Another rebuild needed to apply `amend_id` | medium | Existing rows have no `amend_id`, so supersession cannot act on them. Either backfill from the source or re-sync. A re-sync is ~4h and already proven |
 | `SMRY_CD` is 469 MB | low | Comparable to sources already ingested; filtered to F460 |
 | Reconciliation false positives | medium | Detail *below* official is expected (unitemized) and must not be flagged. Only detail **exceeding** official indicates a fault |
@@ -139,7 +154,11 @@ variance explained by unitemized amounts.
 
 ## Open questions
 
-1. Backfill `amend_id` on existing rows, or re-sync? Re-sync is simpler and proven; backfill avoids
-   ~4 hours of downtime. Decide before subtask 2 ships.
+1. ~~Backfill `amend_id` on existing rows, or re-sync?~~ **Resolved 2026-08-11: re-sync.** Not on
+   simplicity — backfill is unsound. Stored rows were merged under last-write-wins, so a row that
+   collapsed across amendments holds the *content* of whichever version was written last. A backfill
+   can stamp an `amend_id` on that row but cannot restore the right values behind it, and
+   supersession would then delete rows on the strength of those stamps. Only re-ingesting under the
+   monotonic guard produces rows whose `amend_id` and contents agree. Cost stands at ~4h.
 2. Should the unitemized delta appear on representative/proposition pages, or stay internal until a
    design exists? Storing it does not commit us either way.

--- a/docs/plans/992-amendment-supersession-and-filing-summaries.md
+++ b/docs/plans/992-amendment-supersession-and-filing-summaries.md
@@ -1,0 +1,145 @@
+# Plan: amendment supersession + filing summaries (#992)
+
+| | |
+|---|---|
+| **Issue** | [#992](https://github.com/OpusPopuli/opuspopuli/issues/992) |
+| **Follows** | [#980](https://github.com/OpusPopuli/opuspopuli/issues/980) — attribution fixed and verified; totals still inflated on amended filings |
+| **Related** | [#991](https://github.com/OpusPopuli/opuspopuli/issues/991) (EXPN shortfall), [#983](https://github.com/OpusPopuli/opuspopuli/issues/983) (refund signs) |
+| **Date** | 2026-08-11 |
+| **Author** | Rodney Gagnon |
+| **Data classification** | **PII — no PHI.** No new donor fields. `SMRY_CD` is aggregate-only (amounts per filing), so it adds no PII of its own. |
+| **Branch** | `feat/992-amendment-supersession-and-summaries` (+ `opuspopuli-regions`, + migration) |
+| **Status** | Plan written. Implementation starting. |
+
+## Problem
+
+Two findings from #980's subtask-7 verification against official Form 460 totals.
+
+### A. Amended filings double-count
+
+Amendments **restate a filing with new `TRAN_ID` and `LINE_ITEM` values**, so the composite
+`externalId` cannot merge them. Original and restatement both persist.
+
+```
+filing 2505994
+  AMEND_ID 0:  1 row,  $168,135.00
+  AMEND_ID 1:  2 rows, $170,988.25   <- official Form 460 line 1, exactly
+  stored:      3 rows, $339,123.25   <- both
+```
+
+This refines #980's conclusion. Dropping `AMEND_ID` from the key was **necessary** — it collapsed
+3.18M genuinely duplicated `RCPT_CD` rows — but only merges rows that *reuse* identifiers.
+Restatements don't. The 15.9% collision rate measured at the time was real dedup of a different
+case, which is why it read as confirmation.
+
+### B. Unitemized contributions are invisible
+
+Schedule A itemizes contributions of **$100 or more**. Smaller ones are aggregated onto the Form 460
+summary line and appear nowhere in `RCPT_CD`. Our detail is complete; the *displayed total* is not.
+
+```
+644009:   ours 35,250.00 (= raw file exactly)   official 36,694.00   (-1,444)
+1637859:  ours 41,295.00 (= raw file exactly)   official 43,530.00   (-2,235)
+```
+
+A candidate funded by many small donors currently looks less funded than one funded by a few large
+ones. On a transparency platform that is a substantive distortion, not a rounding detail.
+
+## Measured baseline
+
+123 Schedule-A-only filings vs official Form 460 line 1:
+
+| | Count | |
+|---|---:|---|
+| Exact match | 60 (49%) | ✅ |
+| Ours lower | 55 (45%) | ✅ unitemized (B) |
+| Ours higher | **8 (7%)** | ❌ amendment double-count (A) |
+
+Attribution is unaffected and verified: 3,000/3,000 sampled rows matched the filer in the raw
+cover-page file; self-donations fell 40,003 → 1,398.
+
+**This baseline is the acceptance target.** After the work, "ours higher" should be ~0 and the
+unitemized delta should be explicit rather than silent.
+
+## Decisions
+
+**Superseded rows are deleted post-sync** (decided 2026-08-11). A step after ingest retains only
+`max(amend_id)` per filing, mirroring `CoverPageLinkerService`.
+
+Rejected: flagging and filtering on read. It preserves amendment history in-database, which has real
+civic value — "this committee revised its numbers" is itself a fact — but it puts a filter on every
+current and future read path, and #980 demonstrated exactly how a missed filter becomes a wrong
+public number. History remains recoverable from the source archive when a feature needs it.
+
+Rejected: filtering during ingest. The bulk handler streams a single pass and cannot know
+`max(amend_id)` until the file ends; a pre-pass or buffering ~20M rows costs more than a post-sync
+delete.
+
+**Ingest all F460 summary lines** (decided 2026-08-11), not just contributions (1–5). Lines 6+ carry
+expenditure and cash-position totals, which give #991 the same reconciliation lever — and #991 is
+currently a 60% shortfall with no independent check.
+
+## Subtasks
+
+### 1. `amend_id` on contributions and expenditures
+
+- Migration (`/op-migration`): nullable `amend_id` + index supporting `(filing_id, amend_id)`
+- `schema.prisma`, zod schemas in `domain-mapper.service.ts`, `Contribution`/`Expenditure`
+  interfaces in `packages/common`, and the `fields` projections in `campaign-finance-sync.service.ts`
+- Region config: map `AMEND_ID`
+
+Same four-place write path as #980's `filing_id`, and the same trap: `z.object()` strips unknown
+keys, so the schema change is what makes the mapping effective.
+
+### 2. Supersession step
+
+- New service in `apps/backend/src/apps/region/src/domains/`, run from `runPostSyncLinkers`
+- Set-based delete, batched, following `CoverPageLinkerService`: for each `filing_id`, remove rows
+  whose `amend_id` is below the maximum for that filing
+- Must run **before** the cover-page linker — no point attributing rows about to be deleted
+- **Tests:** integration against real `postgres_test`, including the 2505994 shape (original +
+  restatement with different `TRAN_ID`s)
+
+### 3. `filing_summaries` table + `SMRY_CD` ingestion
+
+- Migration: `filing_summaries` (`filing_id`, `amend_id`, `form_type`, `line_item`, `amount_a/b/c`)
+- Region config: new `dataSources` entry for `SMRY_CD.TSV`, `compositeKey`
+  `[FILING_ID, AMEND_ID, FORM_TYPE, LINE_ITEM]`, filtered to `FORM_TYPE=F460`
+- Domain mapper: `FilingSummarySchema` + category routing
+- Sync: upsert config
+
+Note this table keeps `amend_id` — it is the summary *of* an amendment, and reconciliation needs the
+latest one, not a merged view.
+
+### 4. Reconciliation
+
+- Compare itemized detail per filing against the official summary line
+- **Flag where detail exceeds official** — that comparison is what found this defect; automated, it
+  becomes a standing property rather than a manual exercise
+- Expose the unitemized delta (line 1 − itemized) so small-donor money stops being invisible
+
+Surfacing it in the UI is out of scope here; storing and flagging it is not.
+
+### 5. Re-verify
+
+Re-run the subtask-7 method on the rebuilt data. Target: "ours higher" ≈ 0, with the remaining
+variance explained by unitemized amounts.
+
+**Ordering:** 1 → 2 (fixes the defect) → 3 → 4 (proves it, and guards it). 5 last.
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Supersession deletes rows it should keep | high | A filing with a single amendment must be untouched. Integration test asserts that explicitly before any bulk run |
+| Another rebuild needed to apply `amend_id` | medium | Existing rows have no `amend_id`, so supersession cannot act on them. Either backfill from the source or re-sync. A re-sync is ~4h and already proven |
+| `SMRY_CD` is 469 MB | low | Comparable to sources already ingested; filtered to F460 |
+| Reconciliation false positives | medium | Detail *below* official is expected (unitemized) and must not be flagged. Only detail **exceeding** official indicates a fault |
+| Region config in a separate repo | low | Publish `@opuspopuli/regions` before the monorepo consumes it |
+
+## Open questions
+
+1. Backfill `amend_id` on existing rows, or re-sync? Re-sync is simpler and proven; backfill avoids
+   ~4 hours of downtime. Decide before subtask 2 ships.
+2. Should the unitemized delta appear on representative/proposition pages, or stay internal until a
+   design exists? Storing it does not commit us either way.

--- a/docs/plans/992-amendment-supersession-and-filing-summaries.md
+++ b/docs/plans/992-amendment-supersession-and-filing-summaries.md
@@ -9,7 +9,7 @@
 | **Author** | Rodney Gagnon |
 | **Data classification** | **PII — no PHI.** No new donor fields. `SMRY_CD` is aggregate-only (amounts per filing), so it adds no PII of its own. |
 | **Branch** | `feat/992-amendment-supersession-and-summaries` (+ `opuspopuli-regions`, + migration) |
-| **Status** | Subtasks 1–3 complete. 4 (reconciliation) next, then 5 (re-verify on a rebuild). |
+| **Status** | Subtasks 1–4 complete (4 split into 4a/4b after the finding below). 5 (re-verify on a rebuild) is all that remains. |
 
 ## Problem
 
@@ -126,7 +126,50 @@ keys, so the schema change is what makes the mapping effective.
 Note this table keeps `amend_id` — it is the summary *of* an amendment, and reconciliation needs the
 latest one, not a merged view.
 
-### 4. Reconciliation
+### 4a. Schedule discriminator on detail rows
+
+**Added 2026-08-12, measured before writing any reconciliation code.** `RCPT_CD` is not Schedule A —
+it is every receipt schedule in one file, and the schedule letter (`FORM_TYPE`) was never mapped. So
+`contributions` today is an undifferentiated mix with no way to tell the schedules apart:
+
+| `FORM_TYPE` | Rows | Amount | On Form 460 |
+|---|---:|---:|---|
+| `A` | 18,205,803 | $28.70B | line 1 — monetary contributions |
+| `C` | 313,633 | $1.74B | line 4 — nonmonetary |
+| `I` | 197,921 | $1.54B | line 14 — miscellaneous increases to cash |
+| `F496P3` | 237,731 | $1.87B | not an F460 at all |
+| `F401A` | 146,291 | $0.37B | not an F460 at all |
+| `A-1`, `E530`, `F900`, junk | 1,992 | $0.10B | — |
+
+Reconciliation compares against **line 1**, which is Schedule A alone. Summing the table as it stands
+compares a mixture against one of its parts. Measured across all 122,033 F460 filings, counting only
+the surviving amendment (i.e. modelling the post-supersession state):
+
+| Detail summed as | Match | Ours lower | **Ours higher** |
+|---|---:|---:|---:|
+| Schedule A only | 49,575 | 72,084 | **374 (0.31%)** |
+| Every `RCPT_CD` row | 32,753 | 53,568 | **35,712 (29.3%)** |
+
+**35,339 filings (29.0%) would be falsely flagged as over-counting.** The genuine signal is 374
+filings; without the discriminator the noise outnumbers it 95:1 and the check is worthless — it would
+be a fault detector that cries fault on nearly a third of all filings.
+
+This is the "reconciliation false positives" risk in the register, larger than it was scoped at.
+
+`EXPN_CD` is the same shape, and matters to [#991](https://github.com/OpusPopuli/opuspopuli/issues/991):
+`E` 7,824,338 rows (line 6, payments made) mixed with `D` 4,826,727 (a **memo** schedule restating
+Schedule E entries — additive summation double-counts it), `G` 1,342,727, plus `F461P5` / `F465P3` /
+`F450P5` belonging to other forms entirely.
+
+- Region config: map `RCPT_CD.FORM_TYPE` and `EXPN_CD.FORM_TYPE` → `scheduleCode`
+- Migration: nullable `schedule_code` on `contributions` and `expenditures`, index `(filing_id, schedule_code)`
+- `schema.prisma`, zod schemas, `packages/common` interfaces, `fields` projections — the same
+  four-place write path as `amend_id`, with the same `z.object()` strip trap
+
+Named `scheduleCode`, not `formType`: the finance router keys `filingSummaries` off `formType` +
+`lineItem`, and a detail row carrying `formType` sits one field away from being misrouted.
+
+### 4b. Reconciliation
 
 - Compare itemized detail per filing against the official summary line
 - **Flag where detail exceeds official** — that comparison is what found this defect; automated, it
@@ -135,12 +178,16 @@ latest one, not a merged view.
 
 Surfacing it in the UI is out of scope here; storing and flagging it is not.
 
+Note the Schedule-A row above also stands as evidence for subtask 2 at full scale: the sampled
+baseline was 8 of 123 filings (7%) over-counting, and modelling supersession across all 122,033 drops
+that to 374 (0.31%). The residual is small enough to investigate case by case rather than in bulk.
+
 ### 5. Re-verify
 
 Re-run the subtask-7 method on the rebuilt data. Target: "ours higher" ≈ 0, with the remaining
 variance explained by unitemized amounts.
 
-**Ordering:** 1 → 2 (fixes the defect) → 3 → 4 (proves it, and guards it). 5 last.
+**Ordering:** 1 → 2 (fixes the defect) → 3 → 4a → 4b (proves it, and guards it). 5 last.
 
 ## Risks
 
@@ -149,7 +196,7 @@ variance explained by unitemized amounts.
 | Supersession deletes rows it should keep | high | A filing with a single amendment must be untouched. Integration test asserts that explicitly before any bulk run. Second path found and closed during subtask 1: a merged row holding a stale `amend_id` from out-of-order arrival — see the monotonic-write decision above |
 | Another rebuild needed to apply `amend_id` | medium | Existing rows have no `amend_id`, so supersession cannot act on them. Either backfill from the source or re-sync. A re-sync is ~4h and already proven |
 | `SMRY_CD` is 469 MB | low | Comparable to sources already ingested; filtered to F460 |
-| Reconciliation false positives | medium | Detail *below* official is expected (unitemized) and must not be flagged. Only detail **exceeding** official indicates a fault |
+| Reconciliation false positives | ~~medium~~ **realised** | Detail *below* official is expected (unitemized) and must not be flagged. Only detail **exceeding** official indicates a fault. Measured 2026-08-12: without a schedule discriminator this fires on 29% of filings against a true rate of 0.31%, which is what subtask 4a exists to fix |
 | Region config in a separate repo | low | Publish `@opuspopuli/regions` before the monorepo consumes it |
 
 ## Open questions

--- a/packages/common/__tests__/finance-routing.spec.ts
+++ b/packages/common/__tests__/finance-routing.spec.ts
@@ -1,0 +1,118 @@
+import {
+  emptyCampaignFinanceResult,
+  sortCampaignFinanceItems,
+} from "../src/providers/region/finance-routing.js";
+
+/**
+ * These rules decide which table every CAL-ACCESS row lands in, from field
+ * presence alone — the bulk downloads carry no type tag. A row matching no rule
+ * is dropped, and a row matching the wrong rule is counted against the wrong
+ * committee, so the overlaps are what these tests pin down.
+ */
+describe("sortCampaignFinanceItems", () => {
+  const summary = () => ({
+    externalId: "2505994:1:F460:1",
+    filingId: "2505994",
+    amendId: 1,
+    formType: "F460",
+    lineItem: "1",
+    amountA: 170988.25,
+    sourceSystem: "cal_access",
+  });
+
+  it("routes a SMRY_CD row to filingSummaries (#992)", () => {
+    const out = sortCampaignFinanceItems([summary()]);
+
+    expect(out.filingSummaries).toHaveLength(1);
+    expect(out.filingSummaries[0]).toMatchObject({ lineItem: "1" });
+  });
+
+  it("does not let a summary row fall through to contributions (#992)", () => {
+    // Contributions is where a row with an amount lands by default, and a
+    // summary counted as a contribution would inflate the very total this
+    // table exists to check.
+    const out = sortCampaignFinanceItems([summary()]);
+
+    expect(out.contributions).toHaveLength(0);
+    expect(out.expenditures).toHaveLength(0);
+    expect(out.committees).toHaveLength(0);
+    expect(out.cvrFilings).toHaveLength(0);
+  });
+
+  it("routes each finance shape to its own table", () => {
+    const out = sortCampaignFinanceItems([
+      summary(),
+      { externalId: "c1", donorName: "Jane", amount: 100 },
+      { externalId: "e1", payeeName: "Ad Agency", amount: 900 },
+      { externalId: "ie1", committeeName: "PAC-1", supportOrOppose: "S" },
+      { externalId: "f1", filerId: "C1", filingId: "F1" },
+      { externalId: "m1", filingId: "F2", ballotNumber: "Prop 5" },
+      { externalId: "k1", sourceSystem: "fec", type: "pac" },
+    ]);
+
+    expect(out.filingSummaries).toHaveLength(1);
+    expect(out.contributions).toHaveLength(1);
+    expect(out.expenditures).toHaveLength(1);
+    expect(out.independentExpenditures).toHaveLength(1);
+    expect(out.cvrFilings).toHaveLength(1);
+    expect(out.committeeMeasureFilings).toHaveLength(1);
+    expect(out.committees).toHaveLength(1);
+  });
+
+  it("prefers the cover page over the measure filing when both could match (#955)", () => {
+    // A cover page carries filingId and could be read as a measure filing if
+    // it also carries a ballot field. filerId is what distinguishes it, and
+    // the cover-page rule has to come first for that to hold.
+    const out = sortCampaignFinanceItems([
+      {
+        externalId: "f1",
+        filerId: "C1",
+        filingId: "F1",
+        ballotName: "Clean Water Act",
+      },
+    ]);
+
+    expect(out.cvrFilings).toHaveLength(1);
+    expect(out.committeeMeasureFilings).toHaveLength(0);
+  });
+
+  it("prefers the measure filing over the committee when both could match (#936)", () => {
+    // CVR2 rows carry a sourceSystem too, so the looser committee rule must
+    // not get to them first.
+    const out = sortCampaignFinanceItems([
+      {
+        externalId: "m1",
+        filingId: "F2",
+        ballotNumber: "Prop 5",
+        sourceSystem: "cal_access",
+        type: "candidate",
+      },
+    ]);
+
+    expect(out.committeeMeasureFilings).toHaveLength(1);
+    expect(out.committees).toHaveLength(0);
+  });
+
+  it("drops a record no rule claims", () => {
+    const out = sortCampaignFinanceItems([
+      { externalId: "x1", nonsense: true },
+    ]);
+
+    expect(Object.values(out).every((bucket) => bucket.length === 0)).toBe(
+      true,
+    );
+  });
+
+  it("returns every bucket even for an empty stream, so callers can push blind", () => {
+    expect(sortCampaignFinanceItems([])).toEqual(emptyCampaignFinanceResult());
+    expect(Object.keys(emptyCampaignFinanceResult()).sort()).toEqual([
+      "committeeMeasureFilings",
+      "committees",
+      "contributions",
+      "cvrFilings",
+      "expenditures",
+      "filingSummaries",
+      "independentExpenditures",
+    ]);
+  });
+});

--- a/packages/common/src/providers/region/finance-routing.ts
+++ b/packages/common/src/providers/region/finance-routing.ts
@@ -1,0 +1,86 @@
+import type { CampaignFinanceResult } from "./types.js";
+
+/**
+ * Field-presence rules routing each streamed CAL-ACCESS record to its table.
+ * The bulk downloads carry no wire-format type tag, so shape is the only
+ * discriminator available.
+ *
+ * **Order is significant — first match wins.** Several shapes overlap, and the
+ * sequence below encodes which reading takes precedence:
+ *
+ *   - Summaries lead. SMRY_CD is the only shape carrying a form type *and* a
+ *     line number, and it holds no amount/donor/payee (#992).
+ *   - Cover pages precede measure filings: both carry `filingId`, and only the
+ *     cover page carries `filerId` (#955).
+ *   - Committees come last. Their rule is the loosest, so anything more
+ *     specific must have had its chance first.
+ *
+ * A table rather than an if/else chain: the chain reached the
+ * cognitive-complexity gate at seven branches, and every future table would
+ * have pushed it further.
+ */
+const FINANCE_ROUTES: ReadonlyArray<{
+  bucket: keyof CampaignFinanceResult;
+  matches: (rec: Record<string, unknown>) => boolean;
+}> = [
+  {
+    bucket: "filingSummaries",
+    matches: (r) => "formType" in r && "lineItem" in r,
+  },
+  {
+    bucket: "contributions",
+    matches: (r) => "donorName" in r && "amount" in r,
+  },
+  { bucket: "expenditures", matches: (r) => "payeeName" in r && "amount" in r },
+  {
+    bucket: "independentExpenditures",
+    matches: (r) => "supportOrOppose" in r && "committeeName" in r,
+  },
+  // Form 496 cover page — filerId + filingId, no committeeName/ballot fields.
+  // Feeds the IE linker's FILING_ID -> committee join (#955).
+  { bucket: "cvrFilings", matches: (r) => "filerId" in r && "filingId" in r },
+  {
+    bucket: "committeeMeasureFilings",
+    matches: (r) =>
+      "filingId" in r && ("ballotName" in r || "ballotNumber" in r),
+  },
+  { bucket: "committees", matches: (r) => "sourceSystem" in r && "type" in r },
+];
+
+/** An empty result — every bucket present, so callers can push without checks. */
+export function emptyCampaignFinanceResult(): CampaignFinanceResult {
+  return {
+    committees: [],
+    contributions: [],
+    expenditures: [],
+    independentExpenditures: [],
+    committeeMeasureFilings: [],
+    cvrFilings: [],
+    filingSummaries: [],
+  };
+}
+
+/**
+ * Sort a heterogeneous batch of CAL-ACCESS records into the typed shape
+ * `CampaignFinanceResult` expects.
+ *
+ * Lives here rather than at either call site because it had been implemented
+ * twice — once in the region plugin, once in the backend sync service — and the
+ * two had to be edited in lockstep. A table added to one and missed in the
+ * other drops that table's rows silently, which is the failure mode this whole
+ * issue exists to eliminate. One table, one loop, both callers (#992).
+ */
+export function sortCampaignFinanceItems(
+  items: Record<string, unknown>[],
+): CampaignFinanceResult {
+  const sorted = emptyCampaignFinanceResult();
+
+  for (const rec of items) {
+    const route = FINANCE_ROUTES.find(({ matches }) => matches(rec));
+    // Unroutable records are dropped, as they always have been: the stream
+    // carries shapes no table claims.
+    if (route) (sorted[route.bucket] as unknown[]).push(rec);
+  }
+
+  return sorted;
+}

--- a/packages/common/src/providers/region/index.ts
+++ b/packages/common/src/providers/region/index.ts
@@ -1,2 +1,3 @@
 export * from "./types.js";
 export * from "./civics-types.js";
+export * from "./finance-routing.js";

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -552,6 +552,7 @@ export interface Contribution {
   externalId: string;
   committeeId?: string; // resolved post-sync by the cover-page linker via filingId (#980) — RCPT_CD's CMTE_ID is the contributor
   filingId?: string; // CalAccess FILING_ID from RCPT_CD — join key to the campaign-disclosure cover page (#980)
+  amendId?: number; // CalAccess AMEND_ID — numeric so max() picks the latest version, not '9' over '10' (#992)
   donorName: string;
   donorType: "individual" | "committee" | "party" | "self" | "other";
   donorEmployer?: string;
@@ -573,6 +574,7 @@ export interface Expenditure {
   externalId: string;
   committeeId?: string; // resolved post-sync by the cover-page linker via filingId (#980) — EXPN_CD's CMTE_ID is the payee
   filingId?: string; // CalAccess FILING_ID from EXPN_CD — join key to the campaign-disclosure cover page (#980)
+  amendId?: number; // CalAccess AMEND_ID (#992)
   payeeName: string;
   amount: number;
   date: Date;

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -641,6 +641,31 @@ export interface CvrFiling {
 }
 
 /**
+ * One numbered line from a filing's own summary page (CalAccess `SMRY_CD`,
+ * filtered to Form 460) — the totals the committee reported itself, as opposed
+ * to the itemized detail in `Contribution` / `Expenditure` (#992).
+ *
+ * Two uses. Reconciliation: itemized detail exceeding the committee's own
+ * reported total means something is counted twice — the check that found the
+ * amendment double-count. And unitemized contributions: Schedule A itemizes
+ * only $100 and above, so smaller donations exist nowhere else.
+ *
+ * `amendId` is part of the identity here rather than superseded — this is the
+ * summary *of* an amendment, and reconciliation compares against the latest.
+ */
+export interface FilingSummary {
+  externalId: string; // FILING_ID:AMEND_ID:FORM_TYPE:LINE_ITEM
+  filingId: string; // FILING_ID — join key to the itemized detail
+  amendId?: number; // AMEND_ID
+  formType: string; // FORM_TYPE — F460 today
+  lineItem: string; // LINE_ITEM — string: 47 distinct values on F460, not all numeric
+  amountA?: number; // AMOUNT_A — this reporting period
+  amountB?: number; // AMOUNT_B — calendar-year cumulative
+  amountC?: number; // AMOUNT_C — election-cycle cumulative, where the form carries one
+  sourceSystem: "cal_access" | "fec";
+}
+
+/**
  * Aggregated result from campaign finance data fetch
  */
 export interface CampaignFinanceResult {
@@ -650,6 +675,7 @@ export interface CampaignFinanceResult {
   independentExpenditures: IndependentExpenditure[];
   committeeMeasureFilings: CommitteeMeasureFiling[];
   cvrFilings: CvrFiling[];
+  filingSummaries: FilingSummary[];
 }
 
 /**

--- a/packages/common/src/providers/region/types.ts
+++ b/packages/common/src/providers/region/types.ts
@@ -553,6 +553,7 @@ export interface Contribution {
   committeeId?: string; // resolved post-sync by the cover-page linker via filingId (#980) — RCPT_CD's CMTE_ID is the contributor
   filingId?: string; // CalAccess FILING_ID from RCPT_CD — join key to the campaign-disclosure cover page (#980)
   amendId?: number; // CalAccess AMEND_ID — numeric so max() picks the latest version, not '9' over '10' (#992)
+  scheduleCode?: string; // RCPT_CD FORM_TYPE — the SCHEDULE: 'A' monetary (F460 line 1), 'C' nonmonetary, 'I' misc; reconciliation must filter to 'A' (#992)
   donorName: string;
   donorType: "individual" | "committee" | "party" | "self" | "other";
   donorEmployer?: string;
@@ -575,6 +576,7 @@ export interface Expenditure {
   committeeId?: string; // resolved post-sync by the cover-page linker via filingId (#980) — EXPN_CD's CMTE_ID is the payee
   filingId?: string; // CalAccess FILING_ID from EXPN_CD — join key to the campaign-disclosure cover page (#980)
   amendId?: number; // CalAccess AMEND_ID (#992)
+  scheduleCode?: string; // EXPN_CD FORM_TYPE — the SCHEDULE: 'E' payments (F460 line 6); 'D' is a MEMO restating E, so summing both double-counts (#992)
   payeeName: string;
   amount: number;
   date: Date;

--- a/packages/region-provider/__tests__/declarative-region-plugin.spec.ts
+++ b/packages/region-provider/__tests__/declarative-region-plugin.spec.ts
@@ -539,6 +539,37 @@ describe("DeclarativeRegionPlugin", () => {
       });
     });
 
+    it("separates SMRY_CD summary lines out of the contribution bucket (#992)", async () => {
+      // Contributions is the fall-through bucket here, so a summary row landing
+      // there would inflate the very total it exists to reconcile against.
+      // Two campaign_finance sources are configured; only the first carries
+      // summary rows.
+      cfPipeline.execute
+        .mockResolvedValueOnce(
+          createExtractionResult([
+            {
+              externalId: "2505994:1:F460:1",
+              filingId: "2505994",
+              amendId: 1,
+              formType: "F460",
+              lineItem: "1",
+              amountA: 170988.25,
+              sourceSystem: "cal_access",
+            },
+          ]),
+        )
+        .mockResolvedValueOnce(createExtractionResult([]));
+
+      const result = await cfPlugin.fetchCampaignFinance();
+
+      expect(result.filingSummaries).toHaveLength(1);
+      expect(result.filingSummaries[0]).toMatchObject({
+        filingId: "2505994",
+        lineItem: "1",
+      });
+      expect(result.contributions).toEqual([]);
+    });
+
     it("should return empty arrays when pipeline returns no items", async () => {
       cfPipeline.execute.mockResolvedValue(createExtractionResult([]));
 

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.79"
+    "@opuspopuli/regions": "^1.0.80"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/package.json
+++ b/packages/region-provider/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opuspopuli/common": "workspace:*",
     "@opuspopuli/config-provider": "workspace:*",
-    "@opuspopuli/regions": "^1.0.78"
+    "@opuspopuli/regions": "^1.0.79"
   },
   "peerDependencies": {
     "@nestjs/common": "^11.0.0",

--- a/packages/region-provider/src/declarative/declarative-region-plugin.ts
+++ b/packages/region-provider/src/declarative/declarative-region-plugin.ts
@@ -26,6 +26,8 @@ import type {
   ExtractionResult,
   BoundarySourcesConfig,
 } from "@opuspopuli/common";
+// Value import, so it cannot join the `import type` block above.
+import { sortCampaignFinanceItems } from "@opuspopuli/common";
 
 /**
  * Interface for the pipeline service dependency.
@@ -219,62 +221,12 @@ export class DeclarativeRegionPlugin extends BaseRegionPlugin {
       pipelineJobId,
     );
 
-    // The domain mapper already routes by category, but items come back
-    // as a mixed bag. Separate them by checking known fields.
-    const committees: CampaignFinanceResult["committees"] = [];
-    const contributions: CampaignFinanceResult["contributions"] = [];
-    const expenditures: CampaignFinanceResult["expenditures"] = [];
-    const independentExpenditures: CampaignFinanceResult["independentExpenditures"] =
-      [];
-    const committeeMeasureFilings: CampaignFinanceResult["committeeMeasureFilings"] =
-      [];
-    const cvrFilings: CampaignFinanceResult["cvrFilings"] = [];
-
-    for (const item of allItems) {
-      const rec = item;
-      if ("donorName" in rec && "amount" in rec) {
-        contributions.push(
-          rec as unknown as CampaignFinanceResult["contributions"][0],
-        );
-      } else if ("payeeName" in rec && "amount" in rec) {
-        expenditures.push(
-          rec as unknown as CampaignFinanceResult["expenditures"][0],
-        );
-      } else if ("supportOrOppose" in rec && "committeeName" in rec) {
-        independentExpenditures.push(
-          rec as unknown as CampaignFinanceResult["independentExpenditures"][0],
-        );
-      } else if ("filerId" in rec && "filingId" in rec) {
-        // Form 496 cover page — has filerId + filingId (no committeeName, no
-        // ballot fields). Feeds the IE linker's FILING_ID -> committee join (#955).
-        cvrFilings.push(
-          rec as unknown as CampaignFinanceResult["cvrFilings"][0],
-        );
-      } else if (
-        "filingId" in rec &&
-        ("ballotName" in rec || "ballotNumber" in rec)
-      ) {
-        // CVR2 record — Form 410 ballot-measure declaration. Has filingId +
-        // a ballot identifier. Discriminate before "sourceSystem + type"
-        // because a CVR2 row also carries a sourceSystem.
-        committeeMeasureFilings.push(
-          rec as unknown as CampaignFinanceResult["committeeMeasureFilings"][0],
-        );
-      } else if ("sourceSystem" in rec && "type" in rec) {
-        committees.push(
-          rec as unknown as CampaignFinanceResult["committees"][0],
-        );
-      }
-    }
-
-    return {
-      committees,
-      contributions,
-      expenditures,
-      independentExpenditures,
-      committeeMeasureFilings,
-      cvrFilings,
-    };
+    // The domain mapper already routes by category, but items come back as a
+    // mixed bag. The field-presence rules that separate them live in
+    // @opuspopuli/common — the backend sync service sorts the same stream and
+    // needs the identical rules, and two copies had to be edited in lockstep
+    // (#992).
+    return sortCampaignFinanceItems(allItems);
   }
 
   override async healthCheck() {

--- a/packages/relationaldb-provider/prisma/migrations/20260811000000_amend_id_and_filing_summaries/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260811000000_amend_id_and_filing_summaries/migration.sql
@@ -1,0 +1,59 @@
+-- #992: supersede amended filings, and reconcile against official totals.
+--
+-- (1) amend_id on the finance tables. CAL-ACCESS restates a filing on amendment
+-- using NEW TRAN_ID/LINE_ITEM values, so the composite externalId cannot merge
+-- the versions and both persist — filing 2505994 stores $339,123 against an
+-- official $170,988. Retaining only max(amend_id) per filing needs the column.
+--
+-- INTEGER, not text, deliberately: AMEND_ID reaches 10, and under text ordering
+-- '10' < '9', so max() would select amendment 9 as the latest and silently keep
+-- the wrong version.
+--
+-- (2) filing_summaries holds SMRY_CD Form 460 summary lines — the totals each
+-- committee reports itself. Reconciling itemized detail against them is what
+-- found the defect above; stored, it becomes a standing check rather than a
+-- manual exercise. It also exposes unitemized contributions (<$100), which
+-- appear only on the summary and are otherwise invisible.
+--
+-- Additive: two nullable columns, two indexes, one new table. No drops, no
+-- renames, no rewrites (ADD COLUMN with no default is catalog-only).
+--
+-- Data classification: PII, no PHI, and no NEW PII — filing_summaries is
+-- aggregate amounts per filing with no donor detail. No RLS exists on any
+-- finance table (none exists anywhere in this schema); access is mediated by
+-- the region service.
+
+ALTER TABLE "contributions" ADD COLUMN "amend_id" INTEGER;
+ALTER TABLE "expenditures"  ADD COLUMN "amend_id" INTEGER;
+
+-- Supersession scans per filing and compares amendments, so the index leads on
+-- filing_id with amend_id second.
+CREATE INDEX "contributions_filing_amend_idx" ON "contributions"("filing_id", "amend_id");
+CREATE INDEX "expenditures_filing_amend_idx"  ON "expenditures"("filing_id", "amend_id");
+
+CREATE TABLE "filing_summaries" (
+    "id"            TEXT NOT NULL,
+    "external_id"   TEXT NOT NULL,
+    "filing_id"     VARCHAR(50) NOT NULL,
+    -- Kept, not superseded: this is the summary OF an amendment, and
+    -- reconciliation compares against the latest one specifically.
+    "amend_id"      INTEGER,
+    "form_type"     VARCHAR(20) NOT NULL,
+    -- 47 distinct values on F460 alone, not all numeric.
+    "line_item"     VARCHAR(10) NOT NULL,
+    -- Observed range -60,000,000 to 195,446,000; negatives are real.
+    "amount_a"      DECIMAL(14,2),
+    "amount_b"      DECIMAL(14,2),
+    "amount_c"      DECIMAL(14,2),
+    "source_system" VARCHAR(20) NOT NULL,
+    "created_at"    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"    TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "filing_summaries_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "filing_summaries_external_id_key" ON "filing_summaries"("external_id");
+CREATE INDEX "filing_summaries_filing_id_idx" ON "filing_summaries"("filing_id");
+-- Reconciliation looks up one line of one form for a filing.
+CREATE INDEX "filing_summaries_lookup_idx"
+    ON "filing_summaries"("filing_id", "form_type", "line_item");

--- a/packages/relationaldb-provider/prisma/migrations/20260812000000_schedule_code_on_finance_detail/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260812000000_schedule_code_on_finance_detail/migration.sql
@@ -1,0 +1,52 @@
+-- #992 (subtask 4a): record which schedule each finance detail row came from.
+--
+-- RCPT_CD is not Schedule A. It is every receipt schedule in one file, and its
+-- FORM_TYPE column — the schedule letter — was never mapped, so `contributions`
+-- is an undifferentiated mix. Measured on the 2026-04-05 export:
+--
+--   A       18,205,803 rows  $28.70B   Form 460 line 1  (monetary contributions)
+--   C          313,633 rows   $1.74B   Form 460 line 4  (nonmonetary)
+--   I          197,921 rows   $1.54B   Form 460 line 14 (misc increases to cash)
+--   F496P3     237,731 rows   $1.87B   not a Form 460 at all
+--   F401A      146,291 rows   $0.37B   not a Form 460 at all
+--
+-- Reconciliation compares against line 1, which is Schedule A alone, so summing
+-- the table as it stands compares a mixture against one of its parts. Across all
+-- 122,033 F460 filings at their surviving amendment, Schedule A alone yields 374
+-- filings (0.31%) where our detail exceeds the committee's own reported total;
+-- summing every row yields 35,712 (29.3%), of which 35,339 are false. Without
+-- this column the check fires on nearly a third of all filings and is worthless.
+--
+-- EXPN_CD carries the same mixing plus a trap: Schedule D (4,826,727 rows) is a
+-- MEMO schedule restating payments already counted in Schedule E (7,824,338), so
+-- summing D with E double-counts. That is the lever #991 needs for line 6.
+--
+-- VARCHAR(20), not a narrower type or an enum: the observed values include
+-- 'F496P3' and 'F461P5' alongside single letters, and CAL-ACCESS adds form codes
+-- without notice. A CHECK constraint would reject rows the source considers
+-- valid and drop real money on a future export.
+--
+-- Additive: two nullable columns, two indexes. No drops, no renames, no table
+-- rewrite (ADD COLUMN with no default is catalog-only, so it does not touch the
+-- 20M/15M existing rows).
+--
+-- Existing rows get NULL. That is correct rather than a gap to backfill: the
+-- schedule is not derivable from what is stored, and per open question 1 these
+-- tables are re-synced rather than backfilled. Reconciliation treats a NULL
+-- schedule as "unknown" and declines to reconcile that filing instead of
+-- guessing — see FilingReconciliationService.
+--
+-- Data classification: PII, no PHI, and no NEW PII. The schedule letter is a
+-- form-structure code, not donor detail. No RLS on any finance table (none
+-- exists anywhere in this schema); access is mediated by the region service.
+
+ALTER TABLE "contributions" ADD COLUMN "schedule_code" VARCHAR(20);
+ALTER TABLE "expenditures"  ADD COLUMN "schedule_code" VARCHAR(20);
+
+-- Reconciliation aggregates one filing's rows for one schedule, so the index
+-- leads on filing_id with schedule_code second — the same shape, and the same
+-- reasoning, as contributions_filing_amend_idx above it.
+CREATE INDEX "contributions_filing_schedule_idx"
+    ON "contributions"("filing_id", "schedule_code");
+CREATE INDEX "expenditures_filing_schedule_idx"
+    ON "expenditures"("filing_id", "schedule_code");

--- a/packages/relationaldb-provider/prisma/migrations/20260812010000_filing_reconciliations/migration.sql
+++ b/packages/relationaldb-provider/prisma/migrations/20260812010000_filing_reconciliations/migration.sql
@@ -1,0 +1,85 @@
+-- #992 (subtask 4b): reconcile itemized detail against each filing's own totals.
+--
+-- Comparing summed detail against the committee's reported Form 460 figure is
+-- what found the amendment double-count. Stored, it stops being a manual
+-- exercise and becomes a standing property of every sync.
+--
+-- Two distinct readings come out of the same comparison, and conflating them
+-- would make the table useless:
+--
+--   detail  >  reported   A FAULT. We are counting money the committee never
+--                         reported — double-counted amendments, mis-attributed
+--                         rows, a schedule summed that should not have been.
+--
+--   detail  <  reported   EXPECTED, and itself a finding. Schedule A itemizes
+--                         only contributions of $100 or more, so the gap is
+--                         unitemized small-donor money that exists nowhere in
+--                         the detail. Measured across all 122,033 F460 filings,
+--                         59% sit here. Without it a candidate funded by many
+--                         small donors reads as less funded than one funded by
+--                         a few large ones — a substantive distortion on a
+--                         transparency platform, not a rounding detail.
+--
+-- Hence `status` rather than a boolean, and hence storing both figures rather
+-- than only the delta: the delta alone cannot distinguish "we are wrong" from
+-- "the source itemizes less than it totals".
+--
+-- Grain is one row per filing, at its surviving amendment. `filing_id` is
+-- UNIQUE so a re-run upserts rather than accumulating history — the previous
+-- verdict describes data that no longer exists.
+--
+-- Data classification: PII, no PHI, and no NEW PII. Every column is an
+-- aggregate over a filing; no donor detail reaches this table. No RLS on any
+-- finance table (none exists anywhere in this schema); access is mediated by
+-- the region service.
+
+CREATE TABLE "filing_reconciliations" (
+    "id"                        TEXT NOT NULL,
+    "filing_id"                 VARCHAR(50) NOT NULL,
+    -- The amendment actually compared. Recorded because a later sync can move
+    -- it, and a verdict is only meaningful against the version it was drawn on.
+    "amend_id"                  INTEGER,
+    -- Stamped from the detail rows, which the cover-page linker has already
+    -- attributed by the time this runs. Nullable: attribution can fail.
+    "committee_id"              TEXT,
+
+    -- Form 460 line 1 column A — monetary contributions, as reported.
+    "reported_contributions"    DECIMAL(14,2),
+    -- Sum of stored Schedule A rows. Schedule A ALONE: 'C' (nonmonetary), 'I'
+    -- (misc increases) and non-460 rows share the source file, and summing them
+    -- against line 1 flags 29% of filings as faulty against a true rate of 0.31%.
+    "itemized_contributions"    DECIMAL(14,2),
+    -- reported - itemized, when positive. This is the unitemized (<$100) money.
+    "unitemized_contributions"  DECIMAL(14,2),
+    "contribution_status"       VARCHAR(20) NOT NULL,
+
+    -- Form 460 line 6 column A — payments made. Schedule E ALONE: 'D' is a memo
+    -- schedule restating E entries, so summing both double-counts 4.8M rows.
+    -- Present for #991, which has a 40% shortfall and no independent check.
+    "reported_expenditures"     DECIMAL(14,2),
+    "itemized_expenditures"     DECIMAL(14,2),
+    "expenditure_status"        VARCHAR(20) NOT NULL,
+
+    "reconciled_at"             TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at"                TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"                TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "filing_reconciliations_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "filing_reconciliations_filing_id_key"
+    ON "filing_reconciliations"("filing_id");
+
+-- The point of the table: pull every filing whose detail exceeds what was
+-- reported. Plain rather than partial indexes despite that being the only
+-- query — a partial index cannot be expressed in schema.prisma, and the drift
+-- would have every later `prisma migrate` try to reconcile it away. Selectivity
+-- survives anyway: OVER_ITEMIZED is ~0.3% of rows, so the planner uses these.
+CREATE INDEX "filing_reconciliations_contribution_status_idx"
+    ON "filing_reconciliations"("contribution_status");
+CREATE INDEX "filing_reconciliations_expenditure_status_idx"
+    ON "filing_reconciliations"("expenditure_status");
+
+-- Committee-level rollups of unitemized money.
+CREATE INDEX "filing_reconciliations_committee_id_idx"
+    ON "filing_reconciliations"("committee_id");

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -1789,6 +1789,50 @@ model FilingSummary {
   @@map("filing_summaries")
 }
 
+/// Verdict from comparing a filing's itemized detail against the totals the
+/// committee reported on its own Form 460 summary page (#992).
+///
+/// The comparison cuts two ways, and the distinction is the whole point:
+///   - detail ABOVE reported is a FAULT — money counted that was never
+///     reported. This is the check that found the amendment double-count.
+///   - detail BELOW reported is EXPECTED — Schedule A itemizes only $100 and
+///     above, so the gap is unitemized small-donor money that appears nowhere
+///     in the detail. 59% of filings sit here. Surfacing it is what stops a
+///     candidate funded by many small donors from reading as underfunded.
+///
+/// One row per filing at its surviving amendment; a re-run upserts, because the
+/// previous verdict describes data that no longer exists.
+model FilingReconciliation {
+  id          String  @id @default(uuid())
+  filingId    String  @unique @map("filing_id") @db.VarChar(50)
+  /// The amendment compared. A verdict only means something against a version.
+  amendId     Int?    @map("amend_id")
+  /// Stamped from the detail rows, already attributed by the cover-page linker.
+  committeeId String? @map("committee_id")
+
+  /// Form 460 line 1 column A, as reported.
+  reportedContributions   Decimal? @map("reported_contributions") @db.Decimal(14, 2)
+  /// Sum of stored Schedule A rows — that schedule ALONE (see scheduleCode).
+  itemizedContributions   Decimal? @map("itemized_contributions") @db.Decimal(14, 2)
+  /// reported − itemized where positive: the unitemized (<$100) money.
+  unitemizedContributions Decimal? @map("unitemized_contributions") @db.Decimal(14, 2)
+  contributionStatus      String   @map("contribution_status") @db.VarChar(20)
+
+  /// Form 460 line 6 column A, and the Schedule E sum — the lever #991 needs.
+  reportedExpenditures Decimal? @map("reported_expenditures") @db.Decimal(14, 2)
+  itemizedExpenditures Decimal? @map("itemized_expenditures") @db.Decimal(14, 2)
+  expenditureStatus    String   @map("expenditure_status") @db.VarChar(20)
+
+  reconciledAt DateTime @default(now()) @map("reconciled_at") @db.Timestamptz
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt    DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([contributionStatus])
+  @@index([expenditureStatus])
+  @@index([committeeId])
+  @@map("filing_reconciliations")
+}
+
 /// Campaign contribution — money received by a committee from a donor.
 model Contribution {
   id               String   @id @default(uuid())
@@ -1803,6 +1847,14 @@ model Contribution {
   /// CalAccess AMEND_ID. Integer, not text: it reaches 10, and '10' < '9'
   /// under text ordering would make max() select the wrong version (#992).
   amendId          Int?     @map("amend_id")
+  /// CalAccess RCPT_CD.FORM_TYPE — the SCHEDULE this row was itemized on, not
+  /// the form type of the filing. `A` is monetary contributions (Form 460
+  /// line 1), `C` nonmonetary (line 4), `I` misc increases (line 14); `F496P3`
+  /// and `F401A` rows are not Form 460 at all. Reconciliation compares against
+  /// line 1, so it must filter to `A` — summing every schedule falsely flags
+  /// 29% of filings as over-counting against a true rate of 0.31% (#992).
+  /// Null on rows ingested before the mapping existed; those are not reconciled.
+  scheduleCode     String?  @map("schedule_code") @db.VarChar(20)
   donorName        String   @map("donor_name")
   donorType        String   @map("donor_type") @db.VarChar(20) /// individual, committee, party, self, other
   donorEmployer    String?  @map("donor_employer")
@@ -1823,6 +1875,7 @@ model Contribution {
   @@index([committeeId])
   @@index([filingId])
   @@index([filingId, amendId])
+  @@index([filingId, scheduleCode])
   @@index([donorName])
   @@index([date])
   @@index([amount])
@@ -1843,6 +1896,11 @@ model Expenditure {
   filingId           String?  @map("filing_id") @db.VarChar(50)
   /// CalAccess AMEND_ID — see Contribution.amendId (#992).
   amendId            Int?     @map("amend_id")
+  /// CalAccess EXPN_CD.FORM_TYPE — the SCHEDULE, see Contribution.scheduleCode.
+  /// `E` is payments made (Form 460 line 6). `D` is a MEMO schedule restating
+  /// payments already counted in `E`, so summing the two double-counts 4.8M
+  /// rows — reconciling line 6 must filter to `E` alone (#992, #991).
+  scheduleCode       String?  @map("schedule_code") @db.VarChar(20)
   payeeName          String   @map("payee_name")
   amount             Decimal  @db.Decimal(12, 2)
   date               DateTime @db.Date
@@ -1864,6 +1922,7 @@ model Expenditure {
   @@index([committeeId])
   @@index([filingId])
   @@index([filingId, amendId])
+  @@index([filingId, scheduleCode])
   @@index([payeeName])
   @@index([date])
   @@index([sourceSystem])

--- a/packages/relationaldb-provider/prisma/schema.prisma
+++ b/packages/relationaldb-provider/prisma/schema.prisma
@@ -1751,6 +1751,44 @@ model CvrFiling {
   @@map("cvr_filings")
 }
 
+/// A line from a filing's own summary page (CAL-ACCESS `SMRY_CD`) — the totals
+/// the committee itself reported, as opposed to the itemized detail rows in
+/// `contributions` / `expenditures`.
+///
+/// Kept for two reasons (#992):
+///   1. Reconciliation. Itemized detail exceeding the committee's own reported
+///      total means we are counting something twice — which is exactly how the
+///      amendment double-count was found. Stored, that check runs continuously
+///      instead of by hand.
+///   2. Unitemized contributions. Schedule A itemizes only $100 and above, so
+///      smaller donations exist ONLY here. Without this table they are invisible
+///      and every displayed total understates small-donor funding.
+///
+/// `amendId` is retained rather than superseded: this is the summary OF an
+/// amendment, and reconciliation compares against the latest one specifically.
+model FilingSummary {
+  id           String   @id @default(uuid())
+  externalId   String   @unique @map("external_id") /// FILING_ID:AMEND_ID:FORM_TYPE:LINE_ITEM
+  filingId     String   @map("filing_id") @db.VarChar(50)
+  amendId      Int?     @map("amend_id")
+  formType     String   @map("form_type") @db.VarChar(20) /// F460, F450, …
+  /// 47 distinct values on F460 alone, and not all numeric.
+  lineItem     String   @map("line_item") @db.VarChar(10)
+  /// Column A on the form — the reporting period. Negatives are real.
+  amountA      Decimal? @map("amount_a") @db.Decimal(14, 2)
+  /// Column B — calendar-year cumulative.
+  amountB      Decimal? @map("amount_b") @db.Decimal(14, 2)
+  /// Column C — election-cycle cumulative, when the form carries one.
+  amountC      Decimal? @map("amount_c") @db.Decimal(14, 2)
+  sourceSystem String   @map("source_system") @db.VarChar(20)
+  createdAt    DateTime @default(now()) @map("created_at") @db.Timestamptz
+  updatedAt    DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamptz
+
+  @@index([filingId])
+  @@index([filingId, formType, lineItem])
+  @@map("filing_summaries")
+}
+
 /// Campaign contribution — money received by a committee from a donor.
 model Contribution {
   id               String   @id @default(uuid())
@@ -1762,6 +1800,9 @@ model Contribution {
   committeeId      String?  @map("committee_id")
   /// CalAccess FILING_ID from RCPT_CD — the join key to the cover page.
   filingId         String?  @map("filing_id") @db.VarChar(50)
+  /// CalAccess AMEND_ID. Integer, not text: it reaches 10, and '10' < '9'
+  /// under text ordering would make max() select the wrong version (#992).
+  amendId          Int?     @map("amend_id")
   donorName        String   @map("donor_name")
   donorType        String   @map("donor_type") @db.VarChar(20) /// individual, committee, party, self, other
   donorEmployer    String?  @map("donor_employer")
@@ -1781,6 +1822,7 @@ model Contribution {
 
   @@index([committeeId])
   @@index([filingId])
+  @@index([filingId, amendId])
   @@index([donorName])
   @@index([date])
   @@index([amount])
@@ -1799,6 +1841,8 @@ model Expenditure {
   committeeId        String?  @map("committee_id")
   /// CalAccess FILING_ID from EXPN_CD — the join key to the cover page.
   filingId           String?  @map("filing_id") @db.VarChar(50)
+  /// CalAccess AMEND_ID — see Contribution.amendId (#992).
+  amendId            Int?     @map("amend_id")
   payeeName          String   @map("payee_name")
   amount             Decimal  @db.Decimal(12, 2)
   date               DateTime @db.Date
@@ -1819,6 +1863,7 @@ model Expenditure {
 
   @@index([committeeId])
   @@index([filingId])
+  @@index([filingId, amendId])
   @@index([payeeName])
   @@index([date])
   @@index([sourceSystem])

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1393,6 +1393,72 @@ describe("DomainMapperService", () => {
       });
     });
 
+    it("carries scheduleCode through onto contributions (#992)", () => {
+      // The strip trap. `z.object()` drops unknown keys, so mapping FORM_TYPE
+      // in the region config does nothing until the schema names the field —
+      // and a silently-absent scheduleCode makes every filing unreconcilable.
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "2505994:7:BBB",
+              filingId: "2505994",
+              amendId: "1",
+              scheduleCode: "A",
+              donorName: "Jane Q. Public",
+              donorType: "IND",
+              amount: "1500.00",
+              date: "03/01/2026",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Contributions",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.items[0]).toMatchObject({
+        externalId: "2505994:7:BBB",
+        // Schedule A — monetary contributions, Form 460 line 1. Reconciliation
+        // sums this schedule ALONE against that line.
+        scheduleCode: "A",
+      });
+    });
+
+    it("carries scheduleCode through onto expenditures (#992)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "2505994:3:CCC",
+              filingId: "2505994",
+              amendId: "1",
+              // 'D' is a MEMO schedule restating Schedule E entries. It must
+              // survive mapping precisely so reconciliation can exclude it.
+              scheduleCode: "D",
+              payeeName: "Acme Printing",
+              amount: "2500.00",
+              date: "03/01/2026",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Expenditures",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.items[0]).toMatchObject({
+        externalId: "2505994:3:CCC",
+        scheduleCode: "D",
+      });
+    });
+
     it("keeps negative summary amounts, which are real corrections (#992)", () => {
       const result = mapper.map(
         createRawResult({

--- a/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
+++ b/packages/scraping-pipeline/__tests__/domain-mapper.spec.ts
@@ -1356,6 +1356,93 @@ describe("DomainMapperService", () => {
       });
     });
 
+    it("routes 'Filing Summaries' (SMRY_CD) to filing summaries (#992)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "2505994:1:F460:1",
+              filingId: "2505994",
+              amendId: "1",
+              formType: "F460",
+              lineItem: "1",
+              amountA: "170988.25",
+              amountB: "412500.00",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Filing Summaries",
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.items[0]).toMatchObject({
+        externalId: "2505994:1:F460:1",
+        filingId: "2505994",
+        // Numeric, not "1" — the same reason contributions coerce it: max()
+        // over text would rank '10' below '9' (#992).
+        amendId: 1,
+        formType: "F460",
+        // String, deliberately: F460 LINE_ITEM values are not all numeric.
+        lineItem: "1",
+        amountA: 170988.25,
+        amountB: 412500,
+      });
+    });
+
+    it("keeps negative summary amounts, which are real corrections (#992)", () => {
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "F1:0:F460:20",
+              filingId: "F1",
+              formType: "F460",
+              lineItem: "20",
+              amountA: "-4500.00",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Filing Summaries",
+        }),
+      );
+
+      expect(result.items[0]).toMatchObject({ amountA: -4500 });
+    });
+
+    it("leaves an absent summary column absent rather than zero (#992)", () => {
+      // The bulk handler drops empty cells, and a blank column on the form is
+      // genuinely absent — recording it as 0 would make it look reported.
+      const result = mapper.map(
+        createRawResult({
+          items: [
+            {
+              externalId: "F1:0:F460:1",
+              filingId: "F1",
+              formType: "F460",
+              lineItem: "1",
+              amountA: "100.00",
+              sourceSystem: "cal_access",
+            },
+          ],
+        }),
+        createSource({
+          dataType: DataType.CAMPAIGN_FINANCE,
+          category: "CAL-ACCESS Filing Summaries",
+        }),
+      );
+
+      expect(result.items[0]).toMatchObject({ amountA: 100 });
+      expect(result.items[0]).not.toHaveProperty("amountB");
+      expect(result.items[0]).not.toHaveProperty("amountC");
+    });
+
     it("routes 'Committee Positions' (CVR2/Form 410) to measure filings, not committees (#936)", () => {
       const result = mapper.map(
         createRawResult({

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -21,6 +21,7 @@ import {
   type IndependentExpenditure,
   type CommitteeMeasureFiling,
   type CvrFiling,
+  type FilingSummary,
   type RawExtractionResult,
   type ExtractionResult,
   type DataSourceConfig,
@@ -166,6 +167,7 @@ export class DomainMapperService {
     | IndependentExpenditure
     | CommitteeMeasureFiling
     | CvrFiling
+    | FilingSummary
     | null {
     switch (source.dataType) {
       case DataType.PROPOSITIONS:
@@ -195,6 +197,7 @@ export class DomainMapperService {
     | IndependentExpenditure
     | CommitteeMeasureFiling
     | CvrFiling
+    | FilingSummary
     | null {
     const cat = (category ?? "").toLowerCase();
 
@@ -204,7 +207,12 @@ export class DomainMapperService {
     // otherwise misroute to mapCommittee and be rejected for having no `name`
     // — the reason cvr2_filings sat at 0 and no committee→measure link ever
     // formed (#936).
-    if (cat.includes("committee position") || cat.includes("cvr2")) {
+    if (cat.includes("summar")) {
+      // SMRY_CD Form 460 summary lines — the committee's own reported totals,
+      // which reconciliation compares the itemized detail against (#992). No
+      // other category contains "summar", so this branch steals from none.
+      return this.mapFilingSummary(record, diag);
+    } else if (cat.includes("committee position") || cat.includes("cvr2")) {
       return this.mapCommitteeMeasureFiling(record, diag);
     } else if (cat.includes("cover page")) {
       // Form 496 cover pages (CVR_CAMPAIGN_DISCLOSURE_CD, FORM_TYPE=F496).
@@ -395,6 +403,18 @@ export class DomainMapperService {
       externalId: record.externalId ?? record.filingId,
     };
     return this.parseOrCollect(CvrFilingSchema, enriched, "CvrFiling", diag);
+  }
+
+  private mapFilingSummary(
+    record: Record<string, unknown>,
+    diag: MappingDiagnostics,
+  ): FilingSummary | null {
+    return this.parseOrCollect(
+      FilingSummarySchema,
+      record,
+      "FilingSummary",
+      diag,
+    );
   }
 }
 
@@ -1066,6 +1086,29 @@ const CvrFilingSchema = z.object({
     .nullable()
     .optional()
     .transform((val) => (val ? supportOpposeTransform(val) : undefined)),
+  sourceSystem: z.enum(["cal_access", "fec"]),
+});
+
+// SMRY_CD Form 460 summary line (#992) — one numbered line of the totals a
+// committee reports for itself. externalId comes from the config's composite
+// key (FILING_ID:AMEND_ID:FORM_TYPE:LINE_ITEM), which keeps AMEND_ID *in* the
+// identity: unlike RCPT_CD/EXPN_CD detail, each amendment's summary is a
+// distinct fact, and reconciliation compares against the latest one.
+//
+// The amounts are optional because the bulk handler omits empty cells, and a
+// blank column on the form is genuinely absent rather than zero. They are not
+// clamped: negatives are real corrections and refunds.
+const FilingSummarySchema = z.object({
+  externalId: z.string().min(1),
+  filingId: z.string().min(1),
+  amendId: z.coerce.number().int().optional(),
+  formType: z.string().min(1),
+  // String, not a number: F460 alone uses 47 distinct LINE_ITEM values and not
+  // all of them are numeric.
+  lineItem: z.string().min(1),
+  amountA: z.coerce.number().optional(),
+  amountB: z.coerce.number().optional(),
+  amountC: z.coerce.number().optional(),
   sourceSystem: z.enum(["cal_access", "fec"]),
 });
 

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -903,6 +903,9 @@ const ContributionSchema = z.object({
   // IndependentExpenditureSchema has used since #955.
   committeeId: z.string().min(1).optional(),
   filingId: z.string().min(1).optional(),
+  // Coerced to a number so max() orders correctly downstream: AMEND_ID reaches
+  // 10, and '10' < '9' as text would make the wrong version look latest (#992).
+  amendId: z.coerce.number().int().optional(),
   donorName: z.string().min(1),
   donorType: z.string().transform(donorTypeTransform).default("other"),
   donorEmployer: z
@@ -944,6 +947,8 @@ const ExpenditureSchema = z
     // the *payee*, so the spender comes from the cover page via filingId (#980).
     committeeId: z.string().min(1).optional(),
     filingId: z.string().min(1).optional(),
+    /// See ContributionSchema.amendId (#992).
+    amendId: z.coerce.number().int().optional(),
     payeeName: z.string().min(1),
     amount: z.coerce.number(),
     date: coerceFlexibleDate,

--- a/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
+++ b/packages/scraping-pipeline/src/mapping/domain-mapper.service.ts
@@ -926,6 +926,12 @@ const ContributionSchema = z.object({
   // Coerced to a number so max() orders correctly downstream: AMEND_ID reaches
   // 10, and '10' < '9' as text would make the wrong version look latest (#992).
   amendId: z.coerce.number().int().optional(),
+  // RCPT_CD's FORM_TYPE is the SCHEDULE letter, not the filing's form. 'A' is
+  // monetary contributions (F460 line 1), which is the only schedule
+  // reconciliation may sum against that line — 'C', 'I', 'F496P3' and 'F401A'
+  // rows also live in this file and summing them all falsely flags 29% of
+  // filings as over-counting (#992).
+  scheduleCode: z.string().min(1).optional(),
   donorName: z.string().min(1),
   donorType: z.string().transform(donorTypeTransform).default("other"),
   donorEmployer: z
@@ -969,6 +975,9 @@ const ExpenditureSchema = z
     filingId: z.string().min(1).optional(),
     /// See ContributionSchema.amendId (#992).
     amendId: z.coerce.number().int().optional(),
+    /// See ContributionSchema.scheduleCode. 'E' is payments made (F460 line 6);
+    /// 'D' is a MEMO schedule restating E entries, so the two must not be summed.
+    scheduleCode: z.string().min(1).optional(),
     payeeName: z.string().min(1),
     amount: z.coerce.number(),
     date: coerceFlexibleDate,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.79
-        version: 1.0.79
+        specifier: ^1.0.80
+        version: 1.0.80
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -1010,8 +1010,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.79
-        version: 1.0.79
+        specifier: ^1.0.80
+        version: 1.0.80
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -4914,8 +4914,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.79':
-    resolution: {integrity: sha512-TWk2PbBSc5wK0he/1df2YlbtyI+tGqLOEKQpuzWThD+6mjJ44riNd1tDmCIox2agdHWiIm31XeIpt0fTChcsQg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.79/99136a644979afeb03db14ee93facdadccebd020}
+  '@opuspopuli/regions@1.0.80':
+    resolution: {integrity: sha512-llmZ/PJJRkXf+ijVF4BQfx5sO8upDq+QkFqOghGOnwpChEgouMZ1LIRhpBYZ64cbaWcUNLQ/MBTJoCqcfIHPSA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.80/e3a49d5be860bb5059132a40fb6eacccfbe6ad6b}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -16589,7 +16589,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.79':
+  '@opuspopuli/regions@1.0.80':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/region-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.76
-        version: 1.0.76
+        specifier: ^1.0.79
+        version: 1.0.79
       '@opuspopuli/relationaldb-provider':
         specifier: workspace:*
         version: link:../../packages/relationaldb-provider
@@ -554,13 +554,13 @@ importers:
         version: 9.39.4(jiti@2.7.0)
       eslint-config-next:
         specifier: ^16.1.5
-        version: 16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+        version: 16.2.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint-config-prettier:
         specifier: ^10.0.1
         version: 10.1.8(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+        version: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-prettier:
         specifier: ^5.2.1
         version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.1)
@@ -572,7 +572,7 @@ importers:
         version: 16.5.0
       jest:
         specifier: ^30.2.0
-        version: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-axe:
         specifier: ^10.0.0
         version: 10.0.0
@@ -590,7 +590,7 @@ importers:
         version: 4.2.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -633,7 +633,7 @@ importers:
         version: 7.0.11
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -642,7 +642,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -667,10 +667,10 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -713,7 +713,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -722,7 +722,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -740,7 +740,7 @@ importers:
         version: link:../config-provider
       '@xenova/transformers':
         specifier: ^2.17.2
-        version: 2.17.2(@types/node@25.9.1)
+        version: 2.17.2(@types/node@25.5.0)
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -753,7 +753,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -762,7 +762,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -805,7 +805,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -814,7 +814,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -839,7 +839,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -848,7 +848,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -876,10 +876,10 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -894,7 +894,7 @@ importers:
         version: link:../config-provider
       sharp:
         specifier: '>=0.35.0'
-        version: 0.35.3(@types/node@25.9.1)
+        version: 0.35.3(@types/node@25.5.0)
       tesseract.js:
         specifier: ^5.1.1
         version: 5.1.1(encoding@0.1.13)
@@ -910,7 +910,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -919,7 +919,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -947,10 +947,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -959,7 +959,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -990,13 +990,13 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       ts-jest:
         specifier: ^29.2.0
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1010,8 +1010,8 @@ importers:
         specifier: workspace:*
         version: link:../config-provider
       '@opuspopuli/regions':
-        specifier: ^1.0.78
-        version: 1.0.78
+        specifier: ^1.0.79
+        version: 1.0.79
     devDependencies:
       '@nestjs/common':
         specifier: ^11.1.9
@@ -1024,7 +1024,7 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1033,7 +1033,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1061,10 +1061,10 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       jest-mock-extended:
         specifier: ^4.0.0
-        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       prisma:
         specifier: '5'
         version: 5.22.0
@@ -1076,7 +1076,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1134,7 +1134,7 @@ importers:
         version: 5.0.3
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       mupdf:
         specifier: ^1.27.0
         version: 1.27.0
@@ -1146,7 +1146,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1177,7 +1177,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1186,7 +1186,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1223,7 +1223,7 @@ importers:
         version: 22.19.15
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+        version: 30.3.0(@types/node@22.19.15)
       reflect-metadata:
         specifier: ^0.2.2
         version: 0.2.2
@@ -1232,7 +1232,7 @@ importers:
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -1260,13 +1260,13 @@ importers:
         version: 30.0.0
       jest:
         specifier: ^30.0.0
-        version: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+        version: 30.3.0(@types/node@25.5.0)
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
       ts-jest:
         specifier: ^29.2.5
-        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
@@ -4914,12 +4914,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
 
-  '@opuspopuli/regions@1.0.76':
-    resolution: {integrity: sha512-fwzZ5Yh1ZNGh6Fubp0bBoDcr5zXBw4elKx4Wtk2rsNUOzIlctUTdky0o57xYERqyMRg5aFLNymQCXK+/qphIdg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.76/2421750779394a5eb95f8fe17016c6139f3d8556}
-    hasBin: true
-
-  '@opuspopuli/regions@1.0.78':
-    resolution: {integrity: sha512-PvvhZdRCO80O2c9QAlUTqKk4/z9jAOUWCl2zXR2llTzTqECd/bGLAB6chehEfbrGDJ4MbCAOyCm/JWNAv0umbA==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.78/65791c19c80bd4b34349cfedcd29573f2a1c63d6}
+  '@opuspopuli/regions@1.0.79':
+    resolution: {integrity: sha512-TWk2PbBSc5wK0he/1df2YlbtyI+tGqLOEKQpuzWThD+6mjJ44riNd1tDmCIox2agdHWiIm31XeIpt0fTChcsQg==, tarball: https://npm.pkg.github.com/download/@opuspopuli/regions/1.0.79/99136a644979afeb03db14ee93facdadccebd020}
     hasBin: true
 
   '@paralleldrive/cuid2@2.3.1':
@@ -14757,41 +14753,6 @@ snapshots:
       jest-util: 30.3.0
       slash: 3.0.0
 
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 25.8.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
   '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 30.3.0
@@ -14808,76 +14769,6 @@ snapshots:
       graceful-fs: 4.2.11
       jest-changed-files: 30.3.0
       jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 25.8.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
-      jest-haste-map: 30.3.0
-      jest-message-util: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-resolve-dependencies: 30.3.0
-      jest-runner: 30.3.0
-      jest-runtime: 30.3.0
-      jest-snapshot: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      jest-watcher: 30.3.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.3.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))':
-    dependencies:
-      '@jest/console': 30.3.0
-      '@jest/pattern': 30.0.1
-      '@jest/reporters': 30.3.0
-      '@jest/test-result': 30.3.0
-      '@jest/transform': 30.3.0
-      '@jest/types': 30.3.0
-      '@types/node': 25.8.0
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      exit-x: 0.2.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 30.3.0
-      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
       jest-haste-map: 30.3.0
       jest-message-util: 30.3.0
       jest-regex-util: 30.0.1
@@ -16698,16 +16589,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opuspopuli/regions@1.0.76':
-    dependencies:
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      chalk: 5.6.2
-      cheerio: 1.2.0
-      commander: 12.1.0
-      ollama: 0.6.3
-
-  '@opuspopuli/regions@1.0.78':
+  '@opuspopuli/regions@1.0.79':
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
@@ -18453,16 +18335,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@xenova/transformers@2.17.2(@types/node@25.9.1)':
-    dependencies:
-      '@huggingface/jinja': 0.2.2
-      onnxruntime-web: 1.14.0
-      sharp: 0.35.3(@types/node@25.9.1)
-    optionalDependencies:
-      onnxruntime-node: 1.14.0
-    transitivePeerDependencies:
-      - '@types/node'
-
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -19967,13 +19839,13 @@ snapshots:
       source-map: 0.6.1
     optional: true
 
-  eslint-config-next@16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
+  eslint-config-next@16.2.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.1
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.7.0))
@@ -19999,7 +19871,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -20010,22 +19882,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -20036,7 +19907,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -20047,8 +19918,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.57.2(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -21390,15 +21259,34 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-cli@30.3.0(@types/node@22.19.15):
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/test-result': 30.3.0
       '@jest/types': 30.3.0
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-config: 30.3.0(@types/node@22.19.15)
+      jest-util: 30.3.0
+      jest-validate: 30.3.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest-cli@30.3.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/test-result': 30.3.0
+      '@jest/types': 30.3.0
+      chalk: 4.1.2
+      exit-x: 0.2.2
+      import-local: 3.2.0
+      jest-config: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       jest-util: 30.3.0
       jest-validate: 30.3.0
       yargs: 17.7.2
@@ -21428,45 +21316,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest-cli@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
-      '@jest/test-result': 30.3.0
-      '@jest/types': 30.3.0
-      chalk: 4.1.2
-      exit-x: 0.2.2
-      import-local: 3.2.0
-      jest-config: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest-config@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest-config@30.3.0(@types/node@22.19.15):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.1.0
@@ -21493,7 +21343,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.19.15
-      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21530,38 +21379,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.8.0
-      ts-node: 10.9.2(@types/node@22.19.15)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -21590,102 +21407,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.8.0
       ts-node: 10.9.2(@types/node@25.5.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.8.0
-      ts-node: 10.9.2(@types/node@25.8.0)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.8.0
-      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.1.0
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.3.0
-      '@jest/types': 30.3.0
-      babel-jest: 30.3.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.4.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.3.0
-      jest-docblock: 30.2.0
-      jest-environment-node: 30.3.0
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.3.0
-      jest-runner: 30.3.0
-      jest-util: 30.3.0
-      jest-validate: 30.3.0
-      parse-json: 5.2.0
-      pretty-format: 30.3.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.9.1
-      ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21810,10 +21531,10 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
-  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
     dependencies:
       '@jest/globals': 30.3.0
-      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@22.19.15)
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -21824,10 +21545,10 @@ snapshots:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
-  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
+  jest-mock-extended@4.0.0(@jest/globals@30.3.0)(jest@30.3.0)(typescript@5.9.3):
     dependencies:
       '@jest/globals': 30.3.0
-      jest: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest: 30.3.0
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
 
@@ -21999,12 +21720,38 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)):
+  jest@30.3.0:
     dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
       '@jest/types': 30.3.0
       import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest-cli: 30.3.0(@types/node@25.5.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@22.19.15):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - esbuild-register
+      - supports-color
+      - ts-node
+
+  jest@30.3.0(@types/node@25.5.0):
+    dependencies:
+      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
+      '@jest/types': 30.3.0
+      import-local: 3.2.0
+      jest-cli: 30.3.0(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22018,32 +21765,6 @@ snapshots:
       '@jest/types': 30.3.0
       import-local: 3.2.0
       jest-cli: 30.3.0(@types/node@25.5.0)(ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - esbuild-register
-      - supports-color
-      - ts-node
-
-  jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 30.3.0(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
-      '@jest/types': 30.3.0
-      import-local: 3.2.0
-      jest-cli: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -24102,39 +23823,6 @@ snapshots:
       '@img/sharp-win32-x64': 0.35.3
       '@types/node': 25.5.0
 
-  sharp@0.35.3(@types/node@25.9.1):
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.5
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 25.9.1
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -24758,12 +24446,12 @@ snapshots:
 
   ts-graphviz@1.8.2: {}
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@22.19.15))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@22.19.15)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@22.19.15)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24798,12 +24486,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.5.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.8.0)(ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3))
+      jest: 30.3.0(@types/node@25.5.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24818,12 +24506,12 @@ snapshots:
       babel-jest: 30.3.0(@babel/core@7.29.0)
       jest-util: 30.3.0
 
-  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.3.0)(babel-jest@30.3.0(@babel/core@7.29.0))(jest-util@30.3.0)(jest@30.3.0)(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 30.3.0(@types/node@25.9.1)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3))
+      jest: 30.3.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -24866,25 +24554,6 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.15
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
   ts-node@10.9.2(@types/node@25.5.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -24902,44 +24571,6 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-
-  ts-node@10.9.2(@types/node@25.8.0)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.8.0
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.12
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 25.9.1
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.4
-      make-error: 1.3.6
-      typescript: 5.9.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   ts-tqdm@0.8.6: {}
 


### PR DESCRIPTION
Closes the amendment double-count and the unitemized-contribution blind spot found during #980's verification against official Form 460 totals.

## The two defects

**A. Amended filings double-count.** CAL-ACCESS restates a filing's whole schedule on amendment using **new** `TRAN_ID`/`LINE_ITEM` values, so the composite `externalId` cannot merge the versions and both persist:

```
filing 2505994
  AMEND_ID 0:  1 row,  $168,135.00
  AMEND_ID 1:  2 rows, $170,988.25   <- official Form 460 line 1, exactly
  stored:      3 rows, $339,123.25   <- both
```

This refines #980's conclusion rather than contradicting it. Dropping `AMEND_ID` from the key was necessary — it collapsed 3.18M genuinely duplicated rows — but key collapse only merges versions that *reuse* an identifier. Restatements don't.

**B. Unitemized contributions are invisible.** Schedule A itemizes only contributions of $100 or more. Smaller ones are aggregated onto the summary page and appear nowhere in `RCPT_CD`. Our detail is complete; the *displayed total* is not. A candidate funded by many small donors reads as less funded than one funded by a few large ones — a substantive distortion on a transparency platform.

## What's here

| Subtask | |
|---|---|
| 1 | `amend_id` on contributions and expenditures — INTEGER, because it reaches 10 and `'10' < '9'` as text would make `max()` pick the wrong version |
| 2 | `AmendmentSupersessionService` — retains only `max(amend_id)` per filing, runs **first** among post-sync steps |
| 3 | `filing_summaries` + `SMRY_CD` ingestion; the write path now orders amendable rows by `amendId` rather than by arrival |
| 4a | `schedule_code` on detail rows — **added after measurement, see below** |
| 4b | `FilingReconciliationService` + `filing_reconciliations`, running **last** |

## Subtask 4 split in two after measuring

Before writing any reconciliation I compared the raw archive against official totals, and the check as planned would not have worked.

`RCPT_CD` is not Schedule A — it is **every receipt schedule in one file**, and `FORM_TYPE` was never mapped:

| `FORM_TYPE` | Rows | Amount | On Form 460 |
|---|---:|---:|---|
| `A` | 18,205,803 | $28.70B | line 1 — monetary contributions |
| `C` | 313,633 | $1.74B | line 4 — nonmonetary |
| `I` | 197,921 | $1.54B | line 14 — misc increases to cash |
| `F496P3` | 237,731 | $1.87B | not a Form 460 at all |
| `F401A` | 146,291 | $0.37B | not a Form 460 at all |

Reconciliation compares against line 1, which is Schedule A alone. Across all 122,033 F460 filings at their surviving amendment:

| Detail summed as | Match | Ours lower | **Ours higher** |
|---|---:|---:|---:|
| Schedule A only | 49,575 | 72,084 | **374 (0.31%)** |
| Every `RCPT_CD` row | 32,753 | 53,568 | **35,712 (29.3%)** |

**35,339 filings (29.0%) would be falsely flagged.** A fault detector firing on nearly a third of all filings against a true rate of 0.31% is not a check — the signal is outnumbered 95:1. Hence 4a before 4b could mean anything.

**That same measurement independently validates subtask 2 at full scale**: the sampled baseline was 8 of 123 filings (7%) over-counting; modelling supersession across all 122,033 drops it to 0.31%.

## Design notes

**The verdict table stores both figures, not a delta.** The comparison cuts two ways and conflating them would make it useless — detail *above* reported is a fault; detail *below* is expected and is itself a finding (the unitemized money, 59% of filings). A delta alone cannot distinguish "we are wrong" from "the source itemizes less than it totals".

**Where the schedule cannot be read, the service declines rather than guessing.** Rows predating the mapping carry NULL, so the filtered sum is 0 and every comparison would otherwise report "the committee reported money we did not itemize" — confidently and wrongly. Those filings store NULL for *both* itemized and unitemized: zero is a claim, and it would poison any `SUM` over the column.

**`scheduleCode`, not `formType`.** The finance router routes a record to `filingSummaries` when it carries `formType` **and** `lineItem`; naming this field `formType` would put detail rows one field away from being misrouted.

**`EXPN_CD` carries a trap of its own.** Schedule `D` (4,826,727 rows) is a **memo** schedule restating payments Schedule `E` already counts, so summing both double-counts. That is the lever **#991** needs for line 6, where it has a 40% shortfall and no independent check.

## Verification

- **14** new integration tests against a real `postgres_test`
- **Mutation-tested:** deleting the schedule filter flips a healthy filing to `OVER_ITEMIZED` and fails exactly the test that asserts it. Likewise, mutating supersession's predicate from `<` to `<=` fails 5 of its 8 tests
- **2,322** backend unit, **413** scraping-pipeline, **146** region-provider, **143** common — full monorepo suite green
- Region integration 146/151; the 5 failures are `AUTH_JWT_SECRET` missing locally, unchanged from `a8ecfa6`

## Data classification

**PII, no PHI, and no new PII.** Every column added to `filing_reconciliations` is an aggregate over a filing; no donor detail reaches it. `schedule_code` is a form-structure code. No GraphQL surface added — the table is internal, reached only via DI.

## Review status

Self-reviewed via `/op-review` and `/security-review`. `/op-review` found and fixed two issues in this branch (the confident `0` on unreadable filings, and status literals duplicated across three places with no compile-time link). `/security-review` found nothing: every interpolation into the raw SQL is a compile-time constant or a call-site literal, and `reconcileAll()` takes no arguments — no row or request data reaches the statement.

**Sole author, so this counts as a self-review and needs a countersignature to be independent** (SOC 2 CC8.1 / 21 CFR Part 11).

## Deployment

Requires `@opuspopuli/regions` **1.0.80** (config v1.13.0) — OpusPopuli/opuspopuli-regions#68, merged and published.

Two additive migrations; no drops, renames, or table rewrites.

**Existing rows are inert until a re-sync.** They carry no `schedule_code`, so reconciliation reports `UNKNOWN_SCHEDULE` and declines to judge them. Per the plan's resolved open question, backfill is unsound — rows merged under last-write-wins hold the *content* of whichever version landed last, so a stamped `amend_id` would not agree with the values behind it. Only re-ingesting under the monotonic guard produces coherent rows. That re-sync (~4h, already proven) is subtask 5, and the acceptance numbers come from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
