### PR TITLE
fix(region): run supersession to completion, and fail loudly if it cannot (#997)

### DIFF
--- a/apps/backend/__tests__/integration/region/amendment-supersession.integration.spec.ts
+++ b/apps/backend/__tests__/integration/region/amendment-supersession.integration.spec.ts
@@ -193,4 +193,61 @@ describe('AmendmentSupersessionService (#992)', () => {
     const res = await new AmendmentSupersessionService().supersedeAll();
     expect(res.contributions.superseded).toBe(0);
   });
+
+  /**
+   * Regression for #997: the delete loop must run until the work is done, not
+   * until an estimate says it should be.
+   *
+   * The old bound was `ceil((filingsAffected * 50) / 25_000) + 10`, guessing at
+   * most 50 superseded rows per filing. On the 2026-08-13 rebuild the real
+   * figure was ~256, so the loop ran out of iterations with 2,014,849 rows left
+   * and returned reporting success — every abandoned filing then over-counted
+   * on the public totals.
+   *
+   * Reproducing that arithmetic exactly would need >275,000 rows for a single
+   * filing, which is not a reasonable thing to insert on every CI run. So this
+   * asserts the PROPERTY the fix guarantees — a completed run leaves nothing
+   * superseded behind — over a dataset large enough to span several batches.
+   * The old code passed this too; what protects the invariant now is that the
+   * service re-checks the database and throws rather than logging success.
+   */
+  it('deletes every superseded row across multiple batches', async () => {
+    const CURRENT = 'AMEND-1-SURVIVES';
+    const superseded = Array.from({ length: 26_000 }, (_, i) => ({
+      externalId: `910001:${i}:OLD`,
+      filingId: '910001',
+      amendId: 0,
+      donorName: 'Jane Q. Public',
+      donorType: 'individual',
+      amount: '10.00',
+      date: new Date('2026-03-01'),
+      sourceSystem: 'cal_access',
+    }));
+
+    await db.contribution.createMany({ data: superseded });
+    await db.contribution.create({
+      data: {
+        externalId: '910001:0:NEW',
+        filingId: '910001',
+        amendId: 1,
+        donorName: CURRENT,
+        donorType: 'individual',
+        amount: '99.00',
+        date: new Date('2026-03-01'),
+        sourceSystem: 'cal_access',
+      },
+    });
+
+    const res = await svc.supersedeAll();
+
+    expect(res.contributions.superseded).toBe(26_000);
+
+    // The invariant, checked against the database rather than the counter —
+    // the counter is precisely what read as success while 2M rows remained.
+    const left = await db.contribution.findMany({
+      where: { filingId: '910001' },
+      select: { amendId: true, donorName: true },
+    });
+    expect(left).toEqual([{ amendId: 1, donorName: CURRENT }]);
+  }, 120_000);
 });

