### PR TITLE
fix(api): raise subgraph rate limits, which capped the whole platform at 10 req/s

### DIFF
--- a/apps/backend/src/api/src/app.module.ts
+++ b/apps/backend/src/api/src/app.module.ts
@@ -14,6 +14,7 @@ import { IncomingMessage } from 'node:http';
 import { Request, Response } from 'express';
 import { LoggingModule, LogLevel } from '@opuspopuli/logging-provider';
 
+import { GATEWAY_THROTTLER_CONFIG } from 'src/common/config/shared-app.config';
 import configuration from 'src/config';
 import relationaldbConfig from 'src/config/relationaldb.config';
 import { authConfig, supabaseConfig } from '@opuspopuli/config-provider';
@@ -112,49 +113,13 @@ const handleAuth = ({ req, res }: { req: Request; res: Response }) => {
       }),
       inject: [ConfigService],
     }),
-    // Rate limits sized against what ONE briefing page load actually costs.
+    // Limits live in shared-app.config.ts alongside the subgraph ones.
     //
-    // These were 10/s, 50/10s, 100/min, and the app tripped them by simply
-    // being used. A first briefing load fans out to ~21 queries in about two
-    // seconds, with 11 landing inside a single second (GetBill x5,
-    // GetBillBrief x5, committees). Measured from the production audit log:
-    //
-    //   15:20:13.008    4 queries
-    //   15:20:13.063    6 queries
-    //   15:20:15.467   11 queries   <- 11 against a limit of 10
-    //
-    // The user-visible symptom was "Too many requests. Please try again later."
-    // in the Representatives section on first sign-in, clearing once Apollo
-    // retried into a fresh window. The old `medium` was worse than the burst
-    // limit in practice: two briefing loads in ten seconds exceeded it, and
-    // `long` capped a session at roughly four loads per minute.
-    //
-    // Limits are per IP, so anyone behind shared NAT -- an office, a library, a
-    // household -- consumed the same budget collectively.
-    //
-    // Raised to leave headroom for normal navigation while still bounding
-    // abuse: the sustained windows, not the burst window, are what protect
-    // against a scripted client. Reducing the fan-out itself (batching the
-    // per-bill queries, and the duplicate BriefingPrefetch/MyProfile calls) is
-    // the better fix and is tracked separately -- this stops legitimate use
-    // from being throttled today.
-    ThrottlerModule.forRoot([
-      {
-        name: 'short',
-        ttl: 1000, // 1 second
-        limit: 50, // ~2 briefing loads' worth of burst
-      },
-      {
-        name: 'medium',
-        ttl: 10000, // 10 seconds
-        limit: 200, // ~9 page loads in 10s
-      },
-      {
-        name: 'long',
-        ttl: 60000, // 1 minute
-        limit: 600, // ~28 page loads/min — brisk human use, not a script
-      },
-    ]),
+    // They were inline here, and that is exactly how the first fix missed:
+    // raising the gateway's limits left the subgraphs at 10/s, so the briefing
+    // kept failing from the region service while the gateway looked healthy.
+    // Same file now, so the next person changing one sees the other.
+    ThrottlerModule.forRoot(GATEWAY_THROTTLER_CONFIG),
     GraphQLModule.forRootAsync<ApolloGatewayDriverConfig>({
       driver: ApolloGatewayDriver,
       imports: [

--- a/apps/backend/src/common/config/shared-app.config.ts
+++ b/apps/backend/src/common/config/shared-app.config.ts
@@ -38,23 +38,76 @@ export function createSubgraphPlugins(serviceName: string) {
 }
 
 /**
- * Shared throttler configuration for all microservices
+ * Rate limits for the API GATEWAY — the public edge.
+ *
+ * This is the throttler that matters: it keys on the real client IP, so it is
+ * the only one that can distinguish one abusive caller from everyone else.
+ *
+ * Sized against what a page load actually costs. One briefing load fans out to
+ * ~21 queries in about two seconds, with 11 inside a single second. At the
+ * previous 10/s that tripped on first sign-in every time, surfacing as "Too
+ * many requests" in the Representatives section and a phantom "0 committees"
+ * where the query was rejected before it ran.
+ *
+ * Note these are still per IP, so users behind shared NAT — an office, a
+ * library, a household — spend one budget collectively. Reducing the fan-out
+ * (see #1024) is what actually fixes that; these numbers only buy room.
+ */
+export const GATEWAY_THROTTLER_CONFIG = [
+  {
+    name: 'short',
+    ttl: 1000, // 1 second
+    limit: 50, // ~2 briefing loads' worth of burst
+  },
+  {
+    name: 'medium',
+    ttl: 10000, // 10 seconds
+    limit: 200, // ~9 page loads in 10s
+  },
+  {
+    name: 'long',
+    ttl: 60000, // 1 minute
+    limit: 600, // ~28 page loads/min — brisk human use, not a script
+  },
+];
+
+/**
+ * Rate limits for the SUBGRAPHS — internal services behind the gateway.
+ *
+ * These are deliberately far higher than the gateway's, because the throttler
+ * keys on IP and **every subgraph request arrives from the gateway's single
+ * IP**. There is no per-user dimension here at all: the limit is a global cap
+ * on total system throughput, shared by every user at once.
+ *
+ * At the previous 10/s that meant the whole platform could serve ten subgraph
+ * requests per second across all users combined — while ONE briefing load
+ * needs about 21. It held together only because there was effectively one
+ * person using it; a second concurrent user would have throttled both.
+ *
+ * These limits also provide no security. Subgraphs are not publicly reachable
+ * and require a valid `X-HMAC-Auth` signature, so an attacker who could reach
+ * them at volume has already defeated something more important than a rate
+ * limit. The real per-caller control is GATEWAY_THROTTLER_CONFIG above.
+ *
+ * Kept non-infinite purely as a runaway backstop — a bug that loops subgraph
+ * calls should eventually be stopped rather than allowed to saturate the
+ * database.
  */
 export const THROTTLER_CONFIG = [
   {
     name: 'short',
     ttl: 1000, // 1 second
-    limit: 10, // 10 requests per second
+    limit: 2000, // global across all users, not per user
   },
   {
     name: 'medium',
     ttl: 10000, // 10 seconds
-    limit: 50, // 50 requests per 10 seconds
+    limit: 10000,
   },
   {
     name: 'long',
     ttl: 60000, // 1 minute
-    limit: 100, // 100 requests per minute
+    limit: 50000,
   },
 ];
 


### PR DESCRIPTION
## v1.8.5 fixed the wrong layer

Raising the **gateway's** rate limits did not clear the symptoms — still "Too many requests" in the Representatives section, still 0 committees. The logs said why:

```
gateway:            0 throttle rejections
opuspopuli-region:  4 throttle rejections    ← since the v1.8.5 restart
```

Every service registers its own `ThrottlerModule`. The gateway's limits were inline in its module; all four subgraphs share `THROTTLER_CONFIG`, which was still at **10 req/s**.

`BriefingCommittees`, `MyCountySupervisors` and `GetRepresentativesByDistricts` are all region-service queries — exactly the two sections that were failing. The committees section rendered 0 not because nothing matched (85 live committees exist, and the user's `interest_tags` were correct) but because the query was rejected before it ran.

## The subgraph limit was worse than a wrong number

The throttler keys on **IP**, and every subgraph request arrives from the **gateway's single IP**. There is no per-user dimension at all.

So `10/s` was never "10 requests per second per user" — it was a **global cap on total system throughput, shared by every user at once**, against a briefing load that needs ~21 requests. It survived only because there was effectively one person using the platform. Two concurrent users would have throttled each other, and it would have looked like random breakage under launch traffic.

It also buys no security. Subgraphs are not publicly reachable and require a valid `X-HMAC-Auth` signature — anyone able to flood them has already defeated something more important than a rate limit. The meaningful per-caller control is the gateway's, which keys on the real client IP.

Raised to a level that acts as a **runaway backstop** (a looping bug should still be stopped before it saturates the database) rather than a throughput cap.

## Both configs now live together

`GATEWAY_THROTTLER_CONFIG` and `THROTTLER_CONFIG` are both in `shared-app.config.ts`, with comments explaining that one is per-client-IP and the other is effectively global.

The gateway's were inline, which is precisely how the previous fix missed the subgraphs. Same file now, so changing one puts the other in front of you.

## Testing

- All five services build
- Backend suite 138 suites / 2383 tests green
- lint, `lint:sonar`, jscpd clean
- After deploy: the Representatives and committees sections should populate on first sign-in, and `docker logs opuspopuli-region | grep -i throttler` should stay clean

## Note

The underlying defect is still the fan-out — ~21 requests per briefing load, with duplicate `BriefingPrefetch`/`MyProfile` calls and unbatched per-bill queries. Tracked in #1024. These limits buy room; they are not headroom to spend.

## Review status

**Self-reviewed** — needs countersignature for separation of duties.

## Data classification

None — rate limit configuration. No change to what data is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
