### PR TITLE
fix(frontend): onboarding was skipped for every new registration

### DIFF
--- a/apps/frontend/__tests__/pages/auth-callback.test.tsx
+++ b/apps/frontend/__tests__/pages/auth-callback.test.tsx
@@ -13,10 +13,41 @@ jest.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
   }),
-  useSearchParams: () => ({
-    get: (key: string) => mockSearchParamsGet(key),
-  }),
 }));
+
+/**
+ * Render with the params actually in the URL.
+ *
+ * The page reads `location.search` directly rather than `useSearchParams()`,
+ * because this route is prerendered as static and that hook is empty until
+ * hydration — which silently skipped onboarding for every new registration.
+ * Mocking the hook would therefore test a code path the app no longer has, so
+ * these tests put the values where the component genuinely looks for them.
+ *
+ * Each test still declares its params via `mockSearchParamsGet`; this just
+ * translates that into a real URL before mounting.
+ */
+const PARAM_KEYS = ["token", "email", "type", "redirect"] as const;
+
+function renderCallback() {
+  const params = new URLSearchParams();
+  for (const key of PARAM_KEYS) {
+    const value = mockSearchParamsGet?.(key);
+    if (value) params.set(key, value as string);
+  }
+  // history.replaceState, not `location.search = ...`: jsdom implements hash
+  // changes but not navigation, so assigning search would throw. replaceState
+  // updates location without navigating, and preserves any hash the test set
+  // before rendering (the hash-exchange cases rely on that).
+  const qs = params.toString();
+  const hash = globalThis.location.hash || "";
+  globalThis.history.replaceState(
+    {},
+    "",
+    `/auth/callback${qs ? `?${qs}` : ""}${hash}`,
+  );
+  return render(<AuthCallbackPage />);
+}
 
 // Mock Next.js Link
 jest.mock("next/link", () => {
@@ -73,7 +104,7 @@ describe("AuthCallbackPage", () => {
     it("should show error when no valid params are found", async () => {
       mockSearchParamsGet = jest.fn().mockReturnValue(null);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(screen.getByText("Link expired or invalid")).toBeInTheDocument();
@@ -83,7 +114,7 @@ describe("AuthCallbackPage", () => {
     it("should show error description", async () => {
       mockSearchParamsGet = jest.fn().mockReturnValue(null);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -95,7 +126,7 @@ describe("AuthCallbackPage", () => {
     it("should show back to sign in link", async () => {
       mockSearchParamsGet = jest.fn().mockReturnValue(null);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -112,7 +143,7 @@ describe("AuthCallbackPage", () => {
       });
       mockVerifyMagicLink.mockRejectedValue(new Error("Invalid token"));
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(screen.getByText("Link expired or invalid")).toBeInTheDocument();
@@ -126,7 +157,7 @@ describe("AuthCallbackPage", () => {
         error: "Custom error message",
       };
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(screen.getByText("Custom error message")).toBeInTheDocument();
@@ -146,7 +177,7 @@ describe("AuthCallbackPage", () => {
         () => new Promise((resolve) => setTimeout(resolve, 100)),
       );
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       // Should show verifying state initially
       expect(screen.getByText("Verifying your link...")).toBeInTheDocument();
@@ -165,7 +196,7 @@ describe("AuthCallbackPage", () => {
       });
       mockVerifyMagicLink.mockResolvedValue(undefined);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(screen.getByText("You're signed in!")).toBeInTheDocument();
@@ -180,7 +211,7 @@ describe("AuthCallbackPage", () => {
       });
       mockVerifyMagicLink.mockResolvedValue(undefined);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -200,7 +231,7 @@ describe("AuthCallbackPage", () => {
       });
       mockVerifyMagicLink.mockResolvedValue(undefined);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalledWith("/me/briefing");
@@ -216,7 +247,7 @@ describe("AuthCallbackPage", () => {
       });
       mockVerifyMagicLink.mockResolvedValue(undefined);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalledWith("/me/saved");
@@ -232,7 +263,7 @@ describe("AuthCallbackPage", () => {
       // Never resolves — the page must sit on the spinner, not redirect.
       mockVerifyMagicLink.mockReturnValue(new Promise(() => {}));
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(screen.getByText("Verifying your link...")).toBeInTheDocument();
@@ -248,7 +279,7 @@ describe("AuthCallbackPage", () => {
       });
       mockVerifyMagicLink.mockResolvedValue(undefined);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -265,7 +296,7 @@ describe("AuthCallbackPage", () => {
       });
       mockVerifyMagicLink.mockResolvedValue(undefined);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -294,7 +325,7 @@ describe("AuthCallbackPage", () => {
       mockVerifyMagicLink.mockResolvedValue(undefined);
       mockAuthContextValue = { ...defaultAuthContext, supportsPasskeys: false };
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       const continueButton = await screen.findByRole("button", {
         name: "Continue to App",
@@ -320,7 +351,7 @@ describe("AuthCallbackPage", () => {
       mockVerifyMagicLink.mockResolvedValue(undefined);
       mockAuthContextValue = { ...defaultAuthContext, supportsPasskeys: true };
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -340,7 +371,7 @@ describe("AuthCallbackPage", () => {
       mockVerifyMagicLink.mockResolvedValue(undefined);
       mockAuthContextValue = { ...defaultAuthContext, supportsPasskeys: true };
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -359,7 +390,7 @@ describe("AuthCallbackPage", () => {
       mockVerifyMagicLink.mockResolvedValue(undefined);
       mockAuthContextValue = { ...defaultAuthContext, supportsPasskeys: true };
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -380,7 +411,7 @@ describe("AuthCallbackPage", () => {
       mockVerifyMagicLink.mockResolvedValue(undefined);
       mockAuthContextValue = { ...defaultAuthContext, supportsPasskeys: true };
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -399,7 +430,7 @@ describe("AuthCallbackPage", () => {
       mockVerifyMagicLink.mockResolvedValue(undefined);
       mockAuthContextValue = { ...defaultAuthContext, supportsPasskeys: true };
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -418,7 +449,7 @@ describe("AuthCallbackPage", () => {
       mockVerifyMagicLink.mockResolvedValue(undefined);
       mockAuthContextValue = { ...defaultAuthContext, supportsPasskeys: true };
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(
@@ -442,7 +473,7 @@ describe("AuthCallbackPage", () => {
       });
       mockVerifyMagicLink.mockResolvedValue(undefined);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(mockVerifyMagicLink).toHaveBeenCalledWith(
@@ -463,7 +494,7 @@ describe("AuthCallbackPage", () => {
         "#access_token=supabase-jwt&refresh_token=refresh-jwt&token_type=bearer";
       mockExchangeSupabaseSession.mockResolvedValue(undefined);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(mockExchangeSupabaseSession).toHaveBeenCalledWith(
@@ -478,7 +509,7 @@ describe("AuthCallbackPage", () => {
         "#access_token=supabase-jwt&refresh_token=refresh-jwt";
       mockExchangeSupabaseSession.mockResolvedValue(undefined);
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(screen.getByText("You're signed in!")).toBeInTheDocument();
@@ -489,7 +520,7 @@ describe("AuthCallbackPage", () => {
       window.location.hash = "#access_token=bad-token";
       mockExchangeSupabaseSession.mockRejectedValue(new Error("Invalid token"));
 
-      render(<AuthCallbackPage />);
+      renderCallback();
 
       await waitFor(() => {
         expect(screen.getByText("Link expired or invalid")).toBeInTheDocument();

--- a/apps/frontend/app/(auth)/auth/callback/page.tsx
+++ b/apps/frontend/app/(auth)/auth/callback/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Suspense, useEffect, useState, useRef } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/lib/auth-context";
 import { AuthCheckIcon } from "@/components/auth/AuthUI";
@@ -61,10 +61,9 @@ function resolveRedirect(raw: string | null, fallback: string): string {
   return raw;
 }
 
-// Main callback content component that uses useSearchParams
+// Main callback content component
 function AuthCallbackContent() {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const {
     verifyMagicLink,
     exchangeSupabaseSession,
@@ -72,7 +71,27 @@ function AuthCallbackContent() {
     error,
     supportsPasskeys,
   } = useAuth();
-  const rawRedirect = searchParams.get("redirect");
+
+  /**
+   * The query string, read once from `location` on mount.
+   *
+   * Deliberately NOT `useSearchParams()`. This route is prerendered as static,
+   * and on a static page that hook is empty for the first client render,
+   * filling in only after hydration. Anything that reads it before then — most
+   * damagingly the mount effect below — silently sees nothing.
+   *
+   * A `useState` initializer runs during render, so on the server (where there
+   * is no `location`) it yields empty params, and on the client it has the real
+   * values from the very first render. See the note in the effect for what
+   * this cost us.
+   */
+  const [query] = useState(() =>
+    globalThis.location === undefined
+      ? new URLSearchParams()
+      : new URLSearchParams(globalThis.location.search),
+  );
+
+  const rawRedirect = query.get("redirect");
   const skipTarget = resolveRedirect(rawRedirect, "/onboarding");
   const continueTarget = resolveRedirect(rawRedirect, "/me/briefing");
 
@@ -91,10 +110,16 @@ function AuthCallbackContent() {
     }
     hasProcessedRef.current = true;
 
-    // Get params from URL (Supabase magic link format)
-    const token = searchParams.get("token");
-    const email = searchParams.get("email");
-    const type = searchParams.get("type");
+    // `query` is read from location on mount (see above), NOT from
+    // useSearchParams. When it was the hook, this effect ran before hydration
+    // populated it, so `type` was null and `type === "register"` was false —
+    // every newly registered user went to /me/briefing and never saw
+    // onboarding. Sign-in still worked, because the tokens come from the hash
+    // and that was always read straight off `location`. That asymmetry is why
+    // it hid: the visible half of the flow was fine.
+    const token = query.get("token");
+    const email = query.get("email");
+    const type = query.get("type");
 
     // Check for Supabase hash params format (#access_token=...)
     const hash = globalThis.location.hash;

--- a/apps/frontend/components/onboarding/steps/WelcomeStep.tsx
+++ b/apps/frontend/components/onboarding/steps/WelcomeStep.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 import { useMutation } from "@apollo/client/react";
 import { useLocale } from "@/lib/i18n/context";
 import { useToast } from "@/lib/toast";
+import { Sunflower } from "@/components/brand/Sunflower";
 import {
   UPDATE_MY_PROFILE,
   type SupportedLanguage,
@@ -44,8 +45,23 @@ export function WelcomeStep() {
 
   return (
     <div className="text-center max-w-md">
-      <div className="w-24 h-24 bg-inverse-surface text-on-inverse rounded-lg mx-auto mb-8 flex items-center justify-center">
-        <span className="text-4xl font-bold">O</span>
+      {/*
+        The brand mark, not a placeholder. This was a dark rounded square with
+        a letter "O" — the first thing a new account ever saw, and the only
+        screen in the product still showing it.
+
+        `state="idle"` gives the sway animation the header already uses, and
+        the component respects prefers-reduced-motion.
+
+        Deliberately UNtitled, unlike the header's mark. Without a `title` the
+        component renders aria-hidden, which is what we want here: the h1 below
+        already names the screen, so labelling this would make a screen reader
+        announce the brand twice before reaching the actual content. The
+        onboarding a11y suite enforces exactly that — every SVG on a step must
+        be decorative.
+      */}
+      <div className="mx-auto mb-8 flex w-24 items-center justify-center">
+        <Sunflower state="idle" size={96} />
       </div>
 
       <h1 className="text-3xl font-bold mb-4 text-content">


### PR DESCRIPTION
Two fixes to the first-run experience, both blocking the announcement.

## 1. Onboarding was skipped for every new registration

A newly registered user went straight to `/me/briefing` and never saw onboarding, so no profile and no jurisdiction were created for them.

Reproduced against production: account created `17:04:02`, landed on `/me/briefing` five seconds later, `user_profiles` row absent.

### Cause

`/auth/callback` is **prerendered as static** (`prerender-manifest.json`). On a static route `useSearchParams()` is empty for the first client render and only populates after hydration. The mount effect runs exactly once, guarded by `hasProcessedRef`, so it captured that empty value:

```ts
const type = searchParams.get("type");   // ← empty at mount on a static route
const hash = globalThis.location.hash;   // ← direct read, always available
```

`type` read as `null`, `type === "register"` was false, and every registration took the returning-user branch.

**Why it hid:** the tokens come from the URL *hash*, which was always read straight off `location`. Sign-in worked perfectly. Only the routing decision was wrong — and only for people signing up, the group least able to know what should have happened.

### Fix

The query string is read from `location` once on mount, the same shape as the hash read directly below it, so the two cannot drift apart again. This also covers `redirect`, which had the identical latent fault and was surviving only on timing.

### The tests were part of the problem

They mocked `useSearchParams` — the exact thing that was broken — so they passed while production skipped onboarding for every new user. They now put params in a real URL via `replaceState`, so `routes a new user without passkeys to onboarding (#758)` finally exercises the path that was failing.

jsdom implements hash changes but not navigation, so `replaceState` is what works here; assigning `location.search` and redefining `location` both fail.

### How it was verified

Not assumed at any step:

- the audit log shows the app sent `redirectTo: .../auth/callback?type=register` correctly
- GoTrue preserved the query param — reproduced locally end to end through Inbucket
- production's GoTrue log shows the browser was at `.../auth/callback?type=register`

So the parameter reached the browser and the loss was entirely client-side.

## 2. The welcome screen showed a placeholder logo

The first screen a new account ever sees rendered a dark rounded square containing the letter **"O"** — the last place in the product still showing it. Now uses the `Sunflower` brand mark at 96px with the idle sway the header already uses.

Deliberately **untitled**, unlike the header's mark: without a `title` the component renders `aria-hidden`, which is right here because the `<h1>` immediately below already names the screen. Labelling it would make a screen reader announce the brand before reaching any content.

The onboarding a11y suite enforces exactly this — every SVG on a step must be decorative — and it caught the first version of this change, which was titled.

## Verification

- frontend: **121 suites / 1,476 tests** pass, including the a11y suite
- lint and `tsc` clean on all changed files
- no dependency changes; `gitleaks` clean

## Data classification

No PHI, no PII. Client-side routing and a brand asset.

## Review status

**Self-review** — sole author is also reviewer, so this needs countersigning to count as independent under SOC 2 / Part 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