--- a/apps/backend/src/apps/region/src/domains/amendment-supersession.service.ts
+++ b/apps/backend/src/apps/region/src/domains/amendment-supersession.service.ts
@@ -80,14 +80,45 @@ export class AmendmentSupersessionService {
     if (filingsAffected === 0) return { ...EMPTY };
 
     let superseded = 0;
-    // Bounded rather than `while (true)`: the exit depends on a value the
-    // database returns, and a driver answering oddly should not spin forever.
-    const maxBatches =
-      Math.ceil((filingsAffected * 50) / DELETE_BATCH_SIZE) + 10;
+    // The loop is still bounded — an exit condition that depends on what the
+    // database returns should not be able to spin forever if a driver answers
+    // oddly. But the bound is a SAFETY VALVE, not a work estimate.
+    //
+    // It used to be `ceil((filingsAffected * 50) / DELETE_BATCH_SIZE) + 10`,
+    // which guessed at most 50 superseded rows per filing. On the 2026-08-13
+    // rebuild the real figure was ~256, so the loop ran out of iterations with
+    // 2,014,849 rows still to delete, and returned — reporting success (#997).
+    // Every filing it abandoned then over-counted on the public totals.
+    //
+    // Derived from rows now, not filings: at most one batch per batch-sized
+    // slice of the table, doubled. No dataset can legitimately need more, and
+    // nothing about the data's shape can make it too small.
+    const tableRows = await this.countRows(table);
+    const maxBatches = Math.ceil(tableRows / DELETE_BATCH_SIZE) * 2 + 10;
+
+    let exhausted = true;
     for (let i = 0; i < maxBatches; i++) {
       const removed = await this.deleteBatch(table);
-      if (!removed) break;
+      if (!removed) {
+        exhausted = false;
+        break;
+      }
       superseded += removed;
+    }
+
+    // Hitting the cap means the loop stopped early. Verify against the database
+    // rather than trusting the counter: silence here is what made #997 invisible
+    // for a whole rebuild — the log said "removed 800000" and read like success.
+    if (exhausted) {
+      const remaining = await this.countSupersededRows(table);
+      if (remaining > 0) {
+        throw new Error(
+          `Amendment supersession (${table}) stopped after ${maxBatches} batches ` +
+            `with ${remaining} superseded row(s) still present. Totals for the ` +
+            `affected filings are inflated until this completes. Re-run it — the ` +
+            `step is idempotent and needs no re-sync.`,
+        );
+      }
     }
 
     this.logger.log(
@@ -97,9 +128,37 @@ export class AmendmentSupersessionService {
     return { superseded, filingsAffected };
   }
 
+  /** Total rows, used only to size the loop's safety valve. */
+  private async countRows(table: AmendableTable): Promise<number> {
+    const rows = await this.db!.$queryRawUnsafe<Array<{ count: bigint }>>(
+      `SELECT COUNT(*)::bigint AS count FROM "${table}"`,
+    );
+    return Number(rows[0]?.count ?? 0);
+  }
+
+  /**
+   * Rows a later amendment supersedes — i.e. what a completed run must leave at
+   * zero. Deliberately re-derived from the database instead of inferred from
+   * the delete counter, because the counter is exactly what lied in #997.
+   */
+  private async countSupersededRows(table: AmendableTable): Promise<number> {
+    const rows = await this.db!.$queryRawUnsafe<Array<{ count: bigint }>>(
+      `SELECT COUNT(*)::bigint AS count
+         FROM "${table}" r
+         JOIN (
+           SELECT "filing_id", MAX("amend_id") AS latest
+             FROM "${table}"
+            WHERE "filing_id" IS NOT NULL AND "amend_id" IS NOT NULL
+            GROUP BY "filing_id"
+         ) m ON m."filing_id" = r."filing_id"
+        WHERE r."amend_id" IS NOT NULL AND r."amend_id" < m."latest"`,
+    );
+    return Number(rows[0]?.count ?? 0);
+  }
+
   /**
    * Filings carrying more than one amendment version. Used both to skip the
-   * work entirely when there is none, and to bound the batch loop.
+   * work entirely when there is none, and for the reported count.
    */
   private async countAffectedFilings(table: AmendableTable): Promise<number> {
     const rows = await this.db!.$queryRawUnsafe<Array<{ count: bigint }>>(


### PR DESCRIPTION
Closes #997.

## The bug

The delete loop was bounded by a work **estimate** rather than by progress:

```ts
maxBatches = ceil((filingsAffected * 50) / DELETE_BATCH_SIZE) + 10
```

The `50` guessed at most fifty superseded rows per filing. On the 2026-08-13 rebuild the real figure was **~256**, so with ~11,000 affected filings the loop got 32 iterations, deleted exactly **32 × 25,000 = 800,000** rows, ran out, and returned.

**2,014,849 superseded rows across 10,064 filings stayed in the table**, and every one of those filings has been over-counting on public totals since.

## It reported success while doing so

```
Amendment supersession (contributions): removed 800000 superseded row(s) across N amended filing(s)
```

Indistinguishable from having finished. That silence is why a whole rebuild went by before reconciliation surfaced it as **7,140 `OVER_ITEMIZED` filings — 4.1% against a predicted 0.31%.**

## The fix

The loop stays bounded — an exit condition that depends on what the database returns shouldn't spin forever if a driver answers oddly. But the bound is now a **safety valve sized from rows**, not a guess about data shape: one batch per batch-sized slice of the table, doubled. No dataset can legitimately need more, and nothing about row distribution can make it too small.

And if the valve ever trips, the service **re-counts superseded rows straight from the database and throws.** Trusting the delete counter is what hid this — the counter was accurate about what it deleted and said nothing about what it left. A step that silently half-finishes a destructive correction is worse than one that fails.

## Verification

**9 integration tests** against real `postgres_test`, including a new multi-batch case: 26,000 superseded rows for one filing, all removed, only the current amendment left.

**Mutation-tested the guard** — forcing `maxBatches = 1` makes the run throw, naming the 1,000 rows left behind, instead of logging success. That is the exact failure mode of #997, now caught.

One limitation stated plainly: reproducing #997's arithmetic *exactly* would need >275,000 rows for a single filing, which isn't reasonable per CI run. So the test asserts the property the fix guarantees — a completed run leaves nothing superseded — rather than replaying the original numbers.

## Production

The 2,014,849 rows are **still there**. Supersession is idempotent and needs no re-sync, so re-running it alone is enough once this deploys.

Until then, contribution totals remain inflated for those 10,064 filings, and the 7,140 `OVER_ITEMIZED` figure can't be read as a measure of anything else — #992 subtask 5 stays unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)