### PR TITLE
fix(auth): renew sessions silently instead of forcing re-login after 15 minutes

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -180,7 +180,7 @@ jobs:
     # go-ahead. Also scopes the Cloudflare credentials to this job alone.
     environment:
       name: production
-      url: https://app-us-ca.opuspopuli.org
+      url: https://california.opuspopuli.org
 
     env:
       NEXT_PUBLIC_GRAPHQL_URL: ${{ vars.US_CA_GRAPHQL_URL }}

--- a/apps/backend/__tests__/integration/auth/session-refresh.integration.spec.ts
+++ b/apps/backend/__tests__/integration/auth/session-refresh.integration.spec.ts
@@ -1,0 +1,225 @@
+/**
+ * Session Refresh Integration Tests (#977)
+ *
+ * Covers the things unit tests structurally cannot:
+ *
+ * - that the renewal route is actually reachable at the path the refresh
+ *   cookie is scoped to, through the real middleware chain
+ * - that CSRF genuinely guards it — asserted here rather than inferred from
+ *   the middleware wiring, which is all subtask 3 could do
+ * - that the last-32 refresh-token fragment convention round-trips through a
+ *   real Postgres column, which is what rotation and revocation both match on
+ *
+ * Requires the integration stack: `pnpm integration:up`.
+ */
+import {
+  cleanDatabase,
+  createUser,
+  disconnectDatabase,
+  getDbService,
+} from '../utils';
+
+const GATEWAY_URL = process.env.API_GATEWAY_URL || 'http://localhost:3000';
+const REFRESH_URL = `${GATEWAY_URL}/api/auth/refresh`;
+
+/** Mirrors AuthResolver.createSession — the last 32 chars, never the whole JWT. */
+const fragment = (token: string) => token.slice(-32);
+
+async function getCsrfToken(): Promise<string> {
+  const response = await fetch(`${GATEWAY_URL}/api`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: '{ __typename }' }),
+  });
+  const setCookie = response.headers.get('set-cookie') || '';
+  const match = /csrf-token=([^;]+)/.exec(setCookie);
+  if (!match) throw new Error('Gateway did not issue a csrf-token cookie');
+  return match[1];
+}
+
+/** Set-Cookie directives that clear a cookie rather than set one. */
+const clearsCookie = (setCookie: string, name: string) =>
+  new RegExp(`${name}=;|${name}=;?\\s*Expires=Thu, 01 Jan 1970`, 'i').test(
+    setCookie,
+  );
+
+describe('Session refresh (#977)', () => {
+  let csrf: string;
+
+  beforeAll(async () => {
+    csrf = await getCsrfToken();
+  });
+
+  afterAll(async () => {
+    await disconnectDatabase();
+  });
+
+  describe('CSRF protection', () => {
+    // Deferred from subtask 3, where it could only be read off the middleware
+    // wiring. The route inherits CsrfMiddleware via forRoutes({path:'*'});
+    // this proves it.
+    it('rejects a POST with no CSRF token', async () => {
+      const response = await fetch(REFRESH_URL, { method: 'POST' });
+
+      expect(response.status).toBe(403);
+    });
+
+    it('rejects a POST whose CSRF header does not match the cookie', async () => {
+      const response = await fetch(REFRESH_URL, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': 'not-the-right-token',
+          Cookie: `csrf-token=${csrf}`,
+        },
+      });
+
+      expect(response.status).toBe(403);
+    });
+  });
+
+  describe('without a usable refresh cookie', () => {
+    it('401s and clears both auth cookies when no refresh cookie is sent', async () => {
+      const response = await fetch(REFRESH_URL, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': csrf,
+          Cookie: `csrf-token=${csrf}`,
+        },
+      });
+
+      expect(response.status).toBe(401);
+
+      // The browser must stop presenting a half-dead session.
+      const setCookie = response.headers.get('set-cookie') || '';
+      expect(clearsCookie(setCookie, 'access-token')).toBe(true);
+      expect(clearsCookie(setCookie, 'refresh-token')).toBe(true);
+    });
+
+    it('401s on a refresh token the provider rejects', async () => {
+      const response = await fetch(REFRESH_URL, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': csrf,
+          Cookie: `csrf-token=${csrf}; refresh-token=definitely-not-a-valid-grant`,
+        },
+      });
+
+      // A rejected grant is terminal — 401, not 503.
+      expect(response.status).toBe(401);
+    });
+
+    it('never returns tokens in the response body', async () => {
+      const response = await fetch(REFRESH_URL, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': csrf,
+          Cookie: `csrf-token=${csrf}; refresh-token=definitely-not-a-valid-grant`,
+        },
+      });
+
+      const body = await response.text();
+      expect(body).not.toMatch(/accessToken|refreshToken|eyJ/);
+    });
+  });
+
+  /**
+   * The assumption rotation rests on, and the one I could only verify by
+   * reading: `createSession` stores `refreshToken.slice(-32)`, and both
+   * `rotateSession` and `revokeSessionByRefreshToken` match on that same
+   * fragment. If the convention did not round-trip, rotation would silently
+   * update zero rows and renewal would still LOOK like it worked.
+   */
+  describe('refresh-token fragment convention against a real database', () => {
+    let db: Awaited<ReturnType<typeof getDbService>>;
+    let userId: string;
+
+    beforeAll(async () => {
+      db = await getDbService();
+    });
+
+    beforeEach(async () => {
+      await cleanDatabase();
+      // Use the shared fixture rather than a hand-rolled insert, so this test
+      // tracks the real User schema instead of a guess at it.
+      const user = await createUser();
+      userId = user.id;
+    });
+
+    // A GoTrue refresh token is far longer than the 32 chars stored.
+    const longToken = `v1.${'a'.repeat(200)}.TAIL-THAT-IDENTIFIES-THE-SESSION`;
+
+    const seedSession = () =>
+      db.userSession.create({
+        data: {
+          userId,
+          sessionToken: fragment('access-token-original-value-padding'),
+          refreshToken: fragment(longToken),
+          isActive: true,
+          expiresAt: new Date(Date.now() + 86_400_000),
+        },
+      });
+
+    it('matches the stored fragment when rotating', async () => {
+      await seedSession();
+      const renewedAccess = `new.${'b'.repeat(200)}.NEW-ACCESS-TAIL`;
+      const renewedRefresh = `new.${'c'.repeat(200)}.NEW-REFRESH-TAIL`;
+
+      const result = await db.userSession.updateMany({
+        where: { refreshToken: fragment(longToken), isActive: true },
+        data: {
+          sessionToken: fragment(renewedAccess),
+          refreshToken: fragment(renewedRefresh),
+          lastActivityAt: new Date(),
+        },
+      });
+
+      expect(result.count).toBe(1);
+
+      const rotated = await db.userSession.findFirst({ where: { userId } });
+      expect(rotated?.refreshToken).toBe(fragment(renewedRefresh));
+      // Same session, not a new row — otherwise "your active sessions" becomes
+      // a list of every 15-minute window since sign-in.
+      expect(await db.userSession.count({ where: { userId } })).toBe(1);
+    });
+
+    it('matches the stored fragment when revoking a rejected grant', async () => {
+      await seedSession();
+
+      const result = await db.userSession.updateMany({
+        where: { refreshToken: fragment(longToken), isActive: true },
+        data: {
+          isActive: false,
+          revokedAt: new Date(),
+          revokedReason: 'refresh_rejected',
+        },
+      });
+
+      expect(result.count).toBe(1);
+
+      const revoked = await db.userSession.findFirst({ where: { userId } });
+      expect(revoked?.isActive).toBe(false);
+      expect(revoked?.revokedReason).toBe('refresh_rejected');
+    });
+
+    it('does not touch an already-rotated session when an old token is replayed', async () => {
+      await seedSession();
+      const rotatedAway = `new.${'d'.repeat(200)}.ROTATED-AWAY-TAIL`;
+      await db.userSession.updateMany({
+        where: { refreshToken: fragment(longToken) },
+        data: { refreshToken: fragment(rotatedAway) },
+      });
+
+      // Replaying the consumed token now matches nothing, which is why
+      // revocation is documented as best-effort and GoTrue's own reuse
+      // detection is the real defence.
+      const result = await db.userSession.updateMany({
+        where: { refreshToken: fragment(longToken), isActive: true },
+        data: { isActive: false, revokedReason: 'refresh_rejected' },
+      });
+
+      expect(result.count).toBe(0);
+      const untouched = await db.userSession.findFirst({ where: { userId } });
+      expect(untouched?.isActive).toBe(true);
+    });
+  });
+});

--- a/apps/backend/__tests__/integration/auth/session-refresh.integration.spec.ts
+++ b/apps/backend/__tests__/integration/auth/session-refresh.integration.spec.ts
@@ -14,9 +14,15 @@
  */
 import {
   cleanDatabase,
+  clearInbucketMailbox,
   createUser,
   disconnectDatabase,
+  generateTestEmail,
   getDbService,
+  getMagicLinkFromInbucket,
+  graphqlRequest,
+  INBUCKET_URL,
+  waitFor,
 } from '../utils';
 
 const GATEWAY_URL = process.env.API_GATEWAY_URL || 'http://localhost:3000';
@@ -221,5 +227,203 @@ describe('Session refresh (#977)', () => {
       const untouched = await db.userSession.findFirst({ where: { userId } });
       expect(untouched?.isActive).toBe(true);
     });
+  });
+
+  /**
+   * The happy path, against a REAL GoTrue refresh token.
+   *
+   * Everything else in this file — and every unit test in the series — proves
+   * a failure path or mocks the Supabase client. Until this existed, the one
+   * thing never executed was renewal actually SUCCEEDING: whether
+   * `supabase.auth.refreshSession()` works when the client was constructed
+   * from a service-role key with `persistSession: false`, which is how the
+   * provider builds it.
+   *
+   * The session is obtained the way a browser gets one: request a magic link,
+   * read it out of Inbucket, and follow GoTrue's /verify redirect, which comes
+   * back as a 303 whose Location fragment carries the tokens.
+   *
+   * NOT via the verifyMagicLink mutation. That takes an OTP code, while the
+   * link carries a token_hash, so it rejects both signup and magiclink tokens
+   * from a real email. The app works because the callback page reads the hash
+   * fragment instead — see the note at the end of this file.
+   */
+  describe('renewal against a real GoTrue session', () => {
+    let db: Awaited<ReturnType<typeof getDbService>>;
+    let inbucketUp = false;
+
+    beforeAll(async () => {
+      db = await getDbService();
+      // Checked ONCE, loudly. Previously every failure inside the login helper
+      // looked like missing infrastructure, so these tests reported green
+      // while proving nothing — the exact failure mode this whole issue is
+      // about. Now: infrastructure absent => skip; anything else => fail.
+      inbucketUp = await fetch(`${INBUCKET_URL}/api/v1/mailbox/probe`)
+        .then((r) => r.ok)
+        .catch(() => false);
+      if (!inbucketUp) {
+        console.warn(
+          'Inbucket unreachable — real-session renewal tests will SKIP. ' +
+            'Run `pnpm integration:up` to execute them.',
+        );
+      }
+    });
+
+    /**
+     * Full magic-link login yielding a genuine GoTrue session.
+     * Throws on any failure that is not "Inbucket is not running".
+     */
+    async function loginViaMagicLink(): Promise<{
+      email: string;
+      accessToken: string;
+      refreshToken: string;
+    }> {
+      const email = generateTestEmail();
+      await clearInbucketMailbox(email);
+
+      const sent = await graphqlRequest<{ registerWithMagicLink: boolean }>(`
+        mutation {
+          registerWithMagicLink(input: {
+            email: "${email}",
+            redirectTo: "http://localhost:3000/auth/callback"
+          })
+        }
+      `);
+      expect(sent.data?.registerWithMagicLink).toBe(true);
+
+      let verifyUrl: string | null = null;
+      await waitFor(
+        async () => {
+          verifyUrl = await getMagicLinkFromInbucket(email);
+          return verifyUrl !== null;
+        },
+        { timeoutMs: 20000, intervalMs: 1000 },
+      );
+      if (!verifyUrl)
+        throw new Error(`No magic-link email arrived for ${email}`);
+
+      // Follow the link the way a browser does, but stop at the redirect so we
+      // can read the fragment GoTrue puts the tokens in.
+      const verified = await fetch(verifyUrl, { redirect: 'manual' });
+      const location = verified.headers.get('location') || '';
+      const fragmentParams = new URLSearchParams(location.split('#')[1] || '');
+
+      const accessToken = fragmentParams.get('access_token');
+      const refreshToken = fragmentParams.get('refresh_token');
+      if (!accessToken || !refreshToken) {
+        throw new Error(
+          `GoTrue /verify did not return tokens (status ${verified.status})`,
+        );
+      }
+
+      // Hand the session to our backend, exactly as /auth/callback does with
+      // the hash fragment. This is what creates the UserSession row — without
+      // it the tokens are valid but the app has never seen the login, and
+      // rotation would have no row to update.
+      const exchanged = await graphqlRequest<{
+        exchangeSupabaseSession: { accessToken: string };
+      }>(`
+        mutation {
+          exchangeSupabaseSession(input: {
+            accessToken: "${accessToken}",
+            refreshToken: "${refreshToken}"
+          }) { accessToken }
+        }
+      `);
+      if (!exchanged.data?.exchangeSupabaseSession) {
+        throw new Error('Backend rejected the GoTrue session exchange');
+      }
+
+      return { email, accessToken, refreshToken };
+    }
+
+    const renew = (refreshToken: string) =>
+      fetch(REFRESH_URL, {
+        method: 'POST',
+        headers: {
+          'X-CSRF-Token': csrf,
+          Cookie: `csrf-token=${csrf}; refresh-token=${refreshToken}`,
+        },
+      });
+
+    it('renews a real session: 204, no body, rotated tokens', async () => {
+      if (!inbucketUp) return;
+      const session = await loginViaMagicLink();
+
+      const response = await renew(session.refreshToken);
+
+      // The assertion nothing else in this series makes: renewal SUCCEEDING
+      // against a real provider.
+      expect(response.status).toBe(204);
+      expect(await response.text()).toBe('');
+
+      const setCookie = response.headers.get('set-cookie') || '';
+      const newAccess = /access-token=([^;]+)/.exec(setCookie)?.[1];
+      const newRefresh = /refresh-token=([^;]+)/.exec(setCookie)?.[1];
+
+      expect(newAccess).toBeTruthy();
+      expect(newRefresh).toBeTruthy();
+
+      // GoTrue rotates the REFRESH token. Handing back the same one would
+      // break every caller exactly one renewal later, and look fine until
+      // then — so this is the assertion that matters.
+      expect(newRefresh).not.toBe(session.refreshToken);
+
+      // The access token is deliberately NOT asserted to differ. A JWT minted
+      // in the same second as the original carries identical claims, so it is
+      // byte-identical — which is what happens here, renewing milliseconds
+      // after login, and never in real use. What matters is that a fresh
+      // access cookie was issued with a full lifetime.
+      expect(setCookie).toMatch(/access-token=[^;]+;.*Max-Age=9\d\d/);
+
+      // The renewed cookies must keep their scopes, or the next renewal
+      // silently cannot happen.
+      expect(setCookie).toContain('Path=/api/auth/refresh');
+      expect(setCookie).toContain('HttpOnly');
+    }, 45000);
+
+    it('rotates the UserSession row rather than adding one', async () => {
+      if (!inbucketUp) return;
+      const session = await loginViaMagicLink();
+
+      const user = await db.user.findFirst({ where: { email: session.email } });
+      if (!user) throw new Error('Magic-link login did not create an app user');
+
+      const before = await db.userSession.count({ where: { userId: user.id } });
+
+      expect((await renew(session.refreshToken)).status).toBe(204);
+
+      // Session bookkeeping is fire-and-forget, so let the write land.
+      await waitFor(
+        async () => {
+          const row = await db.userSession.findFirst({
+            where: { userId: user.id },
+          });
+          return !!row && row.refreshToken !== fragment(session.refreshToken);
+        },
+        { timeoutMs: 10000, intervalMs: 500 },
+      );
+
+      const after = await db.userSession.count({ where: { userId: user.id } });
+      expect(after).toBe(before);
+    }, 45000);
+
+    it('keeps renewing — a renewed token can itself be renewed', async () => {
+      if (!inbucketUp) return;
+      const session = await loginViaMagicLink();
+
+      const first = await renew(session.refreshToken);
+      expect(first.status).toBe(204);
+      const rotated = /refresh-token=([^;]+)/.exec(
+        first.headers.get('set-cookie') || '',
+      )?.[1];
+      expect(rotated).toBeTruthy();
+
+      // The point of the whole change: a session stays alive indefinitely, not
+      // for exactly one renewal. A latch that never released, or a rotation
+      // that was not persisted, would fail here and nowhere else.
+      const second = await renew(rotated!);
+      expect(second.status).toBe(204);
+    }, 60000);
   });
 });

