### PR TITLE
fix(auth): make logout actually sign the user out

### DIFF
--- a/apps/backend/src/api/src/app.module.ts
+++ b/apps/backend/src/api/src/app.module.ts
@@ -43,6 +43,7 @@ import { HmacRemoteGraphQLDataSource } from './hmac-data-source';
 import { GatewayServicesModule } from './gateway-services.module';
 import { WebSocketConnectionException } from 'src/common/exceptions/app.exceptions';
 import { AuthRefreshController } from './auth-refresh.controller';
+import { AuthLogoutController } from './auth-logout.controller';
 
 /**
  * Extract authenticated user from request context for GraphQL operations.
@@ -233,10 +234,15 @@ const handleAuth = ({ req, res }: { req: Request; res: Response }) => {
     }),
   ],
   controllers: [
-    // Session renewal. The gateway's only REST route, because the refresh
-    // cookie is path-scoped to /api/auth/refresh and the renewal mutation is
+    // Session renewal. REST rather than a mutation because the refresh cookie
+    // is path-scoped to /api/auth/refresh and the renewal mutation is
     // @inaccessible — see the controller for why both of those are deliberate.
     AuthRefreshController,
+    // Sign-out. REST for a different reason: cookies must be cleared on the
+    // response the GATEWAY writes. Clearing them on the users subgraph and
+    // relying on Set-Cookie forwarding did not reach the browser, which left
+    // users signed in after logging out. See the controller.
+    AuthLogoutController,
   ],
   providers: [
     // SECURITY: Exception filters for error sanitization

--- a/apps/backend/src/api/src/auth-logout.controller.spec.ts
+++ b/apps/backend/src/api/src/auth-logout.controller.spec.ts
@@ -1,0 +1,120 @@
+import { ConfigService } from '@nestjs/config';
+import { Request, Response } from 'express';
+import { AuthLogoutController } from './auth-logout.controller';
+import { HmacSignerService } from 'src/common/services/hmac-signer.service';
+
+/**
+ * The behaviour under test is not "logout calls the subgraph" — it is
+ * "the browser stops being signed in, whatever else happens". Every case here
+ * asserts the cookies were cleared, including the ones where the upstream call
+ * fails, because that is precisely where the previous implementation broke.
+ */
+describe('AuthLogoutController', () => {
+  const USERS_URL = 'http://users:3001/graphql';
+
+  let controller: AuthLogoutController;
+  let res: Response & { clearCookie: jest.Mock };
+  let fetchMock: jest.Mock;
+
+  const configService = {
+    get: (key: string) => {
+      if (key === 'MICROSERVICES') {
+        return JSON.stringify([{ name: 'users', url: USERS_URL }]);
+      }
+      if (key === 'cookie.accessTokenName') return 'access-token';
+      if (key === 'cookie.refreshTokenName') return 'refresh-token';
+      if (key === 'cookie.domain') return '.opuspopuli.org';
+      if (key === 'cookie.sameSite') return 'strict';
+      if (key === 'cookie.secure') return true;
+      return undefined;
+    },
+  } as unknown as ConfigService;
+
+  const hmacSigner = {
+    isEnabled: () => true,
+    signGraphQLRequest: () => 'signed',
+  } as unknown as HmacSignerService;
+
+  const requestWith = (cookies: Record<string, string>) =>
+    ({ cookies }) as unknown as Request;
+
+  const clearedCookieNames = () =>
+    res.clearCookie.mock.calls.map((call) => call[0] as string);
+
+  beforeEach(() => {
+    controller = new AuthLogoutController(configService, hmacSigner);
+    res = { clearCookie: jest.fn() } as unknown as Response & {
+      clearCookie: jest.Mock;
+    };
+    fetchMock = jest.fn().mockResolvedValue({ json: async () => ({}) });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('clears both auth cookies on a normal logout', async () => {
+    await controller.logout(requestWith({ 'access-token': 'tok' }), res);
+
+    expect(clearedCookieNames()).toEqual(
+      expect.arrayContaining(['access-token', 'refresh-token']),
+    );
+  });
+
+  it('clears the refresh cookie at the path it was set on', async () => {
+    await controller.logout(requestWith({ 'access-token': 'tok' }), res);
+
+    const refreshCall = res.clearCookie.mock.calls.find(
+      (call) => call[0] === 'refresh-token',
+    );
+    // A clear aimed at the wrong path silently does nothing, leaving a 7-day
+    // credential alive on a session the user believes they ended.
+    expect(refreshCall?.[1]).toMatchObject({ path: '/api/auth/refresh' });
+  });
+
+  it('asks the users subgraph to revoke the session, HMAC-signed', async () => {
+    await controller.logout(requestWith({ 'access-token': 'tok' }), res);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe(USERS_URL);
+    expect((init as RequestInit).headers).toMatchObject({
+      'X-HMAC-Auth': 'signed',
+    });
+    expect((init as RequestInit).body).toContain('RevokeSession');
+  });
+
+  it('still clears cookies when the subgraph is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(
+      controller.logout(requestWith({ 'access-token': 'tok' }), res),
+    ).resolves.toBeUndefined();
+
+    // The whole point. An outage must not be able to leave someone signed in.
+    expect(clearedCookieNames()).toEqual(
+      expect.arrayContaining(['access-token', 'refresh-token']),
+    );
+  });
+
+  it('still clears cookies when the subgraph returns a GraphQL error', async () => {
+    fetchMock.mockResolvedValue({
+      json: async () => ({ errors: [{ message: 'token already revoked' }] }),
+    });
+
+    await controller.logout(requestWith({ 'access-token': 'tok' }), res);
+
+    expect(clearedCookieNames()).toEqual(
+      expect.arrayContaining(['access-token', 'refresh-token']),
+    );
+  });
+
+  it('clears cookies even with no access token to revoke', async () => {
+    // The expired-session path: the access cookie has already been dropped by
+    // the browser, but the 7-day refresh cookie has not. The old auth-guarded
+    // mutation rejected this case outright and cleared nothing.
+    await controller.logout(requestWith({}), res);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(clearedCookieNames()).toEqual(
+      expect.arrayContaining(['access-token', 'refresh-token']),
+    );
+  });
+});

--- a/apps/backend/src/api/src/auth-logout.controller.ts
+++ b/apps/backend/src/api/src/auth-logout.controller.ts
@@ -9,6 +9,7 @@ import type { Request, Response } from 'express';
 import { HmacSignerService } from 'src/common/services/hmac-signer.service';
 import { SecureLogger } from 'src/common/services/secure-logger.service';
 import { clearAuthCookies } from 'src/common/utils/cookie.utils';
