### PR TITLE
fix(ci): pre-push guard blocked tag pushes, and tags are how releases ship

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -7,11 +7,26 @@
 #
 # Matters more under trunk-based than it did with develop: main is now the only
 # long-lived branch, so it is the one you are most likely to be sitting on.
-if [ "$(git branch --show-current)" = "main" ]; then
-  printf '\nPush blocked: direct pushes to main are not allowed.\n'
-  printf 'Cut a branch and open a pull request instead.\n'
-  exit 1
-fi
+#
+# Reads the refs actually being pushed from stdin rather than checking which
+# branch you are standing on. `git push origin v1.6.0` pushes a TAG while you
+# happen to be on main, and the branch-name check rejected it — blocking the
+# v1.6.0 release, which under tag-triggered releases is the deploy itself.
+#
+# git feeds pre-push one line per ref: <local-ref> <local-sha> <remote-ref>
+# <remote-sha>. Only refs/heads/main is a direct push to main; refs/tags/* is
+# not, and neither is any other branch. Nothing below reads stdin, so consuming
+# it here is safe.
+while read -r _local_ref _local_sha remote_ref _remote_sha; do
+  case "$remote_ref" in
+    refs/heads/main)
+      printf '\nPush blocked: direct pushes to main are not allowed.\n'
+      printf 'Cut a branch and open a pull request instead.\n'
+      printf '(Tags are fine: `git push origin v1.2.3` is how a release ships.)\n'
+      exit 1
+      ;;
+  esac
+done
 
 # ── 1. Coverage gate ─────────────────────────────────────────────────────────
 # Thresholds are enforced in each jest.config — this fails if any package drops


### PR DESCRIPTION
`git push origin v1.6.0` was rejected with **"direct pushes to main are not allowed"**.

The guard checked which branch you were *standing on*, but that command pushes a **tag** — `refs/tags/v1.6.0`. Standing on `main` while doing so isn't just legitimate, it's the normal case.

## Self-inflicted, and in one commit

#996 is the change that made `release.yml` trigger on `v*` tags. **It is also the change that added this guard.** So the same commit that made tagging the deploy step added a hook refusing to let you tag — and it blocked the v1.6.0 release the first time it was used.

## Fix

Reads the refs actually being pushed from stdin, which is what git provides `pre-push` for:

```
<local-ref> <local-sha> <remote-ref> <remote-sha>
```

Only `refs/heads/main` is a direct push to main. `refs/tags/*` is not, and neither is any other branch. Nothing else in the hook reads stdin, so consuming it is safe.

## Verified — all three paths

| Push | Expected | Result |
|---|---|---|
| `refs/tags/v1.6.0` | allow | ✅ allowed |
| `refs/heads/fix/foo` | allow | ✅ allowed |
| `refs/heads/main` | **block** | ✅ blocked |

## Same bug in prompt-service

It received the identical guard during its own `develop` collapse, so it has the identical bug — latent only because that repo has never cut a tag. It would have failed on its first release. Fixed there too, in a companion PR.

## Workaround until this merges

The old guard only inspects the current branch, so stepping off `main` releases the tag:

```bash
git checkout -b tmp/tag-push && git push origin v1.6.0 && git checkout main
```

No `--no-verify` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)