### PR TITLE
ci(frontend): deploy the Cloudflare Worker from Actions on a frontend-v* tag

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,180 @@
+# =============================================================================
+# Deploy Frontend — Cloudflare Worker
+# =============================================================================
+#
+# Triggered by pushing a `frontend-v*` tag. Builds the Next.js app through
+# OpenNext and deploys the Worker to Cloudflare.
+#
+#   git tag frontend-v1.0.0 && git push origin frontend-v1.0.0
+#
+# A SEPARATE tag from the backend's `v*`, deliberately. The frontend and the
+# services ship on different clocks: a UI fix should not require cutting a
+# backend release, and a backend patch should not silently redeploy the Worker.
+# Reusing `v*` would couple them in both directions.
+#
+# Before this existed the Worker was deployed by hand with `pnpm cf:deploy`
+# from one developer's Mac. That shipped whatever was in the working tree, with
+# build-time values from a gitignored .env.production.local that existed on
+# exactly one machine, and nothing tied a deployed Worker to a commit. It is
+# also how a real credential reached a deployed bundle on 2026-08-13: OpenNext
+# inlines .env files from the REPOSITORY ROOT, and that machine had one. A
+# runner has no .env files at all, so building here removes that class of
+# failure rather than guarding against it.
+#
+# `pnpm cf:deploy` still works and is kept as break-glass for when Actions is
+# unavailable. It is not the normal path.
+#
+# THE FAILURE MODE THIS WORKFLOW IS BUILT AROUND: NEXT_PUBLIC_GRAPHQL_URL and
+# NEXT_PUBLIC_SITE_URL are inlined at BUILD time and both have localhost
+# fallbacks in source. A build with neither set exits 0 and deploys a Worker
+# whose Apollo client points at localhost:3000 and whose CSP omits the real API
+# origin. Nothing errors. Hence the two assertions below -- one before the
+# build, one after -- which are the reason this can be trusted more than the
+# Mac it replaces.
+#
+# Note that scripts/check-worker-env.mjs (chained inside cf:build) is NOT that
+# safeguard. It fails when a non-public key reaches the bundle, and it reads
+# .env FILES -- which do not exist on a runner. Here it is trivially green. It
+# stays because it costs nothing and still guards local builds.
+# =============================================================================
+
+name: Deploy Frontend
+
+on:
+  push:
+    tags: ['frontend-v*']
+  # Dry runs, and redeploying the current ref without minting a tag.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-frontend
+  # Never cancel a deploy mid-upload -- a half-uploaded Worker is worse than a
+  # queued one. Same reasoning as release.yml.
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+
+    # Gates the job on manual approval and scopes the Cloudflare credentials to
+    # this environment, so no other workflow in the repo can read them.
+    environment:
+      name: production
+      url: https://app-us-ca.opuspopuli.org
+
+    env:
+      # Region config lives in repo Variables, not Secrets: every NEXT_PUBLIC_*
+      # is inlined into the browser bundle and served to every visitor, so
+      # treating them as secret would be theatre. Prefixed by region so a second
+      # node is a new pair of variables plus a matrix entry, not a rewrite.
+      NEXT_PUBLIC_GRAPHQL_URL: ${{ vars.US_CA_GRAPHQL_URL }}
+      NEXT_PUBLIC_SITE_URL: ${{ vars.US_CA_SITE_URL }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@opuspopuli'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # No `pnpm -r --filter './packages/*' build` and no Prisma generate here,
+      # deliberately. ci.yml's build job needs both because it builds the
+      # BACKEND alongside the frontend; this job does not. The frontend declares
+      # no @opuspopuli/* or workspace: dependency, imports none in app/, lib/,
+      # components/ or config/, has no path alias beyond `@/*` -> ./, and never
+      # touches Prisma -- it talks to the API over GraphQL. Adding those steps
+      # back would cost several minutes on every deploy to build artifacts
+      # nothing here consumes.
+
+      # Fail before spending ~10 minutes on a build that would ship localhost.
+      # An unset GitHub Variable expands to an empty string rather than being
+      # absent, so test for emptiness, not for definedness.
+      - name: Require production environment
+        run: |
+          : "${NEXT_PUBLIC_GRAPHQL_URL:?is empty — set the US_CA_GRAPHQL_URL repository variable. Refusing to build a localhost bundle.}"
+          : "${NEXT_PUBLIC_SITE_URL:?is empty — set the US_CA_SITE_URL repository variable. Refusing to build a localhost bundle.}"
+          echo "GraphQL : $NEXT_PUBLIC_GRAPHQL_URL"
+          echo "Site    : $NEXT_PUBLIC_SITE_URL"
+
+      # cf:build, not `opennextjs-cloudflare build`, so check-worker-env.mjs
+      # runs. NEXT_OUTPUT must stay unset: next.config.mjs switches to
+      # output:'standalone' when it is set, which breaks the Cloudflare adapter.
+      # (ci.yml's e2e job does set it -- this job must not inherit that.)
+      - name: Build Worker bundle
+        run: pnpm --filter frontend cf:build
+
+      # The assertion that makes this trustworthy. Next.js substitutes
+      # NEXT_PUBLIC_* textually at build time, so if the values reached the
+      # build they are literally present in the output -- and if they did not,
+      # the localhost fallbacks are there instead. Checked against the built
+      # artifact rather than the inputs, because the inputs being correct is
+      # not evidence the build consumed them.
+      - name: Verify production values were inlined
+        run: |
+          set -euo pipefail
+          cd apps/frontend
+
+          if ! grep -rqF "$NEXT_PUBLIC_GRAPHQL_URL" .open-next/; then
+            echo "::error::Production API origin is absent from the built bundle."
+            echo "The build did not consume NEXT_PUBLIC_GRAPHQL_URL."
+            exit 1
+          fi
+
+          if grep -rqF "localhost:3000/api" .open-next/server-functions/; then
+            echo "::error::The localhost Apollo fallback was inlined into the bundle."
+            echo "This deploys a site that talks to nothing. Refusing to continue."
+            exit 1
+          fi
+
+          echo "Production origin present; no localhost fallback. OK."
+
+      - name: Deploy to Cloudflare
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/frontend
+          command: deploy
+
+      # Proves the deploy took, not merely that wrangler exited 0. Retried
+      # because a freshly-attached custom domain can take a moment to answer at
+      # the edge, and a cold first request is slower than steady state.
+      - name: Smoke test
+        run: |
+          set -euo pipefail
+          url="$NEXT_PUBLIC_SITE_URL"
+          for attempt in 1 2 3 4 5; do
+            code=$(curl -s -o /tmp/body.html -w '%{http_code}' --max-time 30 "$url" || echo 000)
+            if [ "$code" = "200" ]; then
+              echo "$url -> 200"
+              if grep -qF "$NEXT_PUBLIC_GRAPHQL_URL" /tmp/body.html; then
+                echo "Served page references the production API origin. OK."
+              else
+                # Not fatal: the origin may only appear in a lazily-loaded
+                # chunk rather than the initial HTML. The inlining assertion
+                # above already covers the real risk.
+                echo "::warning::Production API origin not found in the initial HTML."
+              fi
+              exit 0
+            fi
+            echo "attempt $attempt: HTTP $code, retrying..."
+            sleep 10
+          done
+          echo "::error::$url did not return 200 after 5 attempts (last: $code)."
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ pnpm test:integration         # Requires docker compose up
 pnpm dev                      # Dev server    :3200
 pnpm test
 pnpm e2e                      # Playwright
-pnpm cf:deploy                # Build + deploy to Cloudflare Pages
+pnpm cf:build                 # Build the Cloudflare Worker bundle locally
+pnpm cf:deploy                # Break-glass deploy — NOT the normal path (see below)
 ```
 
 Each `start:*` script builds before starting watch mode — don't run `nest start` directly.
@@ -146,7 +147,32 @@ How it works:
 - Next.js App Router, React 19, TailwindCSS 4, Apollo Client 4
 - i18next (English/Spanish) — all user-facing strings via `react-i18next`
 - WCAG 2.2 AA required for all UI — run `pnpm test:a11y` before marking UI work done
-- Deployed to Cloudflare Pages via `@opennextjs/cloudflare`
+- Deployed to a Cloudflare **Worker** (not Pages) via `@opennextjs/cloudflare`
+
+### Shipping the frontend
+
+**Tag `frontend-v*`.** `deploy-frontend.yml` builds and deploys the Worker, gated on approval in
+the `production` environment:
+
+```bash
+git tag frontend-v1.1.0 && git push origin frontend-v1.1.0
+```
+
+Separate from the backend's `v*` tag on purpose — a UI fix should not need a backend release, and
+a backend patch should not redeploy the Worker.
+
+`pnpm cf:deploy` still works and is **break-glass only**, for when Actions is unavailable. It
+ships whatever is in your working tree, from a local `.env.production.local` that exists on one
+machine, and nothing records what was deployed.
+
+Two things about the build worth knowing before changing it:
+
+- `NEXT_PUBLIC_*` are inlined at **build** time, so the bundle is region-specific and a rebuild is
+  required to change any of them. CI supplies them from the `US_CA_*` repository variables.
+- `NEXT_PUBLIC_GRAPHQL_URL` and `NEXT_PUBLIC_SITE_URL` have **localhost fallbacks in source**, so a
+  build with them unset succeeds and deploys a site that talks to nothing. `check-worker-env.mjs`
+  does not catch this — it only guards against non-public keys, and reads `.env` files that do not
+  exist on a runner. The workflow asserts the real origin is present in the built bundle instead.
 
 ## SDLC tooling (Claude Code plugin)
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -30,12 +30,39 @@ Full step-by-step is in the deployment template's [README.md](https://github.com
 | Backup pipeline (`pg_dump → R2`) | [Template repo](https://github.com/OpusPopuli/opuspopuli-node) |
 | Observability configs (Prometheus / Grafana / Loki / Tempo) | [Template repo](https://github.com/OpusPopuli/opuspopuli-node) |
 | Per-region operator secrets | Operator's region repo's GitHub Secrets (never here) |
+| **First-party `us-ca` frontend deploy** | **This repo** — `.github/workflows/deploy-frontend.yml` (documented exception, below) |
+
+### The frontend deploy is an exception to the rule above
+
+`deploy-frontend.yml` deploys the `us-ca` Cloudflare Worker from this repo, using a
+`CLOUDFLARE_API_TOKEN` held in this repo's `production` environment. That is a real departure from
+"never centralized," so it is written down rather than left to be discovered.
+
+Why it is here and not in the region repo:
+
+- Every `NEXT_PUBLIC_*` is inlined at **build** time, so a Worker bundle is specific to one
+  region's API and site URLs. There is no build-once-deploy-anywhere artifact to hand an operator,
+  the way `ghcr.io/opuspopuli/*` images are.
+- The frontend source and the `frontend-v*` tag both live here.
+- `apps/frontend/wrangler.toml` already hard-codes `app-us-ca.opuspopuli.org`, so this repo was
+  region-coupled on the frontend before the workflow existed.
+
+**What this does not change.** Backend images stay region-agnostic and operator-pulled. No Mac
+Studio config, Terraform state, or backend credential moves here. The token is scoped to Workers
+plus the `opuspopuli.org` zone, and lives in an environment secret readable only by that one job.
+
+**What is still unsolved.** A third-party operator running their own region cannot use this
+workflow — it would mean handing them our Cloudflare token, or us holding theirs. Until that is
+designed, an independent operator builds and deploys their own frontend from their node repo.
+That gap is tracked, and it blocks the "Adding a region" story below for anyone outside
+OpusPopuli.
 
 ## Adding a region
 
 1. The new region operator forks the template into their preferred org (e.g. `OpusPopuli/opuspopuli-node-<region>` for an OpusPopuli-operated region, or `<their-org>/opuspopuli-node-<region>` for an independently-operated region).
 2. They follow the template's `README.md` end to end. ~5–8 focused hours from zero to public API serving.
-3. Their region's traffic flows through their own Cloudflare account + their own Mac Studio. The central `OpusPopuli/opuspopuli` repo only publishes images and packages — no operator credentials, no operator state.
+3. Their region's traffic flows through their own Cloudflare account + their own Mac Studio. For an independent operator the central `OpusPopuli/opuspopuli` repo publishes only images and packages — none of their credentials, none of their state.
+4. **The frontend is the open edge.** Steps 1–3 get an operator to a public API; they do not get them a deployed frontend. `deploy-frontend.yml` builds for `us-ca` specifically, because `NEXT_PUBLIC_*` values are baked in at build time, and it uses OpusPopuli's own Cloudflare token. An independent operator must build and deploy their own Worker from their node repo today. Designing a supported path for that is open work — see the exception note above.
 
 ## Image verification
 


### PR DESCRIPTION
## Why

The Worker is deployed by hand with `pnpm cf:deploy` from one developer's Mac. That ships whatever is in that working tree, with build-time values from a gitignored `.env.production.local` that exists on exactly one machine and is backed up nowhere. Nothing ties a deployed Worker to a commit, and nobody else can ship.

It is also how a real credential reached a deployed bundle on 2026-08-13 — OpenNext inlines `.env` files from the **repository root**, and that machine had one. A runner has no `.env` files at all, so building there removes that class of failure outright rather than guarding against it.

## ⚠️ Requires setup before it can succeed

The workflow will fail until these exist. Nothing here creates them:

**1. Cloudflare API token** — dashboard → My Profile → API Tokens → *Edit Cloudflare Workers* template, account resources = OpusPopuli, zone resources = `opuspopuli.org` only. Do **not** reuse the token in `opuspopuli.org`.

> `custom_domain = true` in `wrangler.toml` means Cloudflare creates and owns the DNS record on deploy, so the token needs **zone DNS edit**, not just Workers Scripts. If it fails at the route step with an authorization error, that is the missing permission — the Worker itself will already have uploaded.

**2. A `production` environment** (Settings → Environments), you as required reviewer, with **environment** secrets — not repo secrets, so nothing else in the repo can read them:
- `CLOUDFLARE_API_TOKEN`
- `CLOUDFLARE_ACCOUNT_ID`

**3. Repository variables** — `NEXT_PUBLIC_*` is inlined into the browser bundle and served to every visitor, so treating these as secret would be theatre:
- `US_CA_GRAPHQL_URL` = `https://api-us-ca.opuspopuli.org/api`
- `US_CA_SITE_URL` = `https://app-us-ca.opuspopuli.org`

## The part that matters: a broken build currently ships silently

`NEXT_PUBLIC_GRAPHQL_URL` and `NEXT_PUBLIC_SITE_URL` are inlined at build time and **both have localhost fallbacks in source** — `lib/apollo-client.ts:15`, `app/layout.tsx:29`, `config/security-headers.config.mjs:21,117`. A build with neither set **exits 0** and deploys a site whose Apollo client points at `localhost:3000` and whose CSP omits the real API origin. Nothing errors.

**`check-worker-env.mjs` does not catch this.** It fails on non-public keys reaching the bundle, and it reads `.env` *files* — which do not exist on a runner. I verified rather than assumed: rebuilding with the env files hidden produced

```
cf:build exit=0
check-worker-env: ok — only NEXT_PUBLIC_* values reached the Worker bundle.
```

on a bundle containing the localhost fallback and **no** production origin. In CI that guard is unconditionally green and proves nothing about correctness. It stays — it still guards local builds and costs nothing — but it is not the safeguard here.

So the workflow asserts twice:

- **Before the build** — the variables are non-empty. An unset GitHub Variable expands to an empty string rather than being absent, so emptiness is the right test.
- **After the build** — the production origin is literally present in `.open-next/` and the localhost fallback is not. Checked against the *artifact*, because correct inputs are not evidence the build consumed them.

Both were exercised against a real bundle and a deliberately env-less one; each fires only in its intended case.

## Also

Dropped the package-build and Prisma-generate steps that `ci.yml`'s build job carries — that job needs them because it builds the **backend** too. The frontend declares no workspace dependency, imports none in `app/` `lib/` `components/` `config/`, has no path alias beyond `@/*`, and never touches Prisma. Those steps would cost minutes per deploy building artifacts nothing here consumes.

## This contradicts `deployment.md`, so the guide is updated

That guide says production deploys happen from the per-region repo, *"never centralized."* This is the repo's first non-`GITHUB_TOKEN` secret. Rather than leave the contradiction to be discovered, it is now written down as a **scoped exception**: `NEXT_PUBLIC_*` being build-time means a bundle is region-specific, so there is no build-once-deploy-anywhere artifact to hand an operator the way `ghcr.io/opuspopuli/*` images are — and `wrangler.toml` already hard-codes `app-us-ca.opuspopuli.org`.

**What stays unsolved**: a third-party operator can neither use our token nor hand us theirs. Recorded in the guide and in *Adding a region*, which previously implied frontend deployment was covered and did not.

## Verification before trusting it

1. `workflow_dispatch` on `main` first — approve at the gate, confirm the deploy succeeds and the site still serves 200.
2. **Temporarily blank `US_CA_GRAPHQL_URL` and re-run.** The job must fail at *Require production environment*. This is the check everything rests on; do not skip it.
3. Then `git tag frontend-v1.0.0 && git push origin frontend-v1.0.0`. `.husky/pre-push` reads pushed refs from stdin and deliberately allows `refs/tags/*`.
4. Confirm sign-in still works — the CSP is built from these variables, so a wrong value breaks auth without breaking the page.

Rollback is `wrangler rollback`, or tagging an older commit.

## Follow-ups (not this PR)

- Multi-operator frontend deploys — blocks the *Adding a region* story for anyone outside OpusPopuli.
- **Remove the localhost fallbacks** or make them fail loudly in production builds. The assertion is a guard around the real defect, not a fix for it.
- `NEXT_PUBLIC_HMAC_CLIENT_ID` / `NEXT_PUBLIC_HMAC_SECRET` are read by no code — only `.env.example`, compose files and the Dockerfile.

Companion doc fixes: opuspopuli-node#53, opuspopuli-node-us-ca#33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)