+import { callUsersSubgraph } from './users-subgraph.client';
 
 /**
  * `@inaccessible` on the users subgraph, so it is absent from the composed
@@ -21,11 +22,6 @@ const REVOKE_MUTATION = `
     revokeSession(accessToken: $accessToken)
   }
 `;
-
-interface SubgraphConfig {
-  name: string;
-  url: string;
-}
 
 /**
  * Sign-out endpoint — `POST /api/auth/logout`.
@@ -71,16 +67,6 @@ export class AuthLogoutController {
     private readonly hmacSigner: HmacSignerService,
   ) {}
 
-  private getUsersSubgraphUrl(): string {
-    const raw = this.configService.get<string>('MICROSERVICES');
-    const subgraphs = JSON.parse(raw || '[]') as SubgraphConfig[];
-    const users = subgraphs.find((s) => s.name === 'users');
-    if (!users?.url) {
-      throw new Error('No users subgraph configured in MICROSERVICES');
-    }
-    return users.url;
-  }
-
   @Post('logout')
   @HttpCode(204)
   async logout(
@@ -115,26 +101,12 @@ export class AuthLogoutController {
    */
   private async revokeUpstream(accessToken: string): Promise<void> {
     try {
-      const url = this.getUsersSubgraphUrl();
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-      };
-      if (this.hmacSigner.isEnabled()) {
-        headers['X-HMAC-Auth'] = this.hmacSigner.signGraphQLRequest(url);
-      }
-
-      const response = await fetch(url, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-          query: REVOKE_MUTATION,
-          variables: { accessToken },
-        }),
-      });
-
-      const payload = (await response.json()) as {
-        errors?: { message: string }[];
-      };
+      const payload = await callUsersSubgraph<{ revokeSession?: boolean }>(
+        this.configService,
+        this.hmacSigner,
+        REVOKE_MUTATION,
+        { accessToken },
+      );
 
       const error = payload.errors?.[0];
       if (error) {

--- a/apps/backend/src/api/src/auth-logout.controller.ts
+++ b/apps/backend/src/api/src/auth-logout.controller.ts
@@ -1,0 +1,149 @@
+import { Controller, HttpCode, Post, Req, Res } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+// `import type`, not a value import. NestJS emits decorator metadata for
+// `@Req() req: Request`, which turns the type into a RUNTIME reference that
+// webpack then tries to resolve — and express is not a declared dependency
+// of this package, so the bundle build reports it as unresolvable. Erasing
+// the import at compile time removes the reference and the error with it.
+import type { Request, Response } from 'express';
+import { HmacSignerService } from 'src/common/services/hmac-signer.service';
+import { SecureLogger } from 'src/common/services/secure-logger.service';
+import { clearAuthCookies } from 'src/common/utils/cookie.utils';
+
+/**
+ * `@inaccessible` on the users subgraph, so it is absent from the composed
+ * public schema and reachable only by a direct HMAC-signed call from here.
+ * The access token travels as a variable to a service-to-service endpoint, not
+ * from a browser through `/api`.
+ */
+const REVOKE_MUTATION = `
+  mutation RevokeSession($accessToken: String!) {
+    revokeSession(accessToken: $accessToken)
+  }
+`;
+
+interface SubgraphConfig {
+  name: string;
+  url: string;
+}
+
+/**
+ * Sign-out endpoint — `POST /api/auth/logout`.
+ *
+ * Replaces the federated `logout` mutation, which failed to sign anyone out in
+ * production. Two independent defects, both confirmed against the live system:
+ *
+ * 1. **The clear never reached the browser.** `logout` runs on the users
+ *    subgraph and clears cookies on the SUBGRAPH's response, relying on the
+ *    gateway's `didReceiveResponse` to forward `Set-Cookie` onward. Whatever
+ *    the mechanism, it does not survive that hop for the clear: after a
+ *    successful logout the browser still held a valid access token, and was
+ *    still authenticated as the previous user seven minutes later — long
+ *    enough to register a NEW account and land in the OLD account's briefing.
+ *    Clearing from the gateway, where the response to the browser is actually
+ *    written, is verifiable with a single curl and needs no forwarding at all.
+ *
+ * 2. **Logout required a valid access token.** The mutation sits behind the
+ *    auth guard, so once the 15-minute token lapsed, clicking "log out"
+ *    returned `Forbidden resource` and cleared nothing — leaving the 7-day
+ *    refresh cookie intact on exactly the sessions most likely to want out.
+ *    This route is reachable without a live access token by design.
+ *
+ * The ordering rule this is built around: **cookies are cleared no matter what
+ * happens upstream.** Provider down, subgraph unreachable, token already
+ * expired — the browser still stops being signed in. A logout that reports
+ * failure and leaves the user authenticated is the worst of both worlds, and
+ * is what the old path did.
+ *
+ * SECURITY NOTES
+ * - Responds 204 with no body; nothing here is readable by JavaScript.
+ * - `CsrfMiddleware` covers this route via `forRoutes({path: '*'})`, so a POST
+ *   without `X-CSRF-Token` is rejected before any of this runs.
+ * - The refresh cookie is cleared at `REFRESH_COOKIE_PATH`, which is where it
+ *   was set. `clearAuthCookies` owns that correspondence.
+ */
+@Controller('api/auth')
+export class AuthLogoutController {
+  private readonly logger = new SecureLogger(AuthLogoutController.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly hmacSigner: HmacSignerService,
+  ) {}
+
+  private getUsersSubgraphUrl(): string {
+    const raw = this.configService.get<string>('MICROSERVICES');
+    const subgraphs = JSON.parse(raw || '[]') as SubgraphConfig[];
+    const users = subgraphs.find((s) => s.name === 'users');
+    if (!users?.url) {
+      throw new Error('No users subgraph configured in MICROSERVICES');
+    }
+    return users.url;
+  }
+
+  @Post('logout')
+  @HttpCode(204)
+  async logout(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<void> {
+    const accessTokenName =
+      this.configService.get<string>('cookie.accessTokenName') ||
+      'access-token';
+    const accessToken = req.cookies?.[accessTokenName];
+
+    // Revoke upstream FIRST, but never let it decide whether we clear.
+    // Wrapped rather than awaited bare so that a throw cannot skip the clear
+    // below — that skip is the entire bug being fixed here.
+    if (accessToken) {
+      await this.revokeUpstream(accessToken);
+    }
+
+    clearAuthCookies(res, this.configService);
+
+    // 204, no body. The browser is signed out whether or not the provider
+    // agreed, and the response says nothing a caller could act on wrongly.
+  }
+
+  /**
+   * Tell the users subgraph to revoke the session at the auth provider.
+   *
+   * Failures are logged and swallowed. The provider's refresh token outliving
+   * the session is a real problem, but it is not one the user can do anything
+   * about from a sign-out button, and blocking on it would keep them signed
+   * in on the device in front of them.
+   */
+  private async revokeUpstream(accessToken: string): Promise<void> {
+    try {
+      const url = this.getUsersSubgraphUrl();
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+      if (this.hmacSigner.isEnabled()) {
+        headers['X-HMAC-Auth'] = this.hmacSigner.signGraphQLRequest(url);
+      }
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          query: REVOKE_MUTATION,
+          variables: { accessToken },
+        }),
+      });
+
+      const payload = (await response.json()) as {
+        errors?: { message: string }[];
+      };
+
+      const error = payload.errors?.[0];
+      if (error) {
+        this.logger.warn(`Session revocation rejected: ${error.message}`);
+      }
+    } catch (error) {
+      this.logger.warn(
+        `Session revocation call failed: ${(error as Error).message}`,
+      );
+    }
+  }
+}

