### PR TITLE
fix(api): stop AuthMiddleware from blocking the logout it is meant to allow

### DIFF
--- a/apps/backend/src/api/src/auth-refresh.controller.ts
+++ b/apps/backend/src/api/src/auth-refresh.controller.ts
@@ -58,6 +58,15 @@ const REFRESH_MUTATION = `
  * - The global `AuthGuard` defers on non-GraphQL execution contexts, which is
  *   required here: the access token is expired by definition, and the refresh
  *   cookie is the credential.
+ * - `AuthMiddleware` DOES reject. An earlier version of this comment, and the
+ *   #977 plan, both claimed it only copies the cookie into the Authorization
+ *   header and calls next(). It does that only while the token validates; a
+ *   token that fails validation is answered by the middleware itself and the
+ *   route never runs. This path is safe because the browser drops the access
+ *   cookie when it expires (its Max-Age matches the token's), so renewal
+ *   normally arrives with no access cookie at all — but a PRESENT-and-invalid
+ *   one would have killed it. `SESSION_LIFECYCLE_PATHS` in that middleware now
+ *   exempts this route explicitly rather than relying on that coincidence.
  */
 @Controller('api/auth')
 export class AuthRefreshController {

--- a/apps/backend/src/common/middleware/auth.middleware.spec.ts
+++ b/apps/backend/src/common/middleware/auth.middleware.spec.ts
@@ -253,4 +253,86 @@ describe('AuthMiddleware', () => {
       expect(mockNext).toHaveBeenCalledWith(error);
     });
   });
+  describe('session-lifecycle routes with an invalid token', () => {
+    /*
+     * The regression these pin. AuthMiddleware answers the request itself when
+     * a presented access token fails to validate, so the route never runs —
+     * which meant the endpoint whose entire job is to clear your cookies could
+     * not clear them exactly when they most needed clearing. A user clicked
+     * "log out", the request died here, the cookies survived, and they stayed
+     * signed in as the previous account while registering a new one.
+     *
+     * Both the #977 plan and the refresh controller's comment asserted this
+     * middleware "never rejects". It does, and the logout route was built on
+     * that false premise.
+     */
+    const rejectOnAuthFailure = () => {
+      (passport.authenticate as jest.Mock).mockImplementation(
+        (_strategy, _opts, callback) => () => callback(null, false),
+      );
+    };
+
+    const runWith = (path: string) => {
+      rejectOnAuthFailure();
+      const req = {
+        headers: {},
+        cookies: { 'access-token': 'expired-or-malformed' },
+        path,
+        url: path,
+      } as unknown as Request;
+      middleware.use(req, mockResponse as Response, mockNext);
+      return req;
+    };
+
+    it.each(['/api/auth/logout', '/api/auth/refresh'])(
+      'lets %s through so it can clear cookies',
+      (path) => {
+        runWith(path);
+
+        expect(mockNext).toHaveBeenCalled();
+        expect(mockResponse.send).not.toHaveBeenCalled();
+      },
+    );
+
+    it('leaves req.user unset on the routes it lets through', () => {
+      const req = runWith('/api/auth/logout');
+
+      // Passing through is not authenticating. Anything downstream needing a
+      // caller must still find none.
+      expect(req.user).toBeUndefined();
+    });
+
+    it('still rejects other routes carrying an invalid token', () => {
+      runWith('/api/some/protected/thing');
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockResponse.send).toHaveBeenCalledWith(
+        expect.objectContaining({ success: false }),
+      );
+    });
+
+    it('does not exempt a path that merely starts with a lifecycle path', () => {
+      // Guards against a startsWith implementation letting
+      // /api/auth/logout-all-the-things through.
+      runWith('/api/auth/logout-something-else');
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockResponse.send).toHaveBeenCalled();
+    });
+
+    it('ignores the query string when matching', () => {
+      rejectOnAuthFailure();
+      const req = {
+        headers: {},
+        cookies: { 'access-token': 'expired' },
+        // Express sets `path` without the query, but url carries it; the
+        // fallback must not be fooled.
+        url: '/api/auth/logout?redirect=%2F',
+      } as unknown as Request;
+
+      middleware.use(req, mockResponse as Response, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/backend/src/common/middleware/auth.middleware.ts
+++ b/apps/backend/src/common/middleware/auth.middleware.ts
@@ -9,6 +9,35 @@ import passport from 'passport';
 const SENSITIVE_HEADERS = ['authorization', 'cookie', 'x-api-key'];
 
 /**
+ * Routes that must run even when the presented access token does not validate.
+ *
+ * These are the session-lifecycle endpoints, and for both of them a bad token
+ * is the NORMAL case rather than an error: renewal exists because the access
+ * token has expired, and sign-out is most needed by the session that has
+ * already gone stale.
+ *
+ * Without this, the middleware below answers the request itself and the route
+ * never runs — so the endpoint whose entire job is to clear your cookies could
+ * not clear them precisely when they most needed clearing. That was a
+ * production bug: a user clicked "log out", the request was rejected here, the
+ * cookies survived, and they stayed signed in as the previous account while
+ * registering a new one.
+ *
+ * Skipping authentication is safe for exactly these two because neither trusts
+ * `req.user`. Refresh authenticates with the refresh cookie, which GoTrue
+ * validates; logout only clears cookies and asks the provider to revoke a token
+ * that the caller already possessed. Nothing here grants access to data.
+ */
+const SESSION_LIFECYCLE_PATHS = ['/api/auth/refresh', '/api/auth/logout'];
+
+function isSessionLifecyclePath(req: Request): boolean {
+  // `path` excludes the query string; startsWith would let
+  // `/api/auth/logout-something` through.
+  const path = (req.path || req.url || '').split('?')[0];
+  return SESSION_LIFECYCLE_PATHS.includes(path);
+}
+
+/**
  * Mask sensitive headers for safe logging
  */
 function maskSensitiveHeaders(
@@ -56,6 +85,22 @@ export class AuthMiddleware implements NestMiddleware {
           }
 
           if (!user) {
+            // Let the session-lifecycle routes decide for themselves. They are
+            // reached with a dead token by design, and answering here would
+            // stop logout from clearing the very cookie that failed to
+            // validate. `req.user` stays unset, so anything downstream that
+            // needs an authenticated caller still sees none.
+            if (isSessionLifecyclePath(req)) {
+              return next();
+            }
+
+            // NOTE: this answers 200 with `success: false`, which is wrong —
+            // an auth failure is indistinguishable from a successful call to
+            // any client that checks the status code first. Deliberately NOT
+            // changed here: it alters every auth-failure response on the
+            // gateway, which is too wide a blast radius to attach to an urgent
+            // logout fix that cannot be end-to-end tested first. Tracked
+            // separately.
             return res.send({
               success: false,
               message: 'Authorization Token is Invalid!',


### PR DESCRIPTION
## v1.8.3 did not fix logout

Reproduced against production after the deploy:

```
logout with NO access-token cookie   ->  204, both cookies cleared
logout WITH an access-token cookie   ->  200, no clearing headers at all
                                          {"success":false,
                                           "message":"Authorization Token is Invalid!"}
