### PR TITLE
fix(users): register the webauthn config namespace so passkeys can start

### DIFF
--- a/apps/backend/src/apps/users/src/app.module.ts
+++ b/apps/backend/src/apps/users/src/app.module.ts
@@ -26,6 +26,7 @@ import { EmailDomainModule } from './domains/email/email.module';
 import configuration from 'src/config';
 import relationaldbConfig from 'src/config/relationaldb.config';
 import authThrottleConfig from 'src/config/auth-throttle.config';
+import webauthnConfig from 'src/config/webauthn.config';
 import { authConfig } from '@opuspopuli/config-provider';
 import { usersValidationSchema } from 'src/config/env.validation';
 
@@ -47,7 +48,18 @@ import { MetricsModule } from 'src/common/metrics';
 @Module({
   imports: [
     ConfigModule.forRoot({
-      load: [configuration, relationaldbConfig, authThrottleConfig, authConfig],
+      // webauthnConfig is load-bearing, not incidental: PasskeyService reads
+      // `webauthn.*` and THROWS in production when rpId/origin are absent.
+      // Without it registered here those lookups return undefined however the
+      // environment is set, so the users service cannot start in production at
+      // all — which is exactly what happened on 2026-08-13.
+      load: [
+        configuration,
+        relationaldbConfig,
+        authThrottleConfig,
+        authConfig,
+        webauthnConfig,
+      ],
       validationSchema: usersValidationSchema,
       validationOptions: { abortEarly: false },
       isGlobal: true,

--- a/apps/backend/src/config/webauthn.config.spec.ts
+++ b/apps/backend/src/config/webauthn.config.spec.ts
@@ -1,0 +1,62 @@
+import webauthnConfig from './webauthn.config';
+
+/**
+ * Regression tests for the missing `webauthn` namespace (#189 follow-up).
+ *
+ * `PasskeyService` had a thorough spec that passed throughout — because it
+ * mocks `ConfigService` and hands back `webauthn.rpId` / `webauthn.origin`
+ * directly. It verified the service's behaviour GIVEN the config, and nothing
+ * verified the config existed. It did not: no `registerAs('webauthn')` was ever
+ * written, so every lookup returned undefined and passkeys could not start in
+ * production at all.
+ *
+ * These tests cover the seam the service spec cannot see — that the namespace
+ * exists and reads the environment variables its error messages name.
+ */
+describe('webauthn.config', () => {
+  const original = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...original };
+  });
+
+  it('registers under the namespace PasskeyService reads', () => {
+    // `configService.get('webauthn.rpId')` resolves only if the factory is
+    // registered as exactly 'webauthn'. A rename on either side silently
+    // reintroduces the original bug.
+    expect(webauthnConfig.KEY).toBe('CONFIGURATION(webauthn)');
+  });
+
+  it('maps WEBAUTHN_RP_ID and WEBAUTHN_ORIGIN from the environment', () => {
+    process.env.WEBAUTHN_RP_ID = 'opuspopuli.org';
+    process.env.WEBAUTHN_ORIGIN = 'https://app-us-ca.opuspopuli.org';
+
+    const config = webauthnConfig();
+
+    expect(config.rpId).toBe('opuspopuli.org');
+    expect(config.origin).toBe('https://app-us-ca.opuspopuli.org');
+  });
+
+  it('leaves rpId and origin undefined when unset, rather than defaulting', () => {
+    // Deliberate: PasskeyService owns the localhost fallback, and it must be
+    // able to tell "not configured" from "configured as localhost" to decide
+    // whether to throw in production. Defaulting here would silently disarm
+    // that check and let a misconfigured production node boot with a passkey
+    // relying party of 'localhost'.
+    delete process.env.WEBAUTHN_RP_ID;
+    delete process.env.WEBAUTHN_ORIGIN;
+
+    const config = webauthnConfig();
+
+    expect(config.rpId).toBeUndefined();
+    expect(config.origin).toBeUndefined();
+  });
+
+  it('defaults rpName, which is cosmetic and never gates startup', () => {
+    delete process.env.WEBAUTHN_RP_NAME;
+    expect(webauthnConfig().rpName).toBe('Opus Populi');
+
+    process.env.WEBAUTHN_RP_NAME = 'Custom Name';
+    expect(webauthnConfig().rpName).toBe('Custom Name');
+  });
+});

--- a/apps/backend/src/config/webauthn.config.ts
+++ b/apps/backend/src/config/webauthn.config.ts
@@ -1,0 +1,47 @@
+import { registerAs } from '@nestjs/config';
+
+/**
+ * WebAuthn (passkey) configuration.
+ *
+ * `PasskeyService` has read `webauthn.rpId`, `webauthn.origin` and
+ * `webauthn.rpName` since it was written, but **nothing ever registered the
+ * namespace** — no `registerAs('webauthn')` existed anywhere in the backend,
+ * and `WEBAUTHN_RP_ID` appeared in the codebase only inside the error message
+ * complaining that it was missing.
+ *
+ * So every lookup returned `undefined` regardless of the environment, and
+ * passkeys could never work in production: `PasskeyService` throws
+ * unconditionally when `NODE_ENV=production`, naming an environment variable
+ * that nothing read.
+ *
+ * It stayed hidden because the same check is only a warning outside
+ * production. The us-ca node ran in development mode until 2026-08-13, and the
+ * users service crash-looped the moment it was switched over.
+ *
+ * @see https://github.com/OpusPopuli/opuspopuli/issues/189
+ */
+export default registerAs('webauthn', () => ({
+  /**
+   * Relying Party ID — the bare domain a passkey is bound to. No scheme, no
+   * port, no subdomain.
+   *
+   * Use the registrable domain rather than the host actually serving the app:
+   * a credential registered against `opuspopuli.org` is usable from every
+   * subdomain, whereas one bound to `app-us-ca.opuspopuli.org` is not — and
+   * narrowing it later invalidates every passkey already registered.
+   *
+   * Undefined by default rather than falling back to `localhost` here.
+   * `PasskeyService` owns that fallback, and it needs to distinguish "not
+   * configured" from "configured as localhost" to decide whether to throw.
+   */
+  rpId: process.env.WEBAUTHN_RP_ID,
+
+  /**
+   * The full origin (scheme + host + port) the browser is on when registering
+   * or asserting a credential. Must match exactly, including scheme.
+   */
+  origin: process.env.WEBAUTHN_ORIGIN,
+
+  /** Human-readable name shown in the browser's passkey prompt. */
+  rpName: process.env.WEBAUTHN_RP_NAME || 'Opus Populi',
+}));

--- a/docker-compose-e2e.yml
+++ b/docker-compose-e2e.yml
@@ -53,6 +53,25 @@ x-backend-env: &backend-env
   SMTP_ADMIN_EMAIL: noreply@opuspopuli.local
   FRONTEND_URL: http://localhost:3300
 
+# Docker's json-file driver defaults to NO rotation and NO size cap, so container
+# logs grow without bound. On the us-ca production node on 2026-08-13 that was
+# one of two independent paths to a full disk — region-worker's log alone had
+# reached 3,488 MB from a single campaign-finance sync, and nothing ever
+# reclaimed it. Postgres then crash-looped on "No space left on device".
+#
+# Lower stakes here (these files build locally and run on dev machines and CI
+# runners rather than in production) but the identical mechanism: a `pnpm dev`
+# stack runs 24 services indefinitely, and integration/e2e runs are log-heavy
+# and repeat constantly.
+#
+# 50m x 5 caps each container at 250 MB. Fixed on the node repos in
+# opuspopuli-node-us-ca#29 and opuspopuli-node#49 (#1001).
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: '50m'
+    max-file: '5'
+
 services:
   db-migrate:
     build:
@@ -61,6 +80,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-e2e-db-migrate
+    logging: *logging
     environment:
       <<: *backend-env
     depends_on:
@@ -85,6 +105,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-e2e-users
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: users
@@ -120,6 +141,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-e2e-documents
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: documents
@@ -155,6 +177,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-e2e-knowledge
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: knowledge
@@ -190,6 +213,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-e2e-region
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: region
@@ -226,6 +250,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-e2e-api
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: api

--- a/docker-compose-frontend.yml
+++ b/docker-compose-frontend.yml
@@ -11,6 +11,25 @@
 #   # Stop frontend:
 #   docker compose -f docker-compose-frontend.yml down
 
+# Docker's json-file driver defaults to NO rotation and NO size cap, so container
+# logs grow without bound. On the us-ca production node on 2026-08-13 that was
+# one of two independent paths to a full disk — region-worker's log alone had
+# reached 3,488 MB from a single campaign-finance sync, and nothing ever
+# reclaimed it. Postgres then crash-looped on "No space left on device".
+#
+# Lower stakes here (these files build locally and run on dev machines and CI
+# runners rather than in production) but the identical mechanism: a `pnpm dev`
+# stack runs 24 services indefinitely, and integration/e2e runs are log-heavy
+# and repeat constantly.
+#
+# 50m x 5 caps each container at 250 MB. Fixed on the node repos in
+# opuspopuli-node-us-ca#29 and opuspopuli-node#49 (#1001).
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: '50m'
+    max-file: '5'
+
 services:
   frontend:
     build:
@@ -23,6 +42,7 @@ services:
         NEXT_PUBLIC_HMAC_CLIENT_ID: frontend
         NEXT_PUBLIC_HMAC_SECRET: dev-frontend-secret-key-change-in-production
     container_name: opuspopuli-frontend
+    logging: *logging
     ports:
       - "3300:3000"
     healthcheck:

--- a/docker-compose-integration.yml
+++ b/docker-compose-integration.yml
@@ -45,6 +45,25 @@ x-backend-env: &backend-env
   SMTP_ADMIN_EMAIL: noreply@opuspopuli.local
   FRONTEND_URL: http://localhost:3300
 
+# Docker's json-file driver defaults to NO rotation and NO size cap, so container
+# logs grow without bound. On the us-ca production node on 2026-08-13 that was
+# one of two independent paths to a full disk — region-worker's log alone had
+# reached 3,488 MB from a single campaign-finance sync, and nothing ever
+# reclaimed it. Postgres then crash-looped on "No space left on device".
+#
+# Lower stakes here (these files build locally and run on dev machines and CI
+# runners rather than in production) but the identical mechanism: a `pnpm dev`
+# stack runs 24 services indefinitely, and integration/e2e runs are log-heavy
+# and repeat constantly.
+#
+# 50m x 5 caps each container at 250 MB. Fixed on the node repos in
+# opuspopuli-node-us-ca#29 and opuspopuli-node#49 (#1001).
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: '50m'
+    max-file: '5'
+
 services:
   db-migrate:
     build:
@@ -53,6 +72,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-db-migrate
+    logging: *logging
     environment:
       <<: *backend-env
     depends_on:
@@ -69,6 +89,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-integration-users
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: users
@@ -96,6 +117,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-integration-documents
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: documents
@@ -123,6 +145,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-integration-knowledge
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: knowledge
@@ -150,6 +173,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-integration-region
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: region
@@ -177,6 +201,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-integration-api
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: api
@@ -213,6 +238,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-test-runner
+    logging: *logging
     command: ["/bin/sh", "/usr/local/bin/test-runner.sh"]
     environment:
       <<: *backend-env

--- a/docker-compose-uat.yml
+++ b/docker-compose-uat.yml
@@ -89,6 +89,25 @@ x-backend-env: &backend-env
   SMTP_ADMIN_EMAIL: noreply@opuspopuli.local
   FRONTEND_URL: http://localhost:3300
 
+# Docker's json-file driver defaults to NO rotation and NO size cap, so container
+# logs grow without bound. On the us-ca production node on 2026-08-13 that was
+# one of two independent paths to a full disk — region-worker's log alone had
+# reached 3,488 MB from a single campaign-finance sync, and nothing ever
+# reclaimed it. Postgres then crash-looped on "No space left on device".
+#
+# Lower stakes here (these files build locally and run on dev machines and CI
+# runners rather than in production) but the identical mechanism: a `pnpm dev`
+# stack runs 24 services indefinitely, and integration/e2e runs are log-heavy
+# and repeat constantly.
+#
+# 50m x 5 caps each container at 250 MB. Fixed on the node repos in
+# opuspopuli-node-us-ca#29 and opuspopuli-node#49 (#1001).
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: '50m'
+    max-file: '5'
+
 services:
   db-migrate:
     build:
@@ -97,6 +116,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-uat-db-migrate
+    logging: *logging
     environment:
       <<: *backend-env
     depends_on:
@@ -121,6 +141,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-uat-users
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: users
@@ -156,6 +177,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-uat-documents
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: documents
@@ -191,6 +213,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-uat-knowledge
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: knowledge
@@ -233,6 +256,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-uat-region
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: region
@@ -308,6 +332,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-uat-region-worker
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: region-worker
@@ -361,6 +386,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-uat-structural-analysis-worker
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: structural-analysis-worker
@@ -405,6 +431,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-uat-llm-rerank-worker
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: llm-rerank-worker
@@ -454,6 +481,7 @@ services:
       args:
         NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN:-}
     container_name: opuspopuli-uat-api
+    logging: *logging
     environment:
       <<: *backend-env
       APPLICATION: api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,25 @@ networks:
     name: opuspopuli-network
     external: false
 
+# Docker's json-file driver defaults to NO rotation and NO size cap, so container
+# logs grow without bound. On the us-ca production node on 2026-08-13 that was
+# one of two independent paths to a full disk — region-worker's log alone had
+# reached 3,488 MB from a single campaign-finance sync, and nothing ever
+# reclaimed it. Postgres then crash-looped on "No space left on device".
+#
+# Lower stakes here (these files build locally and run on dev machines and CI
+# runners rather than in production) but the identical mechanism: a `pnpm dev`
+# stack runs 24 services indefinitely, and integration/e2e runs are log-heavy
+# and repeat constantly.
+#
+# 50m x 5 caps each container at 250 MB. Fixed on the node repos in
+# opuspopuli-node-us-ca#29 and opuspopuli-node#49 (#1001).
+x-logging: &logging
+  driver: json-file
+  options:
+    max-size: '50m'
+    max-file: '5'
+
 services:
   # ===========================================
   # Supabase Services (Auth, Storage, Vault)
@@ -52,6 +71,7 @@ services:
   opuspopuli-db:
     image: supabase/postgres:17.6.1.091
     container_name: opuspopuli-db
+    logging: *logging
     ports:
       - "5432:5432"
     environment:
@@ -103,6 +123,7 @@ services:
   inbucket:
     image: inbucket/inbucket:3.0.2
     container_name: opuspopuli-inbucket
+    logging: *logging
     ports:
       - "54324:9000"  # Web UI
       - "2500:2500"   # SMTP
@@ -128,6 +149,7 @@ services:
   supabase-auth:
     image: supabase/gotrue:v2.164.0
     container_name: opuspopuli-supabase-auth
+    logging: *logging
     depends_on:
       opuspopuli-db:
         condition: service_healthy
@@ -192,6 +214,7 @@ services:
   supabase-rest:
     image: postgrest/postgrest:v12.2.3
     container_name: opuspopuli-supabase-rest
+    logging: *logging
     depends_on:
       opuspopuli-db:
         condition: service_healthy
@@ -225,6 +248,7 @@ services:
   supabase-storage:
     image: supabase/storage-api:v1.11.8
     container_name: opuspopuli-supabase-storage
+    logging: *logging
     depends_on:
       opuspopuli-db:
         condition: service_healthy
@@ -268,6 +292,7 @@ services:
   supabase-imgproxy:
     image: darthsim/imgproxy:v3.8.0
     container_name: opuspopuli-supabase-imgproxy
+    logging: *logging
     environment:
       IMGPROXY_BIND: ":8080"
       IMGPROXY_LOCAL_FILESYSTEM_ROOT: /
@@ -297,6 +322,7 @@ services:
   supabase-kong:
     image: kong:2.8.1
     container_name: opuspopuli-supabase-kong
+    logging: *logging
     depends_on:
       - supabase-auth
       - supabase-rest
@@ -339,6 +365,7 @@ services:
   supabase-studio:
     image: supabase/studio:20241202-71e5240
     container_name: opuspopuli-supabase-studio
+    logging: *logging
     depends_on:
       - supabase-kong
     ports:
@@ -378,6 +405,7 @@ services:
   supabase-meta:
     image: supabase/postgres-meta:v0.83.2
     container_name: opuspopuli-supabase-meta
+    logging: *logging
     depends_on:
       opuspopuli-db:
         condition: service_healthy
@@ -414,6 +442,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: opuspopuli-redis
+    logging: *logging
     ports:
       - "6379:6379"
     # noeviction required by BullMQ — allkeys-lru would evict job data under
@@ -450,6 +479,7 @@ services:
   redis-cache:
     image: redis:7-alpine
     container_name: opuspopuli-redis-cache
+    logging: *logging
     ports:
       - "6380:6379"
     command: redis-server --maxmemory 512mb --maxmemory-policy allkeys-lru
@@ -480,6 +510,7 @@ services:
   prometheus:
     image: prom/prometheus:v2.51.0
     container_name: opuspopuli-prometheus
+    logging: *logging
     ports:
       - "9090:9090"
     command:
@@ -515,6 +546,7 @@ services:
   loki:
     image: grafana/loki:3.4.2
     container_name: opuspopuli-loki
+    logging: *logging
     ports:
       - "3102:3100"
     command: -config.file=/etc/loki/local-config.yaml
@@ -543,6 +575,7 @@ services:
   promtail:
     image: grafana/promtail:3.4.2
     container_name: opuspopuli-promtail
+    logging: *logging
     depends_on:
       - loki
     volumes:
@@ -566,6 +599,7 @@ services:
   tempo:
     image: grafana/tempo:2.7.2
     container_name: opuspopuli-tempo
+    logging: *logging
     command: ["-config.file=/etc/tempo.yml"]
     volumes:
       - ./observability/tempo.yml:/etc/tempo.yml:ro
@@ -589,6 +623,7 @@ services:
   grafana:
     image: grafana/grafana:10.4.1
     container_name: opuspopuli-grafana
+    logging: *logging
     depends_on:
       - prometheus
       - loki


### PR DESCRIPTION
**Production is currently down on the us-ca node because of this.** `users` is crash-looping and `api` is stuck `created` behind it as a failed dependency.

## The bug

`PasskeyService` has read `webauthn.rpId`, `webauthn.origin` and `webauthn.rpName` since it was written — but **nothing ever registered that namespace.** No `registerAs('webauthn')` exists anywhere in the backend, and `WEBAUTHN_RP_ID` appears in the codebase *only inside the error message complaining it's missing*.

So every lookup returned `undefined` regardless of environment. **Passkeys could never have worked in production**: the constructor throws unconditionally when `NODE_ENV=production`, naming an env var nothing reads.

## Why it stayed hidden

The same check is only a *warning* outside production. The us-ca node ran in development mode until 2026-08-13; `users` crash-looped (10 restarts) the moment it was switched to production for the frontend launch.

The container had `WEBAUTHN_RP_ID=opuspopuli.org` in its environment the entire time:

```
ALLOWED_ORIGINS=https://app-us-ca.opuspopuli.org
WEBAUTHN_RP_ID=opuspopuli.org           <- present, and unread
WEBAUTHN_ORIGIN=https://app-us-ca.opuspopuli.org
NODE_ENV=production
```

Useful signal: `documents`, `region`, `region-worker` and `knowledge` all came up **healthy** in production mode. Production mode is fine — this was one missing namespace.

## Why the tests didn't catch it

`passkey.service.spec.ts` passed throughout, and still does. It mocks `ConfigService` and hands back `webauthn.rpId` / `webauthn.origin` directly — so it verified the service's behaviour **given** the config, and nothing verified the config existed.

The new `webauthn.config.spec.ts` covers that seam, including asserting the registered key is exactly `'webauthn'`. A rename on either side silently reintroduces this.

## One deliberate choice

`rpId` and `origin` are left **undefined** when unset, rather than defaulting to `localhost`.

`PasskeyService` owns that fallback and must distinguish "not configured" from "configured as localhost" to decide whether to throw. Defaulting in the config would disarm the check and let a misconfigured production node boot with a passkey relying party of `localhost` — binding real credentials to the wrong domain, which is worse than failing to start.

## Second commit: #1001

Log rotation across all 5 compose files (39 services) via a YAML anchor. `json-file` defaults to no rotation and no cap — the same defect that contributed to the disk exhaustion that took the node down, where `region-worker`'s log alone reached 3,488 MB.

Verified by rendering, not inspection: all five pass `docker compose config`, and rotation reaches the services in the output.

The other node-repo changes were checked individually and deliberately **not** ported — `op-deploy` prunes published images while these build locally, the Loki cap has no observability stack here, and the cookie-domain vars only matter for sibling subdomains whereas everything here is localhost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)