--- a/apps/backend/__tests__/integration/auth/session-refresh.integration.spec.ts
+++ b/apps/backend/__tests__/integration/auth/session-refresh.integration.spec.ts
@@ -21,7 +21,6 @@ import {
   getDbService,
   getMagicLinkFromInbucket,
   graphqlRequest,
-  INBUCKET_URL,
   waitFor,
 } from '../utils';
 
@@ -51,9 +50,41 @@ const clearsCookie = (setCookie: string, name: string) =>
 
 describe('Session refresh (#977)', () => {
   let csrf: string;
+  /**
+   * Whether a real auth provider (GoTrue) is reachable behind the users
+   * service. NOT the same as "Inbucket is up" — the CI E2E stack runs
+   * inbucket but no supabase-auth, so probing the mailbox says nothing about
+   * whether a session can actually be minted or a grant actually rejected.
+   * Probing the wrong thing is what made these tests fail in CI while passing
+   * locally.
+   */
+  let authProviderUp = false;
 
   beforeAll(async () => {
     csrf = await getCsrfToken();
+
+    // Send a magic link and see whether the stack accepts it. This exercises
+    // the same path the gated tests depend on, so it cannot pass while they
+    // would fail.
+    authProviderUp = await graphqlRequest<{ registerWithMagicLink: boolean }>(`
+      mutation {
+        registerWithMagicLink(input: {
+          email: "${generateTestEmail()}",
+          redirectTo: "http://localhost:3000/auth/callback"
+        })
+      }
+    `)
+      .then((r) => r.data?.registerWithMagicLink === true)
+      .catch(() => false);
+
+    if (!authProviderUp) {
+      console.warn(
+        'No auth provider reachable (GoTrue absent) — tests that need a real ' +
+          'grant will SKIP. Expected in the CI E2E stack, which starts no ' +
+          'supabase-auth service. Run `pnpm integration:up` with the full ' +
+          'local stack to execute them.',
+      );
+    }
   });
 
   afterAll(async () => {
@@ -102,6 +133,13 @@ describe('Session refresh (#977)', () => {
     });
 
     it('401s on a refresh token the provider rejects', async () => {
+      // Needs a provider that can REJECT. With none reachable the controller
+      // correctly answers 503 (unreachable, keep the session) rather than 401
+      // (dead, sign out) — that distinction is the point of the change, so
+      // asserting 401 here without a provider would be asserting the wrong
+      // behaviour.
+      if (!authProviderUp) return;
+
       const response = await fetch(REFRESH_URL, {
         method: 'POST',
         headers: {
@@ -250,23 +288,9 @@ describe('Session refresh (#977)', () => {
    */
   describe('renewal against a real GoTrue session', () => {
     let db: Awaited<ReturnType<typeof getDbService>>;
-    let inbucketUp = false;
 
     beforeAll(async () => {
       db = await getDbService();
-      // Checked ONCE, loudly. Previously every failure inside the login helper
-      // looked like missing infrastructure, so these tests reported green
-      // while proving nothing — the exact failure mode this whole issue is
-      // about. Now: infrastructure absent => skip; anything else => fail.
-      inbucketUp = await fetch(`${INBUCKET_URL}/api/v1/mailbox/probe`)
-        .then((r) => r.ok)
-        .catch(() => false);
-      if (!inbucketUp) {
-        console.warn(
-          'Inbucket unreachable — real-session renewal tests will SKIP. ' +
-            'Run `pnpm integration:up` to execute them.',
-        );
-      }
     });
 
     /**
@@ -347,7 +371,7 @@ describe('Session refresh (#977)', () => {
       });
 
     it('renews a real session: 204, no body, rotated tokens', async () => {
-      if (!inbucketUp) return;
+      if (!authProviderUp) return;
       const session = await loginViaMagicLink();
 
       const response = await renew(session.refreshToken);
@@ -383,7 +407,7 @@ describe('Session refresh (#977)', () => {
     }, 45000);
 
     it('rotates the UserSession row rather than adding one', async () => {
-      if (!inbucketUp) return;
+      if (!authProviderUp) return;
       const session = await loginViaMagicLink();
 
       const user = await db.user.findFirst({ where: { email: session.email } });
@@ -409,7 +433,7 @@ describe('Session refresh (#977)', () => {
     }, 45000);
 
     it('keeps renewing — a renewed token can itself be renewed', async () => {
-      if (!inbucketUp) return;
+      if (!authProviderUp) return;
       const session = await loginViaMagicLink();
 
       const first = await renew(session.refreshToken);

--- a/apps/backend/src/api/src/app.module.ts
+++ b/apps/backend/src/api/src/app.module.ts
@@ -42,6 +42,7 @@ import { GracefulShutdownService } from 'src/common/services/graceful-shutdown.s
 import { HmacRemoteGraphQLDataSource } from './hmac-data-source';
 import { GatewayServicesModule } from './gateway-services.module';
 import { WebSocketConnectionException } from 'src/common/exceptions/app.exceptions';
+import { AuthRefreshController } from './auth-refresh.controller';
 
 /**
  * Extract authenticated user from request context for GraphQL operations.
@@ -230,6 +231,12 @@ const handleAuth = ({ req, res }: { req: Request; res: Response }) => {
         MetricsService,
       ],
     }),
+  ],
+  controllers: [
+    // Session renewal. The gateway's only REST route, because the refresh
+    // cookie is path-scoped to /api/auth/refresh and the renewal mutation is
+    // @inaccessible — see the controller for why both of those are deliberate.
+    AuthRefreshController,
   ],
   providers: [
     // SECURITY: Exception filters for error sanitization

--- a/apps/backend/src/api/src/auth-refresh.controller.spec.ts
+++ b/apps/backend/src/api/src/auth-refresh.controller.spec.ts
@@ -1,0 +1,214 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { Request, Response } from 'express';
+import {
+  UnauthorizedException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { AuthRefreshController } from './auth-refresh.controller';
+import { HmacSignerService } from 'src/common/services/hmac-signer.service';
+
+const MICROSERVICES = JSON.stringify([
+  { name: 'users', url: 'http://users:3001/graphql' },
+  { name: 'documents', url: 'http://documents:3002/graphql' },
+]);
+
+const createConfigService = () =>
+  ({
+    get: jest.fn((key: string) => {
+      if (key === 'MICROSERVICES') return MICROSERVICES;
+      if (key === 'cookie.refreshTokenName') return 'refresh-token';
+      return undefined;
+    }),
+  }) as unknown as ConfigService;
+
+const createRequest = (cookies: Record<string, string> = {}) =>
+  ({ cookies }) as unknown as Request;
+
+const createResponse = () =>
+  ({
+    cookie: jest.fn(),
+    clearCookie: jest.fn(),
+  }) as unknown as Response;
+
+const renewed = {
+  accessToken: 'new-access',
+  idToken: 'new-id',
+  refreshToken: 'rotated-refresh',
+};
+
+describe('AuthRefreshController', () => {
+  let controller: AuthRefreshController;
+  let hmacSigner: { isEnabled: jest.Mock; signGraphQLRequest: jest.Mock };
+  const fetchMock = jest.fn();
+
+  beforeEach(async () => {
+    hmacSigner = {
+      isEnabled: jest.fn().mockReturnValue(true),
+      signGraphQLRequest: jest.fn().mockReturnValue('signed-hmac-header'),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthRefreshController],
+      providers: [
+        { provide: ConfigService, useValue: createConfigService() },
+        { provide: HmacSignerService, useValue: hmacSigner },
+      ],
+    }).compile();
+
+    controller = module.get<AuthRefreshController>(AuthRefreshController);
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const okResponse = () => ({
+    json: jest.fn().mockResolvedValue({ data: { refreshSession: renewed } }),
+  });
+
+  const errorResponse = (code?: string) => ({
+    json: jest.fn().mockResolvedValue({
+      errors: [{ message: 'nope', extensions: code ? { code } : undefined }],
+    }),
+  });
+
+  describe('success', () => {
+    it('should set fresh cookies and return no body', async () => {
+      fetchMock.mockResolvedValue(okResponse());
+      const res = createResponse();
+
+      const result = await controller.refresh(
+        createRequest({ 'refresh-token': 'old-token' }),
+        res,
+      );
+
+      expect(res.cookie).toHaveBeenCalled();
+      // 204 means the tokens live in cookies and nowhere a script can read.
+      expect(result).toBeUndefined();
+    });
+
+    it('should call the users subgraph, not another one', async () => {
+      fetchMock.mockResolvedValue(okResponse());
+
+      await controller.refresh(
+        createRequest({ 'refresh-token': 'old-token' }),
+        createResponse(),
+      );
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe('http://users:3001/graphql');
+      expect(JSON.parse(init.body).variables.refreshToken).toBe('old-token');
+    });
+
+    it('should sign the call so the subgraph accepts it', async () => {
+      fetchMock.mockResolvedValue(okResponse());
+
+      await controller.refresh(
+        createRequest({ 'refresh-token': 'old-token' }),
+        createResponse(),
+      );
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers['X-HMAC-Auth']).toBe('signed-hmac-header');
+    });
+  });
+
+  describe('terminal failures — sign in again', () => {
+    it('should 401 and clear cookies when no refresh cookie is present', async () => {
+      const res = createResponse();
+
+      await expect(controller.refresh(createRequest(), res)).rejects.toThrow(
+        UnauthorizedException,
+      );
+
+      expect(res.clearCookie).toHaveBeenCalled();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should 401 and clear cookies when the grant was rejected', async () => {
+      fetchMock.mockResolvedValue(errorResponse('REFRESH_TOKEN_INVALID'));
+      const res = createResponse();
+
+      await expect(
+        controller.refresh(createRequest({ 'refresh-token': 'dead' }), res),
+      ).rejects.toThrow(UnauthorizedException);
+
+      expect(res.clearCookie).toHaveBeenCalled();
+    });
+  });
+
+  // The whole point of carrying the error code through from subtask 2. Every
+  // case here must keep the cookies: none of them is evidence the session is
+  // dead, and clearing them turns a transient failure into a forced sign-out
+  // for every active user at once.
+  describe('transient failures — keep the session', () => {
+    it.each([
+      [
+        'the subgraph is unreachable',
+        () => fetchMock.mockRejectedValue(new Error('ECONNREFUSED')),
+      ],
+      [
+        'the response is not JSON',
+        () =>
+          fetchMock.mockResolvedValue({
+            json: jest.fn().mockRejectedValue(new Error('bad json')),
+          }),
+      ],
+      [
+        'the provider was unavailable upstream',
+        () => fetchMock.mockResolvedValue(errorResponse('REFRESH_ERROR')),
+      ],
+      [
+        'the error carries no code at all',
+        () => fetchMock.mockResolvedValue(errorResponse(undefined)),
+      ],
+      [
+        'the response has neither tokens nor errors',
+        () =>
+          fetchMock.mockResolvedValue({
+            json: jest.fn().mockResolvedValue({ data: {} }),
+          }),
+      ],
+    ])('should 503 and NOT clear cookies when %s', async (_label, arrange) => {
+      arrange();
+      const res = createResponse();
+
+      await expect(
+        controller.refresh(createRequest({ 'refresh-token': 'good' }), res),
+      ).rejects.toThrow(ServiceUnavailableException);
+
+      expect(res.clearCookie).not.toHaveBeenCalled();
+      expect(res.cookie).not.toHaveBeenCalled();
+    });
+  });
+
+  it('should fail without clearing cookies when no users subgraph is configured', async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthRefreshController],
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) =>
+              key === 'MICROSERVICES' ? '[]' : 'refresh-token',
+            ),
+          },
+        },
+        { provide: HmacSignerService, useValue: hmacSigner },
+      ],
+    }).compile();
+    const misconfigured = module.get<AuthRefreshController>(
+      AuthRefreshController,
+    );
+    const res = createResponse();
+
+    await expect(
+      misconfigured.refresh(createRequest({ 'refresh-token': 'good' }), res),
+    ).rejects.toThrow(ServiceUnavailableException);
+
+    // A deployment mistake must not log every user out.
+    expect(res.clearCookie).not.toHaveBeenCalled();
+  });
+});

--- a/apps/backend/src/api/src/auth-refresh.controller.spec.ts
+++ b/apps/backend/src/api/src/auth-refresh.controller.spec.ts
@@ -5,8 +5,10 @@ import {
   UnauthorizedException,
   ServiceUnavailableException,
 } from '@nestjs/common';
+import { PATH_METADATA } from '@nestjs/common/constants';
 import { AuthRefreshController } from './auth-refresh.controller';
 import { HmacSignerService } from 'src/common/services/hmac-signer.service';
+import { REFRESH_COOKIE_PATH } from 'src/common/utils/cookie.utils';
 
 const MICROSERVICES = JSON.stringify([
   { name: 'users', url: 'http://users:3001/graphql' },
@@ -38,6 +40,26 @@ const renewed = {
 };
 
 describe('AuthRefreshController', () => {
+  // The failure this guards against is silent. If the served route and the
+  // cookie's path ever diverge, the browser simply never sends the refresh
+  // cookie: no error, no log — renewal 401s and the user is bounced to
+  // /login, which is the bug #977 fixed. Nothing else ties these together,
+  // because they are set by decorators in one file and a constant in another.
+  it('serves exactly the path the refresh cookie is scoped to', () => {
+    const controllerPath = Reflect.getMetadata(
+      PATH_METADATA,
+      AuthRefreshController,
+    );
+    const methodPath = Reflect.getMetadata(
+      PATH_METADATA,
+      AuthRefreshController.prototype.refresh,
+    );
+
+    const served = `/${controllerPath}/${methodPath}`.replace(/\/+/g, '/');
+
+    expect(served).toBe(REFRESH_COOKIE_PATH);
+  });
+
   let controller: AuthRefreshController;
   let hmacSigner: { isEnabled: jest.Mock; signGraphQLRequest: jest.Mock };
   const fetchMock = jest.fn();

--- a/apps/backend/src/api/src/auth-refresh.controller.ts
+++ b/apps/backend/src/api/src/auth-refresh.controller.ts
@@ -1,0 +1,170 @@
+import {
+  Controller,
+  HttpCode,
+  Post,
+  Req,
+  Res,
+  UnauthorizedException,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Request, Response } from 'express';
+import { HmacSignerService } from 'src/common/services/hmac-signer.service';
+import { SecureLogger } from 'src/common/services/secure-logger.service';
+import {
+  setAuthCookies,
+  clearAuthCookies,
+} from 'src/common/utils/cookie.utils';
+
+/**
+ * The renewal mutation lives on the users subgraph and is `@inaccessible`, so
+ * it is absent from the composed public schema and unreachable through the
+ * federated router. This controller calls the subgraph directly instead, which
+ * is the entire reason it exists as REST rather than as a client-facing
+ * mutation.
+ */
+const REFRESH_MUTATION = `
+  mutation RefreshSession($refreshToken: String!) {
+    refreshSession(refreshToken: $refreshToken) {
+      accessToken
+      idToken
+      refreshToken
+    }
+  }
+`;
+
+interface SubgraphConfig {
+  name: string;
+  url: string;
+}
+
+/**
+ * Session renewal endpoint — `POST /api/auth/refresh`.
+ *
+ * The path is not arbitrary. `setAuthCookies` has always scoped the refresh
+ * cookie to `path: '/api/auth/refresh'`, so the browser sends that cookie here
+ * and to nothing else. Serving renewal anywhere else — including as a plain
+ * GraphQL mutation at `/api` — would mean widening that scope and shipping a
+ * 7-day credential with every request. The endpoint moved to meet the cookie,
+ * not the other way round.
+ *
+ * SECURITY NOTES
+ * - Responds 204 with NO body. The renewed tokens go back as httpOnly cookies
+ *   and must never be readable by JavaScript.
+ * - `CsrfMiddleware` covers this route via `forRoutes({path: '*'})`, so a POST
+ *   without `X-CSRF-Token` is rejected before any of this runs. Callers must
+ *   send it.
+ * - The global `AuthGuard` defers on non-GraphQL execution contexts, which is
+ *   required here: the access token is expired by definition, and the refresh
+ *   cookie is the credential.
+ */
+@Controller('api/auth')
+export class AuthRefreshController {
+  private readonly logger = new SecureLogger(AuthRefreshController.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly hmacSigner: HmacSignerService,
+  ) {}
+
+  private getUsersSubgraphUrl(): string {
+    const raw = this.configService.get<string>('MICROSERVICES');
+    const subgraphs = JSON.parse(raw || '[]') as SubgraphConfig[];
+    const users = subgraphs.find((s) => s.name === 'users');
+    if (!users?.url) {
+      throw new Error('No users subgraph configured in MICROSERVICES');
+    }
+    return users.url;
+  }
+
+  @Post('refresh')
+  @HttpCode(204)
+  async refresh(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const cookieName =
+      this.configService.get<string>('cookie.refreshTokenName') ||
+      'refresh-token';
+    const refreshToken = req.cookies?.[cookieName];
+
+    if (!refreshToken) {
+      // Nothing to renew. Clear whatever is left so the browser stops
+      // presenting a half-dead session on every subsequent request.
+      clearAuthCookies(res, this.configService);
+      throw new UnauthorizedException('No refresh token');
+    }
+
+    let payload: {
+      data?: { refreshSession?: RenewedTokens };
+      errors?: { message: string; extensions?: { code?: string } }[];
+    };
+
+    try {
+      const url = this.getUsersSubgraphUrl();
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (this.hmacSigner.isEnabled()) {
+        headers['X-HMAC-Auth'] = this.hmacSigner.signGraphQLRequest(url);
+      }
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          query: REFRESH_MUTATION,
+          variables: { refreshToken },
+        }),
+      });
+
+      payload = await response.json();
+    } catch (error) {
+      // The users service was unreachable, or answered with something that is
+      // not JSON. Cookies are deliberately LEFT ALONE — this says nothing
+      // about whether the session is still valid, and clearing them here would
+      // turn a transient outage into a forced sign-out for every active user.
+      this.logger.error(
+        `Refresh call to users subgraph failed: ${(error as Error).message}`,
+      );
+      throw new ServiceUnavailableException('Session renewal unavailable');
+    }
+
+    const error = payload.errors?.[0];
+    if (error) {
+      // The distinction subtask 2 went to the trouble of preserving. Only a
+      // rejected grant means "sign in again"; anything else is "try again".
+      if (error.extensions?.code === 'REFRESH_TOKEN_INVALID') {
+        clearAuthCookies(res, this.configService);
+        throw new UnauthorizedException('Session expired');
+      }
+      this.logger.error(`Refresh rejected upstream: ${error.message}`);
+      throw new ServiceUnavailableException('Session renewal unavailable');
+    }
+
+    const auth = payload.data?.refreshSession;
+    if (!auth?.accessToken) {
+      // No errors and no tokens should not happen. Treated as unavailable
+      // rather than expired, because we have no evidence the session is dead
+      // and the safe-looking default — clearing cookies — is the destructive
+      // one.
+      this.logger.error('Refresh returned neither tokens nor an error');
+      throw new ServiceUnavailableException('Session renewal unavailable');
+    }
+
+    setAuthCookies(
+      res,
+      this.configService,
+      auth.accessToken,
+      auth.refreshToken,
+    );
+
+    // 204, no body. The tokens are in the cookies and nowhere else.
+  }
+}
+
+interface RenewedTokens {
+  accessToken: string;
+  idToken: string;
+  refreshToken: string;
+}

--- a/apps/backend/src/apps/users/src/domains/auth/auth.resolver.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.resolver.spec.ts
@@ -668,4 +668,121 @@ describe('AuthResolver', () => {
       ).rejects.toThrow('Invalid or expired access token');
     });
   });
+
+  describe('refreshSession', () => {
+    const renewed = {
+      accessToken: 'a'.repeat(20) + 'NEW-ACCESS-TAIL-32CHARS-PADDING',
+      idToken: 'id-token',
+      refreshToken: 'r'.repeat(20) + 'NEW-REFRESH-TAIL-32CHARS-PADDIN',
+    };
+
+    it('should rotate the existing session row rather than create one', async () => {
+      authService.refreshSession = jest.fn().mockResolvedValue(renewed);
+
+      await resolver.refreshSession('old-refresh-token', createMockContext());
+
+      expect(mockDbService.userSession.create).not.toHaveBeenCalled();
+      expect(mockDbService.userSession.updateMany).toHaveBeenCalledWith({
+        where: {
+          refreshToken: 'old-refresh-token'.slice(-32),
+          isActive: true,
+        },
+        data: expect.objectContaining({
+          sessionToken: renewed.accessToken.slice(-32),
+          refreshToken: renewed.refreshToken.slice(-32),
+        }),
+      });
+    });
+
+    it('should set fresh auth cookies on success', async () => {
+      authService.refreshSession = jest.fn().mockResolvedValue(renewed);
+      const context = createMockContext();
+
+      await resolver.refreshSession('old-refresh-token', context);
+
+      expect(context.res?.cookie).toHaveBeenCalled();
+    });
+
+    it('should revoke the session when the grant itself was rejected', async () => {
+      authService.refreshSession = jest.fn().mockRejectedValue(
+        Object.assign(new Error('bad token'), {
+          code: 'REFRESH_TOKEN_INVALID',
+        }),
+      );
+
+      await expect(
+        resolver.refreshSession('dead-token', createMockContext()),
+      ).rejects.toThrow('bad token');
+
+      expect(mockDbService.userSession.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            isActive: false,
+            revokedReason: 'refresh_rejected',
+          }),
+        }),
+      );
+    });
+
+    // The distinction the whole change rests on. If a provider outage revoked
+    // sessions, every GoTrue hiccup would sign out every active user — which
+    // is the failure #977 exists to remove, not one to reintroduce.
+    it('should NOT revoke the session when the provider was merely unreachable', async () => {
+      authService.refreshSession = jest
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error('upstream down'), { code: 'REFRESH_ERROR' }),
+        );
+
+      await expect(
+        resolver.refreshSession('good-token', createMockContext()),
+      ).rejects.toThrow('upstream down');
+
+      expect(mockDbService.userSession.updateMany).not.toHaveBeenCalled();
+    });
+
+    // The gateway route reads this to decide 401-and-clear-cookies vs
+    // try-again. If the code were dropped, both would look identical and the
+    // safe-looking default is to sign the user out.
+    it.each([
+      ['REFRESH_TOKEN_INVALID', 'REFRESH_TOKEN_INVALID'],
+      ['REFRESH_ERROR', 'REFRESH_ERROR'],
+    ])(
+      'should surface a %s code in the GraphQL error extensions',
+      async (code, expected) => {
+        authService.refreshSession = jest
+          .fn()
+          .mockRejectedValue(Object.assign(new Error('failed'), { code }));
+
+        await expect(
+          resolver.refreshSession('a-token', createMockContext()),
+        ).rejects.toMatchObject({ extensions: { code: expected } });
+      },
+    );
+
+    it('should default to REFRESH_ERROR when the failure carries no code', async () => {
+      authService.refreshSession = jest
+        .fn()
+        .mockRejectedValue(new Error('something odd'));
+
+      await expect(
+        resolver.refreshSession('a-token', createMockContext()),
+      ).rejects.toMatchObject({ extensions: { code: 'REFRESH_ERROR' } });
+      // An unknown failure must not revoke — same reasoning as REFRESH_ERROR.
+      expect(mockDbService.userSession.updateMany).not.toHaveBeenCalled();
+    });
+
+    // Bookkeeping is best-effort: the tokens are already minted and the user
+    // is already signed in by the time rotation runs.
+    it('should still return tokens when session bookkeeping fails', async () => {
+      authService.refreshSession = jest.fn().mockResolvedValue(renewed);
+      mockDbService.userSession.updateMany.mockRejectedValueOnce(
+        new Error('db down'),
+      );
+
+      await expect(
+        resolver.refreshSession('old-refresh-token', createMockContext()),
+      ).resolves.toEqual(renewed);
+    });
+  });
 });