--- a/apps/backend/src/api/src/auth-refresh.controller.spec.ts
+++ b/apps/backend/src/api/src/auth-refresh.controller.spec.ts
@@ -216,8 +216,10 @@ describe('AuthRefreshController', () => {
    * token. Minutes later they are silently signed in as that person.
    */
   describe('identity swap protection', () => {
-    const USER_A = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiAidXNlci1hIiwgImVtYWlsIjogInVzZXItYUBleGFtcGxlLnRlc3QifQ.sig';
-    const USER_B = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiAidXNlci1iIiwgImVtYWlsIjogInVzZXItYkBleGFtcGxlLnRlc3QifQ.sig';
+    const USER_A =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiAidXNlci1hIiwgImVtYWlsIjogInVzZXItYUBleGFtcGxlLnRlc3QifQ.sig';
+    const USER_B =
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiAidXNlci1iIiwgImVtYWlsIjogInVzZXItYkBleGFtcGxlLnRlc3QifQ.sig';
 
     it('refuses to renew into a different identity than the caller holds', async () => {
       fetchMock.mockResolvedValue({
@@ -229,7 +231,10 @@ describe('AuthRefreshController', () => {
 
       await expect(
         controller.refresh(
-          createRequest({ 'refresh-token': 'belongs-to-B', 'access-token': USER_A }),
+          createRequest({
+            'refresh-token': 'belongs-to-B',
+            'access-token': USER_A,
+          }),
           res,
         ),
       ).rejects.toThrow(UnauthorizedException);
@@ -248,7 +253,10 @@ describe('AuthRefreshController', () => {
       const res = createResponse();
 
       await controller.refresh(
-        createRequest({ 'refresh-token': 'belongs-to-A', 'access-token': USER_A }),
+        createRequest({
+          'refresh-token': 'belongs-to-A',
+          'access-token': USER_A,
+        }),
         res,
       );
 

--- a/apps/backend/src/api/src/auth-refresh.controller.ts
+++ b/apps/backend/src/api/src/auth-refresh.controller.ts
@@ -8,7 +8,12 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Request, Response } from 'express';
+// `import type`, not a value import. NestJS emits decorator metadata for
+// `@Req() req: Request`, which turns the type into a RUNTIME reference that
+// webpack then tries to resolve — and express is not a declared dependency
+// of this package, so the bundle build reports it as unresolvable. Erasing
+// the import at compile time removes the reference and the error with it.
+import type { Request, Response } from 'express';
 import { HmacSignerService } from 'src/common/services/hmac-signer.service';
 import { SecureLogger } from 'src/common/services/secure-logger.service';
 import {
@@ -166,12 +171,21 @@ export class AuthRefreshController {
     // compare and the check is skipped. It fires precisely in the race case,
     // where a FRESH access cookie for one user arrives alongside a refresh
     // cookie for another.
-    const presentedSubject = subjectOf(refreshToken ? req.cookies?.[
-      this.configService.get<string>('cookie.accessTokenName') || 'access-token'
-    ] : undefined);
+    const presentedSubject = subjectOf(
+      refreshToken
+        ? req.cookies?.[
+            this.configService.get<string>('cookie.accessTokenName') ||
+              'access-token'
+          ]
+        : undefined,
+    );
     const renewedSubject = subjectOf(auth.accessToken);
 
-    if (presentedSubject && renewedSubject && presentedSubject !== renewedSubject) {
+    if (
+      presentedSubject &&
+      renewedSubject &&
+      presentedSubject !== renewedSubject
+    ) {
       this.logger.error(
         'Refresh would have swapped identity; rejecting and clearing cookies',
       );

--- a/apps/backend/src/api/src/auth-refresh.controller.ts
+++ b/apps/backend/src/api/src/auth-refresh.controller.ts
@@ -20,6 +20,7 @@ import {
   setAuthCookies,
   clearAuthCookies,
 } from 'src/common/utils/cookie.utils';
+import { callUsersSubgraph } from './users-subgraph.client';
 
 /**
  * The renewal mutation lives on the users subgraph and is `@inaccessible`, so
@@ -37,11 +38,6 @@ const REFRESH_MUTATION = `
     }
   }
 `;
-
-interface SubgraphConfig {
-  name: string;
-  url: string;
-}
 
 /**
  * Session renewal endpoint — `POST /api/auth/refresh`.
@@ -72,16 +68,6 @@ export class AuthRefreshController {
     private readonly hmacSigner: HmacSignerService,
   ) {}
 
-  private getUsersSubgraphUrl(): string {
-    const raw = this.configService.get<string>('MICROSERVICES');
-    const subgraphs = JSON.parse(raw || '[]') as SubgraphConfig[];
-    const users = subgraphs.find((s) => s.name === 'users');
-    if (!users?.url) {
-      throw new Error('No users subgraph configured in MICROSERVICES');
-    }
-    return users.url;
-  }
-
   @Post('refresh')
   @HttpCode(204)
   async refresh(
@@ -106,24 +92,12 @@ export class AuthRefreshController {
     };
 
     try {
-      const url = this.getUsersSubgraphUrl();
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-      };
-      if (this.hmacSigner.isEnabled()) {
-        headers['X-HMAC-Auth'] = this.hmacSigner.signGraphQLRequest(url);
-      }
-
-      const response = await fetch(url, {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-          query: REFRESH_MUTATION,
-          variables: { refreshToken },
-        }),
-      });
-
-      payload = await response.json();
+      payload = await callUsersSubgraph<{ refreshSession?: RenewedTokens }>(
+        this.configService,
+        this.hmacSigner,
+        REFRESH_MUTATION,
+        { refreshToken },
+      );
     } catch (error) {
       // The users service was unreachable, or answered with something that is
       // not JSON. Cookies are deliberately LEFT ALONE — this says nothing

--- a/apps/backend/src/api/src/users-subgraph.client.ts
+++ b/apps/backend/src/api/src/users-subgraph.client.ts
@@ -1,0 +1,79 @@
+import { ConfigService } from '@nestjs/config';
+import { HmacSignerService } from 'src/common/services/hmac-signer.service';
+
+/**
+ * Calling the users subgraph directly, bypassing the federated router.
+ *
+ * Both auth routes on this gateway need it for the same reason: the mutations
+ * they call are `@inaccessible`, so they are absent from the composed public
+ * schema and unreachable through `/api` by design. That keeps a 7-day refresh
+ * token and a live access token out of client-facing GraphQL, where they would
+ * land in query logs, traces and audit payloads.
+ *
+ * Extracted because the refresh and logout controllers were otherwise
+ * byte-identical here — URL lookup, HMAC header, POST, parse — which the CPD
+ * gate correctly rejected. Keeping one copy also means the HMAC signing step
+ * cannot be added to one caller and forgotten in the other.
+ */
+export interface SubgraphConfig {
+  name: string;
+  url: string;
+}
+
+export interface GraphQLErrorShape {
+  message: string;
+  extensions?: { code?: string };
+}
+
+export interface SubgraphResponse<T> {
+  data?: T;
+  errors?: GraphQLErrorShape[];
+}
+
+/**
+ * Resolve the users subgraph URL from `MICROSERVICES`.
+ *
+ * Throws rather than defaulting: a missing entry is a deployment error, and a
+ * guessed localhost URL would fail later and less clearly.
+ */
+export function getUsersSubgraphUrl(configService: ConfigService): string {
+  const raw = configService.get<string>('MICROSERVICES');
+  const subgraphs = JSON.parse(raw || '[]') as SubgraphConfig[];
+  const users = subgraphs.find((s) => s.name === 'users');
+  if (!users?.url) {
+    throw new Error('No users subgraph configured in MICROSERVICES');
+  }
+  return users.url;
+}
+
+/**
+ * POST an HMAC-signed operation to the users subgraph.
+ *
+ * Rejects on transport failure and on non-JSON responses; a GraphQL-level
+ * error comes back in `errors` for the caller to interpret. That split matters
+ * to both callers and they read it in opposite directions — refresh must tell
+ * a rejected grant from an outage before deciding whether to clear cookies,
+ * while logout clears them regardless and only logs what went wrong.
+ */
+export async function callUsersSubgraph<T>(
+  configService: ConfigService,
+  hmacSigner: HmacSignerService,
+  query: string,
+  variables: Record<string, unknown>,
+): Promise<SubgraphResponse<T>> {
+  const url = getUsersSubgraphUrl(configService);
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+  if (hmacSigner.isEnabled()) {
+    headers['X-HMAC-Auth'] = hmacSigner.signGraphQLRequest(url);
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ query, variables }),
+  });
+
+  return (await response.json()) as SubgraphResponse<T>;
+}

--- a/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.resolver.ts
@@ -848,4 +848,43 @@ export class AuthResolver {
       });
     }
   }
+
+  /**
+   * Revoke a session at the auth provider — the server half of logout.
+   *
+   * Same shape as `refreshSession` above and for the same reasons:
+   * `@inaccessible` keeps it out of the composed public schema so it is
+   * reachable only by an HMAC-signed call from the gateway's logout route, and
+   * `@Public()` because the access token being presented may already be
+   * expired. Requiring a valid one is precisely the bug this replaces — the
+   * federated `logout` mutation is auth-guarded, so a user whose 15-minute
+   * token had lapsed got `Forbidden resource` and kept every cookie.
+   *
+   * Returns true unconditionally. The gateway clears cookies regardless of
+   * what happens here, so there is no failure this can report that would
+   * usefully change the caller's behaviour, and an exception would only risk
+   * the gateway treating a revoked session as a failed logout.
+   */
+  @Public()
+  @Directive('@inaccessible')
+  @Throttle({ default: AUTH_THROTTLE.logout })
+  @Mutation(() => Boolean)
+  async revokeSession(
+    @Args('accessToken') accessToken: string,
+    @Context() context: GqlContext,
+  ): Promise<boolean> {
+    const auditContext = createAuditContext(context, this.serviceName);
+
+    await this.authService.revokeSession(accessToken);
+
+    this.auditLogService?.log({
+      ...auditContext,
+      action: AuditAction.LOGOUT,
+      success: true,
+      resolverName: 'revokeSession',
+      operationType: 'mutation',
+    });
+
+    return true;
+  }
 }

--- a/apps/backend/src/apps/users/src/domains/auth/auth.service.ts
+++ b/apps/backend/src/apps/users/src/domains/auth/auth.service.ts
@@ -379,6 +379,36 @@ export class AuthService {
     };
   }
 
+  /**
+   * End a session at the auth provider so its refresh token stops working.
+   *
+   * Best-effort by design, and the inverse of `refreshSession` above: there,
+   * swallowing the provider's error would destroy the signal the caller needs;
+   * here, surfacing it would let a provider outage block sign-out. A logout
+   * that fails is a user still logged in.
+   *
+   * A provider without `signOut` is not an error — the capability is optional
+   * on `IAuthProvider`, and cookie clearing (which the gateway does regardless)
+   * is what actually ends the session from the browser's point of view.
+   */
+  async revokeSession(accessToken: string): Promise<void> {
+    if (!this.authProvider.signOut) {
+      this.logger.warn(
+        'Auth provider cannot revoke sessions; clearing cookies only',
+      );
+      return;
+    }
+
+    try {
+      await this.authProvider.signOut(accessToken);
+      this.logger.log('Session revoked at provider');
+    } catch (err) {
+      this.logger.warn(
+        `Provider session revocation failed: ${(err as Error).message}`,
+      );
+    }
+  }
+
   private async sendWelcomeEmailSafely(
     userId: string,
     email: string,

--- a/apps/backend/src/apps/users/src/domains/profile/geocoding.service.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/geocoding.service.ts
@@ -41,7 +41,7 @@ const DEFAULT_GEOCODER_URL =
 export class GeocoderUnavailableError extends Error {
   constructor(cause: string) {
     super(`Geocoder unavailable: ${cause}`);
-    this.name = "GeocoderUnavailableError";
+    this.name = 'GeocoderUnavailableError';
   }
 }
 

--- a/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
+++ b/apps/backend/src/apps/users/src/domains/profile/profile.service.ts
@@ -347,7 +347,9 @@ export class ProfileService {
         });
 
         if (error instanceof GeocoderUnavailableError) {
-          this.logger.warn(`Address edit rejected, geocoder down: ${error.message}`);
+          this.logger.warn(
+            `Address edit rejected, geocoder down: ${error.message}`,
+          );
           throw new ServiceUnavailableException(
             'We could not verify addresses just now. Please try again shortly.',
           );
@@ -355,7 +357,9 @@ export class ProfileService {
         throw error;
       }
 
-      return this.db.userAddress.findUniqueOrThrow({ where: { id: address.id } });
+      return this.db.userAddress.findUniqueOrThrow({
+        where: { id: address.id },
+      });
     }
 
     return updated;

--- a/apps/backend/src/config/auth-throttle.config.ts
+++ b/apps/backend/src/config/auth-throttle.config.ts
@@ -91,4 +91,8 @@ export const AUTH_THROTTLE = {
   magicLink: { name: 'auth-magic-link', ttl: 60000, limit: 3 },
   passkey: { name: 'auth-passkey', ttl: 60000, limit: 10 },
   refresh: { name: 'auth-refresh', ttl: 60000, limit: 20 },
+  // Deliberately loose. Throttling sign-out protects nothing — the caller
+  // already holds the session — and a rejected logout leaves the user
+  // authenticated, which is the outcome this endpoint exists to prevent.
+  logout: { name: 'auth-logout', ttl: 60000, limit: 30 },
 } as const;

--- a/apps/frontend/__tests__/auth-logout.test.ts
+++ b/apps/frontend/__tests__/auth-logout.test.ts
@@ -86,17 +86,28 @@ describe("auth-logout", () => {
       globalThis.fetch = originalFetch;
     });
 
-    it("clears localStorage, fires backend Logout, and redirects", () => {
+    it("clears localStorage, calls the logout route, and redirects", () => {
       localStorage.setItem(USER_KEY, JSON.stringify({ id: "u1" }));
 
       triggerAuthExpiredRedirect("/settings/privacy");
 
       expect(localStorage.getItem(USER_KEY)).toBeNull();
       expect(fetchMock).toHaveBeenCalledTimes(1);
-      const [, init] = fetchMock.mock.calls[0];
-      const body = JSON.parse((init as RequestInit).body as string);
-      expect(body.operationName).toBe("Logout");
-      expect(body.query).toContain("mutation Logout");
+
+      // The REST route, not `mutation Logout { logout }`. That mutation is
+      // auth-guarded, so on this path — reached only when the session has
+      // ALREADY expired — it could never have passed the guard, and it was
+      // sent without an X-CSRF-Token header so the gateway rejected it 403
+      // first regardless. Either way the httpOnly cookies were never cleared
+      // and the user stayed signed in. Asserting the URL rather than a request
+      // body is the point: there is no body, because the cookie is the
+      // credential.
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(String(url)).toMatch(/\/auth\/logout$/);
+      expect((init as RequestInit).method).toBe("POST");
+      expect((init as RequestInit).credentials).toBe("include");
+      expect((init as RequestInit).body).toBeUndefined();
+
       expect(assignMock).toHaveBeenCalledWith(
         "/login?redirect=%2Fsettings%2Fprivacy&reason=expired",
       );

--- a/apps/frontend/__tests__/pages/auth-callback.test.tsx
+++ b/apps/frontend/__tests__/pages/auth-callback.test.tsx
@@ -27,6 +27,23 @@ jest.mock("next/navigation", () => ({
  * Each test still declares its params via `mockSearchParamsGet`; this just
  * translates that into a real URL before mounting.
  */
+/*
+ * AUTH_FULL_OPTIONS is a build-time constant, so it is mocked through a getter
+ * rather than set — the page reads it on every render, and a plain value would
+ * freeze at whatever the first test happened to leave behind.
+ *
+ * Default OFF, matching production. The passkey screen is gated on this flag
+ * because it was previously the only surface in the product offering
+ * passkeys — sign-in on /login and /register already hid them — so a new user
+ * was invited to enrol a credential they then had nowhere to use.
+ */
+let mockAuthFullOptions = false;
+jest.mock("@/lib/features", () => ({
+  get AUTH_FULL_OPTIONS() {
+    return mockAuthFullOptions;
+  },
+}));
+
 const PARAM_KEYS = ["token", "email", "type", "redirect"] as const;
 
 function renderCallback() {
@@ -334,7 +351,67 @@ describe("AuthCallbackPage", () => {
     });
   });
 
+  describe("passkeys disabled (production default)", () => {
+    /*
+     * The regression this guards. A user registered, verified their email, was
+     * shown a passkey prompt, skipped it — and that prompt was the only place
+     * in the product where passkeys existed at all, since /login and /register
+     * hide them behind the same flag. The screen asked for a decision about a
+     * feature the user could not subsequently use.
+     *
+     * `supportsPasskeys: true` throughout: the browser CAN do WebAuthn. That
+     * is deliberately not the question. Only whether we offer it should decide
+     * whether the screen appears, and conflating the two is what produced the
+     * bug.
+     */
+    const registerAsNewUser = () => {
+      mockSearchParamsGet = jest.fn().mockImplementation((key: string) => {
+        if (key === "email") return "test@example.com";
+        if (key === "token") return "valid-token";
+        if (key === "type") return "register";
+        return null;
+      });
+      mockVerifyMagicLink.mockResolvedValue(undefined);
+      mockAuthContextValue = { ...defaultAuthContext, supportsPasskeys: true };
+    };
+
+    it("does not show the passkey prompt to a new user", async () => {
+      registerAsNewUser();
+
+      renderCallback();
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalled();
+      });
+      expect(screen.queryByText("Add a Passkey")).not.toBeInTheDocument();
+      expect(screen.queryByText("Skip for now")).not.toBeInTheDocument();
+    });
+
+    it("sends the new user straight on to onboarding", async () => {
+      registerAsNewUser();
+
+      renderCallback();
+
+      // Not stranded on a success page with nothing to click: the effect and
+      // the render guard share one condition precisely so that turning the
+      // screen off also turns the redirect on.
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith("/onboarding");
+      });
+    });
+  });
+
   describe("success state - new user with passkey support", () => {
+    // These describe the screen as it behaves when passkeys are ENABLED. They
+    // are kept rather than deleted so the behaviour is still specified for
+    // whenever AUTH_FULL_OPTIONS is flipped back on (see #671).
+    beforeEach(() => {
+      mockAuthFullOptions = true;
+    });
+    afterEach(() => {
+      mockAuthFullOptions = false;
+    });
+
     // The one screen that must still wait for a click. It offers a real choice
     // — "Add a Passkey" or "Skip for now" — so auto-navigating past it would
     // silently kill passkey enrolment for every new user.

--- a/apps/frontend/app/(auth)/auth/callback/page.tsx
+++ b/apps/frontend/app/(auth)/auth/callback/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useAuth } from "@/lib/auth-context";
 import { AuthCheckIcon } from "@/components/auth/AuthUI";
+import { AUTH_FULL_OPTIONS } from "@/lib/features";
 
 /** Reusable spinning indicator shared between the Suspense fallback and the verifying state. */
 function AuthSpinner() {
@@ -181,7 +182,15 @@ function AuthCallbackContent() {
   // "Add a Passkey" or "Skip for now" — so it must NOT be auto-dismissed.
   // Everything else was an interstitial that only ever said "click here to
   // continue", which is the click this removes.
-  const isAwaitingPasskeyChoice = isNewUser && supportsPasskeys;
+  //
+  // Gated on AUTH_FULL_OPTIONS, which is what hides passkey sign-in on /login
+  // and /register. This screen was missing that check, so it was the ONLY
+  // place in the product offering passkeys — a new user was invited to set one
+  // up and then had nowhere to use it. `supportsPasskeys` answers "can this
+  // browser do WebAuthn", which is a different question from "do we offer it",
+  // and only the second one should decide whether the screen appears.
+  const isAwaitingPasskeyChoice =
+    AUTH_FULL_OPTIONS && isNewUser && supportsPasskeys;
 
   useEffect(() => {
     if (status !== "success" || isAwaitingPasskeyChoice) return;
@@ -242,8 +251,11 @@ function AuthCallbackContent() {
     );
   }
 
-  // Success state - show passkey prompt for new users
-  if (isNewUser && supportsPasskeys) {
+  // Success state - show passkey prompt for new users.
+  // Same condition as the effect above, deliberately: if these two disagree,
+  // either the screen renders and is instantly redirected away, or the
+  // redirect is suppressed and the user is stranded on a blank success page.
+  if (isAwaitingPasskeyChoice) {
     return (
       <div className="bg-surface rounded-lg p-8 text-center">
         <AuthCheckIcon />

--- a/apps/frontend/lib/auth-context.tsx
+++ b/apps/frontend/lib/auth-context.tsx
@@ -10,6 +10,7 @@ import {
   ReactNode,
 } from "react";
 import { clearIdentityScopedCache } from "./apollo-cache-keys";
+import { requestServerSignOut } from "./auth-signout";
 import { useMutation } from "@apollo/client/react";
 import { jwtDecode } from "jwt-decode";
 import {
@@ -23,7 +24,6 @@ import {
   VERIFY_PASSKEY_REGISTRATION,
   GENERATE_PASSKEY_AUTHENTICATION_OPTIONS,
   VERIFY_PASSKEY_AUTHENTICATION,
-  LOGOUT,
   LoginUserInput,
   RegisterUserInput,
   LoginUserData,
@@ -32,7 +32,6 @@ import {
   VerifyMagicLinkData,
   RegisterWithMagicLinkData,
   AuthTokens,
-  LogoutData,
 } from "./graphql/auth";
 import {
   startRegistration,
@@ -162,7 +161,6 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
   }>(VERIFY_PASSKEY_AUTHENTICATION);
 
   // Logout mutation to clear httpOnly cookies
-  const [logoutMutation] = useMutation<LogoutData>(LOGOUT);
 
   // Helper to store user info after authentication
   // SECURITY: Tokens are stored in httpOnly cookies by the backend
@@ -533,13 +531,17 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
   // ============================================
 
   const logout = useCallback(async () => {
-    // Call backend to clear httpOnly cookies
-    try {
-      await logoutMutation();
-    } catch {
-      // Continue with local cleanup even if backend call fails
-      console.warn("Failed to call logout endpoint");
-    }
+    // Clear the httpOnly cookies server-side, and revoke the session at the
+    // auth provider.
+    //
+    // Was `await logoutMutation()`. That mutation is auth-guarded, so it threw
+    // `Forbidden resource` for anyone whose 15-minute access token had lapsed,
+    // and even on success its cookie clearing happened on the users subgraph's
+    // response and never reached the browser. Users stayed signed in after
+    // logging out; one registered a new account and landed in the old
+    // account's briefing. requestServerSignOut never throws, so the local
+    // cleanup below always runs.
+    await requestServerSignOut();
 
     // Clear local state
     setUser(null);
@@ -552,7 +554,7 @@ export function AuthProvider({ children }: Readonly<{ children: ReactNode }>) {
     // and personalization signals from the persisted cache, cache-first,
     // before any network request happens.
     void clearIdentityScopedCache();
-  }, [logoutMutation]);
+  }, []);
 
   const clearError = useCallback(() => {
     setError(null);

--- a/apps/frontend/lib/auth-logout.ts
+++ b/apps/frontend/lib/auth-logout.ts
@@ -20,9 +20,7 @@ import {
 } from "@apollo/client/errors";
 import { USER_KEY } from "./auth-context";
 import { purgePersistedCache } from "./apollo-cache-keys";
-
-const GRAPHQL_URL =
-  process.env.NEXT_PUBLIC_GRAPHQL_URL || "http://localhost:3000/api";
+import { requestServerSignOut } from "./auth-signout";
 
 /** Error codes that mean "your session is no longer valid, sign in again". */
 const EXPIRED_SESSION_CODES = new Set(["FORBIDDEN", "UNAUTHENTICATED"]);
@@ -122,19 +120,16 @@ export function triggerAuthExpiredRedirect(pathname: string): void {
   // navigation below tears the in-memory cache down anyway.
   purgePersistedCache();
 
-  // Best-effort backend logout to clear httpOnly cookies. Fire via raw
-  // fetch (not Apollo) so we don't re-enter the link chain during an
-  // auth-failure path. Failures are ignored — the navigation below is
-  // the user-visible outcome either way.
-  fetch(GRAPHQL_URL, {
-    method: "POST",
-    credentials: "include",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      query: "mutation Logout { logout }",
-      operationName: "Logout",
-    }),
-  }).catch(() => {});
+  // Best-effort backend sign-out to clear the httpOnly cookies. Goes through
+  // the gateway's REST route rather than Apollo, so we don't re-enter the link
+  // chain during an auth-failure path.
+  //
+  // This used to POST `mutation Logout { logout }` directly, which cleared
+  // nothing on this path for two reasons: no `X-CSRF-Token` header, so the
+  // gateway rejected it 403 before it ran, and the mutation is auth-guarded,
+  // so an expired session — the only way to reach this function — could not
+  // have passed it anyway. The cookies survived every expiry-driven logout.
+  void requestServerSignOut();
 
   const redirect = encodeURIComponent(pathname || "/");
   performRedirect(`/login?redirect=${redirect}&reason=expired`);

--- a/apps/frontend/lib/auth-signout.ts
+++ b/apps/frontend/lib/auth-signout.ts
@@ -1,0 +1,57 @@
+/**
+ * Server-side sign-out.
+ *
+ * Calls the gateway's logout route, which clears the httpOnly auth cookies and
+ * revokes the session at the auth provider. Cookies are httpOnly, so this is
+ * the ONLY way the browser can be made to stop being signed in — nothing in
+ * JavaScript can clear them directly.
+ *
+ * Replaces a `mutation Logout { logout }` call that did not work. It failed
+ * two different ways at once: the mutation is auth-guarded, so it returned
+ * `Forbidden resource` once the 15-minute access token lapsed, and even when
+ * it succeeded the cookie clearing was performed on the users subgraph's
+ * response and never reached the browser. The observable result was a user who
+ * clicked "log out", got no error, and stayed signed in — long enough to
+ * register a new account and land in the old account's data.
+ */
+import { getCsrfToken } from "./csrf";
+
+const GRAPHQL_URL =
+  process.env.NEXT_PUBLIC_GRAPHQL_URL || "http://localhost:3000/api";
+
+/**
+ * Derived from the GraphQL origin rather than configured separately, exactly
+ * as the refresh route is, so the two cannot drift apart across environments.
+ */
+const LOGOUT_URL = `${GRAPHQL_URL.replace(/\/$/, "")}/auth/logout`;
+
+/**
+ * Ask the server to end the session.
+ *
+ * Never throws and never reports failure. Callers proceed to clear local state
+ * and navigate regardless, because there is no useful branch on the outcome:
+ * if the server could not be reached, leaving the user on a signed-in-looking
+ * screen is strictly worse than signing them out locally and letting the dead
+ * cookie fail on its next use.
+ */
+export async function requestServerSignOut(): Promise<void> {
+  try {
+    const headers: Record<string, string> = {};
+    const csrfToken = getCsrfToken();
+    if (csrfToken) {
+      // Without this the gateway's CSRF middleware rejects the POST outright
+      // and no cookie is ever cleared. The mutation this replaces omitted it.
+      headers["X-CSRF-Token"] = csrfToken;
+    }
+
+    await fetch(LOGOUT_URL, {
+      method: "POST",
+      // Required: the auth cookies are httpOnly, so this is how they reach the
+      // server. No body — the cookie is the only thing being acted on.
+      credentials: "include",
+      headers,
+    });
+  } catch {
+    // Deliberately swallowed; see the contract above.
+  }
+}

--- a/packages/auth-provider/__tests__/supabase.provider.spec.ts
+++ b/packages/auth-provider/__tests__/supabase.provider.spec.ts
@@ -27,6 +27,7 @@ const mockAuth = {
     getUserById: jest.fn(),
     listUsers: jest.fn(),
     generateLink: jest.fn(),
+    signOut: jest.fn(),
   },
 };
 
@@ -1372,6 +1373,72 @@ describe("SupabaseAuthProvider", () => {
         error: null,
       });
       await provider.refreshSession(secret);
+
+      const everythingLogged = [...errorSpy.mock.calls, ...logSpy.mock.calls]
+        .flat()
+        .join(" ");
+      expect(everythingLogged).not.toContain(secret);
+    });
+  });
+  describe("signOut", () => {
+    /*
+     * The contract is "never throws". It is load-bearing rather than
+     * defensive: the gateway awaits this before clearing cookies, so anything
+     * that escapes here would skip the clear and leave the user signed in —
+     * the exact production failure this method was added to fix. Each case
+     * below is a way the provider can fail that must NOT become a failed
+     * logout.
+     */
+    it("revokes the session locally, not across the user's other devices", async () => {
+      mockAuth.admin.signOut.mockResolvedValue({ error: null });
+
+      await provider.signOut("access-token-123");
+
+      // "local" scope: logging out of this browser must not sign the user out
+      // of their phone.
+      expect(mockAuth.admin.signOut).toHaveBeenCalledWith(
+        "access-token-123",
+        "local",
+      );
+    });
+
+    it("does not throw when the provider returns an error", async () => {
+      mockAuth.admin.signOut.mockResolvedValue({
+        error: new Error("token already revoked"),
+      });
+
+      await expect(provider.signOut("tok")).resolves.toBeUndefined();
+    });
+
+    it("does not throw when the provider is unreachable", async () => {
+      mockAuth.admin.signOut.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      await expect(provider.signOut("tok")).resolves.toBeUndefined();
+    });
+
+    it("skips the call entirely for an empty token", async () => {
+      mockAuth.admin.signOut.mockClear();
+
+      await provider.signOut("");
+      await provider.signOut("   ");
+
+      // Nothing to revoke, and a blank token would only earn a 4xx.
+      expect(mockAuth.admin.signOut).not.toHaveBeenCalled();
+    });
+
+    it("never logs the access token", async () => {
+      const secret = "super-secret-access-token";
+      const errorSpy = jest
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn((provider as any).logger, "error")
+        .mockImplementation(() => undefined);
+      const logSpy = jest
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .spyOn((provider as any).logger, "log")
+        .mockImplementation(() => undefined);
+
+      mockAuth.admin.signOut.mockRejectedValue(new Error("boom"));
+      await provider.signOut(secret);
 
       const everythingLogged = [...errorSpy.mock.calls, ...logSpy.mock.calls]
         .flat()

--- a/packages/auth-provider/src/providers/supabase.provider.ts
+++ b/packages/auth-provider/src/providers/supabase.provider.ts
@@ -828,6 +828,44 @@ export class SupabaseAuthProvider implements IAuthProvider {
   }
 
   /**
+   * Revoke a session at GoTrue, so its refresh token stops working.
+   *
+   * Logout previously only deactivated our own `user_sessions` rows and
+   * cleared cookies. GoTrue was never told, so the refresh token it issued
+   * stayed valid for its full 7 days — a logged-out session that anyone
+   * holding that token could still redeem. Verified in production: a refresh
+   * token minted at 15:12 was still `revoked=f` after a successful logout 21
+   * seconds later.
+   *
+   * Scoped to THIS session, not the user's other devices. Logging out of one
+   * browser must not sign you out of your phone.
+   *
+   * Never throws. The caller's next action is to clear cookies and it must
+   * happen regardless — a GoTrue outage that blocked sign-out would leave the
+   * user authenticated on the device in front of them, trading a credential
+   * they cannot see for one they can.
+   */
+  async signOut(accessToken: string): Promise<void> {
+    if (!accessToken?.trim()) return;
+
+    try {
+      // admin.signOut revokes by access token without disturbing the
+      // client-level session this provider instance holds, which is shared
+      // across requests and must not be mutated by one user's logout.
+      const { error } = await this.supabase.auth.admin.signOut(
+        accessToken,
+        "local",
+      );
+      if (error) throw error;
+    } catch (error) {
+      this.logger.error(
+        `Failed to revoke session at provider: ${(error as Error).message}`,
+      );
+      // Deliberately swallowed — see the contract on IAuthProvider.signOut.
+    }
+  }
+
+  /**
    * Send a magic link email via SMTP.
    */
   private async sendMagicLinkEmail(

--- a/packages/common/src/providers/auth/types.ts
+++ b/packages/common/src/providers/auth/types.ts
@@ -152,6 +152,24 @@ export interface IAuthProvider {
    * @returns A fresh set of tokens
    */
   refreshSession?(refreshToken: string): Promise<IAuthResult>;
+
+  /**
+   * Revoke the session behind an access token at the provider.
+   *
+   * Clearing our own cookies is not enough. The provider's refresh token
+   * outlives the access token by days, so a session that is only forgotten
+   * locally can still be redeemed by anyone who kept a copy of that token.
+   * Logout has to end it at the source.
+   *
+   * MUST be treated as best-effort by callers: a provider that is down, slow,
+   * or rejects the token cannot be allowed to block sign-out. Failing to
+   * revoke leaves a credential alive, but failing to CLEAR leaves the user
+   * signed in on the device in front of them, which is worse and is the
+   * failure they will actually notice.
+   *
+   * @param accessToken Access token identifying the session to revoke
+   */
+  signOut?(accessToken: string): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
## The bug

Logging out did not log you out. Confirmed in production: a user signed out, registered a **different** account in the same browser, followed the verify link, and landed in the **first** account's briefing.

The audit log shows the whole registration flow executing as the previous user, seven minutes after a successful logout:

```
15:12:52  LOGOUT                        rodneygagnon@mac.com   ← server received it
15:19:28  RegisterWithMagicLink         rodneygagnon@mac.com   ← still mac.com
15:20:13  ExchangeSupabaseSession       rodneygagnon@mac.com
15:20:13  MyProfile                     rodneygagnon@mac.com
15:20:15  BriefingPrefetch, GetBill×5…  rodneygagnon@mac.com
```

That is server-side attribution, not a stale client cache. This is **not** a recurrence of the #977 refresh swap — no refresh token was minted for the old user after the new one signed in, so the v1.8.2 identity guard held. The session simply never ended.

## Three defects

**1. The cookie clear never reached the browser.** `logout` runs on the users subgraph and clears cookies on the *subgraph's* response, relying on the gateway's `didReceiveResponse` to forward `Set-Cookie`. It does not survive that hop. Established by comparison rather than by reading code: the gateway's own `clearAuthCookies` — same helper, same config, called from the refresh controller — emits both clear headers correctly against production, while the subgraph path leaves every token in place.

**2. Logout required a valid access token.** The mutation sits behind the auth guard, so once the 15-minute token lapsed it returned `Forbidden resource` and cleared nothing — on exactly the sessions most in need of ending. Reproduced directly against production. The frontend's expiry path had the same hole from the other side: it POSTed the mutation with no `X-CSRF-Token`, so the gateway rejected it 403 before it ran.

**3. GoTrue was never told.** Logout only deactivated our own `user_sessions` rows, so the provider's refresh token stayed valid for its full 7 days. A token minted at 15:12 was still `revoked=f` after a logout 21 seconds later.

## The fix

`POST /api/auth/logout` on the gateway, mirroring `auth-refresh.controller.ts` — cookies are cleared where the response to the browser is actually written, needing no forwarding, and the route is reachable without a live access token by design.

The ordering rule it is built around: **cookies are cleared no matter what happens upstream.** Provider down, subgraph unreachable, token already expired — the browser still stops being signed in. A logout that reports failure and leaves the user authenticated is the worst outcome, and is what the old path did.

`IAuthProvider` gains an optional `signOut()`, scoped `"local"` so signing out of one browser does not sign you out of your phone, and contractually non-throwing — if it threw it would skip the cookie clear and reintroduce the original bug.

## Also here

**Passkey prompt hidden** (`3e65739`). A new user finishing registration was shown "Add a Passkey / Skip for now" — the only surface in the product still offering passkeys, since `/login` and `/register` hide them behind `AUTH_FULL_OPTIONS`. It was gated on `supportsPasskeys` ("can this browser do WebAuthn") rather than on whether we offer the feature. Now follows the same flag as everything else.

**Duplication extracted** (`d4711ac`). The logout controller repeated the refresh controller's subgraph plumbing verbatim; jscpd caught it. One helper now serves both, so the HMAC signing step cannot be added to one caller and forgotten in the other.

**Incidental:** `auth-refresh.controller.ts` imported `express` as a value, and NestJS's decorator metadata turned that into a runtime reference webpack could not resolve, so `nest build api` had a pre-existing error. `import type` erases it; the gateway now compiles clean.

## Testing

- 6 on the gateway controller, every one asserting cookies are cleared — including when the subgraph is unreachable and when it returns a GraphQL error
- 5 on the provider covering the never-throws contract and that the access token never reaches a log
- 2 new on the callback for the passkeys-off default; the existing enrolment tests kept and run with the flag forced on, so that path stays specified for #671
- Full monorepo suite green; lint, `lint:sonar` and jscpd all clean; pushed through the complete pre-push gate with no bypass

Verifiable after deploy the same way the diagnosis was done:

```bash
curl -i -X POST https://api-us-ca.opuspopuli.org/api/auth/logout \
  -H "X-CSRF-Token: $T" -H "Cookie: csrf-token=$T"
# expect: 204, plus Set-Cookie clearing access-token and refresh-token
```

## Review status

**Self-reviewed** — needs countersignature for separation of duties.

## Data classification

PII — authentication credentials and session state. No token value enters a log, prompt, fixture or third-party service; the provider test asserts this explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
