### PR TITLE
chore(frontend): flatten a nested template literal in the callback test

### DIFF
--- a/apps/frontend/__tests__/pages/auth-callback.test.tsx
+++ b/apps/frontend/__tests__/pages/auth-callback.test.tsx
@@ -40,12 +40,9 @@ function renderCallback() {
   // updates location without navigating, and preserves any hash the test set
   // before rendering (the hash-exchange cases rely on that).
   const qs = params.toString();
+  const search = qs ? `?${qs}` : "";
   const hash = globalThis.location.hash || "";
-  globalThis.history.replaceState(
-    {},
-    "",
-    `/auth/callback${qs ? `?${qs}` : ""}${hash}`,
-  );
+  globalThis.history.replaceState({}, "", `/auth/callback${search}${hash}`);
   return render(<AuthCallbackPage />);
 }
 


### PR DESCRIPTION
## What

One line in `__tests__/pages/auth-callback.test.tsx` — pulls the conditional query string out of a nested template literal into its own binding.

```
47:27  error  Refactor this code to not use nested template literals  sonarjs/no-nested-template-literals
```

## Why it matters more than the diff suggests

This rule is currently failing **on `main`**, so the pre-push sonar gate (`.husky/pre-push` §2b) blocks every developer's push until it's fixed — including release tags. It blocked `v1.8.2`.

It reached `main` because CI's Lint job runs `pnpm lint`, while this rule only fires under `pnpm lint:sonar`, which runs **only** in the local pre-push hook. So the repo has a class of lint rule that CI cannot catch and that surfaces later, on someone else's push, in a file they didn't touch.

Worth considering as a follow-up: adding `lint:sonar` to `ci.yml` so the gate that blocks pushes is the same one that gates PRs. Not done here to keep this a one-line fix.

## Testing

- `pnpm --filter frontend lint:sonar` — clean
- 24 auth-callback tests pass unchanged; no behaviour change

## Data classification

None — test-only, no runtime code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)