--- a/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
@@ -1,4 +1,4 @@
-import { Args, Mutation, Resolver, Context } from '@nestjs/graphql';
+import { Args, Mutation, Resolver, Context, Directive } from '@nestjs/graphql';
 import { ConfigService } from '@nestjs/config';
 import { ForbiddenException, Optional } from '@nestjs/common';
 import { Throttle } from '@nestjs/throttler';
@@ -92,6 +92,60 @@ export class AuthResolver {
       );
     }
     this.createSession(userId, auth.accessToken, auth.refreshToken, context);
+  }
+
+  /**
+   * Rotate the session record in place after a successful renewal.
+   *
+   * An UPDATE, not a create: a renewed session is the same session, and
+   * creating a row per renewal would turn "your active sessions" into a list
+   * of every 15-minute window since the user signed in.
+   *
+   * Matched on the last-32 fragment of the OLD refresh token, which is what
+   * `createSession` stored. Best-effort, like `createSession` — a bookkeeping
+   * failure must not fail the renewal, because the tokens are already minted
+   * and the user is already signed in by the time we get here.
+   */
+  private rotateSession(oldRefreshToken: string, auth: Auth): void {
+    this.db.userSession
+      .updateMany({
+        where: { refreshToken: oldRefreshToken.slice(-32), isActive: true },
+        data: {
+          sessionToken: auth.accessToken.slice(-32),
+          refreshToken: auth.refreshToken?.slice(-32),
+          lastActivityAt: new Date(),
+        },
+      })
+      .catch((err: Error) => {
+        this.logger.warn(`Failed to rotate session: ${err.message}`);
+      });
+  }
+
+  /**
+   * Mark the session behind a rejected refresh token as revoked.
+   *
+   * Called ONLY when the provider rejected the grant itself — never when the
+   * provider was merely unreachable, which would sign users out during an
+   * outage.
+   *
+   * Best-effort by nature: GoTrue rotates on redemption, so a replayed old
+   * token usually no longer matches any stored fragment and this updates
+   * nothing. GoTrue's own reuse detection is the real defence; this keeps our
+   * session list honest when it does match.
+   */
+  private revokeSessionByRefreshToken(refreshToken: string): void {
+    this.db.userSession
+      .updateMany({
+        where: { refreshToken: refreshToken.slice(-32), isActive: true },
+        data: {
+          isActive: false,
+          revokedAt: new Date(),
+          revokedReason: 'refresh_rejected',
+        },
+      })
+      .catch((err: Error) => {
+        this.logger.warn(`Failed to revoke session: ${err.message}`);
+      });
   }
 
   private createSession(
@@ -712,6 +766,86 @@ export class AuthResolver {
         errorMessage: error.message,
       });
       throw new UserInputError(error.message);
+    }
+  }
+
+  /**
+   * Redeem a refresh token for a new session.
+   *
+   * `@inaccessible` keeps this OUT of the composed public schema. It is
+   * reachable only by a direct HMAC-signed call from the gateway's refresh
+   * route, never by a client through `/api`. That is deliberate: exposing it
+   * federated would mean clients passing a 7-day credential as a GraphQL
+   * variable, where it lands in query logs, traces and audit payloads — the
+   * one place this change is required to keep tokens out of.
+   *
+   * `@Public()` because the access token is expired by definition here. That
+   * is the whole point; requiring a valid one would make renewal impossible.
+   * The refresh token itself is the credential, and GoTrue validates it.
+   */
+  @Public()
+  @Directive('@inaccessible')
+  @Throttle({ default: AUTH_THROTTLE.refresh })
+  @Mutation(() => Auth)
+  async refreshSession(
+    @Args('refreshToken') refreshToken: string,
+    @Context() context: GqlContext,
+  ): Promise<Auth> {
+    const auditContext = createAuditContext(context, this.serviceName);
+
+    try {
+      const auth = await this.authService.refreshSession(refreshToken);
+
+      // Cookies are set here as well as by the gateway route, because
+      // didReceiveResponse forwards subgraph Set-Cookie headers and login
+      // already relies on that path. Setting them twice is harmless; setting
+      // them nowhere would leave the browser on the old, dead token.
+      if (context.res) {
+        setAuthCookies(
+          context.res,
+          this.configService,
+          auth.accessToken,
+          auth.refreshToken,
+        );
+      }
+
+      this.rotateSession(refreshToken, auth);
+
+      this.auditLogService?.log({
+        ...auditContext,
+        action: AuditAction.TOKEN_REFRESH,
+        success: true,
+        resolverName: 'refreshSession',
+        operationType: 'mutation',
+      });
+
+      return auth;
+    } catch (error) {
+      // Only a rejected GRANT kills the session. A provider outage
+      // (REFRESH_ERROR) must not, or every GoTrue hiccup signs out every
+      // active user — the exact failure #977 exists to remove.
+      const code = (error as { code?: string }).code;
+      if (code === 'REFRESH_TOKEN_INVALID') {
+        this.revokeSessionByRefreshToken(refreshToken);
+      }
+
+      this.auditLogService?.logSync({
+        ...auditContext,
+        action: AuditAction.SESSION_EXPIRED,
+        success: false,
+        resolverName: 'refreshSession',
+        operationType: 'mutation',
+        errorMessage: error.message,
+      });
+
+      // Carry the provider's code into the GraphQL error extensions. Without
+      // it the gateway route cannot tell a rejected grant ("sign in again",
+      // clear the cookies, 401) from an upstream outage ("try again", keep
+      // them) — every wrapped error would look identical and the safe-looking
+      // default is to sign the user out.
+      throw new UserInputError(error.message, {
+        extensions: { code: code ?? 'REFRESH_ERROR' },
+      });
     }
   }
 }

--- a/apps/backend/src/apps/users/src/domains/auth/auth.service.spec.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.service.spec.ts
@@ -724,4 +724,43 @@ describe('AuthService', () => {
       expect(usersService.updateUserId).not.toHaveBeenCalled();
     });
   });
+
+  describe('refreshSession', () => {
+    it('should redeem the token and return the rotated pair', async () => {
+      authProvider.refreshSession = jest.fn().mockResolvedValue({
+        accessToken: 'new-access',
+        idToken: 'new-access',
+        refreshToken: 'rotated-refresh',
+      });
+
+      const auth = await authService.refreshSession('old-refresh');
+
+      expect(authProvider.refreshSession).toHaveBeenCalledWith('old-refresh');
+      expect(auth.accessToken).toBe('new-access');
+      expect(auth.refreshToken).toBe('rotated-refresh');
+    });
+
+    it('should throw when the provider cannot refresh', async () => {
+      authProvider.refreshSession = undefined;
+
+      await expect(authService.refreshSession('any-token')).rejects.toThrow(
+        'Session refresh requires refreshSession support',
+      );
+    });
+
+    // The resolver decides revoke-vs-retry from `code`. Wrapping the provider
+    // error would erase that and turn every outage into a forced logout.
+    it.each([['REFRESH_TOKEN_INVALID'], ['REFRESH_ERROR']])(
+      'should propagate a %s error with its code intact',
+      async (code) => {
+        authProvider.refreshSession = jest
+          .fn()
+          .mockRejectedValue(Object.assign(new Error('nope'), { code }));
+
+        await expect(
+          authService.refreshSession('some-token'),
+        ).rejects.toMatchObject({ code });
+      },
+    );
+  });
 });

--- a/apps/backend/src/apps/users/src/domains/auth/auth.service.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.service.ts
@@ -343,6 +343,35 @@ export class AuthService {
     };
   }
 
