### PR TITLE
ci(frontend): install wrangler globally, not into the project tree

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -208,18 +208,35 @@ jobs:
             || { echo "::error::worker.js missing after unpack"; exit 1; }
           echo "Unpacked $(find apps/frontend/.open-next -type f | wc -l) files."
 
+      # Installed GLOBALLY and invoked directly, rather than via
+      # cloudflare/wrangler-action.
+      #
+      # The action installs wrangler into its `workingDirectory`, so it ran
+      # `npm i wrangler@4.78.0` inside apps/frontend -- and npm then resolved
+      # against that package.json and refused:
+      #
+      #   ERESOLVE  apollo3-cache-persist@0.15.0 wants peer @apollo/client@^3.7.17
+      #             but the project is on @apollo/client@4.2.12
+      #
+      # That peer mismatch is real and pre-existing; pnpm tolerates it (no
+      # override is recorded for it) and npm does not, so this repo cannot be
+      # npm-installed at all. Nothing about the deploy needs npm to succeed
+      # there, so the fix is to keep npm away from the project tree entirely.
+      # `npm i -g` resolves in isolation and never reads apps/frontend.
+      #
+      # Pinned rather than floating so an approved bundle always ships via a
+      # known wrangler. Keep roughly in step with apps/frontend/package.json.
+      - name: Install wrangler
+        run: npm i -g wrangler@4.78.0
+
+      # wrangler reads CLOUDFLARE_API_TOKEN and CLOUDFLARE_ACCOUNT_ID from the
+      # environment natively, so the action wrapper bought nothing here.
       - name: Deploy to Cloudflare
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/frontend
-          command: deploy
-          # Pinned rather than floating, so an approved bundle is always shipped
-          # by a known wrangler. This job does not run `pnpm install`, so
-          # node_modules is absent and the action would otherwise fetch latest.
-          # Keep roughly in step with apps/frontend/package.json's `wrangler`.
-          wranglerVersion: '4.78.0'
+        working-directory: apps/frontend
+        run: wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       # Proves the deploy took, not merely that wrangler exited 0. Retried
       # because a freshly-attached custom domain can take a moment to answer at


### PR DESCRIPTION
The deploy job in [run 31815930197](https://github.com/OpusPopuli/opuspopuli/actions/runs/31815930197) failed at the wrangler step — **not** for any credential reason.

## Cause

`cloudflare/wrangler-action` installs wrangler into its `workingDirectory`, so it ran `npm i wrangler@4.78.0` inside `apps/frontend`. npm resolved against that `package.json` and refused:

```
ERESOLVE unable to resolve dependency tree
  Found: @apollo/client@4.2.12
  Could not resolve dependency:
  peer @apollo/client@"^3.7.17" from apollo3-cache-persist@0.15.0
```

That peer mismatch is **real and pre-existing**, not introduced by this workflow. pnpm tolerates it (no override is recorded for it in the root `package.json`); npm does not — so this repo cannot be `npm install`ed at all. It has simply never mattered, because nothing installs it with npm.

## Fix

Nothing about deploying needs npm to succeed in the project tree, so keep it out of there. `npm i -g` resolves in isolation and never reads `apps/frontend/package.json`.

wrangler is then invoked directly — it reads `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` from the environment natively, so the action wrapper was buying nothing else. One fewer third-party action to keep SHA-pinned as a side benefit.

## What already worked

Worth recording, because everything up to this step was correct:

- `build` went green on **both** assertions (*Require production environment*, *Verify production values were inlined*)
- the **15 MB** tarball round-tripped through the artifact store — matching the local measurement exactly
- `Unpack bundle` confirmed `worker.js` survived the round trip
- the gate behaved as intended: approval was requested **after** a green build, which was the point of #1008

Only the wrangler install was broken.

## Follow-up worth considering

`apollo3-cache-persist@0.15.0` has not kept up with Apollo Client 4. The project works because pnpm is lenient, but the package is declaring it does not support the version in use. Worth checking whether it still functions correctly against v4, or whether it wants replacing — separate from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)