### PR TITLE
chore(frontend): remove the legacy app-us-ca hostname

### DIFF
--- a/apps/frontend/wrangler.toml
+++ b/apps/frontend/wrangler.toml
@@ -17,7 +17,7 @@ compatibility_flags = ["nodejs_compat"]
 directory = ".open-next/assets"
 binding = "ASSETS"
 
-# Custom domains.
+# Custom domain.
 #
 # Without these the Worker answers only on
 # opuspopuli-frontend.<subdomain>.workers.dev, and the hostname has no DNS
@@ -41,21 +41,6 @@ binding = "ASSETS"
 # identifiers and every stored row keep their existing values.
 [[routes]]
 pattern = "california.opuspopuli.org"
-custom_domain = true
-
-# The previous hostname, deliberately kept.
-#
-# Deleting it here would make the very next deploy a hard cutover: the Worker
-# would stop answering on app-us-ca the instant california went live, breaking
-# every existing link, bookmark and shared URL with no overlap and no way back
-# short of another deploy. Serving both makes the migration reversible at every
-# step.
-#
-# Remove this once a Cloudflare Redirect Rule 301s app-us-ca -> california, so
-# old links keep working rather than dying. A zone-level Redirect Rule runs
-# ahead of the Worker, so the rule can go in before this block comes out.
-[[routes]]
-pattern = "app-us-ca.opuspopuli.org"
 custom_domain = true
 
 # Environment variables are set via Cloudflare dashboard or wrangler CLI.

--- a/docs/guides/deployment.md
+++ b/docs/guides/deployment.md
@@ -51,13 +51,15 @@ Why it is here and not in the region repo:
 
 | | |
 |---|---|
-| App (canonical) | `california.opuspopuli.org` |
-| App (legacy, still served) | `app-us-ca.opuspopuli.org` |
+| App | `california.opuspopuli.org` |
 | API | `api-us-ca.opuspopuli.org` |
 
-`app-us-ca` encoded an internal region identifier in the one URL citizens are asked to type and
-share. `california` is the canonical name; the old host stays routed so existing links keep
-working, and comes out of `wrangler.toml` once a Cloudflare Redirect Rule 301s it across.
+`app-us-ca.opuspopuli.org` was the previous app hostname. It encoded an internal region identifier
+in the one URL citizens are asked to type and share, and has been **removed** — the Worker route is
+gone, so Cloudflare deleted the DNS record with it and the name no longer resolves. Removed
+outright rather than 301'd: it was retired before public launch, so there were no established links
+to preserve, and keeping a redirect alive would have meant maintaining a DNS record and a rule for
+a name nobody holds.
 
 This is a **hostname** rename only — the region id (`us-ca`), the plugin identifiers and every
 stored row are unchanged. The API keeps its `api-us-ca` name for now: it is not user-facing, and


### PR DESCRIPTION
Retires the previous app hostname now that `california.opuspopuli.org` is verified serving.

## What this does

Drops `app-us-ca.opuspopuli.org` from `wrangler.toml`. Because it is a Worker **Custom Domain**, Cloudflare owns its DNS record — removing the route removes the record with it. After the next `frontend-v*` deploy, `app-us-ca.opuspopuli.org` **does not resolve**.

## Why removed outright rather than 301'd

A redirect would mean keeping a proxied DNS record and a Redirect Rule alive indefinitely for a name retired before public launch. Nothing outside our own landing page ever linked to it, and that link now points at `california` (opuspopuli.org#14, merged). There are no established bookmarks for a redirect to rescue.

## Ordering, which is the risky part

This must not ship before `california` is proven. It now is — verified after `frontend-v1.0.0`:

- serves the new bundle: **14** references to `california.opuspopuli.org` in the served HTML, **zero** to `app-us-ca` (the canonical/OG metadata previously pointed back at the old host)
- `sendMagicLink` accepted from the `california` origin with a `california` redirect — exercises `GOTRUE_URI_ALLOW_LIST`
- `POST /api/auth/refresh` reachable from that origin, correctly 401 without a cookie
- CSP `connect-src` still targets `api-us-ca` — the API is unchanged by this work

And the public landing page now links to `california` before this removes the old name, not after.

## Not included

Studio cleanup — dropping `app-us-ca` from `ALLOWED_ORIGINS` and `GOTRUE_URI_ALLOW_LIST`, and pointing `SITE_URL` at `california`. Those are inert once the hostname stops resolving (no browser can present an origin that does not exist), so they are tidying rather than a fix, and they do not need to land in lockstep with this.

## Verification after deploy

```
dig +short app-us-ca.opuspopuli.org      # expect empty
curl -sI https://california.opuspopuli.org   # expect 200
```

## Data classification

No PHI, no PII. Hostname configuration only.

## Review status

**Self-review.** Sole author is also reviewer, so this needs countersigning to count as independent under SOC 2 / Part 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