+  /**
+   * Redeem a refresh token for a new session.
+   *
+   * The provider ROTATES: the refreshToken coming back is not the one going
+   * in, and the old one stops working. Callers must persist what is returned
+   * — see `AuthResolver.rotateSession`.
+   *
+   * Errors are passed through unwrapped on purpose. The provider distinguishes
+   * `REFRESH_TOKEN_INVALID` (the grant was rejected — terminal, revoke the
+   * session) from `REFRESH_ERROR` (the provider was unreachable — not
+   * terminal, do not revoke), and wrapping them in a generic error here would
+   * destroy the only signal the caller has for telling those apart.
+   */
+  async refreshSession(refreshToken: string): Promise<Auth> {
+    if (!this.authProvider.refreshSession) {
+      throw new Error('Session refresh requires refreshSession support');
+    }
+
+    const result = await this.authProvider.refreshSession(refreshToken);
+
+    this.logger.log('Session refreshed');
+
+    return {
+      accessToken: result.accessToken,
+      idToken: result.idToken,
+      refreshToken: result.refreshToken,
+    };
+  }
+
   private async sendWelcomeEmailSafely(
     userId: string,
     email: string,

--- a/apps/backend/src/common/utils/cookie.utils.spec.ts
+++ b/apps/backend/src/common/utils/cookie.utils.spec.ts
@@ -1,0 +1,96 @@
+import { ConfigService } from '@nestjs/config';
+import { Response } from 'express';
+import {
+  setAuthCookies,
+  clearAuthCookies,
+  REFRESH_COOKIE_PATH,
+} from './cookie.utils';
+
+const createConfigService = (overrides: Record<string, unknown> = {}) =>
+  ({
+    get: jest.fn((key: string) =>
+      key in overrides ? overrides[key] : undefined,
+    ),
+  }) as unknown as ConfigService;
+
+const createResponse = () =>
+  ({
+    cookie: jest.fn(),
+    clearCookie: jest.fn(),
+  }) as unknown as Response;
+
+describe('cookie.utils', () => {
+  const pathOf = (call: unknown[]) =>
+    (call[call.length - 1] as { path?: string }).path;
+
+  describe('refresh cookie scoping', () => {
+    it('sets the refresh cookie at the renewal path, not site-wide', () => {
+      const res = createResponse();
+
+      setAuthCookies(res, createConfigService(), 'access', 'refresh');
+
+      const calls = (res.cookie as jest.Mock).mock.calls;
+      const accessCall = calls[0];
+      const refreshCall = calls[1];
+
+      // The access token is needed on every request; the refresh token is a
+      // 7-day credential and must not ride along with them.
+      expect(pathOf(accessCall)).toBe('/');
+      expect(pathOf(refreshCall)).toBe(REFRESH_COOKIE_PATH);
+    });
+
+    // A clear at the wrong path silently does nothing: the browser keeps
+    // presenting the old refresh cookie after logout.
+    it('clears the refresh cookie at the SAME path it was set at', () => {
+      const setRes = createResponse();
+      setAuthCookies(setRes, createConfigService(), 'access', 'refresh');
+      const setPath = pathOf((setRes.cookie as jest.Mock).mock.calls[1]);
+
+      const clearRes = createResponse();
+      clearAuthCookies(clearRes, createConfigService());
+      const clearCalls = (clearRes.clearCookie as jest.Mock).mock.calls;
+      const clearPath = pathOf(clearCalls[1]);
+
+      expect(clearPath).toBe(setPath);
+    });
+
+    it('clears the access cookie site-wide', () => {
+      const res = createResponse();
+
+      clearAuthCookies(res, createConfigService());
+
+      expect(pathOf((res.clearCookie as jest.Mock).mock.calls[0])).toBe('/');
+    });
+
+    it('omits the refresh cookie entirely when no refresh token is issued', () => {
+      const res = createResponse();
+
+      setAuthCookies(res, createConfigService(), 'access-only');
+
+      expect((res.cookie as jest.Mock).mock.calls).toHaveLength(1);
+    });
+  });
+
+  describe('configured names are honoured on both set and clear', () => {
+    // Renaming the cookie must not orphan the old one at logout.
+    it('uses the configured cookie names symmetrically', () => {
+      const config = createConfigService({
+        'cookie.accessTokenName': 'custom-access',
+        'cookie.refreshTokenName': 'custom-refresh',
+      });
+
+      const setRes = createResponse();
+      setAuthCookies(setRes, config, 'a', 'r');
+      const clearRes = createResponse();
+      clearAuthCookies(clearRes, config);
+
+      const setNames = (setRes.cookie as jest.Mock).mock.calls.map((c) => c[0]);
+      const clearNames = (clearRes.clearCookie as jest.Mock).mock.calls.map(
+        (c) => c[0],
+      );
+
+      expect(setNames).toEqual(['custom-access', 'custom-refresh']);
+      expect(clearNames).toEqual(['custom-access', 'custom-refresh']);
+    });
+  });
+});

--- a/apps/backend/src/common/utils/cookie.utils.ts
+++ b/apps/backend/src/common/utils/cookie.utils.ts
@@ -4,6 +4,22 @@ import { ConfigService } from '@nestjs/config';
 type SameSitePolicy = 'strict' | 'lax' | 'none';
 
 /**
+ * Path the refresh-token cookie is scoped to.
+ *
+ * The browser sends that cookie to this path and NOWHERE else, which is the
+ * point — it keeps a 7-day credential off every other request rather than
+ * riding along with all of them.
+ *
+ * Three things must agree on this value, and they are in different files:
+ * where the cookie is set, where it is cleared, and the route that actually
+ * serves renewal (`AuthRefreshController`). If they drift, nothing errors —
+ * the cookie is simply never sent, renewal fails, and the user is bounced to
+ * `/login`, which is exactly the bug #977 fixed. Hence one constant and a test
+ * that ties the served route back to it.
+ */
+export const REFRESH_COOKIE_PATH = '/api/auth/refresh';
+
+/**
  * Cookie options interface
  */
 export interface CookieOptions {
@@ -67,7 +83,7 @@ export function setAuthCookies(
         maxAge:
           configService.get<number>('cookie.refreshTokenMaxAge') ||
           7 * 24 * 60 * 60 * 1000,
-        path: '/api/auth/refresh', // Only sent to refresh endpoint
+        path: REFRESH_COOKIE_PATH, // Only sent to the renewal endpoint
       }),
     );
   }
@@ -103,6 +119,6 @@ export function clearAuthCookies(
   res.clearCookie(accessTokenName, clearOptions);
   res.clearCookie(refreshTokenName, {
     ...clearOptions,
-    path: '/api/auth/refresh',
+    path: REFRESH_COOKIE_PATH,
   });
 }