```

The request never reaches the controller. `AuthMiddleware` copies the access-token cookie into the `Authorization` header, runs passport, and **when validation fails it answers the request itself** via `res.send()` without calling `next()` (`auth.middleware.ts:58`).

Making the route `@Public` could never have helped — the request dies upstream of the guard.

So the endpoint whose entire job is to clear your cookies could not clear them in exactly the case that matters: a token too dead to validate. **This is the original bug's real mechanism**, and it survived two attempts at fixing it.

## The premise was documented, and wrong

Both `docs/plans/977-session-refresh-flow.md` and `auth-refresh.controller.ts` assert that `AuthMiddleware` *"only copies the cookie into the Authorization header and calls next()"* and *"never rejects"*. It does that **only while the token validates**.

The refresh route has been surviving on a coincidence: the browser drops the access cookie when it expires, because its `Max-Age` matches the token's lifetime — so renewal normally arrives carrying no access cookie at all. A **present-but-invalid** one would have killed refresh too.

Both session-lifecycle routes are now exempted explicitly rather than relying on that.

## Why skipping auth here is safe

Neither route trusts `req.user`, and `req.user` is left unset:

- **refresh** authenticates with the refresh cookie, which GoTrue validates
- **logout** only clears cookies and asks the provider to revoke a token the caller already possessed

Neither grants access to any data. The exemption is an exact-match list, not a prefix — `/api/auth/logout-anything` is deliberately not exempt, and there is a test for it.

## Deliberately NOT fixed here

The middleware answers **200** with `{"success": false}` on auth failure, which is indistinguishable from success to any client that checks the status code first — which is every fetch wrapper in the frontend. That is a real bug, but changing it alters every auth-failure response on the gateway. Too wide a blast radius to attach to an urgent logout fix that cannot be end-to-end tested first. Tracked separately.

## Testing

- 6 new middleware tests: both lifecycle routes pass through with an invalid token; `req.user` stays unset; other routes still rejected; a path merely *starting with* a lifecycle path is still rejected; query strings don't defeat matching
- Backend suite: 138 suites / 2379 tests green
- lint, `lint:sonar`, jscpd all clean

Verifiable immediately after deploy — this is the exact probe that failed:

```bash
curl -i -X POST https://api-us-ca.opuspopuli.org/api/auth/logout \
  -H "X-CSRF-Token: $T" \
  -H "Cookie: csrf-token=$T; access-token=<any-non-validating-token>"
# before: 200, no Set-Cookie
# after:  204 + Set-Cookie clearing access-token AND refresh-token
```

## Review status

**Self-reviewed** — needs countersignature for separation of duties.

## Data classification

PII — authentication credentials. No token value is logged; the middleware already masks `authorization` and `cookie` headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