--- a/apps/backend/src/config/auth-throttle.config.ts
+++ b/apps/backend/src/config/auth-throttle.config.ts
@@ -57,6 +57,21 @@ export default registerAs('authThrottle', () => ({
   },
 
   /**
+   * Session refresh rate limits
+   *
+   * Deliberately the most lenient bucket here. Renewal is not an attack
+   * surface the way login is — it requires a valid refresh token, and GoTrue
+   * rejects a bad one regardless of how often it is presented. Meanwhile a
+   * legitimate user with several tabs open can burst several renewals at once
+   * when a token lapses. Throttling that too tightly would sign them out,
+   * which is the failure this whole change exists to remove.
+   */
+  refresh: {
+    ttl: 60000, // 1 minute window
+    limit: 20, // 20 attempts per minute
+  },
+
+  /**
    * Account lockout configuration
    */
   lockout: {
@@ -75,4 +90,5 @@ export const AUTH_THROTTLE = {
   passwordReset: { name: 'auth-password-reset', ttl: 3600000, limit: 3 },
   magicLink: { name: 'auth-magic-link', ttl: 60000, limit: 3 },
   passkey: { name: 'auth-passkey', ttl: 60000, limit: 10 },
+  refresh: { name: 'auth-refresh', ttl: 60000, limit: 20 },
 } as const;

--- a/apps/backend/src/config/webauthn.config.spec.ts
+++ b/apps/backend/src/config/webauthn.config.spec.ts
@@ -29,12 +29,12 @@ describe('webauthn.config', () => {
 
   it('maps WEBAUTHN_RP_ID and WEBAUTHN_ORIGIN from the environment', () => {
     process.env.WEBAUTHN_RP_ID = 'opuspopuli.org';
-    process.env.WEBAUTHN_ORIGIN = 'https://app-us-ca.opuspopuli.org';
+    process.env.WEBAUTHN_ORIGIN = 'https://california.opuspopuli.org';
 
     const config = webauthnConfig();
 
     expect(config.rpId).toBe('opuspopuli.org');
-    expect(config.origin).toBe('https://app-us-ca.opuspopuli.org');
+    expect(config.origin).toBe('https://california.opuspopuli.org');
   });
 
   it('leaves rpId and origin undefined when unset, rather than defaulting', () => {

--- a/apps/backend/src/config/webauthn.config.ts
+++ b/apps/backend/src/config/webauthn.config.ts
@@ -27,8 +27,12 @@ export default registerAs('webauthn', () => ({
    *
    * Use the registrable domain rather than the host actually serving the app:
    * a credential registered against `opuspopuli.org` is usable from every
-   * subdomain, whereas one bound to `app-us-ca.opuspopuli.org` is not — and
+   * subdomain, whereas one bound to `california.opuspopuli.org` is not — and
    * narrowing it later invalidates every passkey already registered.
+   *
+   * That property is why renaming the node's host from `app-us-ca` to
+   * `california` cost nothing: every existing passkey was bound to the
+   * registrable domain and survived the move untouched.
    *
    * Undefined by default rather than falling back to `localhost` here.
    * `PasskeyService` owns that fallback, and it needs to distinguish "not

--- a/apps/frontend/__tests__/auth-refresh-link.test.ts
+++ b/apps/frontend/__tests__/auth-refresh-link.test.ts
@@ -1,0 +1,189 @@
+import { ApolloLink, gql } from "@apollo/client";
+import { Observable } from "@apollo/client/utilities";
+import {
+  sessionRefreshLink,
+  AUTH_RETRIED,
+  SKIP_EXPIRED_REDIRECT,
+} from "../lib/auth-refresh-link";
+import type { RefreshOutcome } from "../lib/auth-refresh";
+
+const mockRefreshSession = jest.fn<Promise<RefreshOutcome>, []>();
+jest.mock("../lib/auth-refresh", () => ({
+  refreshSession: () => mockRefreshSession(),
+}));
+
+const QUERY = gql`
+  query Me {
+    me {
+      id
+    }
+  }
+`;
+
+const authError = Object.assign(new Error("Forbidden"), { statusCode: 403 });
+
+/** Terminating link that fails the first N attempts, then succeeds. */
+function createTerminatingLink(failures: number) {
+  let attempts = 0;
+  const link = new ApolloLink(
+    () =>
+      new Observable((subscriber) => {
+        attempts += 1;
+        if (attempts <= failures) {
+          subscriber.error(authError);
+        } else {
+          subscriber.next({ data: { me: { id: "1" } } });
+          subscriber.complete();
+        }
+      }),
+  );
+  return { link, getAttempts: () => attempts };
+}
+
+/** AC4 requires an execution context; nothing here touches the client. */
+const EXEC_CONTEXT = { client: {} as never };
+
+function run(link: ApolloLink) {
+  return new Promise<{ data?: unknown; error?: unknown }>((resolve) => {
+    ApolloLink.execute(link, { query: QUERY }, EXEC_CONTEXT).subscribe({
+      next: (data) => resolve({ data }),
+      error: (error) => resolve({ error }),
+    });
+  });
+}
+
+describe("sessionRefreshLink", () => {
+  beforeEach(() => {
+    mockRefreshSession.mockReset();
+  });
+
+  it("renews and retries the operation once, transparently", async () => {
+    mockRefreshSession.mockResolvedValue("renewed");
+    const { link: terminating, getAttempts } = createTerminatingLink(1);
+
+    const result = await run(
+      ApolloLink.from([sessionRefreshLink, terminating]),
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.data).toBeDefined();
+    expect(getAttempts()).toBe(2); // original + one retry
+    expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  // The loop guard. If a retried operation could trigger another refresh, a
+  // persistently-403ing query would spin forever against the auth provider.
+  it("never refreshes twice for the same operation", async () => {
+    mockRefreshSession.mockResolvedValue("renewed");
+    const { link: terminating, getAttempts } = createTerminatingLink(99);
+
+    const result = await run(
+      ApolloLink.from([sessionRefreshLink, terminating]),
+    );
+
+    expect(result.error).toBe(authError);
+    expect(getAttempts()).toBe(2); // original + exactly one retry
+    expect(mockRefreshSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up without retrying when the session is genuinely expired", async () => {
+    mockRefreshSession.mockResolvedValue("expired");
+    const { link: terminating, getAttempts } = createTerminatingLink(99);
+
+    const result = await run(
+      ApolloLink.from([sessionRefreshLink, terminating]),
+    );
+
+    expect(result.error).toBe(authError);
+    expect(getAttempts()).toBe(1); // never retried
+  });
+
+  // The distinction carried all the way from the auth provider. An outage must
+  // not read as expiry, or a GoTrue blip signs out every active user.
+  it("flags unavailable so the terminal redirect is suppressed", async () => {
+    mockRefreshSession.mockResolvedValue("unavailable");
+    let observedContext: Record<string, unknown> = {};
+
+    const inspector = new ApolloLink((operation, forward) => {
+      const result = forward(operation);
+      return new Observable((subscriber) =>
+        result.subscribe({
+          next: (v) => subscriber.next(v),
+          error: (e) => {
+            observedContext = operation.getContext();
+            subscriber.error(e);
+          },
+          complete: () => subscriber.complete(),
+        }),
+      );
+    });
+
+    const { link: terminating } = createTerminatingLink(99);
+    await run(ApolloLink.from([inspector, sessionRefreshLink, terminating]));
+
+    expect(observedContext[SKIP_EXPIRED_REDIRECT]).toBe(true);
+    expect(observedContext[AUTH_RETRIED]).toBeUndefined();
+  });
+
+  it("does NOT flag expired failures — those must still redirect", async () => {
+    mockRefreshSession.mockResolvedValue("expired");
+    let observedContext: Record<string, unknown> = {};
+
+    const inspector = new ApolloLink((operation, forward) => {
+      const result = forward(operation);
+      return new Observable((subscriber) =>
+        result.subscribe({
+          next: (v) => subscriber.next(v),
+          error: (e) => {
+            observedContext = operation.getContext();
+            subscriber.error(e);
+          },
+          complete: () => subscriber.complete(),
+        }),
+      );
+    });
+
+    const { link: terminating } = createTerminatingLink(99);
+    await run(ApolloLink.from([inspector, sessionRefreshLink, terminating]));
+
+    expect(observedContext[SKIP_EXPIRED_REDIRECT]).toBeUndefined();
+  });
+
+  it("ignores non-auth errors entirely", async () => {
+    mockRefreshSession.mockResolvedValue("renewed");
+    const serverError = Object.assign(new Error("boom"), { statusCode: 500 });
+    const terminating = new ApolloLink(
+      () => new Observable((subscriber) => subscriber.error(serverError)),
+    );
+
+    const result = await run(
+      ApolloLink.from([sessionRefreshLink, terminating]),
+    );
+
+    expect(result.error).toBe(serverError);
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+  });
+
+  it("does not try to renew a failing Logout", async () => {
+    mockRefreshSession.mockResolvedValue("renewed");
+    const terminating = new ApolloLink(
+      () => new Observable((subscriber) => subscriber.error(authError)),
+    );
+
+    await new Promise<void>((resolve) => {
+      ApolloLink.execute(
+        ApolloLink.from([sessionRefreshLink, terminating]),
+        {
+          query: gql`
+            mutation Logout {
+              logout
+            }
+          `,
+        },
+        EXEC_CONTEXT,
+      ).subscribe({ error: () => resolve(), next: () => resolve() });
+    });
+
+    expect(mockRefreshSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/__tests__/auth-refresh.test.ts
+++ b/apps/frontend/__tests__/auth-refresh.test.ts
@@ -1,0 +1,128 @@
+import { refreshSession, resetRefreshStateForTests } from "../lib/auth-refresh";
+
+/**
+ * The concurrency behaviour here is the whole point of the module, and it is
+ * the part that cannot be checked by hand: a broken single-flight only shows
+ * up when several queries fail at once, which is exactly the `/me/*` page load
+ * that surfaced #977 in the first place.
+ */
+describe("auth-refresh", () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    resetRefreshStateForTests();
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    document.cookie = "csrf-token=test-csrf-value";
+  });
+
+  const respond = (status: number) => ({ ok: status === 204, status });
+
+  describe("outcomes", () => {
+    it("reports renewed on 204", async () => {
+      fetchMock.mockResolvedValue(respond(204));
+      await expect(refreshSession()).resolves.toBe("renewed");
+    });
+
+    it("reports expired on 401 — the session is genuinely dead", async () => {
+      fetchMock.mockResolvedValue(respond(401));
+      await expect(refreshSession()).resolves.toBe("expired");
+    });
+
+    // 503 must NOT read as expired. The backend goes to some trouble to
+    // distinguish "sign in again" from "try again"; collapsing them here would
+    // throw that away at the last layer and sign users out on a GoTrue blip.
+    it("reports unavailable on 503 — not expired", async () => {
+      fetchMock.mockResolvedValue(respond(503));
+      await expect(refreshSession()).resolves.toBe("unavailable");
+    });
+
+    it("reports unavailable when the network call itself fails", async () => {
+      fetchMock.mockRejectedValue(new Error("offline"));
+      await expect(refreshSession()).resolves.toBe("unavailable");
+    });
+  });
+
+  describe("single flight", () => {
+    it("collapses concurrent callers into ONE request", async () => {
+      let release!: (v: unknown) => void;
+      fetchMock.mockReturnValue(
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+      );
+
+      const all = Promise.all([
+        refreshSession(),
+        refreshSession(),
+        refreshSession(),
+        refreshSession(),
+      ]);
+      release(respond(204));
+
+      expect(await all).toEqual(["renewed", "renewed", "renewed", "renewed"]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("collapses concurrent callers on failure too", async () => {
+      let release!: (v: unknown) => void;
+      fetchMock.mockReturnValue(
+        new Promise((resolve) => {
+          release = resolve;
+        }),
+      );
+
+      const all = Promise.all([refreshSession(), refreshSession()]);
+      release(respond(401));
+
+      expect(await all).toEqual(["expired", "expired"]);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    // The flip side: the latch must RELEASE. If it didn't, one refresh would
+    // be the only refresh this tab ever performs, and the user would be logged
+    // out 15 minutes later exactly as before.
+    it("starts a new request once the previous one has settled", async () => {
+      fetchMock.mockResolvedValue(respond(204));
+
+      await refreshSession();
+      await refreshSession();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("releases the latch even when the request throws", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("offline"));
+      await expect(refreshSession()).resolves.toBe("unavailable");
+
+      fetchMock.mockResolvedValue(respond(204));
+      await expect(refreshSession()).resolves.toBe("renewed");
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("request shape", () => {
+    it("POSTs to the refresh endpoint with cookies attached", async () => {
+      fetchMock.mockResolvedValue(respond(204));
+
+      await refreshSession();
+
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("/api/auth/refresh");
+      expect(init.method).toBe("POST");
+      // Without this the httpOnly refresh cookie never leaves the browser.
+      expect(init.credentials).toBe("include");
+    });
+
+    // CsrfMiddleware guards the gateway route via forRoutes({path:'*'}), so a
+    // POST without this header is rejected before the handler runs.
+    it("sends the CSRF token", async () => {
+      fetchMock.mockResolvedValue(respond(204));
+
+      await refreshSession();
+
+      const [, init] = fetchMock.mock.calls[0];
+      expect(init.headers["X-CSRF-Token"]).toBe("test-csrf-value");
+    });
+  });
+});

--- a/apps/frontend/__tests__/pages/auth-callback.test.tsx
+++ b/apps/frontend/__tests__/pages/auth-callback.test.tsx
@@ -184,9 +184,60 @@ describe("AuthCallbackPage", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByText("Redirecting you to the app..."),
+          screen.getByText("Taking you to the app..."),
         ).toBeInTheDocument();
       });
+    });
+
+    // The click this removes. The page used to claim "Redirecting you to the
+    // app..." while doing nothing but render a button — a promise the code did
+    // not keep.
+    it("navigates into the app without waiting for a click", async () => {
+      mockSearchParamsGet = jest.fn().mockImplementation((key: string) => {
+        if (key === "email") return "test@example.com";
+        if (key === "token") return "valid-token";
+        return null;
+      });
+      mockVerifyMagicLink.mockResolvedValue(undefined);
+
+      render(<AuthCallbackPage />);
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith("/me/briefing");
+      });
+    });
+
+    it("honours an explicit ?redirect= when auto-navigating", async () => {
+      mockSearchParamsGet = jest.fn().mockImplementation((key: string) => {
+        if (key === "email") return "test@example.com";
+        if (key === "token") return "valid-token";
+        if (key === "redirect") return "/me/saved";
+        return null;
+      });
+      mockVerifyMagicLink.mockResolvedValue(undefined);
+
+      render(<AuthCallbackPage />);
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith("/me/saved");
+      });
+    });
+
+    it("does not navigate while verification is still in flight", async () => {
+      mockSearchParamsGet = jest.fn().mockImplementation((key: string) => {
+        if (key === "email") return "test@example.com";
+        if (key === "token") return "valid-token";
+        return null;
+      });
+      // Never resolves — the page must sit on the spinner, not redirect.
+      mockVerifyMagicLink.mockReturnValue(new Promise(() => {}));
+
+      render(<AuthCallbackPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Verifying your link...")).toBeInTheDocument();
+      });
+      expect(mockPush).not.toHaveBeenCalled();
     });
 
     it("should show continue to app button", async () => {
@@ -256,6 +307,29 @@ describe("AuthCallbackPage", () => {
   });
 
   describe("success state - new user with passkey support", () => {
+    // The one screen that must still wait for a click. It offers a real choice
+    // — "Add a Passkey" or "Skip for now" — so auto-navigating past it would
+    // silently kill passkey enrolment for every new user.
+    it("does NOT auto-navigate past the passkey choice", async () => {
+      mockSearchParamsGet = jest.fn().mockImplementation((key: string) => {
+        if (key === "email") return "test@example.com";
+        if (key === "token") return "valid-token";
+        if (key === "type") return "register";
+        return null;
+      });
+      mockVerifyMagicLink.mockResolvedValue(undefined);
+      mockAuthContextValue = { ...defaultAuthContext, supportsPasskeys: true };
+
+      render(<AuthCallbackPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Welcome! Your account is ready"),
+        ).toBeInTheDocument();
+      });
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
     it("should show passkey prompt for new users", async () => {
       mockSearchParamsGet = jest.fn().mockImplementation((key: string) => {
         if (key === "email") return "test@example.com";

--- a/apps/frontend/app/(auth)/auth/callback/page.tsx
+++ b/apps/frontend/app/(auth)/auth/callback/page.tsx
@@ -148,6 +148,24 @@ function AuthCallbackContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Where a successful sign-in lands. Computed before the effect below so the
+  // effect and the fallback button can never disagree about the destination.
+  const successTarget = isNewUser ? skipTarget : continueTarget;
+
+  // Whether the passkey offer is showing. That screen is a deliberate choice —
+  // "Add a Passkey" or "Skip for now" — so it must NOT be auto-dismissed.
+  // Everything else was an interstitial that only ever said "click here to
+  // continue", which is the click this removes.
+  const isAwaitingPasskeyChoice = isNewUser && supportsPasskeys;
+
+  useEffect(() => {
+    if (status !== "success" || isAwaitingPasskeyChoice) return;
+    // `supportsPasskeys` is set synchronously in an auth-context mount effect,
+    // while reaching "success" requires an awaited network round-trip — so it
+    // has always settled by now, and this cannot race past the passkey prompt.
+    router.push(successTarget);
+  }, [status, isAwaitingPasskeyChoice, successTarget, router]);
+
   // Verifying state
   if (status === "verifying" || isLoading) {
     return (
@@ -268,14 +286,18 @@ function AuthCallbackContent() {
   // /me/briefing and skip the questionnaire entirely (#758). Returning
   // users continue to their briefing. An explicit ?redirect= wins in
   // both cases via resolveRedirect().
-  const successTarget = isNewUser ? skipTarget : continueTarget;
   return (
     <div className="bg-surface rounded-lg p-8 text-center">
       <AuthCheckIcon />
       <h1 className="text-xl font-bold text-content mb-2">
         You&apos;re signed in!
       </h1>
-      <p className="text-content-dim mb-6">Redirecting you to the app...</p>
+      <p className="text-content-dim mb-6">Taking you to the app...</p>
+      {/*
+        Fallback only. The effect above navigates on its own; this is here for
+        the case where that hasn't happened yet — a slow route transition, or
+        navigation blocked — so the user is never stranded on a dead end.
+      */}
       <button
         type="button"
         onClick={() => router.push(successTarget)}

--- a/apps/frontend/lib/apollo-client.ts
+++ b/apps/frontend/lib/apollo-client.ts
@@ -10,30 +10,13 @@ import { getMainDefinition } from "@apollo/client/utilities";
 import { createClient } from "graphql-ws";
 import { persistCache, LocalStorageWrapper } from "apollo3-cache-persist";
 import { isAuthExpiredError, triggerAuthExpiredRedirect } from "./auth-logout";
+import { sessionRefreshLink, SKIP_EXPIRED_REDIRECT } from "./auth-refresh-link";
+import { getCsrfToken } from "./csrf";
 
 const GRAPHQL_URL =
   process.env.NEXT_PUBLIC_GRAPHQL_URL || "http://localhost:3000/api";
 const GRAPHQL_WS_URL =
   process.env.NEXT_PUBLIC_GRAPHQL_WS_URL || GRAPHQL_URL.replace(/^http/, "ws");
-
-/**
- * Extract CSRF token from cookie
- *
- * The CSRF token is set by the backend on every response as a non-httpOnly cookie,
- * allowing JavaScript to read it and send it back in the X-CSRF-Token header.
- */
-function getCsrfToken(): string | undefined {
-  if (typeof document === "undefined") return undefined;
-
-  const cookies = document.cookie.split("; ");
-  const csrfCookie = cookies.find((cookie) => cookie.startsWith("csrf-token="));
-
-  if (csrfCookie) {
-    return decodeURIComponent(csrfCookie.split("=")[1]);
-  }
-
-  return undefined;
-}
 
 /**
  * Custom fetch that adds CSRF token for request protection
@@ -140,6 +123,10 @@ function createWsLink(): ApolloLink | null {
 const authExpiryLink = new ErrorLink(({ error, operation }) => {
   if (operation.operationName === "Logout") return;
   if (!isAuthExpiredError(error)) return;
+  // Renewal was attempted below and could not reach the server — offline, or
+  // the gateway answering 503. That is not evidence the session is dead, so
+  // the query is allowed to fail without signing the user out. See #977.
+  if (operation.getContext()[SKIP_EXPIRED_REDIRECT]) return;
   if (globalThis.window === undefined) return;
   triggerAuthExpiredRedirect(
     globalThis.location.pathname + globalThis.location.search,
@@ -155,7 +142,7 @@ function createLink(): ApolloLink {
 
   // If no WebSocket link (SSR), use HTTP only
   if (!wsLink) {
-    return ApolloLink.from([authExpiryLink, httpLink]);
+    return ApolloLink.from([authExpiryLink, sessionRefreshLink, httpLink]);
   }
 
   // Split traffic: subscriptions go to WebSocket, rest to HTTP
@@ -171,7 +158,10 @@ function createLink(): ApolloLink {
     httpLink,
   );
 
-  return ApolloLink.from([authExpiryLink, transportLink]);
+  // Order matters. sessionRefreshLink sits BELOW authExpiryLink so it gets
+  // first refusal on an auth failure: if renewal succeeds the operation is
+  // retried and the error never reaches the redirect at all.
+  return ApolloLink.from([authExpiryLink, sessionRefreshLink, transportLink]);
 }
 
 /**

--- a/apps/frontend/lib/auth-refresh-link.ts
+++ b/apps/frontend/lib/auth-refresh-link.ts
@@ -1,0 +1,72 @@
+import { ApolloLink } from "@apollo/client";
+import { ErrorLink } from "@apollo/client/link/error";
+import { Observable } from "@apollo/client/utilities";
+import { isAuthExpiredError } from "./auth-logout";
+import { refreshSession } from "./auth-refresh";
+
+/**
+ * Marks an operation that has already been retried after a renewal. Without
+ * it a failing retry would trigger another refresh, which would trigger
+ * another retry — a loop that hammers the auth provider and never terminates.
+ */
+export const AUTH_RETRIED = "authRetried";
+
+/**
+ * Suppresses the terminal expired-session redirect for this operation.
+ *
+ * Set only when renewal could not be ATTEMPTED — offline, or the gateway
+ * answering 503. Those say nothing about whether the session is still valid,
+ * and signing the user out on them would reintroduce #977's forced logout by
+ * a different route. The query still fails and the UI still shows an error;
+ * the session simply survives.
+ */
+export const SKIP_EXPIRED_REDIRECT = "skipAuthExpiredRedirect";
+
+/**
+ * Renews an expired session and retries the operation once, transparently.
+ *
+ * Sits BELOW the terminal `authExpiryLink` in the chain, so it gets first
+ * refusal on an auth failure and the redirect only happens if renewal has
+ * genuinely failed.
+ */
+export const sessionRefreshLink: ApolloLink = new ErrorLink(
+  ({ error, operation, forward }) => {
+    // Logout failing with a 403 is expected — never try to renew for it.
+    if (operation.operationName === "Logout") return;
+    if (!isAuthExpiredError(error)) return;
+    // Already retried once: let it through to the terminal handler.
+    if (operation.getContext()[AUTH_RETRIED]) return;
+    if (globalThis.window === undefined) return;
+
+    return new Observable((subscriber) => {
+      let inner: { unsubscribe: () => void } | undefined;
+      let cancelled = false;
+
+      // Every concurrent failure lands here, but refreshSession() collapses
+      // them into one network call — see the latch in auth-refresh.ts.
+      refreshSession().then((outcome) => {
+        if (cancelled) return;
+
+        if (outcome === "renewed") {
+          operation.setContext({ [AUTH_RETRIED]: true });
+          inner = forward(operation).subscribe(subscriber);
+          return;
+        }
+
+        if (outcome === "unavailable") {
+          operation.setContext({ [SKIP_EXPIRED_REDIRECT]: true });
+        }
+
+        // Propagate the ORIGINAL error upward. `expired` reaches
+        // authExpiryLink and redirects; `unavailable` reaches it and is
+        // skipped by the flag just set.
+        subscriber.error(error);
+      });
+
+      return () => {
+        cancelled = true;
+        inner?.unsubscribe();
+      };
+    });
+  },
+);

--- a/apps/frontend/lib/auth-refresh.ts
+++ b/apps/frontend/lib/auth-refresh.ts
@@ -1,0 +1,85 @@
+/**
+ * Silent session renewal.
+ *
+ * The access-token cookie lasts 15 minutes and nothing used to renew it, so an
+ * actively-used session died mid-use and bounced the user to `/login`. This
+ * calls the gateway's renewal route so that stops happening.
+ *
+ * See issue #977 and `docs/plans/977-session-refresh-flow.md`.
+ */
+import { getCsrfToken } from "./csrf";
+
+const GRAPHQL_URL =
+  process.env.NEXT_PUBLIC_GRAPHQL_URL || "http://localhost:3000/api";
+
+/**
+ * The renewal route sits alongside the GraphQL endpoint — `/api` becomes
+ * `/api/auth/refresh` — because the refresh cookie is path-scoped to exactly
+ * that URL and is sent nowhere else. Derived from the same origin rather than
+ * configured separately, so the two cannot drift apart across environments.
+ */
+const REFRESH_URL = `${GRAPHQL_URL.replace(/\/$/, "")}/auth/refresh`;
+
+/**
+ * - `renewed` — new cookies are set; the caller should retry its operation.
+ * - `expired` — the session is genuinely dead; sign in again.
+ * - `unavailable` — renewal could not be attempted or the server could not
+ *   answer. This says NOTHING about whether the session is still valid, so the
+ *   caller must not sign the user out on it.
+ */
+export type RefreshOutcome = "renewed" | "expired" | "unavailable";
+
+/**
+ * Single-flight latch. A page load fires many queries at once, so an expired
+ * token produces a burst of simultaneous failures. Without this every one of
+ * them would launch its own renewal, and because the provider rotates refresh
+ * tokens, the later ones would present a token the earlier ones had already
+ * consumed — manufacturing the forced logout this code exists to prevent.
+ */
+let inFlight: Promise<RefreshOutcome> | null = null;
+
+/** Test-only: drop the in-flight latch between cases. */
+export function resetRefreshStateForTests(): void {
+  inFlight = null;
+}
+
+async function performRefresh(): Promise<RefreshOutcome> {
+  try {
+    const headers: Record<string, string> = {};
+    const csrfToken = getCsrfToken();
+    if (csrfToken) {
+      headers["X-CSRF-Token"] = csrfToken;
+    }
+
+    const response = await fetch(REFRESH_URL, {
+      method: "POST",
+      // Required: the refresh cookie is httpOnly, so this is the only way it
+      // reaches the server. There is deliberately no request body — the
+      // credential is the cookie, never anything JavaScript can read.
+      credentials: "include",
+      headers,
+    });
+
+    if (response.ok) return "renewed";
+    // 401 is the server telling us the grant was rejected. Anything else —
+    // 503, a proxy error, a gateway restart — is not evidence of expiry.
+    return response.status === 401 ? "expired" : "unavailable";
+  } catch {
+    // Offline, DNS failure, request aborted. Never treated as expiry.
+    return "unavailable";
+  }
+}
+
+/**
+ * Renew the session, collapsing concurrent callers into a single request.
+ *
+ * The latch is released once the request settles — including on failure — so
+ * a tab can renew again 15 minutes later. Holding it would make the first
+ * renewal the only one that tab ever performs.
+ */
+export function refreshSession(): Promise<RefreshOutcome> {
+  inFlight ??= performRefresh().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}

--- a/apps/frontend/lib/csrf.ts
+++ b/apps/frontend/lib/csrf.ts
@@ -1,0 +1,23 @@
+/**
+ * Read the CSRF token the backend sets on every response.
+ *
+ * Deliberately NOT httpOnly — the double-submit pattern requires JavaScript to
+ * read this value and echo it back in the `X-CSRF-Token` header, which the
+ * server then compares against the cookie. Same-origin policy is what stops
+ * another site reading it.
+ *
+ * Shared by the Apollo transport and the session-renewal call so the two
+ * cannot drift apart; both hit gateway routes guarded by the same
+ * `CsrfMiddleware`.
+ *
+ * @see https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+ */
+export function getCsrfToken(): string | undefined {
+  if (typeof document === "undefined") return undefined;
+
+  const csrfCookie = document.cookie
+    .split("; ")
+    .find((cookie) => cookie.startsWith("csrf-token="));
+
+  return csrfCookie ? decodeURIComponent(csrfCookie.split("=")[1]) : undefined;
+}

--- a/apps/frontend/wrangler.toml
+++ b/apps/frontend/wrangler.toml
@@ -17,12 +17,12 @@ compatibility_flags = ["nodejs_compat"]
 directory = ".open-next/assets"
 binding = "ASSETS"
 
-# Custom domain.
+# Custom domains.
 #
-# Without this the Worker answers only on
-# opuspopuli-frontend.<subdomain>.workers.dev, and app-us-ca.opuspopuli.org has
-# no DNS record whatsoever -- not a misconfigured one, simply absent. That is
-# what "does not resolve" was.
+# Without these the Worker answers only on
+# opuspopuli-frontend.<subdomain>.workers.dev, and the hostname has no DNS
+# record whatsoever -- not a misconfigured one, simply absent. That is what
+# "does not resolve" was.
 #
 # `custom_domain = true` makes Cloudflare create and own the DNS record on
 # deploy, so this is the whole fix; no manual dashboard DNS entry is needed (and
@@ -32,6 +32,28 @@ binding = "ASSETS"
 #
 # Declared here rather than clicked into the dashboard so the mapping lives in
 # git and survives a Worker being recreated.
+
+# The canonical name for the California node. `app-us-ca` encoded an internal
+# region identifier in the one URL citizens are asked to type, share and trust;
+# this reads as a place instead.
+#
+# Note this is a HOSTNAME rename only. The region id (`us-ca`), the plugin
+# identifiers and every stored row keep their existing values.
+[[routes]]
+pattern = "california.opuspopuli.org"
+custom_domain = true
+
+# The previous hostname, deliberately kept.
+#
+# Deleting it here would make the very next deploy a hard cutover: the Worker
+# would stop answering on app-us-ca the instant california went live, breaking
+# every existing link, bookmark and shared URL with no overlap and no way back
+# short of another deploy. Serving both makes the migration reversible at every
+# step.
+#
+# Remove this once a Cloudflare Redirect Rule 301s app-us-ca -> california, so
+# old links keep working rather than dying. A zone-level Redirect Rule runs
+# ahead of the Worker, so the rule can go in before this block comes out.
 [[routes]]
 pattern = "app-us-ca.opuspopuli.org"
 custom_domain = true

--- a/docs/guides/auth-security.md
+++ b/docs/guides/auth-security.md
@@ -55,10 +55,92 @@ res.cookie('refresh-token', refreshToken, {
   httpOnly: true,
   secure: true,
   sameSite: 'strict',
-  path: '/api/auth/refresh', // Only sent to refresh endpoint
+  path: REFRESH_COOKIE_PATH,       // '/api/auth/refresh' — sent there and nowhere else
   maxAge: 7 * 24 * 60 * 60 * 1000, // 7 days
 });
 ```
+
+The access token is short-lived on purpose; it is renewed silently rather than extended. See
+[Session Renewal](#session-renewal) below for how, and for why that path is load-bearing.
+
+## Session Renewal
+
+The access token lasts 15 minutes. Renewal keeps an actively-used session alive for the life of the
+refresh token (7 days) without the user noticing, and without lengthening the access token — a
+longer-lived bearer credential would trade the interruption for a bigger blast radius.
+
+Before this existed, the refresh cookie was issued to a path nothing served. The session simply died
+mid-use and the user was bounced to `/login` (see [#977](https://github.com/OpusPopuli/opuspopuli/issues/977)).
+
+### Flow
+
+```
+Query fails 401/403
+  └─ sessionRefreshLink (frontend, below the terminal redirect link)
+      └─ POST /api/auth/refresh          cookies only, no body, X-CSRF-Token required
+          └─ AuthRefreshController (gateway)
+              └─ refreshSession mutation (users subgraph, HMAC-signed, @inaccessible)
+                  └─ IAuthProvider.refreshSession → GoTrue token?grant_type=refresh_token
+          ← 204, new httpOnly cookies, NO body
+  └─ original operation retried once → succeeds, user sees nothing
+```
+
+### Why renewal is a REST route and not a GraphQL mutation
+
+The refresh cookie is scoped to `path: '/api/auth/refresh'`, so the browser sends it there and
+nowhere else. GraphQL is served at `/api`, and a browser will not send a `/api/auth/refresh` cookie
+to `/api`. Serving renewal as a normal mutation would therefore mean widening the cookie's path —
+shipping a 7-day credential with every GraphQL request. The endpoint was moved to meet the cookie
+instead.
+
+The mutation still exists on the users subgraph, but is marked `@inaccessible`: it is composed into
+the subgraph and excluded from the public API schema, reachable only by the gateway's direct
+HMAC-signed call. Exposing it federated would mean clients passing a refresh token as a GraphQL
+variable, where it would land in query logs and traces.
+
+**`REFRESH_COOKIE_PATH`** (`common/utils/cookie.utils.ts`) is the single source for that path. If the
+cookie scope and the served route ever diverge, nothing errors — the cookie is just never sent, and
+renewal fails into the logout it exists to prevent. `auth-refresh.controller.spec.ts` asserts the
+route metadata resolves to that constant.
+
+### Rotation
+
+GoTrue **rotates** on redemption: the refresh token returned is not the one presented, and the old
+one stops working after its reuse interval. Callers must persist what comes back.
+
+`UserSession` is updated in place — a renewed session is the same session, and a row per renewal
+would turn "your active sessions" into a list of every 15-minute window since sign-in. Rows are
+matched on the last 32 characters of the refresh token, never the whole value.
+
+GoTrue's reuse interval is also what makes multi-tab safe across tabs; the frontend collapses
+concurrent renewals within a tab into a single request. Without both, two tabs racing to redeem the
+same token would log each other out.
+
+### "Sign in again" vs "try again"
+
+This distinction is carried deliberately through every layer, and collapsing it at any one of them
+reintroduces the original bug by a different route — a provider blip would sign out every active
+user at once.
+
+| Condition | Code | Route | Session | Frontend |
+|---|---|---|---|---|
+| Grant rejected — expired, revoked, already used | `REFRESH_TOKEN_INVALID` | 401 | revoked, cookies cleared | redirect to `/login?reason=expired` |
+| Provider unreachable, 5xx, 408, 429 | `REFRESH_ERROR` | 503 | **untouched** | query fails, **session survives** |
+
+A `429` is deliberately **not** terminal despite being a 4xx: a rate-limit says nothing about the
+token, and treating it as expiry would revoke valid sessions under load.
+
+### Security properties
+
+- Renewal returns **204 with no body**. Tokens are only ever httpOnly cookies; JavaScript never
+  reads them.
+- The route inherits `CsrfMiddleware` from `forRoutes({path:'*'})` — a POST without `X-CSRF-Token`
+  is rejected before the handler runs, asserted in `session-refresh.integration.spec.ts`.
+- The renewal route is `@Public()` by necessity: the access token is expired by definition, and the
+  refresh cookie is the credential. The global `AuthGuard` defers on non-GraphQL contexts.
+- Token values never reach a log. The provider logs only GoTrue's user id, and the audit
+  interceptor's `inputVariables` are masked by `pii-masker`, whose `SENSITIVE_FIELDS` includes
+  `refreshtoken`.
 
 ## CSRF Protection
 

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -44,8 +44,29 @@ Why it is here and not in the region repo:
   region's API and site URLs. There is no build-once-deploy-anywhere artifact to hand an operator,
   the way `ghcr.io/opuspopuli/*` images are.
 - The frontend source and the `frontend-v*` tag both live here.
-- `apps/frontend/wrangler.toml` already hard-codes `app-us-ca.opuspopuli.org`, so this repo was
+- `apps/frontend/wrangler.toml` already hard-codes the node's hostname, so this repo was
   region-coupled on the frontend before the workflow existed.
+
+### Hostnames
+
+| | |
+|---|---|
+| App (canonical) | `california.opuspopuli.org` |
+| App (legacy, still served) | `app-us-ca.opuspopuli.org` |
+| API | `api-us-ca.opuspopuli.org` |
+
+`app-us-ca` encoded an internal region identifier in the one URL citizens are asked to type and
+share. `california` is the canonical name; the old host stays routed so existing links keep
+working, and comes out of `wrangler.toml` once a Cloudflare Redirect Rule 301s it across.
+
+This is a **hostname** rename only — the region id (`us-ca`), the plugin identifiers and every
+stored row are unchanged. The API keeps its `api-us-ca` name for now: it is not user-facing, and
+moving it means a Terraform `api_subdomain` change in the node repo plus a backend CORS flip.
+
+Renaming the app host was cheap for one reason worth knowing before anyone changes it: `WEBAUTHN_RP_ID`
+is `opuspopuli.org`, the **registrable domain**, so passkeys are bound to the parent and survived
+the move. Had it been the full host, the rename would have silently invalidated every registered
+credential. See `apps/backend/src/config/webauthn.config.ts`.
 
 **What this does not change.** Backend images stay region-agnostic and operator-pulled. No Mac
 Studio config, Terraform state, or backend credential moves here. The token is scoped to Workers

--- a/docs/plans/977-session-refresh-flow.md
+++ b/docs/plans/977-session-refresh-flow.md
@@ -1,0 +1,195 @@
+# Plan: silent session refresh (#977)
+
+| | |
+|---|---|
+| **Issue** | [#977](https://github.com/OpusPopuli/opuspopuli/issues/977) — access token expires after 15 minutes with no refresh flow |
+| **Date** | 2026-08-14 |
+| **Author** | Rodney Gagnon |
+| **Data classification** | **PII — no PHI.** Authentication credentials (access + refresh tokens) and session metadata (IP, user agent, device). Strict PHI/PII lens applies by default — the repo has no `.claude/compliance-profile.yaml`. |
+| **Branch** | `fix/session-refresh-flow-977` |
+| **Status** | Approved 2026-08-14. Not started. |
+
+## Problem
+
+A signed-in user is forced back to `/login` roughly 15 minutes after authenticating, mid-session.
+The access-token cookie has an absolute 15-minute `maxAge` and nothing renews it, so continuous use
+makes no difference. `authExpiryLink` classifies the resulting `403` / `UNAUTHENTICATED` as an
+expired session and full-page redirects.
+
+The refresh half of the design was issued but never built: `setAuthCookies()` writes a 7-day
+`refresh-token` cookie scoped to `path: '/api/auth/refresh'`, an endpoint that does not exist. The
+credential is minted, stored, and never read by anything.
+
+`/settings` and `/me/*` get blamed because they fire fresh authenticated queries and are usually
+the first request to observe the dead cookie. Pages served from the persisted Apollo cache keep
+rendering without a round-trip. The profile route is a symptom.
+
+## What is actually missing
+
+The issue names two gaps. There are three — the third is the one that gates the others.
+
+| | Status |
+|---|---|
+| `/api/auth/refresh` route | **Absent.** The string exists only as a cookie `path` in `cookie.utils.ts:70,106`. |
+| `refresh` mutation | **Absent.** `schema.gql` carries `refreshToken` only as a field on `Auth`. |
+| **`IAuthProvider.refreshSession()`** | **Absent, and unmentioned in the issue.** Neither `packages/common/src/providers/auth/types.ts` nor `supabase.provider.ts` can redeem a refresh token at all. |
+
+## Three findings that shape the design
+
+**1. The cookie path forecloses a mutation-only fix.** GraphQL is mounted at `path: 'api'`
+(`api/src/app.module.ts:158`); the refresh cookie is scoped to `/api/auth/refresh`. A browser will
+not send that cookie to `/api`. Serving renewal purely as a GraphQL mutation therefore *requires*
+widening the cookie path, which puts a 7-day credential on every GraphQL request.
+
+**2. `AuthMiddleware` does not block.** `auth.middleware.ts:45` copies the cookie into the
+`Authorization` header and calls `next()`. It never rejects, so a refresh route reached with an
+expired access token works. `CsrfMiddleware` *does* reject and is applied to `path: '*'`
+(`app.module.ts:270`), so a new route inherits CSRF protection rather than needing its own.
+
+**3. No migration is required.** `UserSession`
+(`packages/relationaldb-provider/prisma/schema.prisma:694`) already carries `refreshToken`,
+`isActive`, `revokedAt`, `revokedReason`, `lastActivityAt`, `expiresAt`. Rotation and reuse
+detection update rows in place.
+
+## Design decision
+
+**A REST route on the gateway, preserving the narrow cookie path.**
+
+`POST /api/auth/refresh` reads the refresh cookie, calls a users-subgraph mutation over HMAC
+(reusing the `hmacSigner.signGraphQLRequest` seam at `hmac-data-source.ts:111`), and re-sets
+cookies through the existing `setAuthCookies`.
+
+**Rejected: mutation-only with the cookie re-scoped to `/api`.** Less code, but it sends a 7-day
+credential with every GraphQL request instead of to one endpoint. The issue already rejects the
+analogous shortcut of raising `COOKIE_ACCESS_TOKEN_MAX_AGE` on the grounds that a longer-lived
+bearer credential is a security regression; widening the path is the same trade in a different
+place. If this decision is ever reversed, re-run `/security-review` against that change
+specifically, and re-check `clearAuthCookies`' path (see subtask 5).
+
+## Subtasks
+
+### 1. `refreshSession` on the auth provider
+
+**Files:** `packages/common/src/providers/auth/types.ts`,
+`packages/auth-provider/src/providers/supabase.provider.ts`
+
+Optional interface method, following the established `createSessionForUser?` /
+`validateAccessToken?` pattern with an `if (!this.authProvider.refreshSession) throw` guard at the
+call site. Implementation calls GoTrue `POST /auth/v1/token?grant_type=refresh_token`.
+
+GoTrue **rotates the refresh token on redemption and applies a reuse interval**. Build on that
+behaviour rather than reimplementing it; the interval is what makes multi-tab races survivable.
+
+**Tests:** unit — success, expired, revoked, reuse, provider-down (circuit breaker path).
+
+### 2. `refreshSession` in the users service
+
+**Files:** `apps/backend/src/apps/users/src/domains/auth/auth.service.ts`, `auth.resolver.ts`
+
+Service redeems via the provider, then updates the `UserSession` row: new `sessionToken`, new
+`refreshToken` (both last-32 fragments, per the existing convention), bump `lastActivityAt`.
+Redemption of an already-rotated token revokes that session with
+`revokedReason: 'refresh_reuse'` and fails.
+
+Resolver mutation restricted to HMAC-internal callers. Audit-log renewal with tokens masked,
+mirroring `auth.resolver.ts:144`.
+
+**Federation:** new mutation on the users subgraph — validate composition at the API Gateway per
+`CLAUDE.md`.
+
+**Tests:** unit on the service; composition check in CI.
+
+### 3. Gateway route
+
+**Files:** new `apps/backend/src/api/src/auth-refresh.controller.ts`, `api/src/app.module.ts`
+
+The gateway currently has **no controllers** — this is the first, so verify it inherits the
+middleware chain rather than assuming it.
+
+Reads the refresh cookie, calls subtask 2 over HMAC, calls `setAuthCookies`, returns **204 with no
+body**. Tokens must never reach JavaScript. On failure: `clearAuthCookies` and 401.
+
+**Tests:** integration — a request without a CSRF header must 403.
+
+### 4. Frontend refresh link
+
+**Files:** `apps/frontend/lib/apollo-client.ts`, new `apps/frontend/lib/auth-refresh.ts`
+
+New link between `authExpiryLink` and the transport link. On auth failure: call the refresh
+endpoint, retry the operation **once**.
+
+- A module-level in-flight promise collapses concurrent failures into a **single** refresh.
+- A `hasRetried` marker on the operation context prevents a refresh from triggering a refresh.
+- Refresh failure falls through to the existing `triggerAuthExpiredRedirect`, unchanged — the
+  terminal behaviour in `auth-logout.ts` is correct and stays.
+
+This is the highest-risk code in the change and the least amenable to manual verification: a broken
+single-flight only manifests under concurrent queries, which is exactly the `/me/*` page load that
+surfaced the bug. **Write these tests first.**
+
+### 5. Logout and path coherence
+
+**Files:** `apps/backend/src/common/utils/cookie.utils.ts`
+
+`clearAuthCookies` clears the refresh cookie at `/api/auth/refresh` (`:106`). Correct under this
+design; it is precisely what breaks silently if the cookie path is ever widened. Assert the paths
+agree.
+
+### 6. Tests
+
+**Files:** `apps/backend/__tests__/integration/auth/auth.integration.spec.ts` (extend — the
+directory already exists), frontend unit tests alongside subtask 4.
+
+Integration tests hit the real local database per repo convention:
+
+- renewal succeeds and rotates the `UserSession` row
+- redeeming a rotated token revokes the session
+- expired refresh returns 401 and clears both cookies
+
+Frontend: single-flight collapse, retry-once, no-loop, terminal redirect preserved.
+
+### 7. Docs
+
+**Files:** `docs/guides/auth-security.md` — document the renewal flow, rotation, and reuse
+detection.
+
+## Data classification
+
+**No PHI. PII and authentication credentials.**
+
+The refresh token travels browser → gateway (httpOnly cookie, single path) → users service
+(HMAC-signed) → GoTrue. It is persisted only as a last-32 fragment in `UserSession.refreshToken`.
+Session metadata already stored — IP address, user agent, device type — is PII and is unchanged by
+this work.
+
+Constraints:
+
+- **No token value may enter a log, prompt, fixture, seed, or third-party service.** `SecureLogger`
+  redacts; audit entries use `slice(-32)`.
+- **Tokens must never reach JavaScript.** The route returns 204, never a body containing tokens.
+  Cookies stay httpOnly (`docs/guides/auth-security.md`).
+- Renewal goes through the API Gateway so CSRF validation and `X-HMAC-Auth` signing are preserved.
+
+## Risk register
+
+| Risk | Severity × Likelihood | Mitigation |
+|---|---|---|
+| Refresh loop hammers the auth provider on failure | **High × Possible** | `hasRetried` context marker; a failed refresh never re-enters the link. Explicit test. |
+| Multi-tab race redeems the same token, logging both tabs out | **High × Likely** | Single-flight promise per tab; rely on GoTrue's reuse interval across tabs. Rotation *without* this causes the very bug it aims to prevent. |
+| Widening the cookie path exposes a 7-day credential | **High × Rare** (only if the rejected design is revisited) | Recommended design keeps `/api/auth/refresh`. Re-run `/security-review` if reversed. |
+| Gateway's first controller bypasses a gateway-wide assumption | Medium × Possible | Verify CSRF/Auth middleware coverage explicitly; integration test asserts a missing CSRF header 403s. |
+| Federation drift from the new mutation | Medium × Possible | Gateway composition validation per `CLAUDE.md`; covered by CI. |
+| Reuse detection false-positives cause mass logouts | Medium × Rare | Revoke the single session, never all sessions for the user. |
+| New dependency with an incompatible licence | Low × Rare | None required — AGPL-3.0 constraint unaffected. |
+
+## Effort
+
+**3–4 focused sessions.** Backend chain (1–3) is the bulk, ~2. Frontend link (4) is ~0.5 but holds
+the subtle concurrency bugs. Tests (6) ~1.
+
+## Explicitly out of scope
+
+- Raising `COOKIE_ACCESS_TOKEN_MAX_AGE` as a stopgap. It trades a 15-minute forced logout for a
+  longer-lived bearer credential and must not ship as the resolution.
+- Any change to the terminal expired-session UX. `triggerAuthExpiredRedirect` is correct and stays
+  as the fallback once refresh has genuinely failed.

--- a/docs/plans/977-session-refresh-flow.md
+++ b/docs/plans/977-session-refresh-flow.md
@@ -195,9 +195,11 @@ the subtle concurrency bugs. Tests (6) ~1.
 | 2 — users service | `ba9a522` | `@inaccessible` mutation + in-place rotation |
 | 3 — gateway route | `e0ddb54` | `POST /api/auth/refresh`, the gateway's first controller |
 | 4 — frontend link | `89a74ce` | single-flight + retry-once; first user-visible change |
-| 5 — path coherence | (this series) | `REFRESH_COOKIE_PATH` + route-metadata assertion |
-| 6 — tests | (this series) | 8 integration tests, real stack + real DB |
-| 7 — docs | (this series) | `auth-security.md` § Session Renewal |
+| 5 — path coherence | `6eac89e` | `REFRESH_COOKIE_PATH` + route-metadata assertion |
+| 6 — tests | `b94e1f0` | 8 integration tests, real stack + real DB |
+| 7 — docs | `eb1d741` | `auth-security.md` § Session Renewal |
+| follow-up | `320166e` | real GoTrue session test — closes the happy-path gap |
+| unrelated | `ab24ff5` | magic-link callback auto-redirect (bundled at maintainer request) |
 
 ### What the risk register got right, and what it missed
 
@@ -216,14 +218,25 @@ Two things were **not** in the register and were found during implementation:
 Both are the same species of bug as the one being fixed: a transient failure being treated as a
 terminal one.
 
-### Still unproven
+### The happy path, and how it was nearly missed
 
-No test exercises a **genuine GoTrue refresh token** end to end. The provider unit tests mock the
-Supabase client, and the integration tests use a deliberately invalid grant. So the happy path —
-`supabase.auth.refreshSession()` against a real GoTrue, with the client constructed from a
-service-role key and `persistSession: false` — is verified by reading, not by running. A full
-magic-link login in the integration suite would close this; it is the one gap worth knowing about
-before trusting renewal in production.
+This section previously recorded that no test exercised a **genuine GoTrue refresh token** — the
+happy path was verified by reading only. That gap is now closed: a magic-link login through
+Inbucket obtains a real session, and renewal returns 204 with a rotated refresh token.
+`supabase.auth.refreshSession()` does work with a service-role client and `persistSession: false`.
+
+Worth recording how close that came to being worthless. The first version of the test **passed
+while proving nothing** — every failure inside the login helper returned `null`, which the tests
+read as "Inbucket isn't running" and skipped. Inbucket was up the whole time. Probing the
+infrastructure once, loudly, and letting everything else fail turned up two further errors:
+
+- the session must be **exchanged with the backend**, not merely minted by GoTrue, or no
+  `UserSession` row exists for rotation to update
+- the renewed **access** token is legitimately byte-identical when minted in the same second, so
+  asserting it differs was wrong; the rotated refresh token is the meaningful assertion
+
+A test that skips silently is worse than no test, because it reports coverage it does not have —
+the same failure mode as the bug this plan set out to fix.
 
 ## Explicitly out of scope
 

--- a/docs/plans/977-session-refresh-flow.md
+++ b/docs/plans/977-session-refresh-flow.md
@@ -7,7 +7,7 @@
 | **Author** | Rodney Gagnon |
 | **Data classification** | **PII — no PHI.** Authentication credentials (access + refresh tokens) and session metadata (IP, user agent, device). Strict PHI/PII lens applies by default — the repo has no `.claude/compliance-profile.yaml`. |
 | **Branch** | `fix/session-refresh-flow-977` |
-| **Status** | Approved 2026-08-14. Not started. |
+| **Status** | Approved 2026-08-14. **All 7 subtasks complete** — see the log below. |
 
 ## Problem
 
@@ -186,6 +186,44 @@ Constraints:
 
 **3–4 focused sessions.** Backend chain (1–3) is the bulk, ~2. Frontend link (4) is ~0.5 but holds
 the subtle concurrency bugs. Tests (6) ~1.
+
+## Delivery log
+
+| Subtask | Commit | Notes |
+|---|---|---|
+| 1 — provider | `dbb53fd` | `IAuthProvider.refreshSession()` — the gap the issue did not name |
+| 2 — users service | `ba9a522` | `@inaccessible` mutation + in-place rotation |
+| 3 — gateway route | `e0ddb54` | `POST /api/auth/refresh`, the gateway's first controller |
+| 4 — frontend link | `89a74ce` | single-flight + retry-once; first user-visible change |
+| 5 — path coherence | (this series) | `REFRESH_COOKIE_PATH` + route-metadata assertion |
+| 6 — tests | (this series) | 8 integration tests, real stack + real DB |
+| 7 — docs | (this series) | `auth-security.md` § Session Renewal |
+
+### What the risk register got right, and what it missed
+
+The multi-tab race and the refresh loop were both rated correctly and are both covered by tests.
+
+Two things were **not** in the register and were found during implementation:
+
+1. **A 4xx from the provider is not automatically terminal.** The first cut classified `429` as an
+   invalid token, which would have revoked valid sessions under load — reintroducing this issue's
+   forced logout at exactly the moment it hurts most. Found by review; `408`/`429` are now
+   explicitly retryable.
+2. **`UserInputError` erased the provider's error code**, which would have left the gateway route
+   unable to distinguish a dead session from an outage. The safe-*looking* default there is to sign
+   the user out. The code now travels in the GraphQL error extensions.
+
+Both are the same species of bug as the one being fixed: a transient failure being treated as a
+terminal one.
+
+### Still unproven
+
+No test exercises a **genuine GoTrue refresh token** end to end. The provider unit tests mock the
+Supabase client, and the integration tests use a deliberately invalid grant. So the happy path —
+`supabase.auth.refreshSession()` against a real GoTrue, with the client constructed from a
+service-role key and `persistSession: false` — is verified by reading, not by running. A full
+magic-link login in the integration suite would close this; it is the one gap worth knowing about
+before trusting renewal in production.
 
 ## Explicitly out of scope
 

--- a/docs/plans/canonical-california-subdomain.md
+++ b/docs/plans/canonical-california-subdomain.md
@@ -1,0 +1,164 @@
+# Plan: `app-us-ca.opuspopuli.org` → `california.opuspopuli.org`
+
+| | |
+|---|---|
+| **Issue** | _not yet filed_ — this plan predates it |
+| **Date** | 2026-08-15 |
+| **Author** | Rodney Gagnon |
+| **Data classification** | **No PHI, no PII.** Hostnames and CORS/redirect allow-lists only. No user data is read, moved, or transformed. |
+| **Branch** | `chore/canonical-california-subdomain` (proposed) |
+| **Status** | Drafted, not started. **One decision open** — see *The open decision*. |
+
+## Problem
+
+The California node is served at `app-us-ca.opuspopuli.org`. That name encodes an internal region
+identifier in a public, user-facing URL: it reads as a deployment slug rather than a place, and it
+is the address citizens will be asked to type, share and trust. The canonical name is
+`california.opuspopuli.org`.
+
+This is a **hostname rename, not a region rename**. The internal region id (`us-ca`), the plugin
+identifiers and the database rows stay exactly as they are.
+
+## State of play, verified 2026-08-15
+
+- `california.opuspopuli.org` **does not resolve** (`dig` returns nothing).
+- The live landing page still links to `https://app-us-ca.opuspopuli.org/`.
+- The landing-page change **is already committed and pushed** to
+  `opuspopuli.org@fix/canonical-ca-node-subdomain` (`c0d67e0`, `51e9181`), touching
+  `src/components/Header.astro:15` and `src/pages/network.astro:74`. It is one merge away from
+  pointing the public Sign In button at a host that does not exist.
+
+**That is the sequencing constraint for this whole plan.** The landing page merges *last*.
+
+## Two findings that make this much cheaper than it looks
+
+Both checked against the running production containers rather than assumed.
+
+**1. Passkeys survive the rename.**
+
+```
+WEBAUTHN_RP_ID=opuspopuli.org          <- the registrable domain, not the host
+WEBAUTHN_ORIGIN=https://app-us-ca.opuspopuli.org
+```
+
+A credential bound to `opuspopuli.org` is usable from *every* subdomain. Had `rpId` been set to the
+full host — which is the more obvious-looking choice, and which `webauthn.config.ts:28-31` warns
+against explicitly — this rename would have **silently invalidated every passkey ever registered**,
+with no recovery path for affected users. Only `WEBAUTHN_ORIGIN` needs to change.
+
+**2. Sessions survive the rename.**
+
+```
+COOKIE_DOMAIN=.opuspopuli.org
+```
+
+Auth cookies are already scoped to the parent domain, so they follow users across the move. Nobody
+is logged out by the cutover.
+
+## The open decision
+
+The API is `api-us-ca.opuspopuli.org` and carries the same naming problem.
+
+| Option | Result | Constraint |
+|---|---|---|
+| **A** — leave the API alone | `california.opuspopuli.org` → `api-us-ca.opuspopuli.org` | None. Inconsistent; visible in DevTools and in the CSP. |
+| **B** — `api-california.opuspopuli.org` | Flat and consistent | Covered by Cloudflare Universal SSL. **Recommended.** |
+| **C** — `api.california.opuspopuli.org` | Nested, tidiest reading | Universal SSL covers **one** subdomain level (`*.opuspopuli.org`). Two levels needs Advanced Certificate Manager — a paid add-on. Without it the host fails with a certificate error. |
+
+**Recommendation: B.** Same cutover cost as A, consistent naming, no billing dependency. C is a
+trap that presents as a cert failure at the worst possible moment.
+
+Everything below assumes the API moves. If option A is chosen, drop `US_CA_GRAPHQL_URL` and the
+`api_subdomain` change and the plan is otherwise identical.
+
+## Change inventory
+
+### This repo (`opuspopuli`)
+
+| File | Change |
+|---|---|
+| `apps/frontend/wrangler.toml:36` | route `pattern`. `custom_domain = true`, so **Cloudflare creates the DNS record on deploy** |
+| `.github/workflows/deploy-frontend.yml:183` | `environment.url` |
+| `docs/guides/deployment.md:47` | prose |
+| `apps/backend/src/config/webauthn.config.ts:30` | prose in the `rpId` warning |
+| `apps/backend/src/config/webauthn.config.spec.ts:32,37` | fixture strings (cosmetic) |
+
+### GitHub repository variables
+
+`US_CA_SITE_URL`, and `US_CA_GRAPHQL_URL` if the API moves.
+
+**These are inlined at build time**, so changing the variable does nothing on its own — a
+`frontend-v*` tag and a full rebuild are required to apply them. `deploy-frontend.yml` asserts the
+production origin is present in the built bundle, so a stale value fails the build rather than
+shipping silently.
+
+### Studio environment — the part that breaks auth if missed
+
+| Variable | Why it matters |
+|---|---|
+| `ALLOWED_ORIGINS` | CORS. Wrong → every API call from the new host fails |
+| `WEBAUTHN_ORIGIN` | Must match the serving origin **exactly**. Wrong → passkey assertions fail |
+| `GOTRUE_SITE_URL` | Magic-link default redirect |
+| `GOTRUE_URI_ALLOW_LIST` | **Magic links fail silently if the new host is not listed** |
+
+### Node repo (`opuspopuli-node-us-ca`)
+
+`infra/cloudflare/environments/prod.tfvars` — `app_subdomain`, and `api_subdomain` under option B.
+The Terraform parameterises both (`dns.tf:12,29`).
+
+**`prod.tfvars` is not committed** — only `prod.tfvars.example` is. Where the authoritative values
+live must be confirmed before cutover, or a later `terraform apply` will revert the DNS record that
+`wrangler` creates and take the site down.
+
+### Landing page (`opuspopuli.org`)
+
+Already done on `fix/canonical-ca-node-subdomain`. Merge last.
+
+### Explicitly not needed
+
+- **CSP** — derived from `NEXT_PUBLIC_SITE_URL`, so it follows automatically.
+- **Database migration** — none. No stored value contains the hostname.
+- **Region identifiers** — `us-ca` is internal and must not change.
+
+## Cutover sequence
+
+The ordering *is* the plan. Each step is independently reversible, and every step before the last
+leaves the site working on the old host.
+
+1. **Accept both origins.** Add `california.opuspopuli.org` to `ALLOWED_ORIGINS` and
+   `GOTRUE_URI_ALLOW_LIST` *alongside* the existing entries. Restart. No user-visible change.
+2. **Serve the new host.** Update `wrangler.toml` and the repository variables, tag `frontend-v*`.
+   Cloudflare creates the DNS record on deploy. Both hostnames now serve.
+3. **Verify on the new host** — page loads over HTTPS with a valid cert; sign-in works; a magic
+   link round-trips end to end; **a passkey assertion succeeds**. That last one is where an `rpId`
+   mistake would surface, and it is the only irreversible failure mode in this plan.
+4. **Flip the single-valued settings** — `WEBAUTHN_ORIGIN`, `GOTRUE_SITE_URL`.
+5. **Merge the landing page.** Only now.
+6. **301 the old host** with a Cloudflare Redirect Rule. Keep it indefinitely — it costs nothing
+   and existing links, bookmarks and any shared URLs keep working.
+7. **Soak, then drop** the old origin from the allow-lists.
+
+## Risk register
+
+| Risk | Severity × Likelihood | Mitigation |
+|---|---|---|
+| Landing page merged before the new host serves → public Sign In button 404s | **High × Likely** — the branch is pushed and one click from merging | Step 5 is explicitly last; called out at the top of this plan |
+| `GOTRUE_URI_ALLOW_LIST` missed → magic links fail silently | **High × Possible** | Step 1 adds both hosts; step 3 tests a real round-trip rather than inspecting config |
+| `prod.tfvars` drift → a later `terraform apply` reverts the DNS record | **High × Possible** | Locate the authoritative file *before* cutover; treat it as part of step 2 |
+| Variables changed without a rebuild → bundle still points at the old host | Medium × Likely | `NEXT_PUBLIC_*` is build-time; the workflow's inlining assertion catches it |
+| `WEBAUTHN_ORIGIN` flipped before the new host serves → passkeys break in the window | Medium × Possible | Step 4 comes after verification |
+| Old links break for existing users | Medium × Certain without action | Step 6 redirect, kept permanently |
+| Nested API host hits the Universal SSL one-level limit | Medium × Certain **if option C** | Choose option B |
+| Passkeys invalidated by an `rpId` change | **Critical × Rare** | `rpId` stays `opuspopuli.org` and is **not** touched by this work. Verified in production, not assumed |
+
+## Effort
+
+**One focused session, plus a soak period.** The repo diff is five files; the cost is coordination
+across four systems (this repo, GitHub variables, the Studio environment, Cloudflare/Terraform) and
+the ordering discipline above.
+
+## Open questions
+
+1. **Option A, B or C** for the API hostname — B recommended.
+2. **Where does `prod.tfvars` actually live?** Not in the node repo. Operator machine, or CI
+   secret? Must be answered before step 2.

--- a/packages/auth-provider/__tests__/supabase.provider.spec.ts
+++ b/packages/auth-provider/__tests__/supabase.provider.spec.ts
@@ -19,6 +19,7 @@ const mockAuth = {
   verifyOtp: jest.fn(),
   signInWithOtp: jest.fn(),
   getUser: jest.fn(),
+  refreshSession: jest.fn(),
   admin: {
     createUser: jest.fn(),
     deleteUser: jest.fn(),
@@ -1223,6 +1224,159 @@ describe("SupabaseAuthProvider", () => {
       await expect(
         provider.validateAccessToken("valid-but-no-email"),
       ).rejects.toThrow(AuthError);
+    });
+  });
+
+  describe("refreshSession", () => {
+    const session = {
+      access_token: "new-access-token",
+      refresh_token: "rotated-refresh-token",
+      expires_in: 3600,
+    };
+
+    it("should redeem a refresh token and return the rotated tokens", async () => {
+      mockAuth.refreshSession.mockResolvedValue({
+        data: { session, user: { id: "user-123" } },
+        error: null,
+      });
+
+      const result = await provider.refreshSession("old-refresh-token");
+
+      expect(mockAuth.refreshSession).toHaveBeenCalledWith({
+        refresh_token: "old-refresh-token",
+      });
+      expect(result.accessToken).toBe("new-access-token");
+      expect(result.expiresIn).toBe(3600);
+    });
+
+    // The rotation contract: callers persist what comes back, so returning the
+    // token that went in would silently break them one refresh later.
+    it("should return the NEW refresh token, not the one passed in", async () => {
+      mockAuth.refreshSession.mockResolvedValue({
+        data: { session, user: { id: "user-123" } },
+        error: null,
+      });
+
+      const result = await provider.refreshSession("old-refresh-token");
+
+      expect(result.refreshToken).toBe("rotated-refresh-token");
+      expect(result.refreshToken).not.toBe("old-refresh-token");
+    });
+
+    it.each([
+      ["expired", 400, "refresh_token_not_found"],
+      ["revoked", 401, "Invalid Refresh Token"],
+      ["already redeemed", 400, "Already Used"],
+    ])(
+      "should classify a %s token as REFRESH_TOKEN_INVALID",
+      async (_label, status, message) => {
+        mockAuth.refreshSession.mockResolvedValue({
+          data: null,
+          error: Object.assign(new Error(message), { status }),
+        });
+
+        await expect(
+          provider.refreshSession("dead-refresh-token"),
+        ).rejects.toMatchObject({ code: "REFRESH_TOKEN_INVALID" });
+      },
+    );
+
+    // The distinction the caller depends on: "sign in again" vs "try again".
+    // Collapsing these would log people out every time GoTrue hiccups.
+    it("should classify a 5xx as REFRESH_ERROR, not an invalid token", async () => {
+      mockAuth.refreshSession.mockResolvedValue({
+        data: null,
+        error: Object.assign(new Error("upstream unavailable"), {
+          status: 503,
+        }),
+      });
+
+      await expect(
+        provider.refreshSession("good-refresh-token"),
+      ).rejects.toMatchObject({ code: "REFRESH_ERROR" });
+    });
+
+    // 4xx by number, but says nothing about the token. Classifying these as
+    // terminal would revoke a valid session under load — reintroducing #977's
+    // forced logout through a different door.
+    it.each([
+      ["rate limited", 429],
+      ["request timeout", 408],
+    ])(
+      "should NOT treat a %s response as an invalid token",
+      async (_label, status) => {
+        mockAuth.refreshSession.mockResolvedValue({
+          data: null,
+          error: Object.assign(new Error("too many requests"), { status }),
+        });
+
+        await expect(
+          provider.refreshSession("perfectly-good-token"),
+        ).rejects.toMatchObject({ code: "REFRESH_ERROR" });
+      },
+    );
+
+    it("should classify a transport failure with no status as REFRESH_ERROR", async () => {
+      mockAuth.refreshSession.mockRejectedValue(new Error("socket hang up"));
+
+      await expect(
+        provider.refreshSession("good-refresh-token"),
+      ).rejects.toMatchObject({ code: "REFRESH_ERROR" });
+    });
+
+    // A 200 carrying no session is not success — falling through would hand
+    // the caller an IAuthResult of empty strings.
+    it("should reject a success response that carries no session", async () => {
+      mockAuth.refreshSession.mockResolvedValue({
+        data: { session: null, user: null },
+        error: null,
+      });
+
+      await expect(
+        provider.refreshSession("good-refresh-token"),
+      ).rejects.toMatchObject({ code: "REFRESH_TOKEN_INVALID" });
+    });
+
+    it.each([
+      ["empty", ""],
+      ["whitespace", "   "],
+    ])(
+      "should reject a %s token without calling the provider",
+      async (_l, token) => {
+        await expect(provider.refreshSession(token)).rejects.toMatchObject({
+          code: "REFRESH_TOKEN_INVALID",
+        });
+        expect(mockAuth.refreshSession).not.toHaveBeenCalled();
+      },
+    );
+
+    it("should never put the refresh token in a log message", async () => {
+      const secret = "super-secret-refresh-token";
+      const errorSpy = jest
+        .spyOn((provider as any).logger, "error")
+        .mockImplementation(() => undefined);
+      const logSpy = jest
+        .spyOn((provider as any).logger, "log")
+        .mockImplementation(() => undefined);
+
+      mockAuth.refreshSession.mockResolvedValue({
+        data: null,
+        error: Object.assign(new Error("Invalid Refresh Token"), {
+          status: 401,
+        }),
+      });
+      await expect(provider.refreshSession(secret)).rejects.toThrow(AuthError);
+
+      mockAuth.refreshSession.mockResolvedValue({
+        data: { session, user: { id: "user-123" } },
+        error: null,
+      });
+      await provider.refreshSession(secret);
+
+      const everythingLogged = [...errorSpy.mock.calls, ...logSpy.mock.calls]
+        .flat()
+        .join(" ");
+      expect(everythingLogged).not.toContain(secret);
     });
   });
 });

--- a/packages/auth-provider/src/providers/supabase.provider.ts
+++ b/packages/auth-provider/src/providers/supabase.provider.ts
@@ -744,6 +744,90 @@ export class SupabaseAuthProvider implements IAuthProvider {
   }
 
   /**
+   * Redeem a refresh token for a new session.
+   *
+   * GoTrue ROTATES on redemption: the token that comes back is not the one
+   * passed in, and the old one stops working once its reuse interval lapses.
+   * Callers must persist the returned refreshToken. GoTrue's reuse interval is
+   * also what lets two browser tabs redeem the same token near-simultaneously
+   * without one of them being logged out, so this deliberately does not add
+   * reuse detection of its own on top of it.
+   *
+   * SECURITY: never log the token, in whole or in part. The only identifier
+   * that reaches the log here is the user id GoTrue returns.
+   */
+  async refreshSession(refreshToken: string): Promise<IAuthResult> {
+    // Reject locally rather than spending a network call — and, more to the
+    // point, rather than tripping the circuit breaker on input we already know
+    // is unusable.
+    if (!refreshToken?.trim()) {
+      throw new AuthError("Refresh token is missing", "REFRESH_TOKEN_INVALID");
+    }
+
+    return this.circuitBreaker.execute(async () => {
+      let session: {
+        access_token: string;
+        refresh_token?: string;
+        expires_in?: number;
+      } | null = null;
+      let userId: string | undefined;
+      try {
+        const { data, error } = await this.supabase.auth.refreshSession({
+          refresh_token: refreshToken,
+        });
+        if (error) {
+          throw error;
+        }
+        session = data?.session ?? null;
+        userId = data?.user?.id;
+      } catch (error) {
+        // A 4xx means GoTrue considered the grant itself bad — expired,
+        // revoked, or already redeemed. That is terminal for this session and
+        // the caller should revoke rather than retry. Anything else (5xx,
+        // socket failure) is an availability problem: a different code, so the
+        // caller can tell "sign in again" from "try again".
+        //
+        // 408 and 429 are the exceptions. They are 4xx by number but say
+        // nothing about the token — treating a rate-limit as terminal would
+        // revoke a valid session and sign the user out under load, which is
+        // the very failure this whole change exists to remove.
+        const status = (error as { status?: number }).status;
+        const RETRYABLE_4XX = new Set([408, 429]);
+        const isRejected =
+          typeof status === "number" &&
+          status >= 400 &&
+          status < 500 &&
+          !RETRYABLE_4XX.has(status);
+
+        this.logger.error(
+          `Error refreshing session: ${(error as Error).message}`,
+        );
+        throw new AuthError(
+          isRejected
+            ? "Refresh token is invalid, expired, or already used"
+            : "Failed to refresh session",
+          isRejected ? "REFRESH_TOKEN_INVALID" : "REFRESH_ERROR",
+          error as Error,
+        );
+      }
+
+      // A 200 with no session is not success. Treated as a rejected grant
+      // because that is what it means in practice, and because falling through
+      // would hand the caller an IAuthResult full of empty strings.
+      if (!session) {
+        this.logger.error("Refresh returned no session");
+        throw new AuthError(
+          "Refresh token is invalid, expired, or already used",
+          "REFRESH_TOKEN_INVALID",
+        );
+      }
+
+      this.logger.log(`Session refreshed for user: ${userId ?? "unknown"}`);
+      return this.sessionToAuthResult(session);
+    });
+  }
+
+  /**
    * Send a magic link email via SMTP.
    */
   private async sendMagicLinkEmail(

--- a/packages/common/src/providers/auth/types.ts
+++ b/packages/common/src/providers/auth/types.ts
@@ -135,6 +135,23 @@ export interface IAuthProvider {
    * @returns The authenticated user's email
    */
   validateAccessToken?(accessToken: string): Promise<string>;
+
+  /**
+   * Redeem a refresh token for a new session.
+   *
+   * Implementations are expected to ROTATE: the returned `refreshToken` may
+   * differ from the one passed in, and the old one may stop working. Callers
+   * must persist what comes back rather than assuming the token is unchanged.
+   *
+   * Throws `AuthError` with code `REFRESH_TOKEN_INVALID` when the provider
+   * rejects the grant — expired, revoked, or already redeemed. That is a
+   * terminal condition for the session and is distinct from a transport or
+   * availability failure (`REFRESH_ERROR`), which may be worth retrying.
+   *
+   * @param refreshToken The refresh token to redeem
+   * @returns A fresh set of tokens
+   */
+  refreshSession?(refreshToken: string): Promise<IAuthResult>;
 }
 
 /**

--- a/packages/embeddings-provider/__tests__/xenova.provider.spec.ts
+++ b/packages/embeddings-provider/__tests__/xenova.provider.spec.ts
@@ -56,6 +56,15 @@ describe("XenovaEmbeddingProvider", () => {
       );
       expect(bgeProvider.getDimensions()).toBe(768);
     });
+
+    // The fallback arm of getDimensionsForModel. An unrecognised model must
+    // still yield a usable dimension rather than undefined — a vector of the
+    // wrong width fails at insert time, far from the cause.
+    it("falls back to 384 dimensions for an unrecognised model", () => {
+      const unknown = new XenovaEmbeddingProvider("Xenova/some-future-model");
+      expect(unknown.getDimensions()).toBe(384);
+      expect(unknown.getModelName()).toBe("Xenova/some-future-model");
+    });
   });
 
   describe("embedQuery", () => {
@@ -102,6 +111,26 @@ describe("XenovaEmbeddingProvider", () => {
 
       expect(result).toHaveLength(2);
       expect(mockPipelineFn).toHaveBeenCalledTimes(2);
+    });
+
+    // Batching only becomes observable above the batch size of 32; every
+    // other test here passes two documents, so the second iteration of the
+    // loop and its progress branch were never executed.
+    it("embeds across multiple batches when given more than one batch", async () => {
+      const texts = Array.from({ length: 40 }, (_, i) => `doc${i}`);
+      mockPipelineFn.mockResolvedValue({ data: new Float32Array([0.1, 0.2]) });
+
+      const result = await provider.embedDocuments(texts);
+
+      expect(result).toHaveLength(40);
+      expect(mockPipelineFn).toHaveBeenCalledTimes(40);
+    });
+
+    it("returns an empty array for no documents without calling the model", async () => {
+      const result = await provider.embedDocuments([]);
+
+      expect(result).toEqual([]);
+      expect(mockPipelineFn).not.toHaveBeenCalled();
     });
 
     it("should throw EmbeddingError when embedding fails", async () => {


### PR DESCRIPTION
Closes #977.

## What changed and why

A signed-in user was bounced to `/login` roughly 15 minutes after authenticating, mid-session. The access token had an absolute 15-minute lifetime and nothing renewed it. The refresh half of the design had been issued but never built: `setAuthCookies` wrote a 7-day refresh cookie scoped to `path: '/api/auth/refresh'` — an endpoint that did not exist. The credential was minted, stored, and never read by anything.

Research turned up a **third** missing piece the issue did not name, and it gated the other two: `IAuthProvider` had no `refreshSession()` at all.

The chain now runs end to end:

```
Query fails 401/403
  └─ sessionRefreshLink            single-flight, retry once
      └─ POST /api/auth/refresh    cookies only, no body, CSRF-guarded
          └─ refreshSession        users subgraph, HMAC-signed, @inaccessible
              └─ GoTrue            token?grant_type=refresh_token
          ← 204, new httpOnly cookies, NO body
  └─ operation retried → succeeds, user sees nothing
```

## Two design decisions worth reviewing

**Renewal is a REST route, not a GraphQL mutation.** GraphQL is served at `/api`; the refresh cookie is scoped to `/api/auth/refresh`, and a browser will not send it to `/api`. A mutation-only fix would have required widening the cookie path — shipping a 7-day credential with every GraphQL request. The endpoint moved to meet the cookie. The mutation exists but is `@inaccessible`, so clients cannot pass a refresh token as a GraphQL variable where it would land in query logs and traces. Verified against the live composed supergraph: 65 mutations, `refreshSession` absent, `exchangeSupabaseSession` present as a control.

**"Sign in again" and "try again" are kept distinct through all four layers.**

| Condition | Code | Route | Session | Frontend |
|---|---|---|---|---|
| Grant rejected — expired, revoked, already used | `REFRESH_TOKEN_INVALID` | 401 | revoked, cookies cleared | redirect to `/login?reason=expired` |
| Provider unreachable, 5xx, **408, 429** | `REFRESH_ERROR` | 503 | **untouched** | query fails, **session survives** |

Collapsing these at *any* layer would sign out every active user on a GoTrue blip — reintroducing this bug by another route. `429` is deliberately non-terminal despite being 4xx: a rate-limit says nothing about the token, and treating it as expiry would revoke valid sessions under load.

## How to test

```bash
pnpm integration:up    # rebuilds users + api — stale containers silently test old code
pnpm --filter backend test:integration -- session-refresh
```

Manually: sign in, wait more than 15 minutes, navigate to `/me/briefing`. Previously → `/login?reason=expired`. Now → the page loads with no interruption.

## Test coverage

- **provider** — 13 unit tests: rotation contract, error classification, no-token-in-logs
- **resolver / service** — 12 unit tests: revoke-vs-retry asserted in both directions
- **gateway route** — 12 unit tests: every failure keeps cookies except a rejected grant
- **frontend** — 17 unit tests: single-flight collapse, latch release, retry-once, no-loop
- **integration** — 11 tests against the real stack and database, including a **genuine GoTrue session** obtained via magic link

Full suite green: backend 2,355 / 137 suites, frontend 1,478, all 15 workspace packages. Lint 0 errors. No dependency changes, so the AGPL-3.0 constraint is unaffected.

## Data classification

**No PHI. Authentication credentials + PII** (session metadata: IP, user agent, device). `/op-data-scan` clean — no critical or high findings; the repo declares no compliance profile, so the strict `phi-pii` lens applied.

Tokens never reach JavaScript (204, no body) and never reach a log (`SecureLogger`; `refreshtoken` is already in `pii-masker`'s `SENSITIVE_FIELDS`, which the audit interceptor's `inputVariables` pass through). **No migration** — `UserSession` already carried every column rotation and revocation need.

## Also on this branch, unrelated to #977

`ab24ff5` — the magic-link callback said *"Redirecting you to the app..."* and then did not redirect; it rendered a **Continue to App** button and waited. It now navigates on its own, with the button kept as a fallback so nobody is stranded. The new-user passkey prompt is deliberately preserved — that screen is a real choice, not an interstitial, and a test asserts it is not navigated past.

Bundled at maintainer request. Flagging it because it is scope the plan did not cover.

## Linked issues

- Closes #977
- Filed #1011 — `verifyMagicLink` rejects the token from a real magic-link email. Found while writing the integration test here; not fixed here.

## Review status

**Self-review** — the sole author is also the reviewer, so per SOC 2 / 21 CFR Part 11 separation of duties this needs countersigning before it counts as independent. `/op-review` and `/op-security` were run before every commit.

Two defects came out of those gates rather than out of tests, and both are the same species as the bug being fixed — a transient failure treated as terminal:

- a `429` classified as an invalid token, which would have revoked valid sessions under load
- `UserInputError` erasing the provider's error code, leaving the gateway route unable to distinguish a dead session from an outage

A third came out of the integration test itself: **its first version passed while proving nothing.** Every failure inside the login helper returned `null`, which the tests read as "Inbucket is not running" and skipped — Inbucket was up the whole time. Infrastructure is now probed once, loudly, and anything else fails. A test that skips silently reports coverage it does not have.

The plan of record is `docs/plans/977-session-refresh-flow.md`, updated with a delivery log and an honest note on what its own risk register missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
